### PR TITLE
ci(diagnose): use the existing setup-ssh composite action

### DIFF
--- a/.github/workflows/staging-diagnose.yml
+++ b/.github/workflows/staging-diagnose.yml
@@ -43,15 +43,15 @@ jobs:
             exit 1
           fi
 
+      - name: Checkout (for composite action)
+        uses: actions/checkout@v4
+
       - name: Setup SSH
-        env:
-          SSH_PRIVATE_KEY: ${{ secrets.SERVER_SSH_KEY }}
-        run: |
-          mkdir -p ~/.ssh
-          chmod 700 ~/.ssh
-          printf '%s\n' "$SSH_PRIVATE_KEY" > ~/.ssh/id_ed25519
-          chmod 600 ~/.ssh/id_ed25519
-          ssh-keyscan -H "$SERVER_HOST" >> ~/.ssh/known_hosts 2>/dev/null
+        uses: ./.github/actions/setup-ssh
+        with:
+          ssh-private-key-base64: ${{ secrets.SSH_PRIVATE_KEY_BASE64 }}
+          ssh-known-hosts: ${{ secrets.SSH_KNOWN_HOSTS }}
+          server-host: ${{ env.SERVER_HOST }}
 
       - name: Container inventory
         run: |


### PR DESCRIPTION
First cut had wrong SSH secret name (SERVER_SSH_KEY). Use the repo's setup-ssh composite action which expects SSH_PRIVATE_KEY_BASE64 + SSH_KNOWN_HOSTS — same as test-deploy.yml. Run 26429915675 failed with libcrypto error from missing/wrong secret.