### PR TITLE
feat: Phase 1.3 partial — Tauri hardware suite + Turkish CP-857 + auto-print on payment

### DIFF
--- a/backend/prisma/migrations/20260427081107_add_receipt_snapshots/migration.sql
+++ b/backend/prisma/migrations/20260427081107_add_receipt_snapshots/migration.sql
@@ -1,0 +1,7 @@
+-- Add JSONB snapshot columns for reprintable receipts and kitchen tickets.
+-- See backend/src/modules/orders/services/receipt-snapshot.builder.ts.
+-- Both columns are nullable so the migration is trivially reversible
+-- (no backfill needed; only new payments/orders populate them).
+
+ALTER TABLE "payments" ADD COLUMN "receiptSnapshot" JSONB;
+ALTER TABLE "orders" ADD COLUMN "kitchenTicketSnapshot" JSONB;

--- a/backend/prisma/migrations/20260427104329_add_order_idempotency_key/migration.sql
+++ b/backend/prisma/migrations/20260427104329_add_order_idempotency_key/migration.sql
@@ -1,0 +1,12 @@
+-- Add client-supplied idempotency key for order-create dedup.
+-- Mirrors the Payment.idempotencyKey pattern (see migration
+-- 20260420180000). The partial unique index treats a NULL key as
+-- "no dedup wanted" — multiple legacy NULL-key inserts coexist —
+-- but two inserts with the same non-NULL key collide with P2002,
+-- which the service catches and translates into "return existing".
+
+ALTER TABLE "orders" ADD COLUMN "idempotencyKey" TEXT;
+
+CREATE UNIQUE INDEX "orders_tenantId_idempotencyKey_unique"
+  ON "orders" ("tenantId", "idempotencyKey")
+  WHERE "idempotencyKey" IS NOT NULL;

--- a/backend/prisma/migrations/20260427111033_add_movement_compound_indices/migration.sql
+++ b/backend/prisma/migrations/20260427111033_add_movement_compound_indices/migration.sql
@@ -1,0 +1,16 @@
+-- Add (tenantId, createdAt) compound indices to stock_movements and
+-- ingredient_movements. Hot query pattern: "show me this tenant's
+-- movements for the last 30 days" — without this, the planner uses
+-- the tenantId-only index and then sequential-filters by date,
+-- which gets slow at multi-month tenant history.
+--
+-- Postgres CREATE INDEX is non-blocking only with CONCURRENTLY, but
+-- prisma migrations run in a transaction so we can't use that here.
+-- Both tables are append-only and not in the hot read path during
+-- migration; the brief lock is acceptable for a maintenance window.
+
+CREATE INDEX "stock_movements_tenantId_createdAt_idx"
+  ON "stock_movements" ("tenantId", "createdAt");
+
+CREATE INDEX "ingredient_movements_tenantId_createdAt_idx"
+  ON "ingredient_movements" ("tenantId", "createdAt");

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -516,6 +516,13 @@ model Order {
   // and survives later edits to items/modifiers. Owned by ReceiptSnapshotBuilder.
   kitchenTicketSnapshot Json?
 
+  // Client-generated UUID for double-tap / retry deduplication. The
+  // partial unique index on (tenantId, idempotencyKey) is added by the
+  // companion migration — Prisma's @@unique would also dedupe NULLs
+  // (Postgres treats them as distinct), so the partial index is the
+  // mechanism that actually enforces the guarantee for keyed requests.
+  idempotencyKey String?
+
   // Customer ordering fields
   sessionId        String? // UUID for customer session tracking
   customerPhone    String? // Optional customer phone

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -512,6 +512,10 @@ model Order {
   externalOrderId String?   // Platform's order ID/token for status sync
   externalData    Json?     // Raw platform payload for audit trail
 
+  // Captured at order-create time so the kitchen ticket is reprintable
+  // and survives later edits to items/modifiers. Owned by ReceiptSnapshotBuilder.
+  kitchenTicketSnapshot Json?
+
   // Customer ordering fields
   sessionId        String? // UUID for customer session tracking
   customerPhone    String? // Optional customer phone
@@ -625,6 +629,12 @@ model Payment {
   transactionId  String?
   idempotencyKey String?
   notes          String?
+
+  // Captured at payment-create time so receipts remain reprintable even if
+  // the printer was offline, and survive future product/menu/tenant edits.
+  // Shape is owned by ReceiptSnapshotBuilder; see services/receipt-snapshot.builder.ts.
+  // Versioned via the `version` field inside the JSON.
+  receiptSnapshot Json?
 
   tenantId String
   tenant   Tenant @relation(fields: [tenantId], references: [id], onDelete: Cascade)

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -690,6 +690,11 @@ model StockMovement {
   @@index([tenantId])
   @@index([productId])
   @@index([userId])
+  // Hot list query: "movements for tenant X in date-range Y". The
+  // single-column @@index([tenantId]) above is fine for tenant-scope
+  // alone; this compound index serves the date-bounded variant
+  // without a sequential scan over the tenant's history.
+  @@index([tenantId, createdAt])
   @@map("stock_movements")
 }
 
@@ -2486,6 +2491,10 @@ model IngredientMovement {
   @@index([type])
   @@index([referenceType, referenceId])
   @@index([createdAt])
+  // Same rationale as StockMovement — date-bounded per-tenant queries
+  // (cost reports, waste reports, "last 30 days for this tenant") are
+  // the dominant access pattern.
+  @@index([tenantId, createdAt])
   @@map("ingredient_movements")
 }
 

--- a/backend/src/modules/analytics/gateways/analytics.gateway.spec.ts
+++ b/backend/src/modules/analytics/gateways/analytics.gateway.spec.ts
@@ -1,0 +1,107 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { JwtService } from '@nestjs/jwt';
+import { AnalyticsGateway } from './analytics.gateway';
+import { PrismaService } from '../../../prisma/prisma.service';
+import {
+  mockPrismaClient,
+  MockPrismaClient,
+} from '../../../common/test/prisma-mock.service';
+import { encryptString } from '../../../common/helpers/encryption.helper';
+
+describe('AnalyticsGateway', () => {
+  let gateway: AnalyticsGateway;
+  let prisma: MockPrismaClient;
+
+  // CORS_ORIGIN must be set so the @WebSocketGateway decorator's corsOrigin()
+  // helper doesn't throw in non-production. (See analytics.gateway.ts:15-23.)
+  const originalCorsOrigin = process.env.CORS_ORIGIN;
+  beforeAll(() => {
+    process.env.CORS_ORIGIN = 'http://localhost:5173';
+    // ENCRYPTION_MASTER_KEY must be set so encryptString/decryptString work.
+    // The helper hashes any string ≥32 chars to a 32-byte AES-256 key, so a
+    // simple hex string is fine for tests.
+    process.env.ENCRYPTION_MASTER_KEY =
+      process.env.ENCRYPTION_MASTER_KEY ||
+      '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+  });
+  afterAll(() => {
+    if (originalCorsOrigin === undefined) {
+      delete process.env.CORS_ORIGIN;
+    } else {
+      process.env.CORS_ORIGIN = originalCorsOrigin;
+    }
+  });
+
+  beforeEach(async () => {
+    prisma = mockPrismaClient();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AnalyticsGateway,
+        {
+          provide: JwtService,
+          useValue: { verify: jest.fn(), sign: jest.fn() },
+        },
+        {
+          provide: PrismaService,
+          useValue: prisma,
+        },
+      ],
+    }).compile();
+
+    gateway = module.get(AnalyticsGateway);
+  });
+
+  describe('getDeviceConfig (Bug C — decrypt streamUrl on WebSocket→edge path)', () => {
+    it('returns the streamUrl decrypted, not the AES ciphertext', async () => {
+      const plaintextRtspUrl =
+        'rtsp://camerauser:supersecret@cam-01.local/stream1';
+      const encrypted = encryptString(plaintextRtspUrl);
+
+      prisma.camera.findFirst.mockResolvedValue({
+        id: 'cam-1',
+        streamUrl: encrypted,
+        calibrationData: null,
+      } as any);
+
+      const config = await (gateway as any).getDeviceConfig(
+        'cam-1',
+        'tenant-1',
+      );
+
+      expect(config).not.toBeNull();
+      expect(config.cameraId).toBe('cam-1');
+      expect(config.cameraUrl).toBe(plaintextRtspUrl);
+      // Sanity: ciphertext must differ from plaintext or the assertion above
+      // could pass vacuously.
+      expect(encrypted).not.toBe(plaintextRtspUrl);
+    });
+
+    it('returns an empty cameraUrl (not throwing) when streamUrl is null', async () => {
+      prisma.camera.findFirst.mockResolvedValue({
+        id: 'cam-2',
+        streamUrl: null,
+        calibrationData: null,
+      } as any);
+
+      const config = await (gateway as any).getDeviceConfig(
+        'cam-2',
+        'tenant-1',
+      );
+
+      expect(config).not.toBeNull();
+      expect(config.cameraUrl).toBe('');
+    });
+
+    it('returns null when the camera does not exist for the tenant', async () => {
+      prisma.camera.findFirst.mockResolvedValue(null);
+
+      const config = await (gateway as any).getDeviceConfig(
+        'missing',
+        'tenant-1',
+      );
+
+      expect(config).toBeNull();
+    });
+  });
+});

--- a/backend/src/modules/analytics/gateways/analytics.gateway.ts
+++ b/backend/src/modules/analytics/gateways/analytics.gateway.ts
@@ -31,6 +31,7 @@ import {
   CameraCalibrationDto,
   PersonState,
 } from '../dto/edge-device';
+import { decryptString } from '../../../common/helpers/encryption.helper';
 
 interface EdgeDeviceConnection {
   socketId: string;
@@ -475,7 +476,13 @@ export class AnalyticsGateway implements OnGatewayConnection, OnGatewayDisconnec
 
     return {
       cameraId: camera.id,
-      cameraUrl: camera.streamUrl,
+      // The streamUrl is AES-GCM-encrypted at rest (see camera.service.ts:53).
+      // The edge device receives it over a TLS-protected, JWT-authenticated
+      // WebSocket and uses it directly as an RTSP URL, so it must be
+      // decrypted here. The admin-facing API path already does this in
+      // camera.service.ts; forgetting it here previously broke camera
+      // analytics end-to-end.
+      cameraUrl: camera.streamUrl ? decryptString(camera.streamUrl) : '',
       calibration: camera.calibrationData as EdgeDeviceConfigDto['calibration'],
     };
   }

--- a/backend/src/modules/orders/dto/create-order.dto.ts
+++ b/backend/src/modules/orders/dto/create-order.dto.ts
@@ -1,4 +1,4 @@
-import { IsString, IsOptional, IsEnum, IsArray, ValidateNested, IsNumber, IsInt, Min, Max, ArrayMinSize, ArrayMaxSize, MaxLength } from 'class-validator';
+import { IsString, IsOptional, IsEnum, IsArray, ValidateNested, IsNumber, IsInt, Min, Max, ArrayMinSize, ArrayMaxSize, MaxLength, IsUUID } from 'class-validator';
 import { Type } from 'class-transformer';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { OrderType } from '../../../common/constants/order-status.enum';
@@ -77,4 +77,16 @@ export class CreateOrderDto {
   @ValidateNested({ each: true })
   @Type(() => CreateOrderItemDto)
   items: CreateOrderItemDto[];
+
+  /**
+   * Client-generated UUID for double-tap / retry deduplication.
+   * Backend has a partial unique index on (tenantId, idempotencyKey)
+   * — repeating the same key returns the existing order row instead
+   * of creating a duplicate. Optional: legacy callers without one
+   * still succeed (just without the dedup guarantee).
+   */
+  @ApiPropertyOptional({ description: 'Client UUID for retry deduplication' })
+  @IsUUID()
+  @IsOptional()
+  idempotencyKey?: string;
 }

--- a/backend/src/modules/orders/orders.module.ts
+++ b/backend/src/modules/orders/orders.module.ts
@@ -1,6 +1,7 @@
 import { Module, forwardRef } from '@nestjs/common';
 import { OrdersService } from './services/orders.service';
 import { PaymentsService } from './services/payments.service';
+import { ReceiptSnapshotBuilder } from './services/receipt-snapshot.builder';
 import { OrdersController } from './controllers/orders.controller';
 import { PaymentsController } from './controllers/payments.controller';
 import { PrismaModule } from '../../prisma/prisma.module';
@@ -22,7 +23,7 @@ import { StockManagementModule } from '../stock-management/stock-management.modu
     AccountingModule,
   ],
   controllers: [OrdersController, PaymentsController],
-  providers: [OrdersService, PaymentsService],
-  exports: [OrdersService, PaymentsService],
+  providers: [OrdersService, PaymentsService, ReceiptSnapshotBuilder],
+  exports: [OrdersService, PaymentsService, ReceiptSnapshotBuilder],
 })
 export class OrdersModule {}

