### PR TITLE
ops(deploy): bump staging health budget 180s → 300s

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -122,7 +122,14 @@ configure_env() {
     API_PUBLIC_URL="https://staging.hummytummy.com/api/health"
     FRONTEND_PUBLIC_URL="https://staging.hummytummy.com"
     LANDING_PUBLIC_URL="https://staging.hummytummy.com/landing"
-    HEALTH_BUDGET_SEC=180
+    # Aligned with prod (300s). NestJS bootstrap now registers hundreds of
+    # routes from marketplace + hardware-store + fiscal + caller +
+    # integration-gateway + outbound-webhooks, plus Prisma client
+    # introspection across 50+ tables. The original 180s budget assumed a
+    # leaner module graph; rotation logs show route-mapping continuing
+    # past 180s on cold boots, so the old budget caused false-positive
+    # rollbacks where the backend was simply still booting.
+    HEALTH_BUDGET_SEC=300
     BACKUP_RETENTION_DAYS=3
     BACKUP_PREFIX="staging"
   fi


### PR DESCRIPTION
## Summary
Backend NestJS bootstrap has grown past the 180s staging budget. Modules added in the HummyTummy expansion (marketplace, hardware-store, fiscal, caller, integration-gateway, outbound-webhooks) register hundreds of routes; Prisma client introspects 50+ tables.

Cold-boot route mapping in run 26430079664 was still logging at the time deploy.sh declared failure. Same wall hit on rollback → staging left with no backend container.

300s matches the prod budget. Cold-boot ceiling is ~4 min on this host.

## Test plan
- [ ] Merge → re-trigger Test Environment Deployment → backend reaches healthy within budget → no rollback fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)