### PR TITLE
fix(config): blank env vars must mean unset — unbrick staging deploys

### DIFF
--- a/backend/src/config/env.validation.spec.ts
+++ b/backend/src/config/env.validation.spec.ts
@@ -34,8 +34,23 @@ describe("env validation (typed layer — secrets are owned by common/helpers/en
     ).not.toThrow();
   });
 
-  it("rejects an empty REDIS_URL (set-but-blank is a misconfiguration)", () => {
-    expect(() => validate({ REDIS_URL: "" })).toThrow(/REDIS_URL/);
+  // Regression: a blank OTEL_EXPORTER_OTLP_ENDPOINT= placeholder in the
+  // staging .env crash-looped the backend on 2026-06-11 (health probe
+  // timeout -> rollback). Blank string must mean "unset", matching the
+  // boot validator's `!value || value.trim() === ""` semantics.
+  it("treats blank strings as unset for every optional (VAR= placeholders)", () => {
+    expect(() =>
+      validate({
+        OTEL_EXPORTER_OTLP_ENDPOINT: "",
+        REDIS_URL: "",
+        PORT: "",
+        METRICS_TOKEN: "  ",
+        NODE_ENV: "staging",
+      }),
+    ).not.toThrow();
+  });
+
+  it("still type-checks REDIS_URL when actually set", () => {
     expect(() =>
       validate({ REDIS_URL: "redis://redis:6379/2" }),
     ).not.toThrow();

--- a/backend/src/config/env.validation.ts
+++ b/backend/src/config/env.validation.ts
@@ -64,7 +64,19 @@ export class EnvironmentVariables {
 export function validate(
   config: Record<string, unknown>,
 ): EnvironmentVariables {
-  const validated = plainToInstance(EnvironmentVariables, config, {
+  // Blank string = unset. .env templates routinely ship `VAR=` placeholders
+  // and dotenv delivers those as "", which @IsOptional() does NOT skip —
+  // a blank OTEL_EXPORTER_OTLP_ENDPOINT= crash-looped staging on
+  // 2026-06-11. The boot validator (common/helpers/env-validation.ts:104)
+  // already treats blank-or-missing identically; this layer must agree.
+  // Presence requirements belong in the boot validator's RULES, not here.
+  const normalized = Object.fromEntries(
+    Object.entries(config).filter(
+      ([, value]) => !(typeof value === "string" && value.trim() === ""),
+    ),
+  );
+
+  const validated = plainToInstance(EnvironmentVariables, normalized, {
     enableImplicitConversion: true,
   });
 


### PR DESCRIPTION
## Problem

The first deploy after PR #227 failed: `Deploy staging` crash-looped for 600s and auto-rolled back. Staging is currently healthy **on the previous images** — the new code never went live, and every future push to `test` would hit the same wall.

Root cause from the run logs (`27374737302`):

```
Environment validation failed (NODE_ENV=staging):
  - OTEL_EXPORTER_OTLP_ENDPOINT: OTEL_EXPORTER_OTLP_ENDPOINT must be a URL address
```

The staging `.env` carries a blank `OTEL_EXPORTER_OTLP_ENDPOINT=` placeholder. `@IsOptional()` only skips `null`/`undefined`, so the empty string hit `@IsUrl` and ConfigModule threw on every boot.

## Fix

Strip blank/whitespace-only strings before validation: **blank = unset**, which is exactly the semantics the boot validator already uses (`common/helpers/env-validation.ts:104` — `!value || value.trim() === ""`). Shape rules in the typed layer now apply only to genuinely-set values; presence rules remain the boot validator's job.

This is systemic, not just OTel: a blank `PORT=` would have failed as NaN, a blank `REDIS_URL=` on `@IsNotEmpty` — any `VAR=` template placeholder could brick boot.

## Verification

- New regression spec: blank `OTEL_EXPORTER_OTLP_ENDPOINT` / `REDIS_URL` / `PORT` / whitespace `METRICS_TOKEN` under `NODE_ENV=staging` boots clean; invalid non-blank values still rejected. 8/8 specs green locally.
- Merging this re-triggers the test deploy; staging should come up on the new images this time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
