### PR TITLE
ops(deploy): extend backend healthcheck start_period to 240s

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -122,8 +122,10 @@ services:
       test: ['CMD', 'curl', '-f', 'http://0.0.0.0:3000/api/health']
       interval: 30s
       timeout: 10s
-      retries: 3
-      start_period: 40s
+      retries: 5
+      # See docker-compose.staging.yml for rationale — backend bootstrap
+      # has grown past the old 40s budget.
+      start_period: 240s
     networks:
       - kds_network
 

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -85,8 +85,15 @@ services:
       test: ['CMD', 'curl', '-f', 'http://localhost:3002/api/health']
       interval: 30s
       timeout: 10s
-      retries: 3
-      start_period: 40s
+      retries: 5
+      # Cold backend bootstrap takes ~3-4 min — NestJS registers hundreds
+      # of routes from marketplace + hardware-store + fiscal + caller +
+      # integration-gateway + outbound-webhooks before opening its HTTP
+      # listener, plus Prisma client introspection across 50+ tables.
+      # Old 40s start_period tripped well before the listener was up,
+      # causing docker compose to declare unhealthy → deploy.sh aborted.
+      # 240s leaves comfortable margin.
+      start_period: 240s
     networks:
       - kds_staging_network
     deploy:


### PR DESCRIPTION
## Summary
Root cause of the three failed staging deploys today (runs 26395855804, 26430079664, 26430406824): docker-compose declared the backend container unhealthy at ~130s (40s start_period + 3×30s retries), but NestJS bootstrap takes ~3-4 min on cold boot.

Backend logs from diagnose run 26430329224 show route mapping still in flight past the old deadline. The previous PR bumped deploy.sh's own poll to 300s, but docker compose killed the container first.

## Test plan
- [ ] Merge → re-trigger Test Environment Deployment → backend reaches `healthy` before docker compose times out → no rollback fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)