### PR TITLE
fix(analytics) + feat(orders): camera streamUrl decrypt + receipt/kitchen-ticket snapshot persistence

### DIFF
--- a/backend/prisma/migrations/20260427081107_add_receipt_snapshots/migration.sql
+++ b/backend/prisma/migrations/20260427081107_add_receipt_snapshots/migration.sql
@@ -1,0 +1,7 @@
+-- Add JSONB snapshot columns for reprintable receipts and kitchen tickets.
+-- See backend/src/modules/orders/services/receipt-snapshot.builder.ts.
+-- Both columns are nullable so the migration is trivially reversible
+-- (no backfill needed; only new payments/orders populate them).
+
+ALTER TABLE "payments" ADD COLUMN "receiptSnapshot" JSONB;
+ALTER TABLE "orders" ADD COLUMN "kitchenTicketSnapshot" JSONB;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -512,6 +512,10 @@ model Order {
   externalOrderId String?   // Platform's order ID/token for status sync
   externalData    Json?     // Raw platform payload for audit trail
 
+  // Captured at order-create time so the kitchen ticket is reprintable
+  // and survives later edits to items/modifiers. Owned by ReceiptSnapshotBuilder.
+  kitchenTicketSnapshot Json?
+
   // Customer ordering fields
   sessionId        String? // UUID for customer session tracking
   customerPhone    String? // Optional customer phone
@@ -625,6 +629,12 @@ model Payment {
   transactionId  String?
   idempotencyKey String?
   notes          String?
+
+  // Captured at payment-create time so receipts remain reprintable even if
+  // the printer was offline, and survive future product/menu/tenant edits.
+  // Shape is owned by ReceiptSnapshotBuilder; see services/receipt-snapshot.builder.ts.
+  // Versioned via the `version` field inside the JSON.
+  receiptSnapshot Json?
 
   tenantId String
   tenant   Tenant @relation(fields: [tenantId], references: [id], onDelete: Cascade)

--- a/backend/src/modules/analytics/gateways/analytics.gateway.spec.ts
+++ b/backend/src/modules/analytics/gateways/analytics.gateway.spec.ts
@@ -1,0 +1,107 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { JwtService } from '@nestjs/jwt';
+import { AnalyticsGateway } from './analytics.gateway';
+import { PrismaService } from '../../../prisma/prisma.service';
+import {
+  mockPrismaClient,
+  MockPrismaClient,
+} from '../../../common/test/prisma-mock.service';
+import { encryptString } from '../../../common/helpers/encryption.helper';
+
+describe('AnalyticsGateway', () => {
+  let gateway: AnalyticsGateway;
+  let prisma: MockPrismaClient;
+
+  // CORS_ORIGIN must be set so the @WebSocketGateway decorator's corsOrigin()
+  // helper doesn't throw in non-production. (See analytics.gateway.ts:15-23.)
+  const originalCorsOrigin = process.env.CORS_ORIGIN;
+  beforeAll(() => {
+    process.env.CORS_ORIGIN = 'http://localhost:5173';
+    // ENCRYPTION_MASTER_KEY must be set so encryptString/decryptString work.
+    // The helper hashes any string ≥32 chars to a 32-byte AES-256 key, so a
+    // simple hex string is fine for tests.
+    process.env.ENCRYPTION_MASTER_KEY =
+      process.env.ENCRYPTION_MASTER_KEY ||
+      '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+  });
+  afterAll(() => {
+    if (originalCorsOrigin === undefined) {
+      delete process.env.CORS_ORIGIN;
+    } else {
+      process.env.CORS_ORIGIN = originalCorsOrigin;
+    }
+  });
+
+  beforeEach(async () => {
+    prisma = mockPrismaClient();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AnalyticsGateway,
+        {
+          provide: JwtService,
+          useValue: { verify: jest.fn(), sign: jest.fn() },
+        },
+        {
+          provide: PrismaService,
+          useValue: prisma,
+        },
+      ],
+    }).compile();
+
+    gateway = module.get(AnalyticsGateway);
+  });
+
+  describe('getDeviceConfig (Bug C — decrypt streamUrl on WebSocket→edge path)', () => {
+    it('returns the streamUrl decrypted, not the AES ciphertext', async () => {
+      const plaintextRtspUrl =
+        'rtsp://camerauser:supersecret@cam-01.local/stream1';
+      const encrypted = encryptString(plaintextRtspUrl);
+
+      prisma.camera.findFirst.mockResolvedValue({
+        id: 'cam-1',
+        streamUrl: encrypted,
+        calibrationData: null,
+      } as any);
+
+      const config = await (gateway as any).getDeviceConfig(
+        'cam-1',
+        'tenant-1',
+      );
+
+      expect(config).not.toBeNull();
+      expect(config.cameraId).toBe('cam-1');
+      expect(config.cameraUrl).toBe(plaintextRtspUrl);
+      // Sanity: ciphertext must differ from plaintext or the assertion above
+      // could pass vacuously.
+      expect(encrypted).not.toBe(plaintextRtspUrl);
+    });
+
+    it('returns an empty cameraUrl (not throwing) when streamUrl is null', async () => {
+      prisma.camera.findFirst.mockResolvedValue({
+        id: 'cam-2',
+        streamUrl: null,
+        calibrationData: null,
+      } as any);
+
+      const config = await (gateway as any).getDeviceConfig(
+        'cam-2',
+        'tenant-1',
+      );
+
+      expect(config).not.toBeNull();
+      expect(config.cameraUrl).toBe('');
+    });
+
+    it('returns null when the camera does not exist for the tenant', async () => {
+      prisma.camera.findFirst.mockResolvedValue(null);
+
+      const config = await (gateway as any).getDeviceConfig(
+        'missing',
+        'tenant-1',
+      );
+
+      expect(config).toBeNull();
+    });
+  });
+});

--- a/backend/src/modules/analytics/gateways/analytics.gateway.ts
+++ b/backend/src/modules/analytics/gateways/analytics.gateway.ts
@@ -31,6 +31,7 @@ import {
   CameraCalibrationDto,
   PersonState,
 } from '../dto/edge-device';
+import { decryptString } from '../../../common/helpers/encryption.helper';
 
 interface EdgeDeviceConnection {
   socketId: string;
@@ -475,7 +476,13 @@ export class AnalyticsGateway implements OnGatewayConnection, OnGatewayDisconnec
 
     return {
       cameraId: camera.id,
-      cameraUrl: camera.streamUrl,
+      // The streamUrl is AES-GCM-encrypted at rest (see camera.service.ts:53).
+      // The edge device receives it over a TLS-protected, JWT-authenticated
+      // WebSocket and uses it directly as an RTSP URL, so it must be
+      // decrypted here. The admin-facing API path already does this in
+      // camera.service.ts; forgetting it here previously broke camera
+      // analytics end-to-end.
+      cameraUrl: camera.streamUrl ? decryptString(camera.streamUrl) : '',
       calibration: camera.calibrationData as EdgeDeviceConfigDto['calibration'],
     };
   }

--- a/backend/src/modules/orders/orders.module.ts
+++ b/backend/src/modules/orders/orders.module.ts
@@ -1,6 +1,7 @@
 import { Module, forwardRef } from '@nestjs/common';
 import { OrdersService } from './services/orders.service';
 import { PaymentsService } from './services/payments.service';
+import { ReceiptSnapshotBuilder } from './services/receipt-snapshot.builder';
 import { OrdersController } from './controllers/orders.controller';
 import { PaymentsController } from './controllers/payments.controller';
 import { PrismaModule } from '../../prisma/prisma.module';
@@ -22,7 +23,7 @@ import { StockManagementModule } from '../stock-management/stock-management.modu
     AccountingModule,
   ],
   controllers: [OrdersController, PaymentsController],