--- a/backend/src/modules/orders/services/orders.service.snapshot.spec.ts
+++ b/backend/src/modules/orders/services/orders.service.snapshot.spec.ts
@@ -1,0 +1,123 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { Prisma } from '@prisma/client';
+import { OrdersService } from './orders.service';
+import { PrismaService } from '../../../prisma/prisma.service';
+import { KdsGateway } from '../../kds/kds.gateway';
+import { ReceiptSnapshotBuilder } from './receipt-snapshot.builder';
+import {
+  mockPrismaClient,
+  MockPrismaClient,
+} from '../../../common/test/prisma-mock.service';
+
+/**
+ * Focused test: verifies that orders.service.create writes a versioned
+ * kitchenTicketSnapshot via prisma.order.update inside its transaction.
+ * Other create-order semantics (validation, retries, stock deduction) are
+ * out of scope for this spec.
+ */
+describe('OrdersService — kitchen ticket snapshot persistence', () => {
+  let service: OrdersService;
+  let prisma: MockPrismaClient;
+
+  const tenantId = 'tenant-1';
+  const userId = 'user-1';
+
+  const product = {
+    id: 'p-1',
+    name: 'Adana Kebap',
+    price: new Prisma.Decimal('30.00'),
+    taxRate: 18,
+    tenantId,
+    isAvailable: true,
+  };
+
+  beforeEach(async () => {
+    prisma = mockPrismaClient();
+
+    prisma.product.findMany.mockResolvedValue([product] as any);
+    prisma.modifier.findMany.mockResolvedValue([] as any);
+    prisma.table.findFirst.mockResolvedValue(null as any);
+
+    // The service's withTransaction wrapper calls our callback directly when
+    // there's no Sentry tracing configured; mock as identity.
+    (prisma.$transaction as any).mockImplementation(
+      async (cb: any) => cb(prisma),
+    );
+
+    // The first prisma.order.create returns the persisted order with the
+    // shape orders.service expects (schema shape: subtotal + nested modifier).
+    (prisma.order.create as any).mockImplementation(async ({ data }: any) => ({
+      id: 'order-1',
+      orderNumber: data.orderNumber,
+      type: data.type,
+      status: data.status,
+      requiresApproval: data.requiresApproval,
+      totalAmount: new Prisma.Decimal('60.00'),
+      taxAmount: new Prisma.Decimal('10.80'),
+      discount: new Prisma.Decimal('0.00'),
+      finalAmount: new Prisma.Decimal('60.00'),
+      notes: data.notes ?? null,
+      tenantId: data.tenantId,
+      createdAt: new Date('2026-04-27T10:00:00Z'),
+      table: null,
+      orderItems: [
+        {
+          quantity: 2,
+          unitPrice: new Prisma.Decimal('30.00'),
+          subtotal: new Prisma.Decimal('60.00'),
+          notes: null,
+          product: { name: 'Adana Kebap' },
+          modifiers: [],
+        },
+      ],
+      user: { id: userId, firstName: 'Tester', lastName: 'User' },
+    } as any));
+
+    (prisma.order.update as any).mockImplementation(async ({ data, where }: any) => ({
+      id: where.id,
+      ...data,
+    } as any));
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        OrdersService,
+        ReceiptSnapshotBuilder,
+        { provide: PrismaService, useValue: prisma },
+        {
+          provide: KdsGateway,
+          useValue: {
+            emitNewOrder: jest.fn(),
+            emitLowStockAlert: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get(OrdersService);
+  });
+
+  it('writes a versioned kitchenTicketSnapshot via order.update after create', async () => {
+    await service.create(
+      {
+        type: 'DINE_IN',
+        items: [{ productId: 'p-1', quantity: 2 }],
+      } as any,
+      userId,
+      tenantId,
+    );
+
+    expect(prisma.order.update).toHaveBeenCalled();
+    const updateCalls = (prisma.order.update as jest.Mock).mock.calls;
+    const snapshotCall = updateCalls.find(
+      (c) => c[0]?.data?.kitchenTicketSnapshot,
+    );
+    expect(snapshotCall).toBeDefined();
+    const snap = snapshotCall![0].data.kitchenTicketSnapshot;
+    expect(snap.version).toBe(1);
+    expect(snap.order.type).toBe('DINE_IN');
+    expect(typeof snap.order.orderNumber).toBe('string');
+    expect(snap.items).toHaveLength(1);
+    expect(snap.items[0].name).toBe('Adana Kebap');
+    expect(snap.items[0].quantity).toBe(2);
+  });
+});

--- a/backend/src/modules/orders/services/orders.service.ts
+++ b/backend/src/modules/orders/services/orders.service.ts
@@ -105,6 +105,40 @@ export class OrdersService {
           itemCount: createOrderDto.items.length,
         });
 
+        // Idempotency fast-path: if the client supplied a key and we've
+        // already recorded an order for this (tenantId, key), return the
+        // existing row instead of creating a duplicate. The DB has a
+        // partial unique index on (tenantId, idempotencyKey) WHERE key
+        // IS NOT NULL — this pre-check is the responsiveness path; the
+        // P2002 catch in createWithOrderNumberRetry handles concurrent
+        // retries authoritatively.
+        if (createOrderDto.idempotencyKey) {
+          const existing = await this.prisma.order.findFirst({
+            where: { tenantId, idempotencyKey: createOrderDto.idempotencyKey },
+            include: {
+              orderItems: {
+                include: {
+                  product: { select: { id: true, name: true, price: true, image: true } },
+                  modifiers: {
+                    include: {
+                      modifier: { select: { id: true, name: true, priceAdjustment: true } },
+                    },
+                  },
+                },
+              },
+              table: { select: { id: true, number: true, section: true } },
+              user: { select: { id: true, firstName: true, lastName: true } },
+            },
+          });
+          if (existing) {
+            addBreadcrumb('Idempotency hit — returning existing order', 'order', {
+              orderId: existing.id,
+              orderNumber: existing.orderNumber,
+            });
+            return existing;
+          }
+        }
+
         // Validate table if provided
         if (createOrderDto.tableId) {
           const table = await this.prisma.table.findFirst({
@@ -235,6 +269,7 @@ export class OrdersService {
         customerName: createOrderDto.customerName,
         userId,
         tenantId,
+        idempotencyKey: createOrderDto.idempotencyKey,
         orderItems: {
           create: orderItems,
         },

--- a/backend/src/modules/orders/services/orders.service.ts
+++ b/backend/src/modules/orders/services/orders.service.ts
@@ -23,6 +23,7 @@ import { StockDeductionService } from '../../stock-management/services/stock-ded
 import { SmsNotificationService } from '../../sms-settings/sms-notification.service';
 import { TaxCalculationService } from '../../accounting/services/tax-calculation.service';
 import { withTransaction, addBreadcrumb } from '../../../common/utils/tracing';
+import { ReceiptSnapshotBuilder } from './receipt-snapshot.builder';
 
 @Injectable()
 export class OrdersService {
@@ -30,6 +31,7 @@ export class OrdersService {
 
   constructor(
     private prisma: PrismaService,
+    private receiptSnapshotBuilder: ReceiptSnapshotBuilder,
     @Inject(forwardRef(() => KdsGateway))
     private kdsGateway: KdsGateway,
     @Optional()
@@ -285,6 +287,39 @@ export class OrdersService {
       },
       });
     });
+
+        // Build the kitchen ticket snapshot now that the order has its
+        // generated orderNumber. Fail-soft: if the builder throws, keep the
+        // snapshot null and log — order creation must not fail because of a
+        // reprint convenience. Note: snapshot is written via update outside
+        // the order.create call because we don't have the orderNumber yet at
+        // create-time (it's allocated by the retry helper).
+        try {
+          const orderForBuilder = {
+            ...createdOrder,
+            orderItems: createdOrder.orderItems.map((oi: any) => ({
+              ...oi,
+              totalPrice: oi.subtotal,
+              modifiers: (oi.modifiers ?? []).map((om: any) => ({
+                name: om.modifier?.name ?? '',
+                additionalPrice: om.priceAdjustment,
+              })),
+            })),
+          };
+          const kitchenTicketSnapshot =
+            this.receiptSnapshotBuilder.buildKitchenTicketSnapshot({
+              order: orderForBuilder as any,
+            }) as unknown as Prisma.InputJsonValue;
+          await this.prisma.order.update({
+            where: { id: createdOrder.id },
+            data: { kitchenTicketSnapshot },
+          });
+          (createdOrder as any).kitchenTicketSnapshot = kitchenTicketSnapshot;
+        } catch (snapErr) {
+          this.logger.warn(
+            `Failed to build kitchen ticket snapshot for order ${createdOrder.orderNumber}: ${(snapErr as Error).message}`,
+          );
+        }
 
         // Emit new order to kitchen via WebSocket
         this.kdsGateway.emitNewOrder(tenantId, createdOrder);

--- a/backend/src/modules/orders/services/orders.service.ts
+++ b/backend/src/modules/orders/services/orders.service.ts
@@ -289,26 +289,20 @@ export class OrdersService {
     });
 
         // Build the kitchen ticket snapshot now that the order has its
-        // generated orderNumber. Fail-soft: if the builder throws, keep the
-        // snapshot null and log — order creation must not fail because of a
-        // reprint convenience. Note: snapshot is written via update outside
-        // the order.create call because we don't have the orderNumber yet at
-        // create-time (it's allocated by the retry helper).
+        // generated orderNumber. The snapshot is written via a separate
+        // order.update call because the orderNumber is allocated by the
+        // retry helper inside order.create — we can't include the snapshot
+        // in the create payload without a chicken-and-egg problem.
+        //
+        // Note: this is a second query, not atomic with order.create. That
+        // matches the existing pattern in this method (stockDeduction, sms
+        // notifications also run as separate post-create operations).
+        // Fail-soft: a builder error logs and leaves the snapshot null —
+        // reprintability is a convenience, not source of truth.
         try {
-          const orderForBuilder = {
-            ...createdOrder,
-            orderItems: createdOrder.orderItems.map((oi: any) => ({
-              ...oi,
-              totalPrice: oi.subtotal,
-              modifiers: (oi.modifiers ?? []).map((om: any) => ({
-                name: om.modifier?.name ?? '',
-                additionalPrice: om.priceAdjustment,
-              })),
-            })),
-          };
           const kitchenTicketSnapshot =
             this.receiptSnapshotBuilder.buildKitchenTicketSnapshot({
-              order: orderForBuilder as any,
+              order: ReceiptSnapshotBuilder.toBuilderOrder(createdOrder),
             }) as unknown as Prisma.InputJsonValue;
           await this.prisma.order.update({
             where: { id: createdOrder.id },
@@ -319,6 +313,7 @@ export class OrdersService {
           this.logger.warn(
             `Failed to build kitchen ticket snapshot for order ${createdOrder.orderNumber}: ${(snapErr as Error).message}`,
           );
+          (createdOrder as any).kitchenTicketSnapshot = null;
         }
 
         // Emit new order to kitchen via WebSocket

--- a/backend/src/modules/orders/services/payments.service.snapshot.spec.ts
+++ b/backend/src/modules/orders/services/payments.service.snapshot.spec.ts
@@ -140,6 +140,7 @@ describe('PaymentsService — receipt snapshot persistence', () => {
     const callArg = (prisma.payment.create as jest.Mock).mock.calls[0][0];
     const snapshot = callArg.data.receiptSnapshot;
 
+    expect(callArg.data).toHaveProperty('receiptSnapshot');
     expect(snapshot).toBeDefined();
     expect(snapshot).not.toBeNull();
     expect(snapshot.version).toBe(1);
@@ -149,6 +150,12 @@ describe('PaymentsService — receipt snapshot persistence', () => {
     expect(snapshot.payment.method).toBe('CASH');
     expect(Array.isArray(snapshot.items)).toBe(true);
     expect(snapshot.items).toHaveLength(2);
+    // Verify the schema-to-builder adapter correctly flattened
+    // OrderItemModifier.modifier.name → modifiers[].name. Without this
+    // assertion, a schema rename of `priceAdjustment` or `modifier` would
+    // pass tests silently.
+    expect(snapshot.items[0].modifiers).toEqual(['Acılı']);
+    expect(snapshot.items[1].modifiers).toEqual([]);
   });
 
   it('still creates the payment if tenant lookup returns null (graceful degrade)', async () => {

--- a/backend/src/modules/orders/services/payments.service.snapshot.spec.ts
+++ b/backend/src/modules/orders/services/payments.service.snapshot.spec.ts
@@ -1,0 +1,164 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { Prisma } from '@prisma/client';
+import { PaymentsService } from './payments.service';
+import { OrdersService } from './orders.service';
+import { CustomersService } from '../../customers/customers.service';
+import { PrismaService } from '../../../prisma/prisma.service';
+import { ReceiptSnapshotBuilder } from './receipt-snapshot.builder';
+import {
+  mockPrismaClient,
+  MockPrismaClient,
+} from '../../../common/test/prisma-mock.service';
+
+/**
+ * Focused test: only verifies that the receiptSnapshot column is written
+ * with a v1 shape when a payment is created. Full payment-flow correctness
+ * (state transitions, table updates, customer linking, etc.) is out of scope
+ * for this spec.
+ */
+describe('PaymentsService — receipt snapshot persistence', () => {
+  let service: PaymentsService;
+  let prisma: MockPrismaClient;
+
+  const tenant = {
+    id: 'tenant-1',
+    name: 'Test Restaurant',
+    currency: 'TRY',
+  };
+
+  const baseOrder = {
+    id: 'order-1',
+    orderNumber: 'A-007',
+    type: 'DINE_IN',
+    status: 'SERVED',
+    requiresApproval: false,
+    totalAmount: new Prisma.Decimal('100.00'),
+    taxAmount: new Prisma.Decimal('18.00'),
+    discount: new Prisma.Decimal('0.00'),
+    finalAmount: new Prisma.Decimal('118.00'),
+    notes: null,
+    createdAt: new Date('2026-04-27T10:00:00Z'),
+    tenantId: tenant.id,
+  };
+
+  const orderWithIncludes = {
+    ...baseOrder,
+    table: { number: '5' },
+    orderItems: [
+      {
+        quantity: 2,
+        unitPrice: new Prisma.Decimal('30.00'),
+        totalPrice: new Prisma.Decimal('60.00'),
+        notes: null,
+        product: { name: 'Adana Kebap' },
+        modifiers: [
+          { name: 'Acılı', additionalPrice: new Prisma.Decimal('0.00') },
+        ],
+      },
+      {
+        quantity: 1,
+        unitPrice: new Prisma.Decimal('40.00'),
+        totalPrice: new Prisma.Decimal('40.00'),
+        notes: 'no salt',
+        product: { name: 'Pide' },
+        modifiers: [],
+      },
+    ],
+  };
+
+  beforeEach(async () => {
+    prisma = mockPrismaClient();
+
+    // The transaction runs the callback synchronously with the same prisma mock.
+    (prisma.$transaction as any).mockImplementation(
+      async (cb: any) => cb(prisma),
+    );
+
+    // Lightweight tenant pre-check via OrdersService.
+    const ordersServiceMock = {
+      findOne: jest.fn().mockResolvedValue(baseOrder),
+    };
+
+    const customersServiceMock = {
+      findOrCreateByPhone: jest.fn(),
+    };
+
+    // Inside the create() transaction:
+    //   tx.order.findFirst (tenant pre-check inside tx)
+    //   tx.payment.aggregate (existing paid)
+    //   tx.tenant.findUnique  (snapshot)
+    //   tx.order.findFirst    (snapshot includes)
+    //   tx.payment.create     (writes the snapshot)
+    //   tx.payment.aggregate  (post-create totals)
+    //   tx.order.update       (mark PAID)
+    prisma.tenant.findUnique.mockResolvedValue(tenant as any);
+    prisma.order.findFirst
+      .mockResolvedValueOnce(baseOrder as any) // tenant pre-check
+      .mockResolvedValueOnce(orderWithIncludes as any); // for snapshot
+    prisma.payment.aggregate.mockResolvedValue({
+      _sum: { amount: new Prisma.Decimal('0') },
+    } as any);
+    (prisma.payment.create as any).mockImplementation(
+      async ({ data }: any) => ({
+        ...data,
+        id: 'pay-1',
+        paidAt: new Date('2026-04-27T10:30:00Z'),
+        order: orderWithIncludes,
+      }),
+    );
+    prisma.order.update.mockResolvedValue({
+      ...baseOrder,
+      status: 'PAID',
+    } as any);
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        PaymentsService,
+        ReceiptSnapshotBuilder,
+        { provide: PrismaService, useValue: prisma },
+        { provide: OrdersService, useValue: ordersServiceMock },
+        { provide: CustomersService, useValue: customersServiceMock },
+      ],
+    }).compile();
+
+    service = module.get(PaymentsService);
+  });
+
+  it('writes a versioned receiptSnapshot on payment.create', async () => {
+    await service.create(
+      'order-1',
+      { amount: 118, method: 'CASH' } as any,
+      'tenant-1',
+    );
+
+    expect(prisma.payment.create).toHaveBeenCalledTimes(1);
+    const callArg = (prisma.payment.create as jest.Mock).mock.calls[0][0];
+    const snapshot = callArg.data.receiptSnapshot;
+
+    expect(snapshot).toBeDefined();
+    expect(snapshot).not.toBeNull();
+    expect(snapshot.version).toBe(1);
+    expect(snapshot.restaurant.name).toBe('Test Restaurant');
+    expect(snapshot.order.orderNumber).toBe('A-007');
+    expect(snapshot.totals.total).toBe('118.00');
+    expect(snapshot.payment.method).toBe('CASH');
+    expect(Array.isArray(snapshot.items)).toBe(true);
+    expect(snapshot.items).toHaveLength(2);
+  });
+
+  it('still creates the payment if tenant lookup returns null (graceful degrade)', async () => {
+    prisma.tenant.findUnique.mockResolvedValue(null);
+
+    await service.create(
+      'order-1',
+      { amount: 118, method: 'CASH' } as any,
+      'tenant-1',
+    );
+
+    expect(prisma.payment.create).toHaveBeenCalledTimes(1);
+    const callArg = (prisma.payment.create as jest.Mock).mock.calls[0][0];
+    // Snapshot is JsonNull when we can't build it — better than crashing the
+    // payment, which is the user-visible action.
+    expect(callArg.data.receiptSnapshot).toBe(Prisma.JsonNull);
+  });
+});

--- a/backend/src/modules/orders/services/payments.service.snapshot.spec.ts
+++ b/backend/src/modules/orders/services/payments.service.snapshot.spec.ts
@@ -41,6 +41,8 @@ describe('PaymentsService — receipt snapshot persistence', () => {
     tenantId: tenant.id,
   };
 
+  // Mirrors the schema shape (subtotal, OrderItemModifier wrapping Modifier).
+  // The payments.service adapter flattens this into the builder's contract.
   const orderWithIncludes = {
     ...baseOrder,
     table: { number: '5' },
@@ -48,17 +50,20 @@ describe('PaymentsService — receipt snapshot persistence', () => {
       {
         quantity: 2,
         unitPrice: new Prisma.Decimal('30.00'),
-        totalPrice: new Prisma.Decimal('60.00'),
+        subtotal: new Prisma.Decimal('60.00'),
         notes: null,
         product: { name: 'Adana Kebap' },
         modifiers: [
-          { name: 'Acılı', additionalPrice: new Prisma.Decimal('0.00') },
+          {
+            priceAdjustment: new Prisma.Decimal('0.00'),
+            modifier: { name: 'Acılı' },
+          },
         ],
       },
       {
         quantity: 1,
         unitPrice: new Prisma.Decimal('40.00'),
-        totalPrice: new Prisma.Decimal('40.00'),
+        subtotal: new Prisma.Decimal('40.00'),
         notes: 'no salt',
         product: { name: 'Pide' },
         modifiers: [],

--- a/backend/src/modules/orders/services/payments.service.ts
+++ b/backend/src/modules/orders/services/payments.service.ts
@@ -127,7 +127,7 @@ export class PaymentsService {
 
           // Build the receipt snapshot before payment.create so it's persisted
           // in the same transaction. Fail-soft: if tenant or order data is
-          // unexpectedly missing pieces, fall back to null rather than
+          // unexpectedly missing pieces, fall back to JsonNull rather than
           // crashing the payment — this is a reprint convenience, not the
           // source of truth for accounting.
           let receiptSnapshot: Prisma.InputJsonValue | typeof Prisma.JsonNull =
@@ -141,15 +141,32 @@ export class PaymentsService {
               where: { id: orderId, tenantId },
               include: {
                 orderItems: {
-                  include: { product: true, modifiers: true },
+                  include: {
+                    product: true,
+                    modifiers: { include: { modifier: true } },
+                  },
                 },
                 table: true,
               },
             });
             if (tenantRow && orderForSnap) {
+              // Adapter: schema uses `subtotal` for the line total and
+              // OrderItemModifier wraps Modifier — flatten to the builder's
+              // simpler input contract.
+              const orderForBuilder = {
+                ...orderForSnap,
+                orderItems: orderForSnap.orderItems.map((oi: any) => ({
+                  ...oi,
+                  totalPrice: oi.subtotal,
+                  modifiers: (oi.modifiers ?? []).map((om: any) => ({
+                    name: om.modifier?.name ?? '',
+                    additionalPrice: om.priceAdjustment,
+                  })),
+                })),
+              };
               receiptSnapshot = this.receiptSnapshotBuilder.buildReceiptSnapshot({
                 tenant: tenantRow,
-                order: orderForSnap as any,
+                order: orderForBuilder as any,
                 payment: {
                   method: createPaymentDto.method,
                   transactionId: createPaymentDto.transactionId ?? null,

--- a/backend/src/modules/orders/services/payments.service.ts
+++ b/backend/src/modules/orders/services/payments.service.ts
@@ -16,6 +16,7 @@ import { CustomersService } from '../../customers/customers.service';
 import { withTransaction, addBreadcrumb } from '../../../common/utils/tracing';
 import { SalesInvoiceService } from '../../accounting/services/sales-invoice.service';
 import { AccountingSettingsService } from '../../accounting/services/accounting-settings.service';
+import { ReceiptSnapshotBuilder } from './receipt-snapshot.builder';
 
 @Injectable()
 export class PaymentsService {
@@ -25,6 +26,7 @@ export class PaymentsService {
     private prisma: PrismaService,
     private ordersService: OrdersService,
     private customersService: CustomersService,
+    private receiptSnapshotBuilder: ReceiptSnapshotBuilder,
     @Optional()
     private salesInvoiceService?: SalesInvoiceService,
     @Optional()
@@ -123,6 +125,45 @@ export class PaymentsService {
             );
           }
 
+          // Build the receipt snapshot before payment.create so it's persisted
+          // in the same transaction. Fail-soft: if tenant or order data is
+          // unexpectedly missing pieces, fall back to null rather than
+          // crashing the payment — this is a reprint convenience, not the
+          // source of truth for accounting.
+          let receiptSnapshot: Prisma.InputJsonValue | typeof Prisma.JsonNull =
+            Prisma.JsonNull;
+          try {
+            const tenantRow = await tx.tenant.findUnique({
+              where: { id: tenantId },
+              select: { id: true, name: true, currency: true },
+            });
+            const orderForSnap = await tx.order.findFirst({
+              where: { id: orderId, tenantId },
+              include: {
+                orderItems: {
+                  include: { product: true, modifiers: true },
+                },
+                table: true,
+              },
+            });
+            if (tenantRow && orderForSnap) {
+              receiptSnapshot = this.receiptSnapshotBuilder.buildReceiptSnapshot({
+                tenant: tenantRow,
+                order: orderForSnap as any,
+                payment: {
+                  method: createPaymentDto.method,
+                  transactionId: createPaymentDto.transactionId ?? null,
+                  paidAt: new Date(),
+                },
+              }) as unknown as Prisma.InputJsonValue;
+            }
+          } catch (snapErr) {
+            this.logger.warn(
+              `Failed to build receipt snapshot for order ${orderId}: ${(snapErr as Error).message}`,
+            );
+            receiptSnapshot = Prisma.JsonNull;
+          }
+
           // Create payment
           const payment = await tx.payment.create({
             data: {
@@ -138,6 +179,7 @@ export class PaymentsService {
               // (enforced by the partial unique index on the schema side).
               transactionId: createPaymentDto.transactionId,
               idempotencyKey: createPaymentDto.idempotencyKey,
+              receiptSnapshot,
             },
             include: {
               order: {

--- a/backend/src/modules/orders/services/payments.service.ts
+++ b/backend/src/modules/orders/services/payments.service.ts
@@ -324,7 +324,12 @@ export class PaymentsService {
           throw err;
         }
 
-        // Auto-generate invoice AFTER transaction commits
+        // Auto-generate invoice AFTER transaction commits. Failure is
+        // tagged REVENUE_SYNC_FAILED so it's grep-able in logs/Sentry —
+        // the order is paid, the receipt snapshot is persisted, but the
+        // accounting integration didn't reflect this revenue. Operator
+        // can manually generate the invoice from the order detail page.
+        // Bounded retry is a separate ticket (queue + DLQ).
         if (this.salesInvoiceService && this.accountingSettingsService) {
           try {
             const accSettings = await this.accountingSettingsService.findByTenant(tenantId);
@@ -332,7 +337,17 @@ export class PaymentsService {
               await this.salesInvoiceService.createFromOrder(orderId, tenantId);
             }
           } catch (err) {
-            this.logger.error(`Auto-invoice generation failed for order ${orderId}: ${err.message}`, err.stack);
+            const message = err instanceof Error ? err.message : String(err);
+            const stack = err instanceof Error ? err.stack : undefined;
+            this.logger.error(
+              `REVENUE_SYNC_FAILED auto-invoice generation failed for order ${orderId} (tenant ${tenantId}): ${message}`,
+              stack,
+            );
+            addBreadcrumb('REVENUE_SYNC_FAILED', 'payment', {
+              orderId,
+              tenantId,
+              error: message,
+            });
           }
         }
 

--- a/backend/src/modules/orders/services/payments.service.ts
+++ b/backend/src/modules/orders/services/payments.service.ts
@@ -150,23 +150,9 @@ export class PaymentsService {
               },
             });
             if (tenantRow && orderForSnap) {
-              // Adapter: schema uses `subtotal` for the line total and
-              // OrderItemModifier wraps Modifier — flatten to the builder's
-              // simpler input contract.
-              const orderForBuilder = {
-                ...orderForSnap,
-                orderItems: orderForSnap.orderItems.map((oi: any) => ({
-                  ...oi,
-                  totalPrice: oi.subtotal,
-                  modifiers: (oi.modifiers ?? []).map((om: any) => ({
-                    name: om.modifier?.name ?? '',
-                    additionalPrice: om.priceAdjustment,
-                  })),
-                })),
-              };
               receiptSnapshot = this.receiptSnapshotBuilder.buildReceiptSnapshot({
                 tenant: tenantRow,
-                order: orderForBuilder as any,
+                order: ReceiptSnapshotBuilder.toBuilderOrder(orderForSnap),
                 payment: {
                   method: createPaymentDto.method,
                   transactionId: createPaymentDto.transactionId ?? null,

--- a/backend/src/modules/orders/services/receipt-snapshot.builder.spec.ts
+++ b/backend/src/modules/orders/services/receipt-snapshot.builder.spec.ts
@@ -1,0 +1,196 @@
+import { Prisma } from '@prisma/client';
+import {
+  ReceiptSnapshotBuilder,
+  ReceiptSnapshotV1,
+  KitchenTicketSnapshotV1,
+} from './receipt-snapshot.builder';
+
+type TenantFixture = { id: string; name: string; currency: string };
+type ItemFixture = {
+  quantity: number;
+  unitPrice: Prisma.Decimal;
+  totalPrice: Prisma.Decimal;
+  notes: string | null;
+  product: { name: string };
+  modifiers: Array<{ name: string; additionalPrice?: Prisma.Decimal }>;
+};
+type OrderFixture = {
+  id: string;
+  orderNumber: string;
+  type: string;
+  totalAmount: Prisma.Decimal;
+  taxAmount: Prisma.Decimal;
+  discount: Prisma.Decimal;
+  finalAmount: Prisma.Decimal;
+  notes: string | null;
+  createdAt: Date;
+  table: { number: string } | null;
+  orderItems: ItemFixture[];
+};
+type PaymentFixture = {
+  method: string;
+  transactionId: string | null;
+  paidAt: Date | null;
+};
+
+const tenant: TenantFixture = {
+  id: 'tenant-1',
+  name: 'Test Restaurant',
+  currency: 'TRY',
+};
+
+const order: OrderFixture = {
+  id: 'order-1',
+  orderNumber: 'A-007',
+  type: 'DINE_IN',
+  totalAmount: new Prisma.Decimal('100.00'),
+  taxAmount: new Prisma.Decimal('18.00'),
+  discount: new Prisma.Decimal('0.00'),
+  finalAmount: new Prisma.Decimal('118.00'),
+  notes: null,
+  createdAt: new Date('2026-04-27T10:00:00Z'),
+  table: { number: '5' },
+  orderItems: [
+    {
+      quantity: 2,
+      unitPrice: new Prisma.Decimal('30.00'),
+      totalPrice: new Prisma.Decimal('60.00'),
+      notes: null,
+      product: { name: 'Adana Kebap' },
+      modifiers: [
+        { name: 'Acılı', additionalPrice: new Prisma.Decimal('0.00') },
+      ],
+    },
+    {
+      quantity: 1,
+      unitPrice: new Prisma.Decimal('40.00'),
+      totalPrice: new Prisma.Decimal('40.00'),
+      notes: 'no salt',
+      product: { name: 'Pide' },
+      modifiers: [],
+    },
+  ],
+};
+
+const payment: PaymentFixture = {
+  method: 'CASH',
+  transactionId: null,
+  paidAt: new Date('2026-04-27T10:30:00Z'),
+};
+
+describe('ReceiptSnapshotBuilder', () => {
+  let builder: ReceiptSnapshotBuilder;
+
+  beforeEach(() => {
+    builder = new ReceiptSnapshotBuilder();
+  });
+
+  describe('buildReceiptSnapshot', () => {
+    it('produces a v1 snapshot with restaurant, order, items, totals, and payment', () => {
+      const snap: ReceiptSnapshotV1 = builder.buildReceiptSnapshot({
+        tenant,
+        order,
+        payment,
+      });
+
+      expect(snap.version).toBe(1);
+      expect(snap.restaurant).toEqual({
+        name: 'Test Restaurant',
+        currency: 'TRY',
+      });
+      expect(snap.order).toEqual({
+        id: 'order-1',
+        orderNumber: 'A-007',
+        type: 'DINE_IN',
+        tableNumber: '5',
+        notes: null,
+      });
+      expect(snap.items).toEqual([
+        {
+          name: 'Adana Kebap',
+          quantity: 2,
+          unitPrice: '30.00',
+          totalPrice: '60.00',
+          modifiers: ['Acılı'],
+          notes: null,
+        },
+        {
+          name: 'Pide',
+          quantity: 1,
+          unitPrice: '40.00',
+          totalPrice: '40.00',
+          modifiers: [],
+          notes: 'no salt',
+        },
+      ]);
+      expect(snap.totals).toEqual({
+        subtotal: '100.00',
+        tax: '18.00',
+        discount: '0.00',
+        total: '118.00',
+      });
+      expect(snap.payment).toEqual({
+        method: 'CASH',
+        transactionId: null,
+        paidAt: '2026-04-27T10:30:00.000Z',
+      });
+      expect(typeof snap.printedAt).toBe('string');
+    });
+
+    it('uses string-formatted Decimals (not JS Number) so receipts never drift', () => {
+      const snap = builder.buildReceiptSnapshot({ tenant, order, payment });
+      // String type, two-decimal-places. JS Number would risk 30.000000004
+      // for arithmetic-derived values.
+      expect(snap.totals.total).toBe('118.00');
+      expect(snap.items[0].unitPrice).toBe('30.00');
+    });
+
+    it('handles a takeaway order without a table', () => {
+      const takeawayOrder = { ...order, type: 'TAKEAWAY', table: null };
+      const snap = builder.buildReceiptSnapshot({
+        tenant,
+        order: takeawayOrder,
+        payment,
+      });
+      expect(snap.order.tableNumber).toBeNull();
+    });
+  });
+
+  describe('buildKitchenTicketSnapshot', () => {
+    it('produces a v1 ticket with order header, items + modifiers + per-item notes, and order-level notes', () => {
+      const snap: KitchenTicketSnapshotV1 = builder.buildKitchenTicketSnapshot({
+        order: { ...order, notes: 'Allergy: nuts' },
+      });
+
+      expect(snap.version).toBe(1);
+      expect(snap.order).toEqual({
+        id: 'order-1',
+        orderNumber: 'A-007',
+        type: 'DINE_IN',
+        tableNumber: '5',
+      });
+      expect(snap.items).toEqual([
+        {
+          name: 'Adana Kebap',
+          quantity: 2,
+          modifiers: ['Acılı'],
+          notes: null,
+        },
+        {
+          name: 'Pide',
+          quantity: 1,
+          modifiers: [],
+          notes: 'no salt',
+        },
+      ]);
+      expect(snap.specialInstructions).toBe('Allergy: nuts');
+      expect(typeof snap.createdAt).toBe('string');
+    });
+
+    it('omits totals and payment from kitchen ticket', () => {
+      const snap = builder.buildKitchenTicketSnapshot({ order });
+      expect((snap as any).totals).toBeUndefined();
+      expect((snap as any).payment).toBeUndefined();
+    });
+  });
+});

--- a/backend/src/modules/orders/services/receipt-snapshot.builder.spec.ts
+++ b/backend/src/modules/orders/services/receipt-snapshot.builder.spec.ts
@@ -12,7 +12,7 @@ type ItemFixture = {
   totalPrice: Prisma.Decimal;
   notes: string | null;
   product: { name: string };
-  modifiers: Array<{ name: string; additionalPrice?: Prisma.Decimal }>;
+  modifiers: Array<{ name: string }>;
 };
 type OrderFixture = {
   id: string;
@@ -57,9 +57,7 @@ const order: OrderFixture = {
       totalPrice: new Prisma.Decimal('60.00'),
       notes: null,
       product: { name: 'Adana Kebap' },
-      modifiers: [
-        { name: 'Acılı', additionalPrice: new Prisma.Decimal('0.00') },
-      ],
+      modifiers: [{ name: 'Acılı' }],
     },
     {
       quantity: 1,

--- a/backend/src/modules/orders/services/receipt-snapshot.builder.ts
+++ b/backend/src/modules/orders/services/receipt-snapshot.builder.ts
@@ -78,7 +78,7 @@ interface OrderItemInput {
   totalPrice: DecimalLike;
   notes: string | null;
   product: { name: string };
-  modifiers: Array<{ name: string; additionalPrice?: DecimalLike }>;
+  modifiers: Array<{ name: string }>;
 }
 
 interface OrderInput {
@@ -143,6 +143,30 @@ export class ReceiptSnapshotBuilder {
         paidAt: (payment.paidAt ?? new Date()).toISOString(),
       },
       printedAt: new Date().toISOString(),
+    };
+  }
+
+  /**
+   * Adapter from the schema-shape order (with `OrderItem.subtotal` and
+   * nested `OrderItemModifier.modifier`) to this builder's flatter
+   * `OrderInput` contract. Centralized here so payments + orders services
+   * don't drift if the schema evolves.
+   *
+   * The caller is responsible for ensuring the prisma include pulled in
+   * `orderItems.modifiers.modifier` and `table` — without those the
+   * adapter still works but the snapshot will have empty modifiers and
+   * a null tableNumber.
+   */
+  static toBuilderOrder(orderRow: any): OrderInput {
+    return {
+      ...orderRow,
+      orderItems: (orderRow.orderItems ?? []).map((oi: any) => ({
+        ...oi,
+        totalPrice: oi.subtotal,
+        modifiers: (oi.modifiers ?? []).map((om: any) => ({
+          name: om.modifier?.name ?? '',
+        })),
+      })),
     };
   }
 

--- a/backend/src/modules/orders/services/receipt-snapshot.builder.ts
+++ b/backend/src/modules/orders/services/receipt-snapshot.builder.ts
@@ -1,0 +1,172 @@
+import { Injectable } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
+
+/**
+ * Bumped when the snapshot shape changes in a non-additive way (renamed or
+ * removed fields, semantic changes). Phase 1.3's Rust ESC/POS layer will
+ * branch on this. Additive optional fields don't require a bump.
+ */
+export const RECEIPT_SNAPSHOT_VERSION = 1 as const;
+
+type DecimalLike = Prisma.Decimal | string | number;
+
+const fmt = (value: DecimalLike | null | undefined): string =>
+  new Prisma.Decimal(value ?? 0).toFixed(2);
+
+export interface ReceiptSnapshotV1 {
+  version: 1;
+  restaurant: {
+    name: string;
+    currency: string;
+  };
+  order: {
+    id: string;
+    orderNumber: string;
+    type: string;
+    tableNumber: string | null;
+    notes: string | null;
+  };
+  items: Array<{
+    name: string;
+    quantity: number;
+    unitPrice: string;
+    totalPrice: string;
+    modifiers: string[];
+    notes: string | null;
+  }>;
+  totals: {
+    subtotal: string;
+    tax: string;
+    discount: string;
+    total: string;
+  };
+  payment: {
+    method: string;
+    transactionId: string | null;
+    paidAt: string;
+  };
+  printedAt: string;
+}
+
+export interface KitchenTicketSnapshotV1 {
+  version: 1;
+  order: {
+    id: string;
+    orderNumber: string;
+    type: string;
+    tableNumber: string | null;
+  };
+  items: Array<{
+    name: string;
+    quantity: number;
+    modifiers: string[];
+    notes: string | null;
+  }>;
+  specialInstructions: string | null;
+  createdAt: string;
+}
+
+interface TenantInput {
+  id: string;
+  name: string;
+  currency: string;
+}
+
+interface OrderItemInput {
+  quantity: number;
+  unitPrice: DecimalLike;
+  totalPrice: DecimalLike;
+  notes: string | null;
+  product: { name: string };
+  modifiers: Array<{ name: string; additionalPrice?: DecimalLike }>;
+}
+
+interface OrderInput {
+  id: string;
+  orderNumber: string;
+  type: string;
+  totalAmount: DecimalLike;
+  taxAmount: DecimalLike;
+  discount: DecimalLike;
+  finalAmount: DecimalLike;
+  notes: string | null;
+  createdAt: Date;
+  table: { number: string } | null;
+  orderItems: OrderItemInput[];
+}
+
+interface PaymentInput {
+  method: string;
+  transactionId: string | null;
+  paidAt: Date | null;
+}
+
+@Injectable()
+export class ReceiptSnapshotBuilder {
+  buildReceiptSnapshot(args: {
+    tenant: TenantInput;
+    order: OrderInput;
+    payment: PaymentInput;
+  }): ReceiptSnapshotV1 {
+    const { tenant, order, payment } = args;
+
+    return {
+      version: RECEIPT_SNAPSHOT_VERSION,
+      restaurant: {
+        name: tenant.name,
+        currency: tenant.currency,
+      },
+      order: {
+        id: order.id,
+        orderNumber: order.orderNumber,
+        type: order.type,
+        tableNumber: order.table?.number ?? null,
+        notes: order.notes,
+      },
+      items: order.orderItems.map((item) => ({
+        name: item.product.name,
+        quantity: item.quantity,
+        unitPrice: fmt(item.unitPrice),
+        totalPrice: fmt(item.totalPrice),
+        modifiers: item.modifiers.map((m) => m.name),
+        notes: item.notes ?? null,
+      })),
+      totals: {
+        subtotal: fmt(order.totalAmount),
+        tax: fmt(order.taxAmount),
+        discount: fmt(order.discount),
+        total: fmt(order.finalAmount),
+      },
+      payment: {
+        method: payment.method,
+        transactionId: payment.transactionId ?? null,
+        paidAt: (payment.paidAt ?? new Date()).toISOString(),
+      },
+      printedAt: new Date().toISOString(),
+    };
+  }
+
+  buildKitchenTicketSnapshot(args: {
+    order: OrderInput;
+  }): KitchenTicketSnapshotV1 {
+    const { order } = args;
+
+    return {
+      version: RECEIPT_SNAPSHOT_VERSION,
+      order: {
+        id: order.id,
+        orderNumber: order.orderNumber,
+        type: order.type,
+        tableNumber: order.table?.number ?? null,
+      },
+      items: order.orderItems.map((item) => ({
+        name: item.product.name,
+        quantity: item.quantity,
+        modifiers: item.modifiers.map((m) => m.name),
+        notes: item.notes ?? null,
+      })),
+      specialInstructions: order.notes ?? null,
+      createdAt: order.createdAt.toISOString(),
+    };
+  }
+}

--- a/backend/src/modules/stock-management/services/stock-alerts.service.spec.ts
+++ b/backend/src/modules/stock-management/services/stock-alerts.service.spec.ts
@@ -1,0 +1,131 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { StockAlertsService } from './stock-alerts.service';
+import { PrismaService } from '../../../prisma/prisma.service';
+import { KdsGateway } from '../../kds/kds.gateway';
+import {
+  mockPrismaClient,
+  MockPrismaClient,
+} from '../../../common/test/prisma-mock.service';
+
+/**
+ * Verifies the alert-fatigue dedup logic: same set of low-stock items
+ * across cron ticks emits only once until either the set changes or
+ * 24 hours pass.
+ */
+describe('StockAlertsService — emit dedup', () => {
+  let service: StockAlertsService;
+  let prisma: MockPrismaClient;
+  let emit: jest.Mock;
+
+  const tenantId = 'tenant-1';
+
+  beforeEach(async () => {
+    prisma = mockPrismaClient();
+    emit = jest.fn();
+
+    const kdsMock = {
+      server: {
+        to: jest.fn().mockReturnThis(),
+        emit,
+      },
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        StockAlertsService,
+        { provide: PrismaService, useValue: prisma },
+        { provide: KdsGateway, useValue: kdsMock },
+      ],
+    }).compile();
+
+    service = module.get(StockAlertsService);
+  });
+
+  it('emits on first tick with low-stock items', async () => {
+    (prisma.$queryRaw as any).mockResolvedValueOnce([
+      { id: 'item-1', name: 'Tomato', unit: 'kg', currentStock: 1, minStock: 5 },
+    ]);
+
+    await service.checkLowStock(tenantId);
+
+    expect(emit).toHaveBeenCalledTimes(1);
+    expect(emit).toHaveBeenCalledWith(
+      'stock:low-alert',
+      expect.objectContaining({ count: 1 }),
+    );
+  });
+
+  it('does NOT re-emit on a second tick with the same item set', async () => {
+    const lowStockSet = [
+      { id: 'item-1', name: 'Tomato', unit: 'kg', currentStock: 1, minStock: 5 },
+    ];
+    (prisma.$queryRaw as any)
+      .mockResolvedValueOnce(lowStockSet)
+      .mockResolvedValueOnce(lowStockSet);
+
+    await service.checkLowStock(tenantId);
+    await service.checkLowStock(tenantId);
+
+    // First tick fires, second tick is silent — that's the dedup we want.
+    expect(emit).toHaveBeenCalledTimes(1);
+  });
+
+  it('emits again when a new item drops below threshold', async () => {
+    (prisma.$queryRaw as any)
+      .mockResolvedValueOnce([
+        { id: 'item-1', name: 'Tomato', unit: 'kg', currentStock: 1, minStock: 5 },
+      ])
+      .mockResolvedValueOnce([
+        { id: 'item-1', name: 'Tomato', unit: 'kg', currentStock: 1, minStock: 5 },
+        { id: 'item-2', name: 'Onion', unit: 'kg', currentStock: 2, minStock: 5 },
+      ]);
+
+    await service.checkLowStock(tenantId);
+    await service.checkLowStock(tenantId);
+
+    // Set changed: item-2 newly below threshold → second emit fires.
+    expect(emit).toHaveBeenCalledTimes(2);
+  });
+
+  it('emits again after items recover then a new item drops', async () => {
+    (prisma.$queryRaw as any)
+      .mockResolvedValueOnce([
+        { id: 'item-1', name: 'Tomato', unit: 'kg', currentStock: 1, minStock: 5 },
+      ])
+      .mockResolvedValueOnce([]) // operator restocked tomato
+      .mockResolvedValueOnce([
+        { id: 'item-2', name: 'Onion', unit: 'kg', currentStock: 2, minStock: 5 },
+      ]);
+
+    await service.checkLowStock(tenantId);
+    await service.checkLowStock(tenantId);
+    await service.checkLowStock(tenantId);
+
+    // Tick 1: emit (new low-stock). Tick 2: silent (empty set, nothing to
+    // alert about). Tick 3: emit (Onion newly dropped — fresh problem).
+    expect(emit).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not emit when the item set is empty', async () => {
+    (prisma.$queryRaw as any).mockResolvedValueOnce([]);
+
+    await service.checkLowStock(tenantId);
+
+    expect(emit).not.toHaveBeenCalled();
+  });
+
+  it('isolates per-tenant state — tenant-A alert does not silence tenant-B', async () => {
+    const sameItemSet = [
+      { id: 'item-1', name: 'Tomato', unit: 'kg', currentStock: 1, minStock: 5 },
+    ];
+    (prisma.$queryRaw as any)
+      .mockResolvedValueOnce(sameItemSet)
+      .mockResolvedValueOnce(sameItemSet);
+
+    await service.checkLowStock('tenant-A');
+    await service.checkLowStock('tenant-B');
+
+    // Both tenants get their first-ever emit — no cross-tenant interference.
+    expect(emit).toHaveBeenCalledTimes(2);
+  });
+});

--- a/backend/src/modules/stock-management/services/stock-alerts.service.ts
+++ b/backend/src/modules/stock-management/services/stock-alerts.service.ts
@@ -2,9 +2,38 @@ import { Injectable, Logger, Inject, forwardRef, Optional } from '@nestjs/common
 import { PrismaService } from '../../../prisma/prisma.service';
 import { KdsGateway } from '../../kds/kds.gateway';
 
+/**
+ * Per-tenant in-memory cooldown to prevent alert fatigue: every hourly
+ * cron tick used to re-emit an alert for the same low-stock items, even
+ * when nothing changed. Now we only emit when the SET of alert-eligible
+ * items changed (a new item dropped below threshold, or an existing one
+ * recovered) OR after `RE_ALERT_INTERVAL_MS` if the operator hasn't
+ * fixed anything (so the alert still gets a daily nudge).
+ *
+ * The state is process-local — a multi-replica deployment will see one
+ * extra alert per replica per change, which is acceptable. The
+ * pg_advisory_lock on the scheduler still prevents two replicas from
+ * BOTH running the check on the same tick.
+ *
+ * On restart, the cache resets and the first tick re-emits — also
+ * acceptable, that's the natural "did I miss anything while we were
+ * down" behavior.
+ */
+const RE_ALERT_INTERVAL_MS = 24 * 60 * 60 * 1000; // 24h
+const itemSetSignature = (ids: string[]): string => [...ids].sort().join(',');
+
+interface AlertState {
+  signature: string;
+  emittedAt: number;
+}
+
 @Injectable()
 export class StockAlertsService {
   private readonly logger = new Logger(StockAlertsService.name);
+
+  // tenantId -> last alert signature + when we sent it
+  private readonly lowStockState = new Map<string, AlertState>();
+  private readonly expiringBatchesState = new Map<string, AlertState>();
 
   constructor(
     private prisma: PrismaService,
@@ -24,7 +53,9 @@ export class StockAlertsService {
       ORDER BY si."currentStock" ASC
     `;
 
-    if (lowStockItems.length > 0 && this.kdsGateway?.server) {
+    if (this.shouldEmitAlert(this.lowStockState, tenantId, lowStockItems.map((i) => i.id))
+        && lowStockItems.length > 0
+        && this.kdsGateway?.server) {
       this.kdsGateway.server
         .to(`kitchen-${tenantId}`)
         .to(`pos-${tenantId}`)
@@ -63,7 +94,9 @@ export class StockAlertsService {
       orderBy: { expiryDate: 'asc' },
     });
 
-    if (expiringBatches.length > 0 && this.kdsGateway?.server) {
+    if (this.shouldEmitAlert(this.expiringBatchesState, tenantId, expiringBatches.map((b) => b.id))
+        && expiringBatches.length > 0
+        && this.kdsGateway?.server) {
       this.kdsGateway.server
         .to(`kitchen-${tenantId}`)
         .to(`pos-${tenantId}`)
@@ -80,5 +113,44 @@ export class StockAlertsService {
     }
 
     return expiringBatches;
+  }
+
+  /**
+   * True when the current item set differs from the last-emitted set
+   * for this tenant, OR when RE_ALERT_INTERVAL_MS has elapsed since
+   * the last emit (so the operator gets a daily reminder if they
+   * haven't fixed things). Records the new state on emit.
+   */
+  private shouldEmitAlert(
+    state: Map<string, AlertState>,
+    tenantId: string,
+    itemIds: string[],
+  ): boolean {
+    const signature = itemSetSignature(itemIds);
+    const previous = state.get(tenantId);
+    const now = Date.now();
+
+    // Empty set + no previous emit = nothing to do.
+    if (signature === '' && !previous) return false;
+
+    // Set changed (new item dropped below threshold, or one recovered) = emit.
+    if (!previous || previous.signature !== signature) {
+      if (signature !== '') {
+        state.set(tenantId, { signature, emittedAt: now });
+      } else {
+        // All items recovered — drop the cache entry so a fresh problem
+        // re-emits immediately rather than waiting for the next change.
+        state.delete(tenantId);
+      }
+      return signature !== '';
+    }
+
+    // Same items still problematic — nudge once per RE_ALERT_INTERVAL.
+    if (now - previous.emittedAt >= RE_ALERT_INTERVAL_MS) {
+      state.set(tenantId, { signature, emittedAt: now });
+      return true;
+    }
+
+    return false;
   }
 }

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -20,6 +20,8 @@ tokio = { version = "1", features = ["full"] }
 btleplug = "0.11"
 uuid = "1.6"
 thiserror = "1.0"
+dirs = "5.0"
+chrono = { version = "0.4", features = ["serde"] }
 
 [features]
 # This feature is used for production builds or when `devPath` points to the filesystem

--- a/desktop/src-tauri/src/bluetooth.rs
+++ b/desktop/src-tauri/src/bluetooth.rs
@@ -50,84 +50,10 @@ pub struct ScannedDevice {
     pub is_connected: bool,
 }
 
-/// Bluetooth printer commands (ESC/POS standard)
-#[derive(Debug, Clone)]
-pub enum PrinterCommand {
-    /// Initialize printer
-    Initialize,
-    /// Print text
-    Text(String),
-    /// Print text with newline
-    TextLine(String),
-    /// Feed paper (n lines)
-    Feed(u8),
-    /// Cut paper
-    Cut,
-    /// Set alignment (0=left, 1=center, 2=right)
-    Align(u8),
-    /// Set text size (1-8)
-    TextSize(u8, u8), // width, height
-    /// Bold text (true/false)
-    Bold(bool),
-    /// Print barcode
-    Barcode(String),
-    /// Print QR code
-    QRCode(String),
-}
-
-impl PrinterCommand {
-    /// Convert command to ESC/POS byte sequence
-    pub fn to_bytes(&self) -> Vec<u8> {
-        match self {
-            PrinterCommand::Initialize => vec![0x1B, 0x40], // ESC @
-            PrinterCommand::Text(text) => text.as_bytes().to_vec(),
-            PrinterCommand::TextLine(text) => {
-                let mut bytes = text.as_bytes().to_vec();
-                bytes.extend_from_slice(&[0x0A]); // LF
-                bytes
-            }
-            PrinterCommand::Feed(lines) => vec![0x1B, 0x64, *lines], // ESC d n
-            PrinterCommand::Cut => vec![0x1D, 0x56, 0x00], // GS V 0
-            PrinterCommand::Align(alignment) => vec![0x1B, 0x61, *alignment], // ESC a n
-            PrinterCommand::TextSize(width, height) => {
-                let size = ((width - 1) << 4) | (height - 1);
-                vec![0x1D, 0x21, size] // GS ! n
-            }
-            PrinterCommand::Bold(enabled) => {
-                vec![0x1B, 0x45, if *enabled { 1 } else { 0 }] // ESC E n
-            }
-            PrinterCommand::Barcode(data) => {
-                let mut bytes = vec![
-                    0x1D, 0x68, 0x64, // GS h 100 (height)
-                    0x1D, 0x77, 0x02, // GS w 2 (width)
-                    0x1D, 0x6B, 0x04, // GS k 4 (CODE39)
-                ];
-                bytes.extend_from_slice(data.as_bytes());
-                bytes.push(0x00); // NULL terminator
-                bytes
-            }
-            PrinterCommand::QRCode(data) => {
-                let mut bytes = vec![
-                    0x1D, 0x28, 0x6B, 0x04, 0x00, 0x31, 0x41, 0x32, 0x00, // Model
-                    0x1D, 0x28, 0x6B, 0x03, 0x00, 0x31, 0x43, 0x08, // Size
-                    0x1D, 0x28, 0x6B, 0x03, 0x00, 0x31, 0x45, 0x30, // Error correction
-                ];
-                // Store data
-                let len = data.len() + 3;
-                bytes.extend_from_slice(&[
-                    0x1D, 0x28, 0x6B,
-                    (len & 0xFF) as u8,
-                    ((len >> 8) & 0xFF) as u8,
-                    0x31, 0x50, 0x30,
-                ]);
-                bytes.extend_from_slice(data.as_bytes());
-                // Print
-                bytes.extend_from_slice(&[0x1D, 0x28, 0x6B, 0x03, 0x00, 0x31, 0x51, 0x30]);
-                bytes
-            }
-        }
-    }
-}
+// PrinterCommand moved to crate::escpos. Re-exported below so existing
+// `use bluetooth::PrinterCommand;` import sites in main.rs keep compiling
+// without churn during the Phase 1.3 refactor.
+pub use crate::escpos::PrinterCommand;
 
 /// Bluetooth manager for device scanning and connection
 pub struct BluetoothManager {

--- a/desktop/src-tauri/src/escpos/codepage.rs
+++ b/desktop/src-tauri/src/escpos/codepage.rs
@@ -1,0 +1,192 @@
+//! UTF-8 → CP-857 transcoder for Turkish ESC/POS receipt printing.
+//!
+//! CP-857 covers Latin-5 / Turkish. Most generic thermal printers default to
+//! CP-437 (US ASCII) or CP-850 (Multilingual Latin-1), neither of which has
+//! the dotted/dotless I or the cedilla'd letters Turkish menus use. We send
+//! `ESC t 13` once on Initialize to switch the printer to CP-857, then map
+//! each non-ASCII char in TextLine commands through this table before send.
+//!
+//! Source: Microsoft codepage 857 reference + ESC/POS docs (Star Micronics,
+//! Epson). Covers the full Turkish alphabet (Ç ç Ğ ğ I ı İ Ö ö Ş ş Ü ü)
+//! plus the small set of Latin-1 letters Turkish menus borrow.
+//!
+//! Unmapped characters become `?` (0x3F) — better than silent truncation
+//! or panicking in the print pipeline.
+
+/// CP-857 selector byte (the `n` argument to `ESC t n`).
+///
+/// ESC/POS code-page table puts CP-857 at index 13 on Epson-family printers
+/// and most generic Chinese clones (Xprinter, Goojprt, Munbyn, etc.).
+/// If a particular printer model needs a different selector, switch this
+/// constant once it's calibrated by Phase 1.3 hardware testing.
+pub const CP857_SELECTOR: u8 = 13;
+
+/// Transcode a UTF-8 string to CP-857 bytes. Each input char that has no
+/// CP-857 mapping is replaced by '?' (0x3F).
+pub fn utf8_to_cp857(input: &str) -> Vec<u8> {
+    input.chars().map(map_char).collect()
+}
+
+fn map_char(c: char) -> u8 {
+    // ASCII range pass-through (0x00..0x7F is identical in CP-857).
+    if (c as u32) < 0x80 {
+        return c as u8;
+    }
+    match c {
+        // Latin-1 supplement (CP-857 columns 0x80..0x9F)
+        'Ç' => 0x80,
+        'ü' => 0x81,
+        'é' => 0x82,
+        'â' => 0x83,
+        'ä' => 0x84,
+        'à' => 0x85,
+        'å' => 0x86,
+        'ç' => 0x87,
+        'ê' => 0x88,
+        'ë' => 0x89,
+        'è' => 0x8A,
+        'ï' => 0x8B,
+        'î' => 0x8C,
+        'ı' => 0x8D, // dotless lowercase i — Turkish-specific
+        'Ä' => 0x8E,
+        'Å' => 0x8F,
+        'É' => 0x90,
+        'æ' => 0x91,
+        'Æ' => 0x92,
+        'ô' => 0x93,
+        'ö' => 0x94,
+        'ò' => 0x95,
+        'û' => 0x96,
+        'ù' => 0x97,
+        'İ' => 0x98, // dotted uppercase I — Turkish-specific
+        'Ö' => 0x99,
+        'Ü' => 0x9A,
+        'ø' => 0x9B,
+        '£' => 0x9C,
+        'Ø' => 0x9D,
+        'Ş' => 0x9E,
+        'ş' => 0x9F,
+        // Latin-1 supplement (CP-857 columns 0xA0..0xAF)
+        'á' => 0xA0,
+        'í' => 0xA1,
+        'ó' => 0xA2,
+        'ú' => 0xA3,
+        'ñ' => 0xA4,
+        'Ñ' => 0xA5,
+        'Ğ' => 0xA6, // Turkish-specific
+        'ğ' => 0xA7, // Turkish-specific
+        '¿' => 0xA8,
+        '®' => 0xA9,
+        '¬' => 0xAA,
+        '½' => 0xAB,
+        '¼' => 0xAC,
+        '¡' => 0xAD,
+        '«' => 0xAE,
+        '»' => 0xAF,
+        // Box-drawing range 0xB0..0xDF intentionally unmapped — receipts
+        // don't use them, and a thermal printer set to CP-857 will print
+        // them as graphics if the byte happens to slip through.
+
+        // Currency: € is at 0xD5 in the Microsoft variant of CP-857.
+        '€' => 0xD5,
+
+        // Anything else: emit '?' so the print pipeline never panics on
+        // unexpected unicode. Prefer visible failure to silent truncation.
+        _ => b'?',
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ascii_passthrough() {
+        assert_eq!(utf8_to_cp857("Hello, World!"), b"Hello, World!".to_vec());
+        assert_eq!(utf8_to_cp857(""), Vec::<u8>::new());
+        assert_eq!(utf8_to_cp857("0123456789"), b"0123456789".to_vec());
+    }
+
+    #[test]
+    fn turkish_alphabet_lowercase() {
+        // ç ğ ı ö ş ü
+        assert_eq!(
+            utf8_to_cp857("çğıöşü"),
+            vec![0x87, 0xA7, 0x8D, 0x94, 0x9F, 0x81]
+        );
+    }
+
+    #[test]
+    fn turkish_alphabet_uppercase() {
+        // Ç Ğ İ Ö Ş Ü
+        assert_eq!(
+            utf8_to_cp857("ÇĞİÖŞÜ"),
+            vec![0x80, 0xA6, 0x98, 0x99, 0x9E, 0x9A]
+        );
+    }
+
+    #[test]
+    fn dotted_vs_dotless_i_distinction() {
+        // The whole reason CP-857 exists vs CP-850: Turkish I has 4 forms.
+        // Plain I/i (ASCII), İ (dotted upper, Turkish), ı (dotless lower).
+        // The 'I' in "İstanbul" must NOT collapse to ASCII 'I'.
+        let bytes = utf8_to_cp857("İstanbul");
+        assert_eq!(bytes[0], 0x98); // İ
+        assert_eq!(bytes[1], b's');
+        assert_eq!(bytes[2], b't');
+        assert_eq!(bytes[3], b'a');
+        assert_eq!(bytes[4], b'n');
+        assert_eq!(bytes[5], b'b');
+        assert_eq!(bytes[6], b'u');
+        assert_eq!(bytes[7], b'l');
+    }
+
+    #[test]
+    fn turkish_menu_item_realistic() {
+        // A real receipt line: "Adana Kebap" (no Turkish chars in this name)
+        assert_eq!(utf8_to_cp857("Adana Kebap"), b"Adana Kebap".to_vec());
+        // "Künefe" — has ü
+        assert_eq!(utf8_to_cp857("Künefe"), vec![b'K', 0x81, b'n', b'e', b'f', b'e']);
+        // "Şiş" — has Ş and ş
+        assert_eq!(utf8_to_cp857("Şiş"), vec![0x9E, b'i', 0x9F]);
+    }
+
+    #[test]
+    fn unknown_chars_become_question_mark() {
+        // Emoji is not in CP-857.
+        assert_eq!(utf8_to_cp857("🍔"), vec![b'?']);
+        // CJK is not in CP-857.
+        assert_eq!(utf8_to_cp857("中文"), vec![b'?', b'?']);
+        // Cyrillic is not in CP-857.
+        assert_eq!(utf8_to_cp857("привет"), vec![b'?'; 6]);
+    }
+
+    #[test]
+    fn euro_sign_maps_to_d5() {
+        assert_eq!(utf8_to_cp857("€"), vec![0xD5]);
+        // In a price line: "12,50 €"
+        let bytes = utf8_to_cp857("12,50 €");
+        assert_eq!(bytes, vec![b'1', b'2', b',', b'5', b'0', b' ', 0xD5]);
+    }
+
+    #[test]
+    fn cp857_selector_constant() {
+        // Sanity-check the constant. The `ESC t n` sequence the printer
+        // sees is [0x1B, 0x74, CP857_SELECTOR]. If a future printer model
+        // needs a different code page, this constant is the single point
+        // of truth.
+        assert_eq!(CP857_SELECTOR, 13);
+    }
+
+    #[test]
+    fn round_trip_full_turkish_alphabet() {
+        // Full lower + upper Turkish alphabet in one string.
+        let input = "abcçdefgğhıijklmnoöprsştuüvyzABCÇDEFGĞHIİJKLMNOÖPRSŞTUÜVYZ";
+        let bytes = utf8_to_cp857(input);
+        // Every byte must be a single byte (CP-857 is single-byte).
+        // Verify the count matches char count.
+        assert_eq!(bytes.len(), input.chars().count());
+        // No '?' fallback should fire — every Turkish letter is mapped.
+        assert!(!bytes.contains(&b'?'), "unexpected '?' fallback in: {:?}", bytes);
+    }
+}

--- a/desktop/src-tauri/src/escpos/mod.rs
+++ b/desktop/src-tauri/src/escpos/mod.rs
@@ -1,0 +1,12 @@
+//! ESC/POS thermal-printer command construction.
+//!
+//! This module is being built incrementally as part of Phase 1.3
+//! (see docs/superpowers/plans/2026-04-27-phase-1-3-tauri-hardware-suite.md).
+//!
+//! Today: the CP-857 transcoder for Turkish receipt printing
+//! (Bug E from the reliability audit). The PrinterCommand enum and the
+//! receipt/kitchen-ticket templates land in subsequent commits — they
+//! depend on the bluetooth.rs → hardware/connection/ refactor (Sub-phase
+//! 1.3.A) which itself depends on a clean `cargo check` build.
+
+pub mod codepage;

--- a/desktop/src-tauri/src/escpos/mod.rs
+++ b/desktop/src-tauri/src/escpos/mod.rs
@@ -1,12 +1,149 @@
 //! ESC/POS thermal-printer command construction.
 //!
-//! This module is being built incrementally as part of Phase 1.3
-//! (see docs/superpowers/plans/2026-04-27-phase-1-3-tauri-hardware-suite.md).
+//! Owns:
+//! - `PrinterCommand` enum + `to_bytes()` — the ESC/POS instruction set we use
+//! - `codepage` submodule — UTF-8 → CP-857 transcoder for Turkish receipts
 //!
-//! Today: the CP-857 transcoder for Turkish receipt printing
-//! (Bug E from the reliability audit). The PrinterCommand enum and the
-//! receipt/kitchen-ticket templates land in subsequent commits — they
-//! depend on the bluetooth.rs → hardware/connection/ refactor (Sub-phase
-//! 1.3.A) which itself depends on a clean `cargo check` build.
+//! `PrinterCommand::Initialize` emits the standard reset (`ESC @`) followed
+//! by `ESC t 13` to switch the printer into CP-857 mode so subsequent
+//! `Text` / `TextLine` byte streams (which are CP-857-encoded by the
+//! transcoder) print Turkish characters correctly.
 
 pub mod codepage;
+
+use codepage::{utf8_to_cp857, CP857_SELECTOR};
+
+/// Bluetooth/serial/network thermal-printer commands (ESC/POS standard).
+#[derive(Debug, Clone)]
+pub enum PrinterCommand {
+    /// Reset the printer and select the CP-857 (Turkish) code page.
+    Initialize,
+    /// Print text without trailing newline.
+    Text(String),
+    /// Print text with a trailing newline (LF).
+    TextLine(String),
+    /// Feed paper N lines.
+    Feed(u8),
+    /// Full paper cut.
+    Cut,
+    /// Text alignment: 0=left, 1=center, 2=right.
+    Align(u8),
+    /// Text size: width and height multipliers (1..=8 each).
+    TextSize(u8, u8),
+    /// Toggle bold rendering.
+    Bold(bool),
+    /// CODE39 barcode.
+    Barcode(String),
+    /// QR code (Model 2, error correction L).
+    QRCode(String),
+}
+
+impl PrinterCommand {
+    /// Convert this command into the ESC/POS byte sequence the printer expects.
+    /// Text-bearing variants transcode UTF-8 → CP-857 so Turkish characters
+    /// (ç ğ ı ö ş ü plus uppercase variants) print correctly on receipts.
+    pub fn to_bytes(&self) -> Vec<u8> {
+        match self {
+            PrinterCommand::Initialize => {
+                // ESC @ (reset) + ESC t 13 (select CP-857 / Turkish).
+                // Sending the code-page selector once on Initialize means
+                // every subsequent Text/TextLine on this connection prints
+                // with the correct Turkish glyph table.
+                vec![0x1B, 0x40, 0x1B, 0x74, CP857_SELECTOR]
+            }
+            PrinterCommand::Text(text) => utf8_to_cp857(text),
+            PrinterCommand::TextLine(text) => {
+                let mut bytes = utf8_to_cp857(text);
+                bytes.push(0x0A); // LF
+                bytes
+            }
+            PrinterCommand::Feed(lines) => vec![0x1B, 0x64, *lines], // ESC d n
+            PrinterCommand::Cut => vec![0x1D, 0x56, 0x00], // GS V 0
+            PrinterCommand::Align(alignment) => vec![0x1B, 0x61, *alignment], // ESC a n
+            PrinterCommand::TextSize(width, height) => {
+                let size = ((width - 1) << 4) | (height - 1);
+                vec![0x1D, 0x21, size] // GS ! n
+            }
+            PrinterCommand::Bold(enabled) => {
+                vec![0x1B, 0x45, if *enabled { 1 } else { 0 }] // ESC E n
+            }
+            PrinterCommand::Barcode(data) => {
+                // CODE39 barcodes are 1D ASCII — no CP-857 transcode needed
+                // (and would corrupt the symbol set if applied).
+                let mut bytes = vec![
+                    0x1D, 0x68, 0x64, // GS h 100 (height)
+                    0x1D, 0x77, 0x02, // GS w 2 (width)
+                    0x1D, 0x6B, 0x04, // GS k 4 (CODE39)
+                ];
+                bytes.extend_from_slice(data.as_bytes());
+                bytes.push(0x00); // NULL terminator
+                bytes
+            }
+            PrinterCommand::QRCode(data) => {
+                // QR code data is opaque bytes to the printer; no CP-857
+                // transcode (the QR encoder handles Unicode itself if used).
+                let mut bytes = vec![
+                    0x1D, 0x28, 0x6B, 0x04, 0x00, 0x31, 0x41, 0x32, 0x00, // Model
+                    0x1D, 0x28, 0x6B, 0x03, 0x00, 0x31, 0x43, 0x08, // Size
+                    0x1D, 0x28, 0x6B, 0x03, 0x00, 0x31, 0x45, 0x30, // Error correction
+                ];
+                let len = data.len() + 3;
+                bytes.extend_from_slice(&[
+                    0x1D, 0x28, 0x6B,
+                    (len & 0xFF) as u8,
+                    ((len >> 8) & 0xFF) as u8,
+                    0x31, 0x50, 0x30,
+                ]);
+                bytes.extend_from_slice(data.as_bytes());
+                bytes.extend_from_slice(&[0x1D, 0x28, 0x6B, 0x03, 0x00, 0x31, 0x51, 0x30]);
+                bytes
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn initialize_sends_reset_and_cp857_selector() {
+        // ESC @ resets the printer; ESC t 13 selects CP-857 (Turkish).
+        // Verifies Bug E's wire-level fix lands on every print job.
+        assert_eq!(
+            PrinterCommand::Initialize.to_bytes(),
+            vec![0x1B, 0x40, 0x1B, 0x74, 13]
+        );
+    }
+
+    #[test]
+    fn text_line_transcodes_turkish_chars_to_cp857() {
+        // "Şiş" — three Turkish letters plus newline.
+        // Ş=0x9E, i=ASCII, ş=0x9F, then LF=0x0A.
+        let bytes = PrinterCommand::TextLine("Şiş".to_string()).to_bytes();
+        assert_eq!(bytes, vec![0x9E, b'i', 0x9F, 0x0A]);
+    }
+
+    #[test]
+    fn text_without_newline_omits_lf() {
+        let bytes = PrinterCommand::Text("ok".to_string()).to_bytes();
+        assert_eq!(bytes, b"ok".to_vec());
+    }
+
+    #[test]
+    fn feed_cut_align_unaffected_by_cp857() {
+        assert_eq!(PrinterCommand::Feed(3).to_bytes(), vec![0x1B, 0x64, 3]);
+        assert_eq!(PrinterCommand::Cut.to_bytes(), vec![0x1D, 0x56, 0x00]);
+        assert_eq!(PrinterCommand::Align(1).to_bytes(), vec![0x1B, 0x61, 1]);
+    }
+
+    #[test]
+    fn barcode_keeps_ascii_payload_unchanged() {
+        // CODE39 must stay ASCII — confirm we didn't accidentally run the
+        // payload through utf8_to_cp857.
+        let bytes = PrinterCommand::Barcode("ABC123".to_string()).to_bytes();
+        // Last 7 bytes = "ABC123" + NULL terminator
+        assert_eq!(&bytes[bytes.len() - 7..], &[b'A', b'B', b'C', b'1', b'2', b'3', 0x00]);
+    }
+}
+

--- a/desktop/src-tauri/src/hardware/config.rs
+++ b/desktop/src-tauri/src/hardware/config.rs
@@ -1,0 +1,242 @@
+//! Per-machine hardware configuration persisted at `~/.kds/hardware.json`.
+//!
+//! Hardware setup is per-terminal — each restaurant's POS station has its own
+//! paired printer / drawer / kitchen printer / barcode reader. We do NOT
+//! sync this to the backend tenant settings: a tenant with two terminals
+//! means two `hardware.json` files, one per machine, and that's correct.
+//!
+//! The shape mirrors `frontend/src/types/hardware.ts` so the JSON round-trips
+//! between Rust and the React UI without translation.
+
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::path::PathBuf;
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum ConfigError {
+    #[error("Could not locate user config directory")]
+    NoConfigDir,
+    #[error("Failed to read hardware config at {0}: {1}")]
+    ReadFailed(PathBuf, String),
+    #[error("Failed to write hardware config at {0}: {1}")]
+    WriteFailed(PathBuf, String),
+    #[error("Hardware config JSON is invalid: {0}")]
+    InvalidJson(String),
+}
+
+pub type ConfigResult<T> = Result<T, ConfigError>;
+
+/// Top-level hardware config. Today: a flat list of devices + the user's
+/// default-printer pointer for the legacy PrinterService path. Future
+/// optional fields (e.g. `default_kitchen_printer`, `default_drawer`) get
+/// added as `Option<...>` without bumping the format — JSON is forgiving
+/// of extra/missing keys.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct HardwareConfig {
+    /// All paired devices on this machine.
+    #[serde(default)]
+    pub devices: Vec<DeviceConfig>,
+
+    /// Legacy PrinterService default-printer port. Kept until
+    /// PrinterSettings.tsx is replaced by the new IntegrationsSettingsPage.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub default_printer_port: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DeviceConfig {
+    pub id: String,
+    pub name: String,
+    pub device_type: DeviceType,
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+    #[serde(default)]
+    pub auto_connect: bool,
+    pub connection: ConnectionConfig,
+    /// Per-device free-form settings (e.g. paper width, code page override).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub settings: Option<serde_json::Value>,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum DeviceType {
+    #[serde(rename = "THERMAL_PRINTER")]
+    ThermalPrinter,
+    #[serde(rename = "CASH_DRAWER")]
+    CashDrawer,
+    #[serde(rename = "RESTAURANT_PAGER")]
+    RestaurantPager,
+    #[serde(rename = "BARCODE_READER")]
+    BarcodeReader,
+    #[serde(rename = "CUSTOMER_DISPLAY")]
+    CustomerDisplay,
+    #[serde(rename = "KITCHEN_DISPLAY")]
+    KitchenDisplay,
+    #[serde(rename = "SCALE_DEVICE")]
+    ScaleDevice,
+}
+
+/// Tagged union matching the frontend's `ConnectionConfig` shape:
+/// `{ connection_type: "Bluetooth", config: { device_address, ... } }`.
+/// Bluetooth is the only kind wired up today; Serial / Network land when
+/// the corresponding Connection-trait impls are added (Phase 1.3.A.3
+/// follow-up).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "connection_type", content = "config")]
+pub enum ConnectionConfig {
+    Bluetooth(BluetoothConnectionConfig),
+    Serial(SerialConnectionConfig),
+    Network(NetworkConnectionConfig),
+    UsbHid(UsbHidConnectionConfig),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BluetoothConnectionConfig {
+    pub device_address: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub service_uuid: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub characteristic_uuid: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SerialConnectionConfig {
+    pub port: String,
+    pub baud_rate: u32,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub timeout_ms: Option<u32>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NetworkConnectionConfig {
+    pub ip_address: String,
+    pub port: u16,
+    #[serde(default = "default_protocol")]
+    pub protocol: NetworkProtocol,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub timeout_ms: Option<u32>,
+}
+
+fn default_protocol() -> NetworkProtocol {
+    NetworkProtocol::Tcp
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum NetworkProtocol {
+    Tcp,
+    Udp,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UsbHidConnectionConfig {
+    pub vendor_id: u16,
+    pub product_id: u16,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub timeout_ms: Option<u32>,
+}
+
+/// Resolve the path to `~/.kds/hardware.json`, creating `~/.kds/` if needed.
+pub fn config_path() -> ConfigResult<PathBuf> {
+    let mut path = dirs::home_dir().ok_or(ConfigError::NoConfigDir)?;
+    path.push(".kds");
+    if !path.exists() {
+        fs::create_dir_all(&path).map_err(|e| {
+            ConfigError::WriteFailed(path.clone(), e.to_string())
+        })?;
+    }
+    path.push("hardware.json");
+    Ok(path)
+}
+
+/// Load the hardware config from disk. Missing file = empty default config
+/// (a fresh install on a new terminal). Corrupt file = error so the user
+/// sees the problem rather than silently losing their pairings.
+pub fn load() -> ConfigResult<HardwareConfig> {
+    let path = config_path()?;
+    if !path.exists() {
+        return Ok(HardwareConfig::default());
+    }
+    let raw = fs::read_to_string(&path)
+        .map_err(|e| ConfigError::ReadFailed(path.clone(), e.to_string()))?;
+    serde_json::from_str(&raw).map_err(|e| ConfigError::InvalidJson(e.to_string()))
+}
+
+/// Persist the hardware config to disk atomically: write to a temp file
+/// in the same directory, then rename. If the rename succeeds the file
+/// is consistent on disk; if it fails the previous file is untouched.
+pub fn save(config: &HardwareConfig) -> ConfigResult<()> {
+    let path = config_path()?;
+    let tmp = path.with_extension("json.tmp");
+
+    let json = serde_json::to_string_pretty(config)
+        .map_err(|e| ConfigError::InvalidJson(e.to_string()))?;
+    fs::write(&tmp, json)
+        .map_err(|e| ConfigError::WriteFailed(tmp.clone(), e.to_string()))?;
+    fs::rename(&tmp, &path)
+        .map_err(|e| ConfigError::WriteFailed(path.clone(), e.to_string()))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_device() -> DeviceConfig {
+        DeviceConfig {
+            id: "dev-1".to_string(),
+            name: "Counter Printer".to_string(),
+            device_type: DeviceType::ThermalPrinter,
+            enabled: true,
+            auto_connect: true,
+            connection: ConnectionConfig::Bluetooth(BluetoothConnectionConfig {
+                device_address: "AA:BB:CC:DD:EE:FF".to_string(),
+                service_uuid: None,
+                characteristic_uuid: None,
+            }),
+            settings: None,
+        }
+    }
+
+    #[test]
+    fn round_trips_through_json() {
+        let cfg = HardwareConfig {
+            devices: vec![sample_device()],
+            default_printer_port: Some("/dev/usb/lp0".to_string()),
+        };
+        let json = serde_json::to_string(&cfg).unwrap();
+        let parsed: HardwareConfig = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.devices.len(), 1);
+        assert_eq!(parsed.devices[0].name, "Counter Printer");
+        assert_eq!(parsed.devices[0].device_type, DeviceType::ThermalPrinter);
+        assert_eq!(parsed.default_printer_port.as_deref(), Some("/dev/usb/lp0"));
+    }
+
+    #[test]
+    fn connection_config_uses_tagged_union_shape() {
+        // Frontend uses { connection_type: "Bluetooth", config: {...} } —
+        // confirm the serialized shape matches.
+        let conn = ConnectionConfig::Bluetooth(BluetoothConnectionConfig {
+            device_address: "AA:BB".to_string(),
+            service_uuid: None,
+            characteristic_uuid: None,
+        });
+        let json = serde_json::to_string(&conn).unwrap();
+        assert!(json.contains(r#""connection_type":"Bluetooth""#));
+        assert!(json.contains(r#""config":{"#));
+    }
+
+    #[test]
+    fn missing_devices_field_defaults_to_empty() {
+        // A hardware.json containing just a default_printer_port should
+        // still parse. Tests the #[serde(default)] on devices.
+        let json = r#"{ "default_printer_port": "/dev/lp0" }"#;
+        let cfg: HardwareConfig = serde_json::from_str(json).unwrap();
+        assert!(cfg.devices.is_empty());
+        assert_eq!(cfg.default_printer_port.as_deref(), Some("/dev/lp0"));
+    }
+}

--- a/desktop/src-tauri/src/hardware/connection/mod.rs
+++ b/desktop/src-tauri/src/hardware/connection/mod.rs
@@ -1,0 +1,6 @@
+//! Hardware connection abstractions (BLE / Serial / Network).
+//!
+//! Scaffolding only — the Connection trait and concrete impls land in
+//! Sub-phase 1.3.A.3 of the Phase 1.3 plan
+//! (docs/superpowers/plans/2026-04-27-phase-1-3-tauri-hardware-suite.md)
+//! once the local build environment can run `cargo check`.

--- a/desktop/src-tauri/src/hardware/events.rs
+++ b/desktop/src-tauri/src/hardware/events.rs
@@ -1,0 +1,67 @@
+//! Hardware lifecycle events emitted to the React frontend.
+//!
+//! Mirrors `frontend/src/types/hardware.ts::HardwareEvent` — a tagged
+//! union with `type` + `data` shape. Frontend already subscribes via
+//! `HardwareService.listenToHardwareEvents()`; we just need to fire
+//! events from Rust at the right moments (connect/disconnect/error).
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use tauri::{AppHandle, Manager};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", content = "data")]
+pub enum HardwareEvent {
+    DeviceConnected {
+        device_id: String,
+        device_name: String,
+        timestamp: DateTime<Utc>,
+    },
+    DeviceDisconnected {
+        device_id: String,
+        device_name: String,
+        timestamp: DateTime<Utc>,
+    },
+    ConnectionError {
+        device_id: String,
+        error: String,
+        timestamp: DateTime<Utc>,
+    },
+    PaperOut {
+        device_id: String,
+        timestamp: DateTime<Utc>,
+    },
+    PaperLow {
+        device_id: String,
+        timestamp: DateTime<Utc>,
+    },
+    CashDrawerOpened {
+        device_id: String,
+        timestamp: DateTime<Utc>,
+    },
+    BarcodeScanned {
+        device_id: String,
+        barcode_data: String,
+        barcode_type: String,
+        timestamp: DateTime<Utc>,
+    },
+    PagerCalled {
+        device_id: String,
+        pager_number: u32,
+        timestamp: DateTime<Utc>,
+    },
+    DeviceError {
+        device_id: String,
+        error: String,
+        timestamp: DateTime<Utc>,
+    },
+}
+
+/// Push a hardware event to all open windows. The frontend subscribes
+/// via `HardwareService.listenToHardwareEvents()` (`tauri.ts`).
+pub fn emit(app: &AppHandle, event: HardwareEvent) {
+    if let Err(e) = app.emit_all("hardware-event", &event) {
+        // Don't crash hardware logic for an emit failure — log and move on.
+        eprintln!("Failed to emit hardware-event: {}", e);
+    }
+}

--- a/desktop/src-tauri/src/hardware/mod.rs
+++ b/desktop/src-tauri/src/hardware/mod.rs
@@ -1,0 +1,8 @@
+//! Hardware management (printer, cash drawer, future barcode/scale/pager).
+//!
+//! Scaffolding only — populated by Sub-phase 1.3.C of the Phase 1.3 plan
+//! (docs/superpowers/plans/2026-04-27-phase-1-3-tauri-hardware-suite.md).
+//! Today's BLE printer logic lives in bluetooth.rs and is moved in
+//! Sub-phase 1.3.A once the local build environment can run cargo check.
+
+pub mod connection;

--- a/desktop/src-tauri/src/hardware/mod.rs
+++ b/desktop/src-tauri/src/hardware/mod.rs
@@ -1,8 +1,107 @@
 //! Hardware management (printer, cash drawer, future barcode/scale/pager).
 //!
-//! Scaffolding only — populated by Sub-phase 1.3.C of the Phase 1.3 plan
-//! (docs/superpowers/plans/2026-04-27-phase-1-3-tauri-hardware-suite.md).
-//! Today's BLE printer logic lives in bluetooth.rs and is moved in
-//! Sub-phase 1.3.A once the local build environment can run cargo check.
+//! Today's primary surface:
+//!   - `config` — `~/.kds/hardware.json` persistence + serde structs that
+//!     mirror `frontend/src/types/hardware.ts`
+//!   - `status` — runtime DeviceStatus tracking exposed via list_devices /
+//!     get_device_status Tauri commands
+//!   - `events` — emit hardware lifecycle events (DeviceConnected,
+//!     ConnectionError, etc.) to the React frontend via Tauri's event bus
+//!
+//! All connection logic still goes through BluetoothManager today (see
+//! crate::bluetooth). The `connection` submodule is scaffolded for the
+//! future Connection-trait abstraction that lets us slot in Serial /
+//! Network / USB-HID alongside BLE.
 
+pub mod config;
 pub mod connection;
+pub mod events;
+pub mod status;
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::sync::RwLock;
+
+use config::{DeviceConfig, HardwareConfig};
+use status::DeviceStatus;
+
+/// Central runtime state for the hardware suite. Wraps the persisted
+/// `HardwareConfig` plus an in-memory `DeviceStatus` cache keyed by
+/// device id. Behind an `Arc<RwLock<...>>` so Tauri command handlers
+/// can read concurrently and writers are exclusive.
+#[derive(Debug, Default)]
+pub struct HardwareManagerInner {
+    pub config: HardwareConfig,
+    pub statuses: HashMap<String, DeviceStatus>,
+}
+
+pub type HardwareManager = Arc<RwLock<HardwareManagerInner>>;
+
+/// Build a fresh manager and load the persisted config. Each device row
+/// gets a default `Disconnected/Unknown` status; the connect flow flips
+/// it. Missing/unreadable config = empty default (fresh install).
+pub async fn init_manager() -> HardwareManager {
+    let config = config::load().unwrap_or_else(|err| {
+        eprintln!(
+            "[hardware] could not load ~/.kds/hardware.json ({}); starting empty",
+            err
+        );
+        HardwareConfig::default()
+    });
+
+    let mut statuses = HashMap::new();
+    for dev in &config.devices {
+        statuses.insert(dev.id.clone(), DeviceStatus::from_config(dev));
+    }
+
+    Arc::new(RwLock::new(HardwareManagerInner { config, statuses }))
+}
+
+/// Add or replace a device row, persist the config, and ensure its status
+/// row exists. Used by the `add_device` Tauri command.
+pub async fn upsert_device(
+    manager: &HardwareManager,
+    device: DeviceConfig,
+) -> Result<DeviceConfig, String> {
+    let mut guard = manager.write().await;
+
+    // Replace if id already present, else append.
+    let pos = guard.config.devices.iter().position(|d| d.id == device.id);
+    match pos {
+        Some(i) => guard.config.devices[i] = device.clone(),
+        None => guard.config.devices.push(device.clone()),
+    }
+    guard
+        .statuses
+        .entry(device.id.clone())
+        .or_insert_with(|| DeviceStatus::from_config(&device));
+
+    config::save(&guard.config).map_err(|e| e.to_string())?;
+    Ok(device)
+}
+
+/// Drop a device row + its status. Used by the `remove_device` Tauri command.
+pub async fn remove_device(
+    manager: &HardwareManager,
+    device_id: &str,
+) -> Result<(), String> {
+    let mut guard = manager.write().await;
+    guard.config.devices.retain(|d| d.id != device_id);
+    guard.statuses.remove(device_id);
+    config::save(&guard.config).map_err(|e| e.to_string())
+}
+
+/// Snapshot every device's status. Sorted by name for stable UI ordering.
+pub async fn list_statuses(manager: &HardwareManager) -> Vec<DeviceStatus> {
+    let guard = manager.read().await;
+    let mut out: Vec<DeviceStatus> = guard.statuses.values().cloned().collect();
+    out.sort_by(|a, b| a.name.cmp(&b.name));
+    out
+}
+
+pub async fn get_status(
+    manager: &HardwareManager,
+    device_id: &str,
+) -> Option<DeviceStatus> {
+    manager.read().await.statuses.get(device_id).cloned()
+}

--- a/desktop/src-tauri/src/hardware/status.rs
+++ b/desktop/src-tauri/src/hardware/status.rs
@@ -1,0 +1,74 @@
+//! Runtime `DeviceStatus` shape returned by `list_devices` /
+//! `get_device_status` Tauri commands. Mirrors the frontend's
+//! `DeviceStatus` interface in `types/hardware.ts`.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use super::config::DeviceType;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum ConnectionStatus {
+    Connected,
+    Disconnected,
+    Connecting,
+    Error,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum HealthStatus {
+    Healthy,
+    Warning,
+    Error,
+    Unknown,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct DeviceStatus {
+    pub id: String,
+    pub name: String,
+    pub device_type: DeviceType,
+    pub connection_status: ConnectionStatus,
+    pub health: HealthStatus,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_activity: Option<DateTime<Utc>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error_message: Option<String>,
+}
+
+impl DeviceStatus {
+    /// Construct a fresh, never-connected status entry from a config row.
+    /// New devices start `Disconnected` + `Unknown` health; the connect
+    /// flow flips them to `Connected`/`Healthy`.
+    pub fn from_config(cfg: &super::config::DeviceConfig) -> Self {
+        Self {
+            id: cfg.id.clone(),
+            name: cfg.name.clone(),
+            device_type: cfg.device_type.clone(),
+            connection_status: ConnectionStatus::Disconnected,
+            health: HealthStatus::Unknown,
+            last_activity: None,
+            error_message: None,
+        }
+    }
+
+    pub fn mark_connected(&mut self) {
+        self.connection_status = ConnectionStatus::Connected;
+        self.health = HealthStatus::Healthy;
+        self.last_activity = Some(Utc::now());
+        self.error_message = None;
+    }
+
+    pub fn mark_disconnected(&mut self) {
+        self.connection_status = ConnectionStatus::Disconnected;
+        self.health = HealthStatus::Unknown;
+        self.error_message = None;
+    }
+
+    pub fn mark_error(&mut self, message: String) {
+        self.connection_status = ConnectionStatus::Error;
+        self.health = HealthStatus::Error;
+        self.error_message = Some(message);
+    }
+}

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -2,6 +2,8 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 mod bluetooth;
+mod escpos;
+mod hardware;
 
 use bluetooth::{BluetoothManager, PrinterCommand, ScannedDevice};
 use std::sync::Arc;

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -136,11 +136,13 @@ async fn read_characteristic(
     Ok(data)
 }
 
-/// Print a receipt to a Bluetooth printer
+/// Print a receipt. Accepts the versioned snapshot shape that the backend
+/// persists on Payment.receiptSnapshot — frontend can pass it through
+/// without translation.
 #[tauri::command]
 async fn print_receipt(
     device_id: String,
-    receipt_data: ReceiptData,
+    receipt: ReceiptSnapshot,
     state: State<'_, AppState>,
 ) -> Result<String, String> {
     let bt = state.bluetooth.lock().await;
@@ -148,81 +150,8 @@ async fn print_receipt(
         .as_ref()
         .ok_or("Bluetooth not initialized")?;
 
-    // Build printer commands from receipt data
-    let mut commands = vec![
-        PrinterCommand::Initialize,
-        PrinterCommand::Align(1), // Center align
-        PrinterCommand::Bold(true),
-        PrinterCommand::TextSize(2, 2),
-        PrinterCommand::TextLine(receipt_data.restaurant_name.clone()),
-        PrinterCommand::Bold(false),
-        PrinterCommand::TextSize(1, 1),
-        PrinterCommand::TextLine(receipt_data.restaurant_address.clone()),
-        PrinterCommand::Feed(1),
-        PrinterCommand::Align(0), // Left align
-    ];
+    let commands = build_receipt_commands(&receipt);
 
-    // Add separator
-    commands.push(PrinterCommand::TextLine("--------------------------------".to_string()));
-
-    // Add items
-    for item in receipt_data.items {
-        let line = format!(
-            "{} x{:<3} {:>10}",
-            item.name,
-            item.quantity,
-            format!("{:.2}", item.price)
-        );
-        commands.push(PrinterCommand::TextLine(line));
-    }
-
-    // Add separator
-    commands.push(PrinterCommand::TextLine("--------------------------------".to_string()));
-
-    // Add totals
-    commands.push(PrinterCommand::TextLine(format!(
-        "Subtotal:          {:>10}",
-        format!("{:.2}", receipt_data.subtotal)
-    )));
-    commands.push(PrinterCommand::TextLine(format!(
-        "Tax:               {:>10}",
-        format!("{:.2}", receipt_data.tax)
-    )));
-    commands.push(PrinterCommand::Bold(true));
-    commands.push(PrinterCommand::TextLine(format!(
-        "TOTAL:             {:>10}",
-        format!("{:.2}", receipt_data.total)
-    )));
-    commands.push(PrinterCommand::Bold(false));
-
-    // Add payment method
-    commands.push(PrinterCommand::Feed(1));
-    commands.push(PrinterCommand::TextLine(format!(
-        "Payment: {}",
-        receipt_data.payment_method
-    )));
-
-    // Add footer
-    commands.push(PrinterCommand::Feed(1));
-    commands.push(PrinterCommand::Align(1)); // Center align
-    commands.push(PrinterCommand::TextLine("Thank you for your order!".to_string()));
-
-    if let Some(order_number) = receipt_data.order_number {
-        commands.push(PrinterCommand::Feed(1));
-        commands.push(PrinterCommand::TextLine(format!("Order #: {}", order_number)));
-    }
-
-    // Add QR code if provided
-    if let Some(qr_data) = receipt_data.qr_code_data {
-        commands.push(PrinterCommand::Feed(1));
-        commands.push(PrinterCommand::QRCode(qr_data));
-    }
-
-    // Feed and cut
-    commands.push(PrinterCommand::Feed(3));
-    commands.push(PrinterCommand::Cut);
-
-    // Send to printer
     manager
         .print(&device_id, commands)
         .await
@@ -231,25 +160,269 @@ async fn print_receipt(
     Ok("Receipt printed successfully".to_string())
 }
 
-/// Receipt data structure
+/// Print a kitchen ticket. Accepts the kitchenTicketSnapshot shape that
+/// orders.service.create persists on Order.kitchenTicketSnapshot.
+#[tauri::command]
+async fn print_kitchen_order(
+    device_id: String,
+    ticket: KitchenTicketSnapshot,
+    state: State<'_, AppState>,
+) -> Result<String, String> {
+    let bt = state.bluetooth.lock().await;
+    let manager = bt
+        .as_ref()
+        .ok_or("Bluetooth not initialized")?;
+
+    let commands = build_kitchen_ticket_commands(&ticket);
+
+    manager
+        .print(&device_id, commands)
+        .await
+        .map_err(|e| e.to_string())?;
+
+    Ok("Kitchen ticket printed successfully".to_string())
+}
+
+/// Open the cash drawer connected to a thermal printer.
+///
+/// ESC/POS sends a "drawer kick-out" pulse: ESC p m t1 t2 — `m=0` selects
+/// pin 2 (the standard cash-drawer pin on Epson + Star + most clones),
+/// `t1=50` and `t2=250` give a ~25ms on / 250ms off pulse the drawer
+/// solenoid responds to.
+#[tauri::command]
+async fn open_cash_drawer(
+    device_id: String,
+    state: State<'_, AppState>,
+) -> Result<String, String> {
+    let bt = state.bluetooth.lock().await;
+    let manager = bt
+        .as_ref()
+        .ok_or("Bluetooth not initialized")?;
+
+    let pulse = vec![0x1B, 0x70, 0x00, 0x32, 0xFA];
+    manager
+        .write_characteristic(&device_id, "0000ff01-0000-1000-8000-00805f9b34fb", &pulse)
+        .await
+        .map_err(|e| e.to_string())?;
+
+    Ok("Cash drawer opened".to_string())
+}
+
+/// Backend-shape receipt snapshot (Payment.receiptSnapshot, version 1).
+/// Mirrors the JSON written by ReceiptSnapshotBuilder in the NestJS
+/// backend. New fields can be added as `Option<...>` without bumping
+/// `version`. Renamed/removed fields require a v2 + a Rust dispatch on
+/// the version field.
 #[derive(serde::Deserialize)]
-struct ReceiptData {
-    restaurant_name: String,
-    restaurant_address: String,
-    items: Vec<ReceiptItem>,
-    subtotal: f64,
-    tax: f64,
-    total: f64,
-    payment_method: String,
-    order_number: Option<String>,
-    qr_code_data: Option<String>,
+struct ReceiptSnapshot {
+    #[allow(dead_code)]
+    version: u32,
+    restaurant: SnapshotRestaurant,
+    order: SnapshotOrderHeader,
+    items: Vec<SnapshotItem>,
+    totals: SnapshotTotals,
+    payment: SnapshotPayment,
+    #[allow(dead_code)]
+    #[serde(rename = "printedAt")]
+    printed_at: String,
 }
 
 #[derive(serde::Deserialize)]
-struct ReceiptItem {
+struct SnapshotRestaurant {
+    name: String,
+    currency: String,
+}
+
+#[derive(serde::Deserialize)]
+struct SnapshotOrderHeader {
+    #[allow(dead_code)]
+    id: String,
+    #[serde(rename = "orderNumber")]
+    order_number: String,
+    #[allow(dead_code)]
+    #[serde(rename = "type")]
+    order_type: String,
+    #[serde(rename = "tableNumber")]
+    table_number: Option<String>,
+    notes: Option<String>,
+}
+
+#[derive(serde::Deserialize)]
+struct SnapshotItem {
     name: String,
     quantity: u32,
-    price: f64,
+    #[allow(dead_code)]
+    #[serde(rename = "unitPrice")]
+    unit_price: String,
+    #[serde(rename = "totalPrice")]
+    total_price: String,
+    modifiers: Vec<String>,
+    notes: Option<String>,
+}
+
+#[derive(serde::Deserialize)]
+struct SnapshotTotals {
+    subtotal: String,
+    tax: String,
+    discount: String,
+    total: String,
+}
+
+#[derive(serde::Deserialize)]
+struct SnapshotPayment {
+    method: String,
+    #[allow(dead_code)]
+    #[serde(rename = "transactionId")]
+    transaction_id: Option<String>,
+    #[allow(dead_code)]
+    #[serde(rename = "paidAt")]
+    paid_at: String,
+}
+
+/// Backend-shape kitchen ticket snapshot (Order.kitchenTicketSnapshot, v1).
+#[derive(serde::Deserialize)]
+struct KitchenTicketSnapshot {
+    #[allow(dead_code)]
+    version: u32,
+    order: SnapshotOrderHeader,
+    items: Vec<KitchenItem>,
+    #[serde(rename = "specialInstructions")]
+    special_instructions: Option<String>,
+    #[allow(dead_code)]
+    #[serde(rename = "createdAt")]
+    created_at: String,
+}
+
+#[derive(serde::Deserialize)]
+struct KitchenItem {
+    name: String,
+    quantity: u32,
+    modifiers: Vec<String>,
+    notes: Option<String>,
+}
+
+const SEPARATOR: &str = "--------------------------------";
+
+/// Render a customer receipt as a Vec<PrinterCommand>.
+fn build_receipt_commands(r: &ReceiptSnapshot) -> Vec<PrinterCommand> {
+    let mut cmds = vec![
+        PrinterCommand::Initialize,
+        PrinterCommand::Align(1),
+        PrinterCommand::Bold(true),
+        PrinterCommand::TextSize(2, 2),
+        PrinterCommand::TextLine(r.restaurant.name.clone()),
+        PrinterCommand::Bold(false),
+        PrinterCommand::TextSize(1, 1),
+        PrinterCommand::Feed(1),
+        PrinterCommand::TextLine(format!("Order #{}", r.order.order_number)),
+    ];
+
+    if let Some(table) = &r.order.table_number {
+        cmds.push(PrinterCommand::TextLine(format!("Table: {}", table)));
+    }
+
+    cmds.push(PrinterCommand::Align(0));
+    cmds.push(PrinterCommand::TextLine(SEPARATOR.to_string()));
+
+    for item in &r.items {
+        cmds.push(PrinterCommand::TextLine(format!(
+            "{} x{:<3} {:>10}",
+            item.name, item.quantity, item.total_price
+        )));
+        for modifier in &item.modifiers {
+            cmds.push(PrinterCommand::TextLine(format!("  + {}", modifier)));
+        }
+        if let Some(notes) = &item.notes {
+            cmds.push(PrinterCommand::TextLine(format!("  ({})", notes)));
+        }
+    }
+
+    cmds.push(PrinterCommand::TextLine(SEPARATOR.to_string()));
+    cmds.push(PrinterCommand::TextLine(format!(
+        "Subtotal:          {:>10}",
+        r.totals.subtotal
+    )));
+    if r.totals.discount != "0.00" {
+        cmds.push(PrinterCommand::TextLine(format!(
+            "Discount:          {:>10}",
+            r.totals.discount
+        )));
+    }
+    cmds.push(PrinterCommand::TextLine(format!(
+        "Tax:               {:>10}",
+        r.totals.tax
+    )));
+    cmds.push(PrinterCommand::Bold(true));
+    cmds.push(PrinterCommand::TextLine(format!(
+        "TOTAL ({}):    {:>10}",
+        r.restaurant.currency, r.totals.total
+    )));
+    cmds.push(PrinterCommand::Bold(false));
+
+    cmds.push(PrinterCommand::Feed(1));
+    cmds.push(PrinterCommand::TextLine(format!("Payment: {}", r.payment.method)));
+
+    if let Some(notes) = &r.order.notes {
+        cmds.push(PrinterCommand::Feed(1));
+        cmds.push(PrinterCommand::TextLine(format!("Notes: {}", notes)));
+    }
+
+    cmds.push(PrinterCommand::Feed(1));
+    cmds.push(PrinterCommand::Align(1));
+    cmds.push(PrinterCommand::TextLine("Thank you!".to_string()));
+    cmds.push(PrinterCommand::Feed(3));
+    cmds.push(PrinterCommand::Cut);
+
+    cmds
+}
+
+/// Render a kitchen ticket as a Vec<PrinterCommand>. No totals, larger
+/// item names, special-instructions footer.
+fn build_kitchen_ticket_commands(t: &KitchenTicketSnapshot) -> Vec<PrinterCommand> {
+    let mut cmds = vec![
+        PrinterCommand::Initialize,
+        PrinterCommand::Align(1),
+        PrinterCommand::Bold(true),
+        PrinterCommand::TextSize(2, 2),
+        PrinterCommand::TextLine(format!("Order #{}", t.order.order_number)),
+        PrinterCommand::TextSize(1, 1),
+        PrinterCommand::Bold(false),
+    ];
+
+    if let Some(table) = &t.order.table_number {
+        cmds.push(PrinterCommand::TextLine(format!("Table {}", table)));
+    }
+
+    cmds.push(PrinterCommand::Align(0));
+    cmds.push(PrinterCommand::TextLine(SEPARATOR.to_string()));
+
+    for item in &t.items {
+        cmds.push(PrinterCommand::Bold(true));
+        cmds.push(PrinterCommand::TextSize(2, 1));
+        cmds.push(PrinterCommand::TextLine(format!(
+            "{}x  {}",
+            item.quantity, item.name
+        )));
+        cmds.push(PrinterCommand::TextSize(1, 1));
+        cmds.push(PrinterCommand::Bold(false));
+        for modifier in &item.modifiers {
+            cmds.push(PrinterCommand::TextLine(format!("  + {}", modifier)));
+        }
+        if let Some(notes) = &item.notes {
+            cmds.push(PrinterCommand::TextLine(format!("  ({})", notes)));
+        }
+    }
+
+    if let Some(special) = &t.special_instructions {
+        cmds.push(PrinterCommand::TextLine(SEPARATOR.to_string()));
+        cmds.push(PrinterCommand::Bold(true));
+        cmds.push(PrinterCommand::TextLine(format!("** {} **", special)));
+        cmds.push(PrinterCommand::Bold(false));
+    }
+
+    cmds.push(PrinterCommand::Feed(3));
+    cmds.push(PrinterCommand::Cut);
+    cmds
 }
 
 fn main() {
@@ -266,6 +439,8 @@ fn main() {
             write_characteristic,
             read_characteristic,
             print_receipt,
+            print_kitchen_order,
+            open_cash_drawer,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -55,17 +55,54 @@ async fn scan_devices(
 
 /// Connect to a Bluetooth device
 #[tauri::command]
-async fn connect_device(device_id: String, state: State<'_, AppState>) -> Result<String, String> {
+async fn connect_device(
+    device_id: String,
+    app: tauri::AppHandle,
+    state: State<'_, AppState>,
+) -> Result<String, String> {
     let bt = state.bluetooth.lock().await;
     let manager = bt
         .as_ref()
         .ok_or("Bluetooth not initialized")?;
 
-    manager
-        .connect_device(&device_id)
-        .await
-        .map_err(|e| e.to_string())?;
+    let result = manager.connect_device(&device_id).await;
 
+    // Reflect the outcome in HardwareManager's status cache and emit a
+    // hardware-event so the UI can update its DeviceStatusIndicator
+    // without polling list_devices.
+    let mut hw = state.hardware.write().await;
+    if let Some(status) = hw.statuses.get_mut(&device_id) {
+        let device_name = status.name.clone();
+        match &result {
+            Ok(_) => {
+                status.mark_connected();
+                drop(hw);
+                hardware::events::emit(
+                    &app,
+                    hardware::events::HardwareEvent::DeviceConnected {
+                        device_id: device_id.clone(),
+                        device_name,
+                        timestamp: chrono::Utc::now(),
+                    },
+                );
+            }
+            Err(e) => {
+                let msg = e.to_string();
+                status.mark_error(msg.clone());
+                drop(hw);
+                hardware::events::emit(
+                    &app,
+                    hardware::events::HardwareEvent::ConnectionError {
+                        device_id: device_id.clone(),
+                        error: msg,
+                        timestamp: chrono::Utc::now(),
+                    },
+                );
+            }
+        }
+    }
+
+    result.map_err(|e| e.to_string())?;
     Ok(format!("Connected to device: {}", device_id))
 }
 
@@ -73,6 +110,7 @@ async fn connect_device(device_id: String, state: State<'_, AppState>) -> Result
 #[tauri::command]
 async fn disconnect_device(
     device_id: String,
+    app: tauri::AppHandle,
     state: State<'_, AppState>,
 ) -> Result<String, String> {
     let bt = state.bluetooth.lock().await;
@@ -84,6 +122,22 @@ async fn disconnect_device(
         .disconnect_device(&device_id)
         .await
         .map_err(|e| e.to_string())?;
+
+    // Update status + emit DeviceDisconnected event.
+    let mut hw = state.hardware.write().await;
+    if let Some(status) = hw.statuses.get_mut(&device_id) {
+        let device_name = status.name.clone();
+        status.mark_disconnected();
+        drop(hw);
+        hardware::events::emit(
+            &app,
+            hardware::events::HardwareEvent::DeviceDisconnected {
+                device_id: device_id.clone(),
+                device_name,
+                timestamp: chrono::Utc::now(),
+            },
+        );
+    }
 
     Ok(format!("Disconnected from device: {}", device_id))
 }

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -6,13 +6,17 @@ mod escpos;
 mod hardware;
 
 use bluetooth::{BluetoothManager, PrinterCommand, ScannedDevice};
+use hardware::config::DeviceConfig;
+use hardware::status::DeviceStatus;
+use hardware::HardwareManager;
 use std::sync::Arc;
-use tauri::{Manager, State};
+use tauri::State;
 use tokio::sync::Mutex;
 
-/// Application state holding the Bluetooth manager
+/// Application state holding the Bluetooth manager + hardware manager.
 struct AppState {
     bluetooth: Arc<Mutex<Option<BluetoothManager>>>,
+    hardware: HardwareManager,
 }
 
 /// Initialize Bluetooth manager
@@ -425,10 +429,200 @@ fn build_kitchen_ticket_commands(t: &KitchenTicketSnapshot) -> Vec<PrinterComman
     cmds
 }
 
+// ============================================================================
+// Hardware-suite Tauri commands
+// ============================================================================
+//
+// These back the `HardwareService` calls in `frontend/src/lib/tauri.ts` that
+// the React `IntegrationsSettingsPage` and `HardwareDeviceCard` UI invoke.
+// All read/write the persisted `hardware.json` via `hardware::*` helpers.
+
+/// Initialize the hardware subsystem. Loads `~/.kds/hardware.json`,
+/// populates the per-device status cache, and lazy-initializes the BLE
+/// manager so the connect flow has somewhere to land. The `backend_url`
+/// argument is accepted for forwards compatibility with future telemetry
+/// uploads but is not used today.
+#[tauri::command]
+async fn initialize_hardware(
+    _backend_url: Option<String>,
+    state: State<'_, AppState>,
+) -> Result<String, String> {
+    // Reload hardware.json so the in-memory state matches the file. Useful
+    // when an external editor changed the file between sessions.
+    let fresh = hardware::init_manager().await;
+    {
+        let mut guard = state.hardware.write().await;
+        let inner = fresh.read().await;
+        guard.config = inner.config.clone();
+        guard.statuses = inner.statuses.clone();
+    }
+
+    // Boot BLE if we have any Bluetooth devices configured (lazy init keeps
+    // the app launchable on machines that lack BLE adapters entirely).
+    let has_bluetooth = {
+        let guard = state.hardware.read().await;
+        guard.config.devices.iter().any(|d| {
+            matches!(
+                d.connection,
+                hardware::config::ConnectionConfig::Bluetooth(_)
+            )
+        })
+    };
+    if has_bluetooth {
+        let mut bt = state.bluetooth.lock().await;
+        if bt.is_none() {
+            *bt = Some(
+                BluetoothManager::new()
+                    .await
+                    .map_err(|e| e.to_string())?,
+            );
+        }
+    }
+
+    Ok("Hardware initialized".to_string())
+}
+
+/// List all configured devices with their current runtime status.
+#[tauri::command]
+async fn list_devices(state: State<'_, AppState>) -> Result<Vec<DeviceStatus>, String> {
+    Ok(hardware::list_statuses(&state.hardware).await)
+}
+
+/// Look up a single device's status by id.
+#[tauri::command]
+async fn get_device_status(
+    device_id: String,
+    state: State<'_, AppState>,
+) -> Result<DeviceStatus, String> {
+    hardware::get_status(&state.hardware, &device_id)
+        .await
+        .ok_or_else(|| format!("Device not found: {}", device_id))
+}
+
+/// Persist a new device row (or update an existing one with the same id).
+/// Returns the saved row so the frontend can echo it back into the list.
+#[tauri::command]
+async fn add_device(
+    device: DeviceConfig,
+    state: State<'_, AppState>,
+) -> Result<DeviceConfig, String> {
+    hardware::upsert_device(&state.hardware, device).await
+}
+
+/// Drop a device row + its status from the persisted config.
+#[tauri::command]
+async fn remove_device(
+    device_id: String,
+    state: State<'_, AppState>,
+) -> Result<String, String> {
+    hardware::remove_device(&state.hardware, &device_id).await?;
+    Ok(format!("Device {} removed", device_id))
+}
+
+/// Run a printer-specific test: prints a small receipt showcasing the
+/// CP-857 Turkish character set so the operator can confirm the printer
+/// is paired correctly and the code page is accepted.
+#[tauri::command]
+async fn test_device(
+    device_id: String,
+    state: State<'_, AppState>,
+) -> Result<String, String> {
+    let bt = state.bluetooth.lock().await;
+    let manager = bt
+        .as_ref()
+        .ok_or("Bluetooth not initialized — call initialize_hardware first")?;
+
+    let test_commands = vec![
+        PrinterCommand::Initialize,
+        PrinterCommand::Align(1),
+        PrinterCommand::Bold(true),
+        PrinterCommand::TextSize(2, 2),
+        PrinterCommand::TextLine("Test Receipt".to_string()),
+        PrinterCommand::Bold(false),
+        PrinterCommand::TextSize(1, 1),
+        PrinterCommand::Feed(1),
+        PrinterCommand::Align(0),
+        PrinterCommand::TextLine("--------------------------------".to_string()),
+        // Smoke-test the Turkish letter set end-to-end.
+        PrinterCommand::TextLine("Türkçe karakter testi".to_string()),
+        PrinterCommand::TextLine("ÇĞİÖŞÜ çğıöşü".to_string()),
+        PrinterCommand::TextLine("Adana Şiş Künefe Pide".to_string()),
+        PrinterCommand::TextLine("Hesap: 123,45 TL".to_string()),
+        PrinterCommand::TextLine("--------------------------------".to_string()),
+        PrinterCommand::Align(1),
+        PrinterCommand::TextLine("If you can read this,".to_string()),
+        PrinterCommand::TextLine("CP-857 is working.".to_string()),
+        PrinterCommand::Feed(3),
+        PrinterCommand::Cut,
+    ];
+
+    manager
+        .print(&device_id, test_commands)
+        .await
+        .map_err(|e| e.to_string())?;
+
+    Ok("Test print sent".to_string())
+}
+
+// ----------------------------------------------------------------------------
+// Legacy printer commands kept for the deprecated `PrinterService` path
+// (`frontend/src/components/desktop/PrinterSettings.tsx`). Implemented as
+// thin filters over the new hardware suite — when PrinterSettings.tsx is
+// replaced these can be deleted.
+// ----------------------------------------------------------------------------
+
+#[derive(serde::Serialize)]
+struct LegacyPrinterInfo {
+    name: String,
+    port: String,
+    status: String,
+}
+
+#[tauri::command]
+async fn list_printers(state: State<'_, AppState>) -> Result<Vec<LegacyPrinterInfo>, String> {
+    let guard = state.hardware.read().await;
+    let printers = guard
+        .config
+        .devices
+        .iter()
+        .filter(|d| {
+            matches!(
+                d.device_type,
+                hardware::config::DeviceType::ThermalPrinter
+            )
+        })
+        .map(|d| LegacyPrinterInfo {
+            name: d.name.clone(),
+            port: d.id.clone(),
+            status: guard
+                .statuses
+                .get(&d.id)
+                .map(|s| format!("{:?}", s.connection_status))
+                .unwrap_or_else(|| "Unknown".to_string()),
+        })
+        .collect();
+    Ok(printers)
+}
+
+#[tauri::command]
+async fn set_printer(port: String, state: State<'_, AppState>) -> Result<String, String> {
+    let mut guard = state.hardware.write().await;
+    guard.config.default_printer_port = Some(port.clone());
+    hardware::config::save(&guard.config).map_err(|e| e.to_string())?;
+    Ok(format!("Default printer set to {}", port))
+}
+
+#[tauri::command]
+async fn get_printer(state: State<'_, AppState>) -> Result<Option<String>, String> {
+    Ok(state.hardware.read().await.config.default_printer_port.clone())
+}
+
 fn main() {
+    let hardware = tauri::async_runtime::block_on(async { hardware::init_manager().await });
     tauri::Builder::default()
         .manage(AppState {
             bluetooth: Arc::new(Mutex::new(None)),
+            hardware,
         })
         .invoke_handler(tauri::generate_handler![
             init_bluetooth,
@@ -441,6 +635,17 @@ fn main() {
             print_receipt,
             print_kitchen_order,
             open_cash_drawer,
+            // hardware-suite commands
+            initialize_hardware,
+            list_devices,
+            get_device_status,
+            add_device,
+            remove_device,
+            test_device,
+            // legacy printer-service shims (kept until PrinterSettings.tsx replaced)
+            list_printers,
+            set_printer,
+            get_printer,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/frontend/src/components/hardware/HardwareDeviceCard.tsx
+++ b/frontend/src/components/hardware/HardwareDeviceCard.tsx
@@ -1,8 +1,10 @@
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { toast } from 'sonner';
 import { DeviceStatus, DeviceType } from '@/types/hardware';
 import { DeviceStatusIndicator } from './DeviceStatusIndicator';
 import { HardwareService } from '@/lib/tauri';
+import { useUiStore } from '@/store/uiStore';
 import Button from '@/components/ui/Button';
 import {
   Card,
@@ -16,9 +18,18 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
-import { MoreVertical, Printer, DollarSign, Radio, Barcode } from 'lucide-react';
+import {
+  MoreVertical,
+  Printer,
+  DollarSign,
+  Radio,
+  Barcode,
+  Star,
+  ChefHat,
+} from 'lucide-react';
 
 interface HardwareDeviceCardProps {
   device: DeviceStatus;
@@ -36,6 +47,19 @@ export function HardwareDeviceCard({
   const { t } = useTranslation(['settings', 'common']);
   const [isConnecting, setIsConnecting] = useState(false);
   const [isTesting, setIsTesting] = useState(false);
+
+  // Per-machine default-printer prefs from uiStore. THERMAL_PRINTER
+  // devices can be marked as the default receipt or kitchen printer —
+  // those defaults are what POSPage and usePosSocket read when firing
+  // auto-print on payment-success / order:new respectively.
+  const defaultReceiptPrinterId = useUiStore((s) => s.defaultReceiptPrinterId);
+  const defaultKitchenPrinterId = useUiStore((s) => s.defaultKitchenPrinterId);
+  const setDefaultReceiptPrinterId = useUiStore((s) => s.setDefaultReceiptPrinterId);
+  const setDefaultKitchenPrinterId = useUiStore((s) => s.setDefaultKitchenPrinterId);
+
+  const isPrinter = device.device_type === DeviceType.THERMAL_PRINTER;
+  const isDefaultReceipt = defaultReceiptPrinterId === device.id;
+  const isDefaultKitchen = defaultKitchenPrinterId === device.id;
 
   const getDeviceIcon = () => {
     switch (device.device_type) {
@@ -86,6 +110,36 @@ export function HardwareDeviceCard({
     }
   };
 
+  const handleSetDefaultReceipt = () => {
+    const next = isDefaultReceipt ? null : device.id;
+    setDefaultReceiptPrinterId(next);
+    toast.success(
+      next
+        ? t('settings.hardware.defaultReceiptSet', {
+            name: device.name,
+            defaultValue: '{{name}} is now the default receipt printer',
+          })
+        : t('settings.hardware.defaultReceiptCleared', {
+            defaultValue: 'Default receipt printer cleared',
+          }),
+    );
+  };
+
+  const handleSetDefaultKitchen = () => {
+    const next = isDefaultKitchen ? null : device.id;
+    setDefaultKitchenPrinterId(next);
+    toast.success(
+      next
+        ? t('settings.hardware.defaultKitchenSet', {
+            name: device.name,
+            defaultValue: '{{name}} is now the default kitchen printer',
+          })
+        : t('settings.hardware.defaultKitchenCleared', {
+            defaultValue: 'Default kitchen printer cleared',
+          }),
+    );
+  };
+
   const formatLastActivity = (lastActivity?: string) => {
     if (!lastActivity) return t('settings.hardware.lastActivity.never');
     const date = new Date(lastActivity);
@@ -106,8 +160,28 @@ export function HardwareDeviceCard({
           <div className="rounded-lg bg-primary/10 p-2 text-primary">
             {getDeviceIcon()}
           </div>
-          <div>
-            <CardTitle className="text-lg">{device.name}</CardTitle>
+          <div className="flex flex-col gap-1">
+            <CardTitle className="text-lg flex items-center gap-2">
+              {device.name}
+              {isDefaultReceipt && (
+                <span
+                  className="inline-flex items-center gap-1 rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-800"
+                  title={t('settings.hardware.defaultReceiptBadge', { defaultValue: 'Default receipt printer' })}
+                >
+                  <Star className="h-3 w-3 fill-current" />
+                  {t('settings.hardware.defaultReceiptShort', { defaultValue: 'Receipt' })}
+                </span>
+              )}
+              {isDefaultKitchen && (
+                <span
+                  className="inline-flex items-center gap-1 rounded-full bg-orange-100 px-2 py-0.5 text-xs font-medium text-orange-800"
+                  title={t('settings.hardware.defaultKitchenBadge', { defaultValue: 'Default kitchen printer' })}
+                >
+                  <ChefHat className="h-3 w-3" />
+                  {t('settings.hardware.defaultKitchenShort', { defaultValue: 'Kitchen' })}
+                </span>
+              )}
+            </CardTitle>
             <CardDescription>{t(`settings.integrationTypes.${device.device_type}`)}</CardDescription>
           </div>
         </div>
@@ -124,6 +198,24 @@ export function HardwareDeviceCard({
             <DropdownMenuItem onClick={handleTest} disabled={isTesting}>
               {isTesting ? t('settings.hardware.testing') : t('settings.hardware.testDevice')}
             </DropdownMenuItem>
+            {isPrinter && (
+              <>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem onClick={handleSetDefaultReceipt}>
+                  <Star className="h-4 w-4 mr-2" />
+                  {isDefaultReceipt
+                    ? t('settings.hardware.unsetDefaultReceipt', { defaultValue: 'Unset as default receipt printer' })
+                    : t('settings.hardware.setDefaultReceipt', { defaultValue: 'Set as default receipt printer' })}
+                </DropdownMenuItem>
+                <DropdownMenuItem onClick={handleSetDefaultKitchen}>
+                  <ChefHat className="h-4 w-4 mr-2" />
+                  {isDefaultKitchen
+                    ? t('settings.hardware.unsetDefaultKitchen', { defaultValue: 'Unset as default kitchen printer' })
+                    : t('settings.hardware.setDefaultKitchen', { defaultValue: 'Set as default kitchen printer' })}
+                </DropdownMenuItem>
+              </>
+            )}
+            <DropdownMenuSeparator />
             <DropdownMenuItem
               onClick={() => onDelete?.(device.id)}
               className="text-red-600"

--- a/frontend/src/components/pos/ReprintReceiptButton.tsx
+++ b/frontend/src/components/pos/ReprintReceiptButton.tsx
@@ -1,0 +1,83 @@
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { toast } from 'sonner';
+import { Printer } from 'lucide-react';
+import { Button } from '../ui/Button';
+import { HardwareService, isTauri } from '../../lib/tauri';
+import { useUiStore } from '../../store/uiStore';
+import type { Payment } from '../../types';
+
+interface ReprintReceiptButtonProps {
+  payment: Pick<Payment, 'id' | 'receiptSnapshot'>;
+  variant?: 'primary' | 'secondary' | 'outline' | 'ghost';
+  size?: 'sm' | 'md' | 'lg';
+  className?: string;
+}
+
+/**
+ * Reprint a customer receipt from a persisted snapshot. Disabled (with
+ * an explanatory tooltip) when:
+ *   - not running inside Tauri (web-only users have no printer)
+ *   - no default receipt printer configured in uiStore
+ *   - the payment has no `receiptSnapshot` (legacy payments from
+ *     before PR #216, or a payment whose snapshot build failed)
+ *
+ * Always works against the backend-persisted snapshot, never re-derives
+ * receipt content from order data — that way a reprint matches the
+ * original byte-for-byte even if the order was edited later.
+ */
+export function ReprintReceiptButton({
+  payment,
+  variant = 'outline',
+  size = 'sm',
+  className,
+}: ReprintReceiptButtonProps) {
+  const { t } = useTranslation(['pos', 'common']);
+  const defaultPrinterId = useUiStore((s) => s.defaultReceiptPrinterId);
+  const [isPrinting, setIsPrinting] = useState(false);
+
+  const inTauri = isTauri();
+  const hasSnapshot = !!payment.receiptSnapshot;
+  const hasPrinter = !!defaultPrinterId;
+  const enabled = inTauri && hasSnapshot && hasPrinter && !isPrinting;
+
+  const tooltip = !inTauri
+    ? t('pos.reprint.desktopOnly', 'Reprint is only available on the desktop POS app')
+    : !hasPrinter
+      ? t('pos.reprint.noPrinter', 'No default receipt printer configured')
+      : !hasSnapshot
+        ? t('pos.reprint.noSnapshot', 'This payment has no stored receipt snapshot')
+        : undefined;
+
+  const handleClick = async () => {
+    if (!enabled || !defaultPrinterId || !payment.receiptSnapshot) return;
+    setIsPrinting(true);
+    try {
+      await HardwareService.printReceipt(defaultPrinterId, payment.receiptSnapshot);
+      toast.success(t('pos.reprint.success', 'Receipt sent to printer'));
+    } catch (err) {
+      console.error('Reprint failed:', err);
+      toast.error(t('pos.reprint.failed', 'Reprint failed — check printer connection'));
+    } finally {
+      setIsPrinting(false);
+    }
+  };
+
+  return (
+    <Button
+      variant={variant}
+      size={size}
+      onClick={handleClick}
+      disabled={!enabled}
+      title={tooltip}
+      className={className}
+    >
+      <Printer className="h-4 w-4 mr-1.5" />
+      {isPrinting
+        ? t('pos.reprint.printing', 'Printing...')
+        : t('pos.reprint.label', 'Reprint Receipt')}
+    </Button>
+  );
+}
+
+export default ReprintReceiptButton;

--- a/frontend/src/features/pos/usePosSocket.ts
+++ b/frontend/src/features/pos/usePosSocket.ts
@@ -3,6 +3,8 @@ import { useQueryClient } from '@tanstack/react-query';
 import { initializeSocket, disconnectSocket } from '../../lib/socket';
 import { toast } from 'sonner';
 import i18n from '../../i18n/config';
+import { HardwareService, isTauri } from '../../lib/tauri';
+import { useUiStore } from '../../store/uiStore';
 
 export const usePosSocket = () => {
   const [isConnected, setIsConnected] = useState(false);
@@ -46,6 +48,26 @@ export const usePosSocket = () => {
 
     const handleNewOrder = (event: any) => {
       console.log('[POS Socket] New order received:', event);
+
+      // Auto-print kitchen ticket on the desktop POS terminal. Gated on
+      // isTauri() and a configured default kitchen printer; web users
+      // see no prints. Failures are logged but never surface to the
+      // operator — the snapshot is persisted on the backend so the
+      // ticket can be reprinted from the order detail view.
+      // Skip pending-approval orders: those go to kitchen only after a
+      // waiter approves, at which point they're emitted as a status
+      // change rather than order:new.
+      if (isTauri() && !event.requiresApproval) {
+        const kitchenPrinterId = useUiStore.getState().defaultKitchenPrinterId;
+        if (kitchenPrinterId && event.kitchenTicketSnapshot) {
+          HardwareService.printKitchenOrder(
+            kitchenPrinterId,
+            event.kitchenTicketSnapshot,
+          ).catch((err) => {
+            console.error('Kitchen ticket print failed:', err);
+          });
+        }
+      }
 
       // Pure Socket.IO Push: Directly inject order into React Query cache
       // No API calls, instant UI updates

--- a/frontend/src/lib/tauri.ts
+++ b/frontend/src/lib/tauri.ts
@@ -60,6 +60,58 @@ export class HardwareService {
   }
 
   /**
+   * Persist a new device row in `~/.kds/hardware.json` (or update an
+   * existing one with the same `id`). Per-machine config — each POS
+   * terminal has its own paired hardware. The frontend
+   * IntegrationsSettingsPage save flow calls this AFTER a successful
+   * backend integration write, so the tenant-level metadata and the
+   * per-terminal pairing stay in sync.
+   *
+   * The `device` shape is the JSON the Rust side deserializes into
+   * `hardware::config::DeviceConfig`. Matching field names + tagged
+   * connection union are documented in `frontend/src/types/hardware.ts`.
+   */
+  static async addDevice(device: {
+    id: string;
+    name: string;
+    device_type: string;
+    enabled: boolean;
+    auto_connect: boolean;
+    connection: { connection_type: string; config: Record<string, any> };
+    settings?: Record<string, any>;
+  }): Promise<unknown> {
+    if (!isTauri()) {
+      console.warn('addDevice only available in desktop mode');
+      return null;
+    }
+
+    try {
+      return await invoke('add_device', { device });
+    } catch (error) {
+      console.error('Failed to add device:', error);
+      throw error;
+    }
+  }
+
+  /**
+   * Drop a device row from `~/.kds/hardware.json`. Disconnect first if
+   * still connected; the caller can `disconnectDevice` separately to
+   * be explicit (we do that in IntegrationsSettingsPage's delete flow).
+   */
+  static async removeDevice(deviceId: string): Promise<string> {
+    if (!isTauri()) {
+      throw new Error('Hardware service only available in desktop mode');
+    }
+
+    try {
+      return await invoke<string>('remove_device', { deviceId });
+    } catch (error) {
+      console.error('Failed to remove device:', error);
+      throw error;
+    }
+  }
+
+  /**
    * Connect to a specific device
    */
   static async connectDevice(deviceId: string): Promise<string> {

--- a/frontend/src/lib/tauri.ts
+++ b/frontend/src/lib/tauri.ts
@@ -11,7 +11,9 @@ import type {
   HardwareConfig,
   HardwareEvent,
   ReceiptData as NewReceiptData,
+  ReceiptSnapshot,
   KitchenOrderData,
+  KitchenTicketSnapshot,
   TextAlignment,
   TextStyle,
   BarcodeType,
@@ -106,11 +108,14 @@ export class HardwareService {
   }
 
   /**
-   * Print receipt to a specific printer device
+   * Print a receipt by passing the backend-persisted snapshot directly.
+   * The Rust side accepts the same versioned shape (ReceiptSnapshot) so
+   * no client-side translation is needed — the JSON from
+   * Payment.receiptSnapshot ships through unchanged.
    */
   static async printReceipt(
     deviceId: string,
-    receipt: NewReceiptData
+    receipt: ReceiptSnapshot
   ): Promise<string> {
     if (!isTauri()) {
       console.warn('Hardware printing only available in desktop mode');
@@ -127,18 +132,20 @@ export class HardwareService {
   }
 
   /**
-   * Print kitchen order to a specific printer device
+   * Print a kitchen ticket from the backend-persisted snapshot.
+   * Same pass-through pattern as printReceipt — Rust accepts
+   * KitchenTicketSnapshot directly from Order.kitchenTicketSnapshot.
    */
   static async printKitchenOrder(
     deviceId: string,
-    order: KitchenOrderData
+    ticket: KitchenTicketSnapshot
   ): Promise<string> {
     if (!isTauri()) {
       throw new Error('Hardware printing only available in desktop mode');
     }
 
     try {
-      return await invoke<string>('print_kitchen_order', { deviceId, order });
+      return await invoke<string>('print_kitchen_order', { deviceId, ticket });
     } catch (error) {
       console.error('Failed to print kitchen order:', error);
       throw error;

--- a/frontend/src/lib/tauri.ts
+++ b/frontend/src/lib/tauri.ts
@@ -58,22 +58,6 @@ export class HardwareService {
   }
 
   /**
-   * Get status of a specific device
-   */
-  static async getDeviceStatus(deviceId: string): Promise<DeviceStatus> {
-    if (!isTauri()) {
-      throw new Error('Hardware service only available in desktop mode');
-    }
-
-    try {
-      return await invoke<DeviceStatus>('get_device_status', { deviceId });
-    } catch (error) {
-      console.error('Failed to get device status:', error);
-      throw error;
-    }
-  }
-
-  /**
    * Connect to a specific device
    */
   static async connectDevice(deviceId: string): Promise<string> {
@@ -173,30 +157,6 @@ export class HardwareService {
       return await invoke<string>('open_cash_drawer', { deviceId });
     } catch (error) {
       console.error('Failed to open cash drawer:', error);
-      throw error;
-    }
-  }
-
-  /**
-   * Call a restaurant pager
-   */
-  static async callPager(
-    deviceId: string,
-    pagerNumber: number,
-    alertType?: string
-  ): Promise<string> {
-    if (!isTauri()) {
-      throw new Error('Hardware control only available in desktop mode');
-    }
-
-    try {
-      return await invoke<string>('call_pager', {
-        deviceId,
-        pagerNumber,
-        alertType,
-      });
-    } catch (error) {
-      console.error('Failed to call pager:', error);
       throw error;
     }
   }

--- a/frontend/src/pages/pos/POSPage.tsx
+++ b/frontend/src/pages/pos/POSPage.tsx
@@ -348,6 +348,13 @@ const POSPage = () => {
           quantity: m.quantity,
         })),
       })),
+      // Stable per-click idempotency key. Backend dedupes by
+      // (tenantId, idempotencyKey) so a double-tap on a slow network
+      // returns the existing order instead of creating a duplicate.
+      // Generated here (in the click handler) — NOT in render — so it
+      // doesn't change between Axios's first request and any 401-refresh
+      // retry of the same logical action.
+      idempotencyKey: crypto.randomUUID(),
     };
 
     // Update existing order if currentOrderId exists, otherwise create new
@@ -424,6 +431,13 @@ const POSPage = () => {
           quantity: m.quantity,
         })),
       })),
+      // Stable per-click idempotency key. Backend dedupes by
+      // (tenantId, idempotencyKey) so a double-tap on a slow network
+      // returns the existing order instead of creating a duplicate.
+      // Generated here (in the click handler) — NOT in render — so it
+      // doesn't change between Axios's first request and any 401-refresh
+      // retry of the same logical action.
+      idempotencyKey: crypto.randomUUID(),
     };
 
     // Update existing order if currentOrderId exists, otherwise create new
@@ -485,6 +499,10 @@ const POSPage = () => {
         method: data.method as any,
         transactionId: data.transactionId,
         customerPhone: data.customerPhone || undefined,
+        // Same idempotency rationale as createOrder: backend has a partial
+        // unique index on (orderId, idempotencyKey) — a double-tap or
+        // 401-retry returns the existing payment instead of charging twice.
+        idempotencyKey: crypto.randomUUID(),
       },
       {
         onSuccess: (payment: Payment) => {

--- a/frontend/src/pages/pos/POSPage.tsx
+++ b/frontend/src/pages/pos/POSPage.tsx
@@ -490,16 +490,36 @@ const POSPage = () => {
         onSuccess: (payment: Payment) => {
           // Auto-print on the desktop POS terminal. Gated on isTauri()
           // and a configured default printer; web users see no prints.
-          // Failures are toasted but never block payment success — the
-          // snapshot is persisted on the backend so a manual reprint is
-          // always available.
+          // Failures are toasted with a one-tap Reprint action — the
+          // snapshot is persisted on the backend so a manual reprint
+          // never re-derives content (it matches the original
+          // byte-for-byte even if the order is edited later).
           if (isTauri()) {
             const printerId = useUiStore.getState().defaultReceiptPrinterId;
             if (printerId && payment.receiptSnapshot) {
-              HardwareService.printReceipt(printerId, payment.receiptSnapshot)
+              const snapshot = payment.receiptSnapshot;
+              HardwareService.printReceipt(printerId, snapshot)
                 .catch((err) => {
                   console.error('Receipt print failed:', err);
-                  toast.error(t('pos.payment.receiptPrintFailed', 'Receipt print failed — payment recorded; reprint available.'));
+                  toast.error(
+                    t('pos.payment.receiptPrintFailed', 'Receipt print failed — payment recorded.'),
+                    {
+                      action: {
+                        label: t('pos.reprint.label', 'Reprint Receipt'),
+                        onClick: () => {
+                          HardwareService.printReceipt(printerId, snapshot).catch(
+                            (e) => {
+                              console.error('Reprint failed:', e);
+                              toast.error(
+                                t('pos.reprint.failed', 'Reprint failed — check printer connection'),
+                              );
+                            },
+                          );
+                        },
+                      },
+                      duration: 10_000,
+                    },
+                  );
                 });
             }
             // Pop the cash drawer for cash payments.

--- a/frontend/src/pages/pos/POSPage.tsx
+++ b/frontend/src/pages/pos/POSPage.tsx
@@ -21,10 +21,12 @@ import BillSplitModal from '../../components/pos/BillSplitModal';
 import { useTables, useUpdateTableStatus, useMergeTables, useUnmergeTable, useUnmergeAll } from '../../features/tables/tablesApi';
 import { useGetPosSettings } from '../../features/pos/posApi';
 import { usePosSocket } from '../../features/pos/usePosSocket';
-import { Product, Table, TableStatus, OrderType, OrderStatus, SplitType, SplitPaymentEntry } from '../../types';
+import { Product, Table, TableStatus, OrderType, OrderStatus, SplitType, SplitPaymentEntry, Payment } from '../../types';
 import { Card, CardHeader, CardTitle, CardContent } from '../../components/ui/Card';
 import { useResponsive } from '../../hooks/useResponsive';
 import Spinner from '../../components/ui/Spinner';
+import { HardwareService, isTauri } from '../../lib/tauri';
+import { useUiStore } from '../../store/uiStore';
 
 // View state type
 type POSView = 'table-selection' | 'order';
@@ -485,7 +487,29 @@ const POSPage = () => {
         customerPhone: data.customerPhone || undefined,
       },
       {
-        onSuccess: () => {
+        onSuccess: (payment: Payment) => {
+          // Auto-print on the desktop POS terminal. Gated on isTauri()
+          // and a configured default printer; web users see no prints.
+          // Failures are toasted but never block payment success — the
+          // snapshot is persisted on the backend so a manual reprint is
+          // always available.
+          if (isTauri()) {
+            const printerId = useUiStore.getState().defaultReceiptPrinterId;
+            if (printerId && payment.receiptSnapshot) {
+              HardwareService.printReceipt(printerId, payment.receiptSnapshot)
+                .catch((err) => {
+                  console.error('Receipt print failed:', err);
+                  toast.error(t('pos.payment.receiptPrintFailed', 'Receipt print failed — payment recorded; reprint available.'));
+                });
+            }
+            // Pop the cash drawer for cash payments.
+            if (printerId && data.method === 'CASH') {
+              HardwareService.openCashDrawer(printerId).catch((err) => {
+                console.error('Cash drawer open failed:', err);
+              });
+            }
+          }
+
           // Refetch orders to update the list
           refetchOrders();
 

--- a/frontend/src/pages/settings/IntegrationsSettingsPage.tsx
+++ b/frontend/src/pages/settings/IntegrationsSettingsPage.tsx
@@ -151,26 +151,76 @@ const IntegrationsSettingsPage = () => {
 
     try {
       await deleteIntegration.mutateAsync(id);
-  toast.success(t('integrations.deleteSuccess'));
+      toast.success(t('integrations.deleteSuccess'));
+
+      // Remove from local hardware config too. Same fail-soft as save:
+      // a backend deletion that fails to remove the local row leaves
+      // the user with a "ghost" pairing, but it's recoverable by
+      // editing ~/.kds/hardware.json or re-adding/removing.
+      if (isTauri()) {
+        try {
+          await HardwareService.disconnectDevice(id).catch(() => undefined);
+          await HardwareService.removeDevice(id);
+        } catch (localErr) {
+          console.error('Failed to remove device from local hardware config:', localErr);
+        }
+      }
+
       refetch();
       loadHardwareDevices();
     } catch (error) {
-  toast.error(t('integrations.deleteFailed'));
+      toast.error(t('integrations.deleteFailed'));
     }
   };
 
   const handleSaveDevice = async (config: any) => {
     try {
+      // Backend integrations table holds tenant-level abstract metadata
+      // ("we use a Star Micronics printer of model X"). Each terminal's
+      // physical pairing lives in ~/.kds/hardware.json on that machine,
+      // managed via HardwareService.addDevice. We update both: the
+      // tenant row + the local row. The local row is what the auto-
+      // print path reads when firing on payment-success / order:new.
+      let savedRow;
       if (editingDevice) {
-        await updateIntegration.mutateAsync({
+        savedRow = await updateIntegration.mutateAsync({
           id: editingDevice.id,
           data: config,
         });
-  toast.success(t('hardware.deviceUpdated'));
+        toast.success(t('hardware.deviceUpdated'));
       } else {
-        await createIntegration.mutateAsync(config);
-  toast.success(t('hardware.deviceAdded'));
+        savedRow = await createIntegration.mutateAsync(config);
+        toast.success(t('hardware.deviceAdded'));
       }
+
+      // Mirror to ~/.kds/hardware.json on the current terminal so the
+      // POS print path can find this device. Failure here is logged
+      // but doesn't fail the save — the backend row still exists,
+      // and the user can retry by re-saving.
+      if (isTauri() && savedRow) {
+        try {
+          const cfg = config.configuration || {};
+          await HardwareService.addDevice({
+            id: savedRow.id ?? editingDevice?.id,
+            name: config.provider,
+            device_type: config.integrationType,
+            enabled: !!config.isEnabled,
+            auto_connect: !!cfg.auto_connect,
+            connection: {
+              connection_type: cfg.connection_type,
+              config: cfg.connection_config,
+            },
+          });
+        } catch (localErr) {
+          console.error('Failed to mirror device to local hardware config:', localErr);
+          toast.warning(
+            t('hardware.localMirrorFailed', {
+              defaultValue: 'Saved on backend but local pairing failed — check ~/.kds/hardware.json',
+            }),
+          );
+        }
+      }
+
       setDeviceConfigModalOpen(false);
       setEditingDevice(null);
       refetch();
@@ -180,7 +230,7 @@ const IntegrationsSettingsPage = () => {
         loadHardwareDevices();
       }, 1000);
     } catch (error) {
-  toast.error(t('hardware.deviceSaveFailed'));
+      toast.error(t('hardware.deviceSaveFailed'));
     }
   };
 

--- a/frontend/src/store/uiStore.ts
+++ b/frontend/src/store/uiStore.ts
@@ -25,6 +25,15 @@ interface UiState {
   resetTour: (tourId: string) => void;
   setSkipAllTours: (skip: boolean) => void;
   resetAllOnboarding: () => void;
+
+  // Per-machine hardware preferences. Persisted in localStorage so each
+  // POS terminal remembers its own paired printer / drawer / kitchen
+  // printer; not synced to the backend (each terminal has its own
+  // hardware).
+  defaultReceiptPrinterId: string | null;
+  defaultKitchenPrinterId: string | null;
+  setDefaultReceiptPrinterId: (id: string | null) => void;
+  setDefaultKitchenPrinterId: (id: string | null) => void;
 }
 
 const initialOnboardingState: OnboardingState = {
@@ -97,6 +106,16 @@ export const useUiStore = create<UiState>()(
 
       resetAllOnboarding: () => {
         set({ onboarding: initialOnboardingState });
+      },
+
+      // Per-machine hardware preferences
+      defaultReceiptPrinterId: null,
+      defaultKitchenPrinterId: null,
+      setDefaultReceiptPrinterId: (id) => {
+        set({ defaultReceiptPrinterId: id });
+      },
+      setDefaultKitchenPrinterId: (id) => {
+        set({ defaultKitchenPrinterId: id });
       },
     }),
     {

--- a/frontend/src/types/hardware.ts
+++ b/frontend/src/types/hardware.ts
@@ -178,6 +178,77 @@ export type HardwareEvent =
     };
 
 // Printing Data Types
+
+/**
+ * Versioned receipt snapshot — produced by the backend
+ * ReceiptSnapshotBuilder (see backend/src/modules/orders/services/
+ * receipt-snapshot.builder.ts) and stored on Payment.receiptSnapshot.
+ *
+ * The desktop Tauri app accepts this shape directly via
+ * HardwareService.printReceipt(deviceId, snapshot). Decimal-bearing
+ * fields are STRINGS (e.g. "118.00") so JS Number arithmetic can't
+ * drift them. Bump `version` only when renaming/removing fields;
+ * additive optional fields don't require a bump.
+ */
+export interface ReceiptSnapshot {
+  version: 1;
+  restaurant: {
+    name: string;
+    currency: string;
+  };
+  order: {
+    id: string;
+    orderNumber: string;
+    type: string;
+    tableNumber: string | null;
+    notes: string | null;
+  };
+  items: Array<{
+    name: string;
+    quantity: number;
+    unitPrice: string;
+    totalPrice: string;
+    modifiers: string[];
+    notes: string | null;
+  }>;
+  totals: {
+    subtotal: string;
+    tax: string;
+    discount: string;
+    total: string;
+  };
+  payment: {
+    method: string;
+    transactionId: string | null;
+    paidAt: string;
+  };
+  printedAt: string;
+}
+
+/**
+ * Versioned kitchen-ticket snapshot — produced by the same builder and
+ * stored on Order.kitchenTicketSnapshot.
+ */
+export interface KitchenTicketSnapshot {
+  version: 1;
+  order: {
+    id: string;
+    orderNumber: string;
+    type: string;
+    tableNumber: string | null;
+  };
+  items: Array<{
+    name: string;
+    quantity: number;
+    modifiers: string[];
+    notes: string | null;
+  }>;
+  specialInstructions: string | null;
+  createdAt: string;
+}
+
+// Legacy types — kept for the deprecated PrinterService path until
+// PrinterSettings.tsx is replaced. New callsites use ReceiptSnapshot.
 export interface ReceiptItem {
   name: string;
   quantity: number;

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -437,6 +437,13 @@ export interface Payment {
   tenantId: string;
   createdAt: string;
   updatedAt: string;
+  // Versioned receipt content captured at payment-create time. Backend
+  // builds via ReceiptSnapshotBuilder; desktop Tauri app accepts the
+  // shape directly via HardwareService.printReceipt. See
+  // frontend/src/types/hardware.ts for the ReceiptSnapshot interface
+  // and backend/src/modules/orders/services/receipt-snapshot.builder.ts
+  // for the producer.
+  receiptSnapshot?: import('./hardware').ReceiptSnapshot | null;
 }
 
 export interface CreatePaymentDto {

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -400,6 +400,14 @@ export interface CreateOrderDto {
   items: CreateOrderItemDto[];
   notes?: string;
   discount?: number;
+  /**
+   * Client-generated UUID — same value across retries of the same logical
+   * "Send to Kitchen" click so a double-tap or 401-refresh-retry never
+   * creates duplicate orders. Backend dedupes by (tenantId, idempotencyKey)
+   * via a partial unique index. Optional: legacy callers without one still
+   * succeed (just without the dedup guarantee).
+   */
+  idempotencyKey?: string;
 }
 
 export interface UpdateOrderDto {
@@ -452,6 +460,14 @@ export interface CreatePaymentDto {
   method: PaymentMethod;
   transactionId?: string;
   customerPhone?: string;
+  /**
+   * Client-generated UUID for the "Confirm Payment" click. Backend has
+   * a partial unique index on (orderId, idempotencyKey) — repeating the
+   * same key returns the existing payment row instead of creating a
+   * second one. See payments.service.ts:62-78 for the fast-path read
+   * and the P2002 catch that handles the concurrent-retry race.
+   */
+  idempotencyKey?: string;
 }
 
 export interface UpdatePaymentDto {


### PR DESCRIPTION
## Summary

Phase 1.3 partial — the desktop+POS+camera reliability work that follows PR #216. Implements:

- **Bug E (Turkish encoding):** `desktop/src-tauri/src/escpos/codepage.rs` UTF-8→CP-857 transcoder. \`PrinterCommand::Initialize\` now emits \`ESC @ + ESC t 13\` (select CP-857) so Turkish menu items (Adana, Şiş, Künefe, etc.) print legibly.
- **Bug A Tier 1 partial:** Rust \`print_receipt\` now accepts the backend's versioned \`ReceiptSnapshot\` shape directly. New Tauri commands: \`print_kitchen_order\`, \`open_cash_drawer\`. Removed dead frontend wrappers (\`callPager\`, \`getDeviceStatus\`).
- **Frontend wiring:** \`POSPage\` payment-success now auto-prints the receipt and opens the cash drawer (CASH method). \`usePosSocket.handleNewOrder\` auto-prints kitchen tickets on \`order:new\`. Both gated on \`isTauri()\` + per-machine \`defaultReceiptPrinterId\` / \`defaultKitchenPrinterId\` in \`uiStore\`. Failures toast but never block payment.

Built on PR #216 — that one **must merge first** since this branch reads \`Payment.receiptSnapshot\` and \`Order.kitchenTicketSnapshot\` columns added there.

## Verified

- \`cargo check\` passes (Tauri 1.x on Ubuntu 24.04 needs the libwebkit2gtk-4.0 → 4.1 .pc symlink).
- \`tsc --noEmit\` introduces zero new errors. (Pre-existing errors in unrelated files like \`PrinterSettings.tsx\` are untouched.)
- CP-857 transcoder: 9/9 tests pass via standalone \`rustc --test\` (full \`cargo test\` requires \`libwebkit2gtk-4.0.so\` symlink which is environmental).

## What's NOT in this PR (deferred to follow-up)

Phase 1.3 plan has 27 tasks; this PR covers ~12 of them. Still needed:

- Sub-phase 1.3.A.3 — \`Connection\` trait + Serial + Network connection types (today: BLE only)
- Sub-phase 1.3.C — \`HardwareConfig\` persistence to \`~/.kds/hardware.json\`, \`HardwareManager\`, hardware events emitter, \`initialize_hardware\`/\`list_devices\`/\`add_device\`/\`remove_device\`/\`test_device\` commands
- Reprint button on payment detail
- Replace legacy \`PrinterService\` + \`PrinterSettings.tsx\`
- End-to-end smoke test on real hardware

Plan at \`docs/superpowers/plans/2026-04-27-phase-1-3-tauri-hardware-suite.md\`.

## Test plan

- [ ] PR #216 merged first (this branch needs the snapshot columns).
- [ ] Build desktop app on a Tauri-buildable env: \`cd desktop && npm run tauri:build\`.
- [ ] On a real BLE thermal printer, pair via existing settings flow.
- [ ] Set printer ID into uiStore: \`localStorage.setItem('ui-storage', JSON.stringify({...current, defaultReceiptPrinterId: '<deviceId>'}))\` (UI for this is Phase 1.3.D follow-up).
- [ ] Take an order with a Turkish item (e.g. "Şiş Kebap"). Send to kitchen → kitchen ticket prints.
- [ ] Pay in cash → receipt prints + cash drawer opens.
- [ ] Pay by card → receipt prints, cash drawer does NOT open.
- [ ] Disconnect printer → pay → toast fires + payment succeeds + snapshot is persisted (verifiable via DB query on \`Payment.receiptSnapshot\`).
- [ ] Web mode (\`isTauri() === false\`): no print attempts, no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)