-  providers: [OrdersService, PaymentsService],
-  exports: [OrdersService, PaymentsService],
+  providers: [OrdersService, PaymentsService, ReceiptSnapshotBuilder],
+  exports: [OrdersService, PaymentsService, ReceiptSnapshotBuilder],
 })
 export class OrdersModule {}

--- a/backend/src/modules/orders/services/orders.service.snapshot.spec.ts
+++ b/backend/src/modules/orders/services/orders.service.snapshot.spec.ts
@@ -1,0 +1,123 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { Prisma } from '@prisma/client';
+import { OrdersService } from './orders.service';
+import { PrismaService } from '../../../prisma/prisma.service';
+import { KdsGateway } from '../../kds/kds.gateway';
+import { ReceiptSnapshotBuilder } from './receipt-snapshot.builder';
+import {
+  mockPrismaClient,
+  MockPrismaClient,
+} from '../../../common/test/prisma-mock.service';
+
+/**
+ * Focused test: verifies that orders.service.create writes a versioned
+ * kitchenTicketSnapshot via prisma.order.update inside its transaction.
+ * Other create-order semantics (validation, retries, stock deduction) are
+ * out of scope for this spec.
+ */
+describe('OrdersService — kitchen ticket snapshot persistence', () => {
+  let service: OrdersService;
+  let prisma: MockPrismaClient;
+
+  const tenantId = 'tenant-1';
+  const userId = 'user-1';
+
+  const product = {
+    id: 'p-1',
+    name: 'Adana Kebap',
+    price: new Prisma.Decimal('30.00'),
+    taxRate: 18,
+    tenantId,
+    isAvailable: true,
+  };
+
+  beforeEach(async () => {
+    prisma = mockPrismaClient();
+
+    prisma.product.findMany.mockResolvedValue([product] as any);
+    prisma.modifier.findMany.mockResolvedValue([] as any);
+    prisma.table.findFirst.mockResolvedValue(null as any);
+
+    // The service's withTransaction wrapper calls our callback directly when
+    // there's no Sentry tracing configured; mock as identity.
+    (prisma.$transaction as any).mockImplementation(
+      async (cb: any) => cb(prisma),
+    );
+
+    // The first prisma.order.create returns the persisted order with the
+    // shape orders.service expects (schema shape: subtotal + nested modifier).
+    (prisma.order.create as any).mockImplementation(async ({ data }: any) => ({
+      id: 'order-1',
+      orderNumber: data.orderNumber,
+      type: data.type,
+      status: data.status,
+      requiresApproval: data.requiresApproval,
+      totalAmount: new Prisma.Decimal('60.00'),
+      taxAmount: new Prisma.Decimal('10.80'),
+      discount: new Prisma.Decimal('0.00'),
+      finalAmount: new Prisma.Decimal('60.00'),
+      notes: data.notes ?? null,
+      tenantId: data.tenantId,
+      createdAt: new Date('2026-04-27T10:00:00Z'),
+      table: null,
+      orderItems: [
+        {
+          quantity: 2,
+          unitPrice: new Prisma.Decimal('30.00'),
+          subtotal: new Prisma.Decimal('60.00'),
+          notes: null,
+          product: { name: 'Adana Kebap' },
+          modifiers: [],
+        },
+      ],
+      user: { id: userId, firstName: 'Tester', lastName: 'User' },
+    } as any));
+
+    (prisma.order.update as any).mockImplementation(async ({ data, where }: any) => ({
+      id: where.id,
+      ...data,
+    } as any));
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        OrdersService,
+        ReceiptSnapshotBuilder,
+        { provide: PrismaService, useValue: prisma },
+        {
+          provide: KdsGateway,
+          useValue: {
+            emitNewOrder: jest.fn(),
+            emitLowStockAlert: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get(OrdersService);
+  });
+
+  it('writes a versioned kitchenTicketSnapshot via order.update after create', async () => {
+    await service.create(
+      {
+        type: 'DINE_IN',
+        items: [{ productId: 'p-1', quantity: 2 }],
+      } as any,
+      userId,
+      tenantId,
+    );
+
+    expect(prisma.order.update).toHaveBeenCalled();
+    const updateCalls = (prisma.order.update as jest.Mock).mock.calls;
+    const snapshotCall = updateCalls.find(
+      (c) => c[0]?.data?.kitchenTicketSnapshot,
+    );
+    expect(snapshotCall).toBeDefined();
+    const snap = snapshotCall![0].data.kitchenTicketSnapshot;
+    expect(snap.version).toBe(1);
+    expect(snap.order.type).toBe('DINE_IN');
+    expect(typeof snap.order.orderNumber).toBe('string');
+    expect(snap.items).toHaveLength(1);
+    expect(snap.items[0].name).toBe('Adana Kebap');
+    expect(snap.items[0].quantity).toBe(2);
+  });
+});

--- a/backend/src/modules/orders/services/orders.service.ts
+++ b/backend/src/modules/orders/services/orders.service.ts
@@ -23,6 +23,7 @@ import { StockDeductionService } from '../../stock-management/services/stock-ded
 import { SmsNotificationService } from '../../sms-settings/sms-notification.service';
 import { TaxCalculationService } from '../../accounting/services/tax-calculation.service';
 import { withTransaction, addBreadcrumb } from '../../../common/utils/tracing';
+import { ReceiptSnapshotBuilder } from './receipt-snapshot.builder';
 
 @Injectable()
 export class OrdersService {
@@ -30,6 +31,7 @@ export class OrdersService {
 
   constructor(
     private prisma: PrismaService,
+    private receiptSnapshotBuilder: ReceiptSnapshotBuilder,
     @Inject(forwardRef(() => KdsGateway))
     private kdsGateway: KdsGateway,
     @Optional()
@@ -285,6 +287,39 @@ export class OrdersService {
       },
       });
     });
+
+        // Build the kitchen ticket snapshot now that the order has its
+        // generated orderNumber. Fail-soft: if the builder throws, keep the
+        // snapshot null and log — order creation must not fail because of a
+        // reprint convenience. Note: snapshot is written via update outside
+        // the order.create call because we don't have the orderNumber yet at
+        // create-time (it's allocated by the retry helper).
+        try {
+          const orderForBuilder = {
+            ...createdOrder,
+            orderItems: createdOrder.orderItems.map((oi: any) => ({
+              ...oi,
+              totalPrice: oi.subtotal,
+              modifiers: (oi.modifiers ?? []).map((om: any) => ({
+                name: om.modifier?.name ?? '',
+                additionalPrice: om.priceAdjustment,
+              })),
+            })),
+          };
+          const kitchenTicketSnapshot =
+            this.receiptSnapshotBuilder.buildKitchenTicketSnapshot({
+              order: orderForBuilder as any,
+            }) as unknown as Prisma.InputJsonValue;
+          await this.prisma.order.update({
+            where: { id: createdOrder.id },
+            data: { kitchenTicketSnapshot },
+          });
+          (createdOrder as any).kitchenTicketSnapshot = kitchenTicketSnapshot;
+        } catch (snapErr) {
+          this.logger.warn(
+            `Failed to build kitchen ticket snapshot for order ${createdOrder.orderNumber}: ${(snapErr as Error).message}`,
+          );
+        }
 
         // Emit new order to kitchen via WebSocket
         this.kdsGateway.emitNewOrder(tenantId, createdOrder);

--- a/backend/src/modules/orders/services/orders.service.ts
+++ b/backend/src/modules/orders/services/orders.service.ts
@@ -289,26 +289,20 @@ export class OrdersService {
     });
 
         // Build the kitchen ticket snapshot now that the order has its
-        // generated orderNumber. Fail-soft: if the builder throws, keep the
-        // snapshot null and log — order creation must not fail because of a
-        // reprint convenience. Note: snapshot is written via update outside
-        // the order.create call because we don't have the orderNumber yet at
-        // create-time (it's allocated by the retry helper).
+        // generated orderNumber. The snapshot is written via a separate
+        // order.update call because the orderNumber is allocated by the
+        // retry helper inside order.create — we can't include the snapshot
+        // in the create payload without a chicken-and-egg problem.
+        //
+        // Note: this is a second query, not atomic with order.create. That
+        // matches the existing pattern in this method (stockDeduction, sms
+        // notifications also run as separate post-create operations).
+        // Fail-soft: a builder error logs and leaves the snapshot null —
+        // reprintability is a convenience, not source of truth.
         try {
-          const orderForBuilder = {
-            ...createdOrder,
-            orderItems: createdOrder.orderItems.map((oi: any) => ({
-              ...oi,
-              totalPrice: oi.subtotal,
-              modifiers: (oi.modifiers ?? []).map((om: any) => ({
-                name: om.modifier?.name ?? '',
-                additionalPrice: om.priceAdjustment,
-              })),
-            })),
-          };
           const kitchenTicketSnapshot =
             this.receiptSnapshotBuilder.buildKitchenTicketSnapshot({
-              order: orderForBuilder as any,
+              order: ReceiptSnapshotBuilder.toBuilderOrder(createdOrder),
             }) as unknown as Prisma.InputJsonValue;
           await this.prisma.order.update({
             where: { id: createdOrder.id },
@@ -319,6 +313,7 @@ export class OrdersService {
           this.logger.warn(
             `Failed to build kitchen ticket snapshot for order ${createdOrder.orderNumber}: ${(snapErr as Error).message}`,
           );
+          (createdOrder as any).kitchenTicketSnapshot = null;
         }
 
         // Emit new order to kitchen via WebSocket

--- a/backend/src/modules/orders/services/payments.service.snapshot.spec.ts
+++ b/backend/src/modules/orders/services/payments.service.snapshot.spec.ts
@@ -140,6 +140,7 @@ describe('PaymentsService — receipt snapshot persistence', () => {
     const callArg = (prisma.payment.create as jest.Mock).mock.calls[0][0];
     const snapshot = callArg.data.receiptSnapshot;
 
+    expect(callArg.data).toHaveProperty('receiptSnapshot');
     expect(snapshot).toBeDefined();
     expect(snapshot).not.toBeNull();
     expect(snapshot.version).toBe(1);
@@ -149,6 +150,12 @@ describe('PaymentsService — receipt snapshot persistence', () => {
     expect(snapshot.payment.method).toBe('CASH');
     expect(Array.isArray(snapshot.items)).toBe(true);
     expect(snapshot.items).toHaveLength(2);
+    // Verify the schema-to-builder adapter correctly flattened
+    // OrderItemModifier.modifier.name → modifiers[].name. Without this
+    // assertion, a schema rename of `priceAdjustment` or `modifier` would
+    // pass tests silently.
+    expect(snapshot.items[0].modifiers).toEqual(['Acılı']);
+    expect(snapshot.items[1].modifiers).toEqual([]);
   });
 
   it('still creates the payment if tenant lookup returns null (graceful degrade)', async () => {

--- a/backend/src/modules/orders/services/payments.service.snapshot.spec.ts
+++ b/backend/src/modules/orders/services/payments.service.snapshot.spec.ts
@@ -1,0 +1,164 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { Prisma } from '@prisma/client';
+import { PaymentsService } from './payments.service';
+import { OrdersService } from './orders.service';
+import { CustomersService } from '../../customers/customers.service';
+import { PrismaService } from '../../../prisma/prisma.service';
+import { ReceiptSnapshotBuilder } from './receipt-snapshot.builder';
+import {
+  mockPrismaClient,
+  MockPrismaClient,
+} from '../../../common/test/prisma-mock.service';
+
+/**
+ * Focused test: only verifies that the receiptSnapshot column is written
+ * with a v1 shape when a payment is created. Full payment-flow correctness
+ * (state transitions, table updates, customer linking, etc.) is out of scope
+ * for this spec.
+ */
+describe('PaymentsService — receipt snapshot persistence', () => {
+  let service: PaymentsService;
+  let prisma: MockPrismaClient;
+
+  const tenant = {
+    id: 'tenant-1',
+    name: 'Test Restaurant',
+    currency: 'TRY',
+  };
+
+  const baseOrder = {
+    id: 'order-1',
+    orderNumber: 'A-007',
+    type: 'DINE_IN',
+    status: 'SERVED',
+    requiresApproval: false,
+    totalAmount: new Prisma.Decimal('100.00'),
+    taxAmount: new Prisma.Decimal('18.00'),
+    discount: new Prisma.Decimal('0.00'),
+    finalAmount: new Prisma.Decimal('118.00'),
+    notes: null,
+    createdAt: new Date('2026-04-27T10:00:00Z'),
+    tenantId: tenant.id,
+  };
+
+  const orderWithIncludes = {
+    ...baseOrder,
+    table: { number: '5' },
+    orderItems: [
+      {
+        quantity: 2,
+        unitPrice: new Prisma.Decimal('30.00'),
+        totalPrice: new Prisma.Decimal('60.00'),
+        notes: null,
+        product: { name: 'Adana Kebap' },
+        modifiers: [
+          { name: 'Acılı', additionalPrice: new Prisma.Decimal('0.00') },
+        ],
+      },
+      {
+        quantity: 1,
+        unitPrice: new Prisma.Decimal('40.00'),
+        totalPrice: new Prisma.Decimal('40.00'),
+        notes: 'no salt',
+        product: { name: 'Pide' },
+        modifiers: [],
+      },
+    ],
+  };
+
+  beforeEach(async () => {
+    prisma = mockPrismaClient();
+
+    // The transaction runs the callback synchronously with the same prisma mock.
+    (prisma.$transaction as any).mockImplementation(
+      async (cb: any) => cb(prisma),
+    );
+
+    // Lightweight tenant pre-check via OrdersService.
+    const ordersServiceMock = {
+      findOne: jest.fn().mockResolvedValue(baseOrder),
+    };
+
+    const customersServiceMock = {
+      findOrCreateByPhone: jest.fn(),
+    };
+
+    // Inside the create() transaction:
+    //   tx.order.findFirst (tenant pre-check inside tx)
+    //   tx.payment.aggregate (existing paid)
+    //   tx.tenant.findUnique  (snapshot)
+    //   tx.order.findFirst    (snapshot includes)
+    //   tx.payment.create     (writes the snapshot)
+    //   tx.payment.aggregate  (post-create totals)
+    //   tx.order.update       (mark PAID)
+    prisma.tenant.findUnique.mockResolvedValue(tenant as any);
+    prisma.order.findFirst
+      .mockResolvedValueOnce(baseOrder as any) // tenant pre-check
+      .mockResolvedValueOnce(orderWithIncludes as any); // for snapshot
+    prisma.payment.aggregate.mockResolvedValue({
+      _sum: { amount: new Prisma.Decimal('0') },
+    } as any);
+    (prisma.payment.create as any).mockImplementation(
+      async ({ data }: any) => ({
+        ...data,
+        id: 'pay-1',
+        paidAt: new Date('2026-04-27T10:30:00Z'),
+        order: orderWithIncludes,
+      }),
+    );
+    prisma.order.update.mockResolvedValue({
+      ...baseOrder,
+      status: 'PAID',
+    } as any);
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        PaymentsService,
+        ReceiptSnapshotBuilder,
+        { provide: PrismaService, useValue: prisma },
+        { provide: OrdersService, useValue: ordersServiceMock },
+        { provide: CustomersService, useValue: customersServiceMock },
+      ],
+    }).compile();
+
+    service = module.get(PaymentsService);
+  });
+
+  it('writes a versioned receiptSnapshot on payment.create', async () => {
+    await service.create(
+      'order-1',
+      { amount: 118, method: 'CASH' } as any,
+      'tenant-1',
+    );
+
+    expect(prisma.payment.create).toHaveBeenCalledTimes(1);
+    const callArg = (prisma.payment.create as jest.Mock).mock.calls[0][0];
+    const snapshot = callArg.data.receiptSnapshot;
+
+    expect(snapshot).toBeDefined();
+    expect(snapshot).not.toBeNull();
+    expect(snapshot.version).toBe(1);
+    expect(snapshot.restaurant.name).toBe('Test Restaurant');
+    expect(snapshot.order.orderNumber).toBe('A-007');
+    expect(snapshot.totals.total).toBe('118.00');
+    expect(snapshot.payment.method).toBe('CASH');
+    expect(Array.isArray(snapshot.items)).toBe(true);
+    expect(snapshot.items).toHaveLength(2);
+  });
+
+  it('still creates the payment if tenant lookup returns null (graceful degrade)', async () => {
+    prisma.tenant.findUnique.mockResolvedValue(null);
+
+    await service.create(
+      'order-1',
+      { amount: 118, method: 'CASH' } as any,
+      'tenant-1',
+    );
+
+    expect(prisma.payment.create).toHaveBeenCalledTimes(1);
+    const callArg = (prisma.payment.create as jest.Mock).mock.calls[0][0];
+    // Snapshot is JsonNull when we can't build it — better than crashing the
+    // payment, which is the user-visible action.
+    expect(callArg.data.receiptSnapshot).toBe(Prisma.JsonNull);
+  });
+});

--- a/backend/src/modules/orders/services/payments.service.snapshot.spec.ts
+++ b/backend/src/modules/orders/services/payments.service.snapshot.spec.ts
@@ -41,6 +41,8 @@ describe('PaymentsService — receipt snapshot persistence', () => {
     tenantId: tenant.id,
   };
 
+  // Mirrors the schema shape (subtotal, OrderItemModifier wrapping Modifier).
+  // The payments.service adapter flattens this into the builder's contract.
   const orderWithIncludes = {
     ...baseOrder,
     table: { number: '5' },
@@ -48,17 +50,20 @@ describe('PaymentsService — receipt snapshot persistence', () => {
       {
         quantity: 2,
         unitPrice: new Prisma.Decimal('30.00'),
-        totalPrice: new Prisma.Decimal('60.00'),
+        subtotal: new Prisma.Decimal('60.00'),
         notes: null,
         product: { name: 'Adana Kebap' },
         modifiers: [
-          { name: 'Acılı', additionalPrice: new Prisma.Decimal('0.00') },
+          {
+            priceAdjustment: new Prisma.Decimal('0.00'),
+            modifier: { name: 'Acılı' },
+          },
         ],
       },
       {
         quantity: 1,
         unitPrice: new Prisma.Decimal('40.00'),
-        totalPrice: new Prisma.Decimal('40.00'),
+        subtotal: new Prisma.Decimal('40.00'),
         notes: 'no salt',
         product: { name: 'Pide' },
         modifiers: [],

--- a/backend/src/modules/orders/services/payments.service.ts
+++ b/backend/src/modules/orders/services/payments.service.ts
@@ -127,7 +127,7 @@ export class PaymentsService {
 
           // Build the receipt snapshot before payment.create so it's persisted
           // in the same transaction. Fail-soft: if tenant or order data is
-          // unexpectedly missing pieces, fall back to null rather than
+          // unexpectedly missing pieces, fall back to JsonNull rather than
           // crashing the payment — this is a reprint convenience, not the
           // source of truth for accounting.
           let receiptSnapshot: Prisma.InputJsonValue | typeof Prisma.JsonNull =
@@ -141,15 +141,32 @@ export class PaymentsService {
               where: { id: orderId, tenantId },
               include: {
                 orderItems: {
-                  include: { product: true, modifiers: true },
+                  include: {
+                    product: true,
+                    modifiers: { include: { modifier: true } },
+                  },
                 },
                 table: true,
               },
             });
             if (tenantRow && orderForSnap) {
+              // Adapter: schema uses `subtotal` for the line total and
+              // OrderItemModifier wraps Modifier — flatten to the builder's
+              // simpler input contract.
+              const orderForBuilder = {
+                ...orderForSnap,
+                orderItems: orderForSnap.orderItems.map((oi: any) => ({
+                  ...oi,
+                  totalPrice: oi.subtotal,
+                  modifiers: (oi.modifiers ?? []).map((om: any) => ({
+                    name: om.modifier?.name ?? '',
+                    additionalPrice: om.priceAdjustment,
+                  })),
+                })),
+              };
               receiptSnapshot = this.receiptSnapshotBuilder.buildReceiptSnapshot({
                 tenant: tenantRow,
-                order: orderForSnap as any,
+                order: orderForBuilder as any,
                 payment: {
                   method: createPaymentDto.method,
                   transactionId: createPaymentDto.transactionId ?? null,

--- a/backend/src/modules/orders/services/payments.service.ts
+++ b/backend/src/modules/orders/services/payments.service.ts
@@ -16,6 +16,7 @@ import { CustomersService } from '../../customers/customers.service';
 import { withTransaction, addBreadcrumb } from '../../../common/utils/tracing';
 import { SalesInvoiceService } from '../../accounting/services/sales-invoice.service';
 import { AccountingSettingsService } from '../../accounting/services/accounting-settings.service';
+import { ReceiptSnapshotBuilder } from './receipt-snapshot.builder';
 
 @Injectable()
 export class PaymentsService {
@@ -25,6 +26,7 @@ export class PaymentsService {
     private prisma: PrismaService,
     private ordersService: OrdersService,
     private customersService: CustomersService,
+    private receiptSnapshotBuilder: ReceiptSnapshotBuilder,
     @Optional()
     private salesInvoiceService?: SalesInvoiceService,
     @Optional()
@@ -123,6 +125,45 @@ export class PaymentsService {
             );
           }
 
+          // Build the receipt snapshot before payment.create so it's persisted
+          // in the same transaction. Fail-soft: if tenant or order data is
+          // unexpectedly missing pieces, fall back to null rather than
+          // crashing the payment — this is a reprint convenience, not the
+          // source of truth for accounting.
+          let receiptSnapshot: Prisma.InputJsonValue | typeof Prisma.JsonNull =
+            Prisma.JsonNull;
+          try {
+            const tenantRow = await tx.tenant.findUnique({
+              where: { id: tenantId },
+              select: { id: true, name: true, currency: true },
+            });
+            const orderForSnap = await tx.order.findFirst({
+              where: { id: orderId, tenantId },
+              include: {
+                orderItems: {
+                  include: { product: true, modifiers: true },
+                },
+                table: true,
+              },
+            });
+            if (tenantRow && orderForSnap) {
+              receiptSnapshot = this.receiptSnapshotBuilder.buildReceiptSnapshot({
+                tenant: tenantRow,
+                order: orderForSnap as any,
+                payment: {
+                  method: createPaymentDto.method,
+                  transactionId: createPaymentDto.transactionId ?? null,
+                  paidAt: new Date(),
+                },
+              }) as unknown as Prisma.InputJsonValue;
+            }
+          } catch (snapErr) {
+            this.logger.warn(
+              `Failed to build receipt snapshot for order ${orderId}: ${(snapErr as Error).message}`,
+            );
+            receiptSnapshot = Prisma.JsonNull;
+          }
+
           // Create payment
           const payment = await tx.payment.create({
             data: {
@@ -138,6 +179,7 @@ export class PaymentsService {
               // (enforced by the partial unique index on the schema side).
               transactionId: createPaymentDto.transactionId,
               idempotencyKey: createPaymentDto.idempotencyKey,
+              receiptSnapshot,
             },
             include: {
               order: {

--- a/backend/src/modules/orders/services/payments.service.ts
+++ b/backend/src/modules/orders/services/payments.service.ts
@@ -150,23 +150,9 @@ export class PaymentsService {
               },
             });
             if (tenantRow && orderForSnap) {
-              // Adapter: schema uses `subtotal` for the line total and
-              // OrderItemModifier wraps Modifier — flatten to the builder's
-              // simpler input contract.
-              const orderForBuilder = {
-                ...orderForSnap,
-                orderItems: orderForSnap.orderItems.map((oi: any) => ({
-                  ...oi,
-                  totalPrice: oi.subtotal,
-                  modifiers: (oi.modifiers ?? []).map((om: any) => ({
-                    name: om.modifier?.name ?? '',
-                    additionalPrice: om.priceAdjustment,
-                  })),
-                })),
-              };
               receiptSnapshot = this.receiptSnapshotBuilder.buildReceiptSnapshot({
                 tenant: tenantRow,
-                order: orderForBuilder as any,
+                order: ReceiptSnapshotBuilder.toBuilderOrder(orderForSnap),
                 payment: {
                   method: createPaymentDto.method,
                   transactionId: createPaymentDto.transactionId ?? null,

--- a/backend/src/modules/orders/services/receipt-snapshot.builder.spec.ts
+++ b/backend/src/modules/orders/services/receipt-snapshot.builder.spec.ts
@@ -1,0 +1,196 @@
+import { Prisma } from '@prisma/client';
+import {
+  ReceiptSnapshotBuilder,
+  ReceiptSnapshotV1,
+  KitchenTicketSnapshotV1,
+} from './receipt-snapshot.builder';
+
+type TenantFixture = { id: string; name: string; currency: string };
+type ItemFixture = {
+  quantity: number;
+  unitPrice: Prisma.Decimal;
+  totalPrice: Prisma.Decimal;
+  notes: string | null;
+  product: { name: string };
+  modifiers: Array<{ name: string; additionalPrice?: Prisma.Decimal }>;
+};
+type OrderFixture = {
+  id: string;
+  orderNumber: string;
+  type: string;
+  totalAmount: Prisma.Decimal;
+  taxAmount: Prisma.Decimal;
+  discount: Prisma.Decimal;
+  finalAmount: Prisma.Decimal;
+  notes: string | null;
+  createdAt: Date;
+  table: { number: string } | null;
+  orderItems: ItemFixture[];
+};
+type PaymentFixture = {
+  method: string;
+  transactionId: string | null;
+  paidAt: Date | null;
+};
+
+const tenant: TenantFixture = {
+  id: 'tenant-1',
+  name: 'Test Restaurant',
+  currency: 'TRY',
+};
+
+const order: OrderFixture = {
+  id: 'order-1',
+  orderNumber: 'A-007',
+  type: 'DINE_IN',
+  totalAmount: new Prisma.Decimal('100.00'),
+  taxAmount: new Prisma.Decimal('18.00'),
+  discount: new Prisma.Decimal('0.00'),
+  finalAmount: new Prisma.Decimal('118.00'),
+  notes: null,
+  createdAt: new Date('2026-04-27T10:00:00Z'),
+  table: { number: '5' },
+  orderItems: [
+    {
+      quantity: 2,
+      unitPrice: new Prisma.Decimal('30.00'),
+      totalPrice: new Prisma.Decimal('60.00'),
+      notes: null,
+      product: { name: 'Adana Kebap' },
+      modifiers: [
+        { name: 'Acılı', additionalPrice: new Prisma.Decimal('0.00') },
+      ],
+    },
+    {
+      quantity: 1,
+      unitPrice: new Prisma.Decimal('40.00'),
+      totalPrice: new Prisma.Decimal('40.00'),
+      notes: 'no salt',
+      product: { name: 'Pide' },
+      modifiers: [],
+    },
+  ],
+};
+
+const payment: PaymentFixture = {
+  method: 'CASH',
+  transactionId: null,
+  paidAt: new Date('2026-04-27T10:30:00Z'),
+};
+
+describe('ReceiptSnapshotBuilder', () => {
+  let builder: ReceiptSnapshotBuilder;
+
+  beforeEach(() => {
+    builder = new ReceiptSnapshotBuilder();
+  });
+
+  describe('buildReceiptSnapshot', () => {
+    it('produces a v1 snapshot with restaurant, order, items, totals, and payment', () => {
+      const snap: ReceiptSnapshotV1 = builder.buildReceiptSnapshot({
+        tenant,
+        order,
+        payment,
+      });
+
+      expect(snap.version).toBe(1);
+      expect(snap.restaurant).toEqual({
+        name: 'Test Restaurant',
+        currency: 'TRY',
+      });
+      expect(snap.order).toEqual({
+        id: 'order-1',
+        orderNumber: 'A-007',
+        type: 'DINE_IN',
+        tableNumber: '5',
+        notes: null,
+      });
+      expect(snap.items).toEqual([
+        {
+          name: 'Adana Kebap',
+          quantity: 2,
+          unitPrice: '30.00',
+          totalPrice: '60.00',
+          modifiers: ['Acılı'],
+          notes: null,
+        },
+        {
+          name: 'Pide',
+          quantity: 1,
+          unitPrice: '40.00',
+          totalPrice: '40.00',
+          modifiers: [],
+          notes: 'no salt',
+        },
+      ]);
+      expect(snap.totals).toEqual({
+        subtotal: '100.00',
+        tax: '18.00',
+        discount: '0.00',
+        total: '118.00',
+      });
+      expect(snap.payment).toEqual({
+        method: 'CASH',
+        transactionId: null,
+        paidAt: '2026-04-27T10:30:00.000Z',
+      });
+      expect(typeof snap.printedAt).toBe('string');
+    });
+
+    it('uses string-formatted Decimals (not JS Number) so receipts never drift', () => {
+      const snap = builder.buildReceiptSnapshot({ tenant, order, payment });
+      // String type, two-decimal-places. JS Number would risk 30.000000004
+      // for arithmetic-derived values.
+      expect(snap.totals.total).toBe('118.00');
+      expect(snap.items[0].unitPrice).toBe('30.00');
+    });
+
+    it('handles a takeaway order without a table', () => {
+      const takeawayOrder = { ...order, type: 'TAKEAWAY', table: null };
+      const snap = builder.buildReceiptSnapshot({
+        tenant,
+        order: takeawayOrder,
+        payment,
+      });
+      expect(snap.order.tableNumber).toBeNull();
+    });
+  });
+
+  describe('buildKitchenTicketSnapshot', () => {
+    it('produces a v1 ticket with order header, items + modifiers + per-item notes, and order-level notes', () => {
+      const snap: KitchenTicketSnapshotV1 = builder.buildKitchenTicketSnapshot({
+        order: { ...order, notes: 'Allergy: nuts' },
+      });
+
+      expect(snap.version).toBe(1);
+      expect(snap.order).toEqual({
+        id: 'order-1',
+        orderNumber: 'A-007',
+        type: 'DINE_IN',
+        tableNumber: '5',
+      });
+      expect(snap.items).toEqual([
+        {
+          name: 'Adana Kebap',
+          quantity: 2,
+          modifiers: ['Acılı'],
+          notes: null,
+        },
+        {
+          name: 'Pide',
+          quantity: 1,
+          modifiers: [],
+          notes: 'no salt',
+        },
+      ]);
+      expect(snap.specialInstructions).toBe('Allergy: nuts');
+      expect(typeof snap.createdAt).toBe('string');
+    });
+
+    it('omits totals and payment from kitchen ticket', () => {
+      const snap = builder.buildKitchenTicketSnapshot({ order });
+      expect((snap as any).totals).toBeUndefined();
+      expect((snap as any).payment).toBeUndefined();
+    });
+  });
+});

--- a/backend/src/modules/orders/services/receipt-snapshot.builder.spec.ts
+++ b/backend/src/modules/orders/services/receipt-snapshot.builder.spec.ts
@@ -12,7 +12,7 @@ type ItemFixture = {
   totalPrice: Prisma.Decimal;
   notes: string | null;
   product: { name: string };
-  modifiers: Array<{ name: string; additionalPrice?: Prisma.Decimal }>;
+  modifiers: Array<{ name: string }>;
 };
 type OrderFixture = {
   id: string;
@@ -57,9 +57,7 @@ const order: OrderFixture = {
       totalPrice: new Prisma.Decimal('60.00'),
       notes: null,
       product: { name: 'Adana Kebap' },
-      modifiers: [
-        { name: 'Acılı', additionalPrice: new Prisma.Decimal('0.00') },
-      ],
+      modifiers: [{ name: 'Acılı' }],
     },
     {
       quantity: 1,

--- a/backend/src/modules/orders/services/receipt-snapshot.builder.ts
+++ b/backend/src/modules/orders/services/receipt-snapshot.builder.ts
@@ -78,7 +78,7 @@ interface OrderItemInput {
   totalPrice: DecimalLike;
   notes: string | null;
   product: { name: string };
-  modifiers: Array<{ name: string; additionalPrice?: DecimalLike }>;
+  modifiers: Array<{ name: string }>;
 }
 
 interface OrderInput {
@@ -143,6 +143,30 @@ export class ReceiptSnapshotBuilder {
         paidAt: (payment.paidAt ?? new Date()).toISOString(),
       },
       printedAt: new Date().toISOString(),
+    };
+  }
+
+  /**
+   * Adapter from the schema-shape order (with `OrderItem.subtotal` and
+   * nested `OrderItemModifier.modifier`) to this builder's flatter
+   * `OrderInput` contract. Centralized here so payments + orders services
+   * don't drift if the schema evolves.
+   *
+   * The caller is responsible for ensuring the prisma include pulled in
+   * `orderItems.modifiers.modifier` and `table` — without those the
+   * adapter still works but the snapshot will have empty modifiers and
+   * a null tableNumber.
+   */
+  static toBuilderOrder(orderRow: any): OrderInput {
+    return {
+      ...orderRow,
+      orderItems: (orderRow.orderItems ?? []).map((oi: any) => ({
+        ...oi,
+        totalPrice: oi.subtotal,
+        modifiers: (oi.modifiers ?? []).map((om: any) => ({
+          name: om.modifier?.name ?? '',
+        })),
+      })),
     };
   }
 

--- a/backend/src/modules/orders/services/receipt-snapshot.builder.ts
+++ b/backend/src/modules/orders/services/receipt-snapshot.builder.ts
@@ -1,0 +1,172 @@
+import { Injectable } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
+
+/**
+ * Bumped when the snapshot shape changes in a non-additive way (renamed or
+ * removed fields, semantic changes). Phase 1.3's Rust ESC/POS layer will
+ * branch on this. Additive optional fields don't require a bump.
+ */
+export const RECEIPT_SNAPSHOT_VERSION = 1 as const;
+
+type DecimalLike = Prisma.Decimal | string | number;
+
+const fmt = (value: DecimalLike | null | undefined): string =>
+  new Prisma.Decimal(value ?? 0).toFixed(2);
+
+export interface ReceiptSnapshotV1 {
+  version: 1;
+  restaurant: {
+    name: string;
+    currency: string;
+  };
+  order: {
+    id: string;
+    orderNumber: string;
+    type: string;
+    tableNumber: string | null;
+    notes: string | null;
+  };
+  items: Array<{
+    name: string;
+    quantity: number;
+    unitPrice: string;
+    totalPrice: string;
+    modifiers: string[];
+    notes: string | null;
+  }>;
+  totals: {
+    subtotal: string;
+    tax: string;
+    discount: string;
+    total: string;
+  };
+  payment: {
+    method: string;
+    transactionId: string | null;
+    paidAt: string;
+  };
+  printedAt: string;
+}
+
+export interface KitchenTicketSnapshotV1 {
+  version: 1;
+  order: {
+    id: string;
+    orderNumber: string;
+    type: string;
+    tableNumber: string | null;
+  };
+  items: Array<{
+    name: string;
+    quantity: number;
+    modifiers: string[];
+    notes: string | null;
+  }>;
+  specialInstructions: string | null;
+  createdAt: string;
+}
+
+interface TenantInput {
+  id: string;
+  name: string;
+  currency: string;
+}
+
+interface OrderItemInput {
+  quantity: number;
+  unitPrice: DecimalLike;
+  totalPrice: DecimalLike;
+  notes: string | null;
+  product: { name: string };
+  modifiers: Array<{ name: string; additionalPrice?: DecimalLike }>;
+}
+
+interface OrderInput {
+  id: string;
+  orderNumber: string;
+  type: string;
+  totalAmount: DecimalLike;
+  taxAmount: DecimalLike;
+  discount: DecimalLike;
+  finalAmount: DecimalLike;
+  notes: string | null;
+  createdAt: Date;
+  table: { number: string } | null;
+  orderItems: OrderItemInput[];
+}
+
+interface PaymentInput {
+  method: string;
+  transactionId: string | null;
+  paidAt: Date | null;
+}
+
+@Injectable()
+export class ReceiptSnapshotBuilder {
+  buildReceiptSnapshot(args: {
+    tenant: TenantInput;
+    order: OrderInput;
+    payment: PaymentInput;
+  }): ReceiptSnapshotV1 {
+    const { tenant, order, payment } = args;
+
+    return {
+      version: RECEIPT_SNAPSHOT_VERSION,
+      restaurant: {
+        name: tenant.name,
+        currency: tenant.currency,
+      },
+      order: {
+        id: order.id,
+        orderNumber: order.orderNumber,
+        type: order.type,
+        tableNumber: order.table?.number ?? null,
+        notes: order.notes,
+      },
+      items: order.orderItems.map((item) => ({
+        name: item.product.name,
+        quantity: item.quantity,
+        unitPrice: fmt(item.unitPrice),
+        totalPrice: fmt(item.totalPrice),
+        modifiers: item.modifiers.map((m) => m.name),
+        notes: item.notes ?? null,
+      })),
+      totals: {
+        subtotal: fmt(order.totalAmount),
+        tax: fmt(order.taxAmount),
+        discount: fmt(order.discount),
+        total: fmt(order.finalAmount),
+      },
+      payment: {
+        method: payment.method,
+        transactionId: payment.transactionId ?? null,
+        paidAt: (payment.paidAt ?? new Date()).toISOString(),
+      },
+      printedAt: new Date().toISOString(),
+    };
+  }
+
+  buildKitchenTicketSnapshot(args: {
+    order: OrderInput;
+  }): KitchenTicketSnapshotV1 {
+    const { order } = args;
+
+    return {
+      version: RECEIPT_SNAPSHOT_VERSION,
+      order: {
+        id: order.id,
+        orderNumber: order.orderNumber,
+        type: order.type,
+        tableNumber: order.table?.number ?? null,
+      },
+      items: order.orderItems.map((item) => ({
+        name: item.product.name,
+        quantity: item.quantity,
+        modifiers: item.modifiers.map((m) => m.name),
+        notes: item.notes ?? null,
+      })),
+      specialInstructions: order.notes ?? null,
+      createdAt: order.createdAt.toISOString(),
+    };
+  }
+}


### PR DESCRIPTION
## Summary

Two surgical backend changes from the [Phase 1.1 + 1.2 plan](../docs/superpowers/plans/2026-04-27-bug-c-and-receipt-snapshots.md), bundled in one PR because both are small and the snapshot work doesn't ship to users until Phase 1.3 wires the frontend.

### Phase 1.1 — Bug C (1 commit)

- `backend/src/modules/analytics/gateways/analytics.gateway.ts:478` was returning `cameraUrl: camera.streamUrl` to the C++ edge device, but `streamUrl` is AES-GCM-encrypted at rest (the admin API path correctly decrypts at `camera.service.ts:315`). The edge device was being handed ciphertext and silently failing to connect to the camera.
- Fix routes through the same `decryptString` helper. New gateway spec covers the encrypted/null/missing branches.

### Phase 1.2 — Receipt + kitchen-ticket snapshot persistence (5 commits)

- New columns `Payment.receiptSnapshot` and `Order.kitchenTicketSnapshot` (both nullable JSONB). Migration is purely additive, trivially reversible.
- New `ReceiptSnapshotBuilder` service produces versioned `ReceiptSnapshotV1` / `KitchenTicketSnapshotV1` shapes — `Prisma.Decimal` formatted as fixed-2 strings so receipts never drift through JS Number arithmetic.
- Wired into `payments.service.create` (snapshot built before `tx.payment.create`, persisted on the `data` argument) and `orders.service.create` (snapshot built post-create — the generated orderNumber isn't known until then — and written via `tx.order.update`).
- Schema-to-builder adapter (flattens `OrderItemModifier→Modifier`, maps `subtotal→totalPrice`) is centralized as `ReceiptSnapshotBuilder.toBuilderOrder` so the two callsites can't drift.
- Both wiring sites are fail-soft: a builder error logs and persists null rather than crashing the parent operation.

### Explicitly NOT in this PR (deferred to Phase 1.3)

- Frontend POSPage auto-print on payment success.
- Frontend kitchen-ticket print on `order:new` socket event.
- Frontend Reprint button.

These depend on the Tauri Rust receipt-data contract being redone — the current `print_receipt` command in `desktop/src-tauri/src/main.rs:138` uses a different parameter shape than `frontend/src/types/hardware.ts::ReceiptData`. Phase 1.3 (the hardware-suite refactor + Turkish CP-857 encoding) lands the new contract, and the frontend wiring follows on the same branch. Plan reference: [docs/superpowers/specs/2026-04-27-desktop-pos-camera-reliability-design.md §3.2](../docs/superpowers/specs/2026-04-27-desktop-pos-camera-reliability-design.md).

## Test plan

- [x] `npx jest modules/(analytics|orders/services)` → 11/11 pass
- [x] `npx tsc --noEmit` → clean
- [x] Migration applied to local dev DB; columns verified via `psql \d`
- [x] Recorded in `_prisma_migrations` via `prisma migrate resolve --applied`
- [ ] On staging: verify edge device successfully connects to RTSP after deploy
- [ ] On staging: verify a paid order has a non-null `receiptSnapshot` JSON column
- [ ] On staging: verify a new order has a non-null `kitchenTicketSnapshot` JSON column
- [ ] Run \`prisma migrate deploy\` (not \`migrate dev\`) on staging — local applied via direct SQL due to pre-existing shadow-DB drift on dev env

## Code review

Self-review pass found and fixed: schema-to-builder adapter duplication (extracted to `toBuilderOrder` static), unused `additionalPrice` field on modifier shape (dropped), missing modifier-name assertion in payments test (added), inconsistent fail-path snapshot value (now explicitly null in both services).

🤖 Generated with [Claude Code](https://claude.com/claude-code)