### PR TITLE
Deep code review hardening: money/security/correctness across backend, frontend & native

### DIFF
--- a/apps/kds-kiosk/src/api/mesh.spec.ts
+++ b/apps/kds-kiosk/src/api/mesh.spec.ts
@@ -4,6 +4,7 @@ import {
   heartbeat,
   claimNextCommand,
   ackCommand,
+  DeviceAuthError,
   type DeviceCommand,
   type PairOut,
 } from './mesh';
@@ -108,6 +109,12 @@ describe('claimNextCommand', () => {
     fetchMock.mockResolvedValueOnce(jsonResponse('', { ok: false, status: 503 }));
     await expect(claimNextCommand(token)).rejects.toThrow('next-command 503');
   });
+
+  // deep-review NH8: 401/403 must be a distinct, recoverable auth error.
+  it('throws DeviceAuthError on a 401 next-command response', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse('', { ok: false, status: 401 }));
+    await expect(claimNextCommand(token)).rejects.toBeInstanceOf(DeviceAuthError);
+  });
 });
 
 describe('heartbeat', () => {
@@ -135,5 +142,33 @@ describe('ackCommand', () => {
     expect(init.method).toBe('POST');
     expect((init.headers as Headers).get('Authorization')).toBe('Device secret-token');
     expect(JSON.parse(init.body as string)).toEqual({ status: 'done', result: { printed: true } });
+  });
+
+  // deep-review NM3: a failed ack must throw, not be treated as success, so the
+  // poll loop retries it instead of abandoning the command to redelivery.
+  it('throws on a 500 ack response', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse('', { ok: false, status: 500 }));
+    await expect(ackCommand(token, 'cmd-42', { status: 'done' })).rejects.toThrow('ack 500');
+  });
+
+  // deep-review NH8/NM3: 401 on ack is the typed auth error so the loop re-pairs.
+  it('throws DeviceAuthError on a 401 ack response', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse('', { ok: false, status: 401 }));
+    await expect(ackCommand(token, 'cmd-42', { status: 'done' })).rejects.toBeInstanceOf(
+      DeviceAuthError,
+    );
+  });
+});
+
+describe('heartbeat auth', () => {
+  // deep-review NH8: heartbeat previously ignored res.ok entirely.
+  it('throws DeviceAuthError on a 403 heartbeat response', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse('', { ok: false, status: 403 }));
+    await expect(heartbeat(token, { queueDepth: 1 })).rejects.toBeInstanceOf(DeviceAuthError);
+  });
+
+  it('does not throw on a non-auth non-ok heartbeat response (best-effort)', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse('', { ok: false, status: 500 }));
+    await expect(heartbeat(token, { queueDepth: 1 })).resolves.toBeUndefined();
   });
 });

--- a/apps/kds-kiosk/src/api/mesh.ts
+++ b/apps/kds-kiosk/src/api/mesh.ts
@@ -9,6 +9,18 @@
  */
 import type { DeviceToken } from '../store/deviceToken';
 
+/**
+ * Thrown when the cloud rejects the device token (401/403) — distinct from a
+ * generic transient/network error so callers can branch to a re-pair flow
+ * instead of folding it into exponential backoff. deep-review NH8.
+ */
+export class DeviceAuthError extends Error {
+  constructor(message = 'device token rejected') {
+    super(message);
+    this.name = 'DeviceAuthError';
+  }
+}
+
 export interface PairOut {
   deviceId: string;
   tenantId: string;
@@ -46,18 +58,32 @@ export async function pairDevice(apiUrl: string, pairCode: string): Promise<Pair
   return res.json();
 }
 
+/**
+ * Throw a typed auth error on 401/403 so callers can route to re-pair, before
+ * any generic status handling. deep-review NH8 / NM3.
+ */
+function assertAuthed(res: Response): void {
+  if (res.status === 401 || res.status === 403) {
+    throw new DeviceAuthError(`device token rejected (${res.status})`);
+  }
+}
+
 export async function heartbeat(
   token: DeviceToken,
   payload: { batteryPct?: number; queueDepth?: number; agentVersion?: string },
 ): Promise<void> {
-  await withToken('/v1/devices/heartbeat', token, {
+  const res = await withToken('/v1/devices/heartbeat', token, {
     method: 'POST',
     body: JSON.stringify(payload),
   });
+  // heartbeat is best-effort, but a 401/403 must still surface so the kiosk
+  // can re-pair rather than silently pumping rejected heartbeats. deep-review NH8.
+  assertAuthed(res);
 }
 
 export async function claimNextCommand(token: DeviceToken): Promise<DeviceCommand | null> {
   const res = await withToken('/v1/devices/next-command', token, { method: 'GET' });
+  assertAuthed(res);
   if (!res.ok) throw new Error(`next-command ${res.status}`);
   const body = (await res.json()) as DeviceCommand | null;
   return body && body.id ? body : null;
@@ -68,8 +94,14 @@ export async function ackCommand(
   commandId: string,
   payload: { status: 'done' | 'failed'; result?: Record<string, unknown>; error?: string },
 ): Promise<void> {
-  await withToken(`/v1/devices/commands/${commandId}/ack`, token, {
+  const res = await withToken(`/v1/devices/commands/${commandId}/ack`, token, {
     method: 'POST',
     body: JSON.stringify(payload),
   });
+  // deep-review NM3: a failed ack was previously treated as success, so the
+  // server redelivered the command while the client moved on. Surface non-2xx
+  // (401/403 as DeviceAuthError, else a thrown error) so the poll loop retries
+  // the ack once connectivity/token recovers.
+  assertAuthed(res);
+  if (!res.ok) throw new Error(`ack ${res.status}`);
 }

--- a/apps/kds-kiosk/src/screens/KitchenScreen.tsx
+++ b/apps/kds-kiosk/src/screens/KitchenScreen.tsx
@@ -1,7 +1,24 @@
 import { useEffect, useRef, useState } from 'react';
-import { ackCommand, claimNextCommand, heartbeat } from '../api/mesh';
+import { ackCommand, claimNextCommand, DeviceAuthError, heartbeat, type DeviceCommand } from '../api/mesh';
 import type { DeviceToken } from '../store/deviceToken';
 import { ageOf, applyCommand, type OrderTicket } from './kitchenLogic';
+
+/**
+ * Whether this build can meaningfully execute a command. Mirrors the kinds
+ * applyCommand actually acts on, plus the shared-bus 'noop'. Anything else
+ * (a future print/fiscal kind, a typo'd kind, or show/clear without an
+ * orderId) is NOT handled and must be acked 'failed' rather than silently
+ * acked 'done' — otherwise the cloud marks it complete and never retries.
+ * deep-review NM4. (Prescribed fix lives in kitchenLogic.applyCommand, which
+ * is out of scope for this cluster; computed here once, outside the setTickets
+ * updater, so applyCommand stays pure and is called exactly once.)
+ */
+function isHandledCommand(cmd: DeviceCommand): boolean {
+  const orderId = (cmd.payload?.orderId as string | undefined) ?? '';
+  if (cmd.kind === 'show_order' || cmd.kind === 'clear_order') return orderId !== '';
+  if (cmd.kind === 'noop') return true;
+  return false;
+}
 
 /**
  * Main kitchen view.
@@ -23,6 +40,19 @@ export default function KitchenScreen({ token, onLogout }: { token: DeviceToken;
 
   useEffect(() => {
     let stop = false;
+    // deep-review NH8: PairOut tokens are time-bounded (expiresAt). If the
+    // persisted token is already expired (with a small clock-skew margin),
+    // re-pair immediately rather than burning a round-trip on a guaranteed 401.
+    const SKEW_MS = 30_000;
+    function expiredNow(): boolean {
+      const exp = Date.parse(token.expiresAt);
+      return Number.isFinite(exp) && exp - SKEW_MS <= Date.now();
+    }
+    if (expiredNow()) {
+      setLastError('Session expired — re-pair this device');
+      onLogout();
+      return;
+    }
     // Guard against overlapping iterations. ESC/POS prints can take 3-5s;
     // without this flag the 2s setInterval would re-enter loop() before
     // the previous ack completes, claim the same command in the new race,
@@ -35,17 +65,46 @@ export default function KitchenScreen({ token, onLogout }: { token: DeviceToken;
 
     async function loop() {
       if (inFlight || stop) return;
+      // deep-review NH8: proactively re-pair once the token crosses expiry,
+      // rather than waiting for the next server 401.
+      if (expiredNow()) {
+        stop = true;
+        setLastError('Session expired — re-pair this device');
+        onLogout();
+        return;
+      }
       inFlight = true;
       try {
         const cmd = await claimNextCommand(token);
         if (stop) return;
         consecutiveErrors = 0;
         if (!cmd) return;
+        // Compute handled + next list once, outside the updater, so the result
+        // is available to the ack and applyCommand stays pure. deep-review NM4.
+        const handled = isHandledCommand(cmd);
         setTickets((prev) => applyCommand(prev, cmd, Date.now()));
         if (stop) return;
-        await ackCommand(token, cmd.id, { status: 'done', result: {} });
+        if (handled) {
+          await ackCommand(token, cmd.id, { status: 'done', result: {} });
+        } else {
+          // Unknown / unactionable kind: ack 'failed' so the cloud surfaces it
+          // (device.command.failed.v1) instead of recording a silent success.
+          // deep-review NM4.
+          console.warn(`[kds] unhandled command kind '${cmd.kind}' (id=${cmd.id})`);
+          await ackCommand(token, cmd.id, { status: 'failed', error: `unsupported kind: ${cmd.kind}` });
+          setLastError(`Ignored unsupported command: ${cmd.kind}`);
+        }
       } catch (e: any) {
         if (stop) return;
+        // deep-review NH8: a rejected device token is a recoverable, distinct
+        // state — drop straight back to pairing instead of throttling forever
+        // behind exponential backoff with a frozen ticket list.
+        if (e instanceof DeviceAuthError) {
+          stop = true;
+          setLastError('Session expired — re-pair this device');
+          onLogout();
+          return;
+        }
         consecutiveErrors = Math.min(consecutiveErrors + 1, 6);
         setLastError(e?.message ?? 'poll failed');
       } finally {

--- a/apps/kds-kiosk/src/screens/PairingScreen.spec.ts
+++ b/apps/kds-kiosk/src/screens/PairingScreen.spec.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { validateApiUrl } from './PairingScreen';
+
+/**
+ * deep-review NM5: the pair code is a bearer secret, so the API URL it is sent
+ * to must be validated (https + host allow-list) before submit.
+ */
+describe('validateApiUrl', () => {
+  it('accepts the production host and strips a trailing slash', () => {
+    expect(validateApiUrl('https://hummytummy.com/api')).toBe('https://hummytummy.com/api');
+    expect(validateApiUrl('https://hummytummy.com/api/')).toBe('https://hummytummy.com/api');
+    expect(validateApiUrl('  https://hummytummy.com/api  ')).toBe('https://hummytummy.com/api');
+  });
+
+  it('accepts subdomains of an allow-listed host', () => {
+    expect(validateApiUrl('https://kds.hummytummy.com/api')).toBe('https://kds.hummytummy.com/api');
+  });
+
+  it('rejects non-https schemes', () => {
+    expect(() => validateApiUrl('http://hummytummy.com/api')).toThrow(/https/);
+  });
+
+  it('rejects hosts that are not allow-listed', () => {
+    expect(() => validateApiUrl('https://evil.example.com/api')).toThrow(/not allowed/);
+  });
+
+  it('rejects a host that merely contains the allow-listed host as a suffix-without-dot', () => {
+    // "evilhummytummy.com" must not be treated as a subdomain of hummytummy.com
+    expect(() => validateApiUrl('https://evilhummytummy.com/api')).toThrow(/not allowed/);
+  });
+
+  it('rejects unparseable input', () => {
+    expect(() => validateApiUrl('not a url')).toThrow(/Invalid API URL/);
+  });
+});

--- a/apps/kds-kiosk/src/screens/PairingScreen.tsx
+++ b/apps/kds-kiosk/src/screens/PairingScreen.tsx
@@ -4,6 +4,46 @@ import type { DeviceToken } from '../store/deviceToken';
 import { normalizePairCode } from './pairingLogic';
 
 /**
+ * Allow-list of hostnames the kiosk may pair against. The pair code is a
+ * bearer secret that mints a long-lived device token; without this gate an
+ * operator (or someone with brief physical access to the unattended pairing
+ * screen) could point the kiosk at a malicious host and exfiltrate the code.
+ * deep-review NM5.
+ *
+ * A host matches if it equals an allow-listed entry or is a subdomain of one.
+ * To support genuine private/LAN self-host, extend this list at build time.
+ */
+const ALLOWED_API_HOSTS = ['hummytummy.com'] as const;
+
+function hostAllowed(host: string): boolean {
+  const h = host.toLowerCase();
+  return ALLOWED_API_HOSTS.some((allowed) => h === allowed || h.endsWith(`.${allowed}`));
+}
+
+/**
+ * Validate an operator-entered API URL before the pair code is sent to it:
+ * must parse, must be https, and the host must be allow-listed. Returns a
+ * normalized origin+path or throws with an operator-readable message.
+ * deep-review NM5.
+ */
+export function validateApiUrl(raw: string): string {
+  let url: URL;
+  try {
+    url = new URL(raw.trim());
+  } catch {
+    throw new Error('Invalid API URL');
+  }
+  if (url.protocol !== 'https:') {
+    throw new Error('API URL must use https');
+  }
+  if (!hostAllowed(url.hostname)) {
+    throw new Error(`API host not allowed: ${url.hostname}`);
+  }
+  // Strip any trailing slash so the joined `${apiUrl}/v1/...` stays well-formed.
+  return raw.trim().replace(/\/+$/, '');
+}
+
+/**
  * First-boot screen. The operator scans (or types) the 6-character pair
  * code displayed in the admin UI. The kiosk POSTs to /v1/devices/pair on
  * the configured API URL and stores the returned token in the keyring.
@@ -24,13 +64,17 @@ export default function PairingScreen({ onPaired }: { onPaired: (token: DeviceTo
     setSubmitting(true);
     setError(null);
     try {
-      const out = await pairDevice(apiUrl, normalizePairCode(pairCode));
+      // deep-review NM5: validate (https + host allow-list) BEFORE the pair
+      // code leaves the device, so a malicious/typo'd API URL can never
+      // receive the bearer secret.
+      const safeUrl = validateApiUrl(apiUrl);
+      const out = await pairDevice(safeUrl, normalizePairCode(pairCode));
       // Persist ONLY after the server has accepted the pair. The earlier
       // version wrote pre-pair, so a typo or attacker URL became the
       // persisted default even on failure — the next pair attempt's
       // code would then leak to that server.
-      localStorage.setItem('kds_api_url', apiUrl);
-      onPaired({ ...out, apiUrl });
+      localStorage.setItem('kds_api_url', safeUrl);
+      onPaired({ ...out, apiUrl: safeUrl });
     } catch (e: any) {
       setError(e?.message ?? 'Pair failed');
     } finally {

--- a/apps/local-bridge-agent/src/cloud_ws.rs
+++ b/apps/local-bridge-agent/src/cloud_ws.rs
@@ -39,6 +39,13 @@ pub enum FetchResponse {
     /// Any non-success status. Carried so the client can log it and move on
     /// without treating a transient 5xx as fatal.
     NonSuccess(u16),
+    /// deep-review NH2/NH6: a 2xx whose body could not be decoded into a command
+    /// batch (schema drift, truncated body, weird LAN proxy interstitial). This
+    /// is NOT an empty batch — the cloud may actually have queued
+    /// payment/print commands. Surfaced as its own variant so `fetch_more` can
+    /// back off and leave the commands server-side for re-offer, instead of the
+    /// old `unwrap_or_default()` which silently dropped the whole batch.
+    DecodeError,
 }
 
 /// The transport seam over the cloud HTTP API.
@@ -106,6 +113,14 @@ impl CloudClient {
             FetchResponse::NonSuccess(status) => {
                 warn!(status, "cloud fetch_more non-success");
                 Ok(())
+            }
+            FetchResponse::DecodeError => {
+                // deep-review NH2/NH6: do NOT treat an undecodable body as "no
+                // work". Return Err so the main loop logs it and engages its 5s
+                // backoff; the commands were never acked, so the cloud re-offers
+                // them on the next poll instead of being silently lost.
+                warn!("cloud fetch_more: undecodable command body — backing off, commands stay queued server-side");
+                anyhow::bail!("undecodable commands/next body")
             }
             FetchResponse::Commands(commands) => {
                 for c in commands {
@@ -192,8 +207,20 @@ impl CloudTransport for ReqwestTransport {
         if !resp.status().is_success() {
             return Ok(FetchResponse::NonSuccess(resp.status().as_u16()));
         }
-        let commands: Vec<PendingCommand> = resp.json().await.unwrap_or_default();
-        Ok(FetchResponse::Commands(commands))
+        // deep-review NH2/NH6: never `unwrap_or_default()` a command-bearing 2xx
+        // body — that silently turned schema drift / a truncated body into "0
+        // commands", losing whole batches of queued payment/print commands with
+        // no log. Read the bytes (network error still propagates via `?`), then
+        // decode explicitly and surface a decode failure as `DecodeError` so the
+        // loop backs off and the commands remain server-side for re-offer.
+        let body = resp.bytes().await?;
+        match serde_json::from_slice::<Vec<PendingCommand>>(&body) {
+            Ok(commands) => Ok(FetchResponse::Commands(commands)),
+            Err(e) => {
+                warn!(error = %e, len = body.len(), "commands/next body failed to decode; treating as fetch failure, not empty");
+                Ok(FetchResponse::DecodeError)
+            }
+        }
     }
 
     async fn post_ack(&self, cmd_id: &str, outcome: &CommandOutcome) -> Result<()> {
@@ -346,6 +373,29 @@ mod tests {
             .await
             .expect("non-success is tolerated, not fatal");
         assert!(queue.pop_next().await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn fetch_more_errors_on_decode_failure_and_enqueues_nothing() {
+        // deep-review NH2/NH6: an undecodable 2xx body must NOT look like "no
+        // work". fetch_more returns Err (so main.rs backs off) and queues nothing
+        // — the commands stay server-side for re-offer rather than being lost.
+        let dir = TempDir::new().unwrap();
+        let queue = CommandQueue::open(dir.path().join("q.db")).unwrap();
+        let (client, _) = client_with(FakeTransport {
+            next: Mutex::new(Some(FetchResponse::DecodeError)),
+            ..Default::default()
+        });
+
+        let err = client
+            .fetch_more(&queue)
+            .await
+            .expect_err("decode failure must surface as Err, not silent empty");
+        assert!(err.to_string().contains("undecodable"));
+        assert!(
+            queue.pop_next().await.unwrap().is_none(),
+            "nothing enqueued on decode failure"
+        );
     }
 
     #[tokio::test]

--- a/apps/local-bridge-agent/src/command_queue.rs
+++ b/apps/local-bridge-agent/src/command_queue.rs
@@ -30,6 +30,34 @@ pub struct CommandOutcome {
     pub error: Option<String>,
 }
 
+/// deep-review NH1/NH4/NH5/NM1: a side-effecting command (card charge, fiscal
+/// receipt, refund) must NEVER be auto-re-executed without an idempotency
+/// guarantee — re-running it double-charges the customer or double-prints a
+/// legally-binding fiscal receipt. Until the driver/acquirer layer carries an
+/// idempotency key end-to-end, these kinds are parked in `needs_review` instead
+/// of being requeued. Matched broadly (current cloud kind strings are not yet
+/// finalised; the driver scaffolds are stubs) so a new spelling of "charge"
+/// can't silently slip back onto the auto-retry path.
+fn is_side_effecting(kind: &str) -> bool {
+    const SIDE_EFFECTING: &[&str] = &[
+        "payment",
+        "pos_charge",
+        "charge",
+        "refund",
+        "void",
+        "reversal",
+        "fiscal",
+        "fiscal_receipt",
+    ];
+    SIDE_EFFECTING.contains(&kind)
+}
+
+/// Lease TTL for inflight rows. A dispatch that has held a command longer than
+/// this is treated as wedged/dead and reclaimed by the runtime reaper in
+/// `pop_next`. Chosen longer than the cloud HTTP timeout (30s in cloud_ws) so a
+/// merely-slow-but-alive dispatch is not stolen out from under itself.
+const INFLIGHT_LEASE_MS: i64 = 60_000;
+
 pub struct CommandQueue {
     // Mutex is fine here — the queue is a low-throughput coordination point.
     // If we ever need higher concurrency, a Tokio mpsc channel layered on top
@@ -40,6 +68,22 @@ pub struct CommandQueue {
 impl CommandQueue {
     pub fn open<P: AsRef<Path>>(path: P) -> Result<Self> {
         let conn = Connection::open(path.as_ref())?;
+        // deep-review NL1 + NM2: durability + contention hygiene, set BEFORE the
+        // first table is created so auto_vacuum takes effect on a fresh DB.
+        //   - WAL + synchronous=FULL: a committed status survives power loss, so
+        //     reboot does not silently re-open the double-execute window.
+        //   - busy_timeout: tolerate transient SQLITE_BUSY instead of dropping a
+        //     command if a second connection ever shares this file.
+        //   - auto_vacuum=INCREMENTAL: lets sweep() reclaim file pages so the DB
+        //     does not grow without bound on a busy restaurant.
+        // journal_mode/auto_vacuum return a row, so they must go through
+        // execute_batch / pragma_query rather than conn.execute().
+        conn.execute_batch(
+            "PRAGMA auto_vacuum = INCREMENTAL;
+             PRAGMA journal_mode = WAL;
+             PRAGMA synchronous = FULL;
+             PRAGMA busy_timeout = 5000;",
+        )?;
         conn.execute_batch(
             "CREATE TABLE IF NOT EXISTS commands (
                 id TEXT PRIMARY KEY,
@@ -49,15 +93,66 @@ impl CommandQueue {
                 status TEXT NOT NULL DEFAULT 'queued',
                 attempts INTEGER NOT NULL DEFAULT 0,
                 error TEXT,
+                result TEXT,
                 created_at INTEGER NOT NULL,
                 updated_at INTEGER NOT NULL
             );
             CREATE INDEX IF NOT EXISTS idx_commands_queue
               ON commands (status, priority DESC, created_at);",
         )?;
-        Ok(Self {
+        // Migration for DBs created before the `result` column existed (so the
+        // outcome can be persisted for durable, restart-surviving acks — NH3/NH7).
+        // ALTER ... ADD COLUMN errors if it already exists; ignore that case.
+        let _ = conn.execute("ALTER TABLE commands ADD COLUMN result TEXT", []);
+
+        let queue = Self {
             conn: Mutex::new(conn),
-        })
+        };
+        queue.recover()?;
+        Ok(queue)
+    }
+
+    /// deep-review NH1/NH4: crash-recovery sweep. A power cut or kill between
+    /// `pop_next` (which sets status='inflight') and `mark_done` leaves a row
+    /// stranded in 'inflight' forever — `pop_next`'s `WHERE status='queued'`
+    /// never re-selects it, so the charge/print is silently lost with no signal.
+    ///
+    /// Kind-aware on purpose (NH4 step 3): re-executing a payment/fiscal command
+    /// could double-charge or double-print, so those go to a terminal
+    /// `needs_review` state for human reconciliation, surfaced to the cloud.
+    /// Side-effect-free kinds (e.g. escpos order tickets) are safe to retry and
+    /// go back to 'queued', still bounded by the same 5-attempt cap as
+    /// `mark_failed` so a poison command can't loop forever.
+    fn recover(&self) -> Result<()> {
+        let conn = self.conn.lock().expect("queue mutex poisoned");
+        let now = chrono_unix_now();
+        // Money/fiscal kinds: park, do NOT auto-requeue.
+        let parked = conn.execute(
+            "UPDATE commands
+                SET status = 'needs_review',
+                    error = COALESCE(error, 'recovered from inflight after restart — needs reconciliation'),
+                    updated_at = ?1
+              WHERE status = 'inflight'
+                AND kind IN ('payment','pos_charge','charge','refund','void','reversal','fiscal','fiscal_receipt')",
+            params![now],
+        )?;
+        // Safe-to-retry kinds: requeue, honouring the 5-attempt cap.
+        let requeued = conn.execute(
+            "UPDATE commands
+                SET status = CASE WHEN attempts >= 5 THEN 'failed' ELSE 'queued' END,
+                    error = COALESCE(error, 'recovered from inflight after restart'),
+                    updated_at = ?1
+              WHERE status = 'inflight'",
+            params![now],
+        )?;
+        if parked > 0 || requeued > 0 {
+            tracing::warn!(
+                parked_needs_review = parked,
+                requeued,
+                "command_queue: recovered inflight rows orphaned by a previous crash/reboot"
+            );
+        }
+        Ok(())
     }
 
     pub async fn push(&self, cmd: &PendingCommand) -> Result<()> {
@@ -80,8 +175,17 @@ impl CommandQueue {
 
     pub async fn pop_next(&self) -> Result<Option<PendingCommand>> {
         let conn = self.conn.lock().expect("queue mutex poisoned");
+        let now = chrono_unix_now();
+        let lease_cutoff = now - INFLIGHT_LEASE_MS;
         // Atomically claim the next queued command. SQLite serialises, so
         // race conditions are impossible at this point.
+        //
+        // deep-review NH4 step 2: also reclaim a wedged-but-alive dispatch whose
+        // inflight lease has expired (process hung past INFLIGHT_LEASE_MS without
+        // dying), so a stuck dispatch is recovered without waiting for a restart.
+        // Side-effecting (money/fiscal) kinds are deliberately EXCLUDED from
+        // lease reclaim — re-popping them could double-charge; they stay inflight
+        // and are surfaced/parked at next startup recovery or via reconciliation.
         let mut stmt = conn.prepare(
             "UPDATE commands
                 SET status = 'inflight',
@@ -89,12 +193,14 @@ impl CommandQueue {
                     updated_at = ?1
               WHERE id = (SELECT id FROM commands
                            WHERE status = 'queued'
+                              OR (status = 'inflight'
+                                  AND updated_at < ?2
+                                  AND kind NOT IN ('payment','pos_charge','charge','refund','void','reversal','fiscal','fiscal_receipt'))
                            ORDER BY priority DESC, created_at
                            LIMIT 1)
             RETURNING id, kind, payload, priority, attempts",
         )?;
-        let now = chrono_unix_now();
-        let mut rows = stmt.query(params![now])?;
+        let mut rows = stmt.query(params![now, lease_cutoff])?;
         if let Some(row) = rows.next()? {
             let payload_s: String = row.get(2)?;
             return Ok(Some(PendingCommand {
@@ -108,30 +214,153 @@ impl CommandQueue {
         Ok(None)
     }
 
+    /// Mark a command as executed locally, AWAITING cloud ack.
+    ///
+    /// deep-review NH3/NH7: the ack is part of the durable command lifecycle, not
+    /// fire-and-forget. We move to an intermediate `done` (= executed, ack
+    /// pending) state and PERSIST the outcome (previously dropped via
+    /// `let _ = outcome`), so if connectivity drops right after a charge the
+    /// outcome survives a restart and the ack can be retried — instead of the
+    /// cloud reissuing the logical charge under a new id and double-charging.
+    /// `mark_acked` later moves `done` → `acked` once the cloud confirms.
     pub async fn mark_done(&self, id: &str, outcome: &CommandOutcome) -> Result<()> {
         let conn = self.conn.lock().expect("queue mutex poisoned");
         conn.execute(
-            "UPDATE commands SET status = 'done', error = NULL, updated_at = ?2 WHERE id = ?1",
+            "UPDATE commands SET status = 'done', error = ?2, result = ?3, updated_at = ?4 WHERE id = ?1",
+            params![
+                id,
+                outcome.error,
+                serde_json::to_string(&outcome.result)?,
+                chrono_unix_now()
+            ],
+        )?;
+        Ok(())
+    }
+
+    /// deep-review NH3/NH7: terminal state reached only once the cloud has
+    /// confirmed the ack. A row is "settled" (eligible for retention sweep) only
+    /// after this transition; until then it is replayable via `pending_acks`.
+    pub async fn mark_acked(&self, id: &str) -> Result<()> {
+        let conn = self.conn.lock().expect("queue mutex poisoned");
+        conn.execute(
+            "UPDATE commands SET status = 'acked', updated_at = ?2 WHERE id = ?1",
             params![id, chrono_unix_now()],
         )?;
-        // outcome is forwarded to the cloud; we keep only minimal local state
-        // to avoid bloating the SQLite file with completed payloads.
-        let _ = outcome;
         Ok(())
+    }
+
+    /// deep-review NH3/NH7: rows executed successfully but not yet confirmed by
+    /// the cloud (status='done', i.e. ack pending). The main loop drains this and
+    /// retries the ack so a successful charge/print outcome is never lost on a
+    /// connectivity blip — preventing the cloud from reissuing the logical
+    /// command under a fresh id and double-executing it. Returns each command
+    /// with its PERSISTED outcome so the exact original outcome is re-acked
+    /// (never a freshly-fabricated one).
+    pub async fn pending_acks(&self, limit: i64) -> Result<Vec<(PendingCommand, CommandOutcome)>> {
+        let conn = self.conn.lock().expect("queue mutex poisoned");
+        let mut stmt = conn.prepare(
+            "SELECT id, kind, payload, priority, attempts, status, error, result
+               FROM commands
+              WHERE status = 'done'
+              ORDER BY updated_at
+              LIMIT ?1",
+        )?;
+        let rows = stmt.query_map(params![limit], |row| {
+            let payload_s: String = row.get(2)?;
+            let status: String = row.get(5)?;
+            let error: Option<String> = row.get(6)?;
+            let result_s: Option<String> = row.get(7)?;
+            Ok((
+                PendingCommand {
+                    id: row.get(0)?,
+                    kind: row.get(1)?,
+                    payload: serde_json::from_str(&payload_s).unwrap_or(serde_json::Value::Null),
+                    priority: row.get(3)?,
+                    attempts: row.get(4)?,
+                },
+                CommandOutcome {
+                    // a `done` row was executed successfully; the ack outcome is
+                    // "done" regardless of the (null) error column.
+                    status,
+                    result: result_s
+                        .and_then(|s| serde_json::from_str(&s).ok())
+                        .unwrap_or(serde_json::Value::Null),
+                    error,
+                },
+            ))
+        })?;
+        let mut out = Vec::new();
+        for r in rows {
+            out.push(r?);
+        }
+        Ok(out)
     }
 
     pub async fn mark_failed(&self, id: &str, error: &str) -> Result<()> {
         let conn = self.conn.lock().expect("queue mutex poisoned");
-        // 5-attempt cap matches the cloud-side retry policy.
-        conn.execute(
-            "UPDATE commands
-                SET status = CASE WHEN attempts >= 5 THEN 'failed' ELSE 'queued' END,
-                    error = ?2,
-                    updated_at = ?3
-              WHERE id = ?1",
-            params![id, error, chrono_unix_now()],
-        )?;
+        // deep-review NM1/NH5: kind-aware requeue. A side-effecting command
+        // (payment/fiscal/refund) that returned Err may ALREADY have performed
+        // its side effect on the device (the classic ACK-timeout-after-card-
+        // captured case). Auto-requeuing it would double-charge / double-print.
+        // So such kinds go straight to a terminal `needs_review` state for human
+        // reconciliation, regardless of attempts. Only idempotent/side-effect-
+        // free kinds keep the original 5-attempt auto-retry policy.
+        let kind: Option<String> = conn
+            .query_row(
+                "SELECT kind FROM commands WHERE id = ?1",
+                params![id],
+                |row| row.get(0),
+            )
+            .ok();
+        let now = chrono_unix_now();
+        if kind.as_deref().map(is_side_effecting).unwrap_or(false) {
+            conn.execute(
+                "UPDATE commands SET status = 'needs_review', error = ?2, updated_at = ?3 WHERE id = ?1",
+                params![id, error, now],
+            )?;
+        } else {
+            // 5-attempt cap matches the cloud-side retry policy.
+            conn.execute(
+                "UPDATE commands
+                    SET status = CASE WHEN attempts >= 5 THEN 'failed' ELSE 'queued' END,
+                        error = ?2,
+                        updated_at = ?3
+                  WHERE id = ?1",
+                params![id, error, now],
+            )?;
+        }
         Ok(())
+    }
+
+    /// deep-review NM2: bounded retention sweep. Deletes terminal rows older than
+    /// `max_age_ms` and reclaims file pages, so command_queue.db does not grow
+    /// without bound on a busy restaurant (eventually disk-full → all new
+    /// charges/prints fail). Only fully-settled rows are eligible:
+    ///   - `acked`: executed AND cloud-confirmed — safe to drop.
+    ///   - `failed`: terminal failure, already attempted to ack.
+    /// `done` (ack still pending) and `needs_review` (awaiting human action) are
+    /// deliberately retained until they reach a settled state.
+    pub async fn sweep(&self, max_age_ms: i64) -> Result<usize> {
+        let conn = self.conn.lock().expect("queue mutex poisoned");
+        let cutoff = chrono_unix_now() - max_age_ms;
+        let n = conn.execute(
+            "DELETE FROM commands WHERE status IN ('acked','failed') AND updated_at < ?1",
+            params![cutoff],
+        )?;
+        conn.execute_batch("PRAGMA incremental_vacuum;")?;
+        Ok(n)
+    }
+
+    /// deep-review NH1: count of rows parked for human reconciliation, so the
+    /// main loop can surface them to the cloud/operator via telemetry.
+    pub async fn needs_review_count(&self) -> Result<i64> {
+        let conn = self.conn.lock().expect("queue mutex poisoned");
+        let n: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM commands WHERE status = 'needs_review'",
+            [],
+            |row| row.get(0),
+        )?;
+        Ok(n)
     }
 }
 
@@ -141,4 +370,138 @@ fn chrono_unix_now() -> i64 {
         .duration_since(std::time::UNIX_EPOCH)
         .map(|d| d.as_millis() as i64)
         .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use tempfile::TempDir;
+
+    fn cmd(id: &str, kind: &str) -> PendingCommand {
+        PendingCommand {
+            id: id.to_string(),
+            kind: kind.to_string(),
+            payload: json!({ "target": "escpos" }),
+            priority: 0,
+            attempts: 0,
+        }
+    }
+
+    fn done_outcome() -> CommandOutcome {
+        CommandOutcome {
+            status: "done".to_string(),
+            result: json!({ "ok": true }),
+            error: None,
+        }
+    }
+
+    /// deep-review NH1/NH4: reopening the queue must reclaim orphaned inflight
+    /// rows — but kind-aware: a side-effect-free row becomes re-poppable while a
+    /// money/fiscal row lands in `needs_review` (never auto-re-executed).
+    #[tokio::test]
+    async fn recover_requeues_safe_kinds_but_parks_money_kinds() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("q.db");
+        {
+            let q = CommandQueue::open(&path).unwrap();
+            q.push(&cmd("safe", "print_receipt")).await.unwrap();
+            q.push(&cmd("money", "payment")).await.unwrap();
+            // Claim both → both go 'inflight'.
+            q.pop_next().await.unwrap().unwrap();
+            q.pop_next().await.unwrap().unwrap();
+            assert!(q.pop_next().await.unwrap().is_none(), "both inflight");
+        }
+        // Simulate a crash + restart by reopening the same DB file.
+        let q = CommandQueue::open(&path).unwrap();
+        // Money row must NOT be re-poppable; it is parked for reconciliation.
+        let popped = q.pop_next().await.unwrap().expect("safe row re-poppable");
+        assert_eq!(popped.id, "safe");
+        assert!(
+            q.pop_next().await.unwrap().is_none(),
+            "money row must not be requeued"
+        );
+        assert_eq!(q.needs_review_count().await.unwrap(), 1);
+    }
+
+    /// deep-review NM1/NH5: a failed side-effecting command must NOT return to
+    /// 'queued' (which would double-charge); it goes to terminal needs_review.
+    #[tokio::test]
+    async fn failed_money_command_is_parked_not_requeued() {
+        let dir = TempDir::new().unwrap();
+        let q = CommandQueue::open(dir.path().join("q.db")).unwrap();
+        q.push(&cmd("pay1", "pos_charge")).await.unwrap();
+        let c = q.pop_next().await.unwrap().unwrap();
+        q.mark_failed(&c.id, "ack timeout after card captured")
+            .await
+            .unwrap();
+        assert!(
+            q.pop_next().await.unwrap().is_none(),
+            "failed money command must not be re-popped"
+        );
+        assert_eq!(q.needs_review_count().await.unwrap(), 1);
+    }
+
+    /// A failed idempotent command keeps the original 5-attempt auto-retry.
+    #[tokio::test]
+    async fn failed_safe_command_requeues_until_cap() {
+        let dir = TempDir::new().unwrap();
+        let q = CommandQueue::open(dir.path().join("q.db")).unwrap();
+        q.push(&cmd("p1", "print_receipt")).await.unwrap();
+        // First failure → back to queued, re-poppable.
+        let c = q.pop_next().await.unwrap().unwrap();
+        q.mark_failed(&c.id, "printer offline").await.unwrap();
+        assert!(
+            q.pop_next().await.unwrap().is_some(),
+            "safe command requeues"
+        );
+    }
+
+    /// deep-review NH3/NH7: mark_done persists the outcome and leaves the row in
+    /// a non-terminal 'done' state surfaced by pending_acks until mark_acked.
+    #[tokio::test]
+    async fn outcome_is_durable_until_acked() {
+        let dir = TempDir::new().unwrap();
+        let q = CommandQueue::open(dir.path().join("q.db")).unwrap();
+        q.push(&cmd("c1", "print_receipt")).await.unwrap();
+        let c = q.pop_next().await.unwrap().unwrap();
+        q.mark_done(&c.id, &done_outcome()).await.unwrap();
+
+        let pending = q.pending_acks(10).await.unwrap();
+        assert_eq!(pending.len(), 1);
+        assert_eq!(pending[0].0.id, "c1");
+        assert_eq!(pending[0].1.result, json!({ "ok": true }));
+
+        q.mark_acked("c1").await.unwrap();
+        assert!(
+            q.pending_acks(10).await.unwrap().is_empty(),
+            "acked row no longer pending"
+        );
+    }
+
+    /// deep-review NM2: sweep removes settled rows past the cutoff but leaves
+    /// queued/inflight/needs_review/ack-pending rows untouched.
+    #[tokio::test]
+    async fn sweep_removes_only_old_settled_rows() {
+        let dir = TempDir::new().unwrap();
+        let q = CommandQueue::open(dir.path().join("q.db")).unwrap();
+        q.push(&cmd("acked1", "print_receipt")).await.unwrap();
+        q.push(&cmd("queued1", "print_receipt")).await.unwrap();
+        // Drive acked1 to the terminal 'acked' state.
+        let c = q.pop_next().await.unwrap().unwrap();
+        // pop_next is priority/created ordered; ensure we acted on acked1.
+        q.mark_done(&c.id, &done_outcome()).await.unwrap();
+        q.mark_acked(&c.id).await.unwrap();
+
+        // max_age_ms=-1 makes every row "older than cutoff" (cutoff in future).
+        let removed = q.sweep(-1).await.unwrap();
+        assert_eq!(removed, 1, "only the acked row is swept");
+        // The still-queued (or inflight, depending on pop order) row remains.
+        let remaining: i64 = {
+            let conn = q.conn.lock().unwrap();
+            conn.query_row("SELECT COUNT(*) FROM commands", [], |r| r.get(0))
+                .unwrap()
+        };
+        assert_eq!(remaining, 1);
+    }
 }

--- a/apps/local-bridge-agent/src/main.rs
+++ b/apps/local-bridge-agent/src/main.rs
@@ -55,7 +55,42 @@ async fn main() -> Result<()> {
     // The command queue is the single source of truth for "what does this
     // bridge owe?". It outlives the cloud connection, so the agent keeps
     // working through transient internet outages.
-    let queue = command_queue::CommandQueue::open(cfg.data_dir.join("command_queue.db"))?;
+    // Arc-wrapped so a low-frequency retention sweep can run alongside the main
+    // loop without moving the queue. open() also runs crash recovery (NH1/NH4):
+    // inflight rows orphaned by a previous crash are requeued (safe kinds) or
+    // parked in needs_review (money/fiscal kinds).
+    let queue = std::sync::Arc::new(command_queue::CommandQueue::open(
+        cfg.data_dir.join("command_queue.db"),
+    )?);
+
+    // deep-review NM2: bounded retention sweep on a low-frequency cadence so the
+    // SQLite file does not grow without bound (eventually disk-full → all new
+    // charges/prints fail). Drops only fully-settled rows (acked/failed) older
+    // than 48h and reclaims pages via incremental_vacuum.
+    let _sweep_handle = {
+        let q = queue.clone();
+        tokio::spawn(async move {
+            let mut tick = tokio::time::interval(std::time::Duration::from_secs(3600));
+            const RETENTION_MS: i64 = 48 * 3600 * 1000;
+            loop {
+                tick.tick().await;
+                match q.sweep(RETENTION_MS).await {
+                    Ok(n) if n > 0 => info!(swept = n, "command_queue retention sweep"),
+                    Ok(_) => {}
+                    Err(e) => warn!(error = %e, "command_queue retention sweep failed"),
+                }
+            }
+        })
+    };
+    // Surface any rows parked for human reconciliation at boot so a stranded
+    // charge/fiscal receipt is operator-visible rather than silent (NH1).
+    match queue.needs_review_count().await {
+        Ok(n) if n > 0 => warn!(
+            needs_review = n,
+            "command_queue: commands parked for reconciliation (likely interrupted money/fiscal ops)"
+        ),
+        _ => {}
+    }
 
     // The drivers registry resolves device kinds → executors at runtime.
     // A driver that fails to initialise (e.g. printer not yet wired) is
@@ -78,18 +113,51 @@ async fn main() -> Result<()> {
     // -D warnings.
     let _heartbeat_handle = telemetry::spawn_heartbeat(cloud.clone());
 
-    // Main loop: pull next queued command, dispatch, ack.
+    // Main loop: retry outstanding acks, then pull next queued command,
+    // dispatch, ack.
     loop {
+        // deep-review NH3/NH7: an executed-but-unacked command is NOT settled.
+        // Before fetching new work, drain any outcomes that were persisted by a
+        // previous dispatch but whose ack failed (network blip / 5xx / crash
+        // before ack). Without this, the cloud still considers the command
+        // outstanding and re-issues it — often under a NEW command id that the
+        // local INSERT-OR-IGNORE dedup misses — re-executing the charge/print.
+        for (acked_cmd, outcome) in queue.pending_acks(32).await? {
+            match cloud.ack(&acked_cmd, &outcome).await {
+                Ok(()) => queue.mark_acked(&acked_cmd.id).await?,
+                Err(e) => {
+                    warn!(cmd = %acked_cmd.id, error = %e, "ack retry failed — outcome still not confirmed to cloud");
+                    // Leave the row in 'done' so it is retried on the next pass.
+                    // Back off so we don't spin while the cloud is unreachable.
+                    tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+                    break;
+                }
+            }
+        }
+
         if let Some(cmd) = queue.pop_next().await? {
             match drivers.dispatch(&cmd).await {
                 Ok(outcome) => {
+                    // Persist the outcome first (durable), THEN ack. On ack
+                    // failure the row stays 'done' and the pending-acks drain
+                    // above retries it — never silently lose the outcome.
                     queue.mark_done(&cmd.id, &outcome).await?;
-                    let _ = cloud.ack(&cmd, &outcome).await;
+                    match cloud.ack(&cmd, &outcome).await {
+                        Ok(()) => queue.mark_acked(&cmd.id).await?,
+                        Err(e) => {
+                            warn!(cmd = %cmd.id, error = %e, "ack failed — outcome persisted, will retry");
+                        }
+                    }
                 }
                 Err(e) => {
                     warn!(cmd = %cmd.id, error = %e, "command failed");
+                    // mark_failed is kind-aware: side-effecting (money/fiscal)
+                    // kinds are parked in 'needs_review' here rather than
+                    // requeued, so the ack_failed below does not race a retry.
                     queue.mark_failed(&cmd.id, &e.to_string()).await?;
-                    let _ = cloud.ack_failed(&cmd, &e.to_string()).await;
+                    if let Err(ack_err) = cloud.ack_failed(&cmd, &e.to_string()).await {
+                        warn!(cmd = %cmd.id, error = %ack_err, "ack_failed not confirmed to cloud");
+                    }
                 }
             }
         } else if let Err(e) = cloud.fetch_more(&queue).await {
@@ -101,10 +169,11 @@ async fn main() -> Result<()> {
         tokio::task::yield_now().await;
     }
 
-    // (_heartbeat_handle drops with the process; the OS reclaims it.)
+    // (background task handles drop with the process; the OS reclaims them.)
     #[allow(unreachable_code)]
     {
         drop(_heartbeat_handle);
+        drop(_sweep_handle);
         Ok(())
     }
 }

--- a/backend/src/modules/accounting/services/sales-invoice.service.spec.ts
+++ b/backend/src/modules/accounting/services/sales-invoice.service.spec.ts
@@ -1,5 +1,9 @@
-import { SalesInvoiceService } from './sales-invoice.service';
-import { mockPrismaClient, MockPrismaClient } from '../../../common/test/prisma-mock.service';
+import { SalesInvoiceService } from "./sales-invoice.service";
+import { TaxCalculationService } from "./tax-calculation.service";
+import {
+  mockPrismaClient,
+  MockPrismaClient,
+} from "../../../common/test/prisma-mock.service";
 
 /**
  * Iter-33 regression: findAll must clamp page/limit even if a caller
@@ -7,7 +11,7 @@ import { mockPrismaClient, MockPrismaClient } from '../../../common/test/prisma-
  * internal worker/RPC that constructs the query object directly would
  * be unguarded without the service-side Math.min.
  */
-describe('SalesInvoiceService.findAll (iter-33)', () => {
+describe("SalesInvoiceService.findAll (iter-33)", () => {
   let prisma: MockPrismaClient;
   let svc: SalesInvoiceService;
 
@@ -20,8 +24,8 @@ describe('SalesInvoiceService.findAll (iter-33)', () => {
     (prisma.salesInvoice.count as any).mockResolvedValue(0);
   });
 
-  it('caps limit at 200 even when caller passes a million', async () => {
-    await svc.findAll('t1', { limit: 1_000_000 } as any);
+  it("caps limit at 200 even when caller passes a million", async () => {
+    await svc.findAll("t1", { limit: 1_000_000 } as any);
 
     const findArgs = (prisma.salesInvoice.findMany as any).mock.calls[0][0];
     // Load-bearing: the take=200 ceiling protects against an unbounded
@@ -29,19 +33,117 @@ describe('SalesInvoiceService.findAll (iter-33)', () => {
     expect(findArgs.take).toBe(200);
   });
 
-  it('clamps page to 1 when caller passes 0 or negative', async () => {
-    await svc.findAll('t1', { page: 0, limit: 20 } as any);
+  it("clamps page to 1 when caller passes 0 or negative", async () => {
+    await svc.findAll("t1", { page: 0, limit: 20 } as any);
     const args1 = (prisma.salesInvoice.findMany as any).mock.calls[0][0];
     expect(args1.skip).toBe(0); // (1-1)*20
 
-    await svc.findAll('t1', { page: -5, limit: 20 } as any);
+    await svc.findAll("t1", { page: -5, limit: 20 } as any);
     const args2 = (prisma.salesInvoice.findMany as any).mock.calls[1][0];
     expect(args2.skip).toBe(0);
   });
 
-  it('falls back to limit=20 when caller passes a non-numeric value', async () => {
-    await svc.findAll('t1', { limit: 'abc' as any } as any);
+  it("falls back to limit=20 when caller passes a non-numeric value", async () => {
+    await svc.findAll("t1", { limit: "abc" as any } as any);
     const args = (prisma.salesInvoice.findMany as any).mock.calls[0][0];
     expect(args.take).toBe(20);
+  });
+});
+
+/**
+ * deep-review M11 regression: for a discounted order the persisted
+ * invoice must be internally consistent — sum(item.total) == header
+ * totalAmount (== order.finalAmount) and sum(item.taxAmount) == header
+ * taxAmount — otherwise e-fatura providers that validate sum(lines)==total
+ * reject the document. Pre-fix the lines summed to the GROSS while the
+ * header total was the NET.
+ */
+describe("SalesInvoiceService.createFromOrder discount consistency (deep-review M11)", () => {
+  let prisma: MockPrismaClient;
+  let svc: SalesInvoiceService;
+
+  beforeEach(() => {
+    prisma = mockPrismaClient();
+    const settings: any = {
+      findByTenant: jest.fn().mockResolvedValue({
+        defaultPaymentTermDays: 0,
+        autoSync: false,
+        provider: "NONE",
+      }),
+      getNextInvoiceNumber: jest.fn().mockResolvedValue("INV-001"),
+    };
+    // Use the real tax math — it is pure and is the unit under test here.
+    svc = new SalesInvoiceService(
+      prisma as any,
+      settings,
+      new TaxCalculationService(),
+    );
+
+    // $transaction(cb) runs the callback against a tx that mirrors the
+    // client mock; salesInvoice.create echoes back the data it was given so
+    // the test can assert on the persisted line items.
+    (prisma.$transaction as any).mockImplementation(async (cb: any) => {
+      const tx: any = {
+        salesInvoice: {
+          findFirst: jest.fn().mockResolvedValue(null),
+          create: jest.fn().mockImplementation(async ({ data }: any) => ({
+            id: "inv-1",
+            ...data,
+            items: data.items.create,
+          })),
+        },
+      };
+      return cb(tx);
+    });
+  });
+
+  it("apportions the order discount so lines sum to finalAmount and taxAmount reconciles", async () => {
+    // Gross 100 (two 10% KDV lines of 60 + 40), 10 TRY order discount,
+    // finalAmount 90. Net lines: 60 - 6 = 54 and 40 - 4 = 36 -> sum 90.
+    (prisma.order.findFirst as any).mockResolvedValue({
+      id: "order-1",
+      tenantId: "t1",
+      customerName: "Acme",
+      customerPhone: null,
+      totalAmount: 100,
+      discount: 10,
+      finalAmount: 90,
+      payments: [{ method: "CASH" }],
+      salesInvoices: [],
+      orderItems: [
+        {
+          id: "oi-1",
+          quantity: 2,
+          subtotal: 60,
+          taxRate: 10,
+          product: { name: "A" },
+        },
+        {
+          id: "oi-2",
+          quantity: 1,
+          subtotal: 40,
+          taxRate: 10,
+          product: { name: "B" },
+        },
+      ],
+    });
+
+    const invoice: any = await svc.createFromOrder("order-1", "t1");
+
+    const lineTotalSum = invoice.items.reduce(
+      (s: number, i: any) => s + i.total,
+      0,
+    );
+    const lineTaxSum = invoice.items.reduce(
+      (s: number, i: any) => s + i.taxAmount,
+      0,
+    );
+
+    // Load-bearing: line totals must reconcile to the discounted header total.
+    expect(Math.round(lineTotalSum * 100) / 100).toBe(invoice.totalAmount);
+    expect(invoice.totalAmount).toBe(90);
+    // KDV breakdown must come from the adjusted (net) lines.
+    expect(Math.round(lineTaxSum * 100) / 100).toBe(invoice.taxAmount);
+    expect(invoice.discount).toBe(10);
   });
 });

--- a/backend/src/modules/accounting/services/sales-invoice.service.ts
+++ b/backend/src/modules/accounting/services/sales-invoice.service.ts
@@ -57,11 +57,33 @@ export class SalesInvoiceService {
     // the transaction short.
     const settings = await this.settingsService.findByTenant(tenantId);
 
-    const invoiceItems = order.orderItems.map((item) => {
-      const lineTotal = Number(item.subtotal);
-      const taxRate = item.taxRate ?? 10;
-      const tax = this.taxService.extractTax(lineTotal, taxRate);
+    // deep-review M11: the order may carry an order-level discount
+    // (order.totalAmount = gross, order.finalAmount = net, the delta is
+    // order.discount). Pre-fix we built each line from its GROSS subtotal
+    // but persisted header totalAmount = finalAmount (net). That made the
+    // invoice internally inconsistent: sum(line totals) == gross while the
+    // header total == net, so e-fatura providers that validate
+    // sum(lines)==total reject the document or mis-book the net.
+    //
+    // Fix: apportion the order-level discount across the lines pro-rata by
+    // each line's gross share, in Decimal, so sum(net line totals) ==
+    // finalAmount EXACTLY (the rounding remainder is pushed onto the
+    // largest line). Each line's subtotal/taxAmount are then re-extracted
+    // from its NET gross at the line's own KDV rate, and the header
+    // subtotal/taxAmount/taxBreakdown are recomputed from the adjusted
+    // lines — never the pre-discount ones.
+    const D = (v: Prisma.Decimal | number | string) => new Prisma.Decimal(v);
+    const round2 = (d: Prisma.Decimal) =>
+      d.toDecimalPlaces(2, Prisma.Decimal.ROUND_HALF_UP);
 
+    const orderGross = D(order.totalAmount);
+    const orderDiscount = D(order.discount);
+    // Guard div-by-zero: a fully-comped (gross 0) order with a discount is
+    // nonsensical, but if gross is 0 there is nothing to apportion against.
+    const hasDiscount = orderDiscount.gt(0) && orderGross.gt(0);
+
+    // First pass: validate quantities and capture each line's gross.
+    const lineGross = order.orderItems.map((item) => {
       // quantity===0 would back-calc unitPrice as NaN and persist into the
       // Decimal column, breaking downstream math and tax-authority XML.
       if (!item.quantity || item.quantity <= 0) {
@@ -69,6 +91,37 @@ export class SalesInvoiceService {
           `Invoice cannot be generated: order item "${item.product?.name ?? item.id}" has non-positive quantity`,
         );
       }
+      return D(item.subtotal);
+    });
+
+    // Apportion the discount across lines pro-rata by gross share, rounding
+    // each apportioned discount to 2dp. Track the largest line so the
+    // rounding remainder lands there and the net lines sum to finalAmount
+    // to the cent.
+    const netLineGross: Prisma.Decimal[] = lineGross.map((g) => g);
+    if (hasDiscount) {
+      let allocated = D(0);
+      let largestIdx = 0;
+      for (let i = 0; i < lineGross.length; i++) {
+        const share = round2(lineGross[i].div(orderGross).mul(orderDiscount));
+        netLineGross[i] = lineGross[i].sub(share);
+        allocated = allocated.add(share);
+        if (lineGross[i].gt(lineGross[largestIdx])) largestIdx = i;
+      }
+      // Push the rounding remainder (orderDiscount − Σ apportioned) onto the
+      // largest line so Σ(net line gross) == finalAmount exactly.
+      const remainder = orderDiscount.sub(allocated);
+      if (!remainder.isZero()) {
+        netLineGross[largestIdx] = netLineGross[largestIdx].sub(remainder);
+      }
+    }
+
+    const invoiceItems = order.orderItems.map((item, i) => {
+      const taxRate = item.taxRate ?? 10;
+      // extractTax pulls the KDV component out of the (now net) inclusive
+      // line gross, so subtotal/taxAmount reconcile to the discounted total.
+      const netGross = round2(netLineGross[i]).toNumber();
+      const tax = this.taxService.extractTax(netGross, taxRate);
 
       return {
         description: item.product?.name || "Ürün",
@@ -78,7 +131,7 @@ export class SalesInvoiceService {
         taxRate,
         taxAmount: tax.taxAmount,
         subtotal: tax.subtotalExcludingTax,
-        total: lineTotal,
+        total: netGross,
       };
     });
 
@@ -275,9 +328,15 @@ export class SalesInvoiceService {
             subtotal: Math.round(subtotal * 100) / 100,
             taxAmount: Math.round(taxAmount * 100) / 100,
             totalAmount,
-            // Pro-rata discount portion of this payment, derived from
-            // (totalAmount − subtotal − taxAmount). Negative noise is
-            // clamped at 0.
+            // deep-review M11: no order-level discount line here. Each
+            // OrderItemPayment.amount is, by definition, "this allocation's
+            // contribution to Payment.amount" — i.e. already net of any
+            // order discount that was distributed at payment time. The
+            // lines are derived from those allocation amounts, so
+            // Σ(line totals) == Σ(alloc.amount) == payment.amount ==
+            // totalAmount, and there is nothing left to discount on the
+            // invoice. (Pre-fix this carried a misleading comment claiming
+            // a pro-rata discount it never actually computed.)
             discount: 0,
             taxBreakdown,
             orderId: payment.orderId,

--- a/backend/src/modules/auth/auth.service.social-email-verified.spec.ts
+++ b/backend/src/modules/auth/auth.service.social-email-verified.spec.ts
@@ -1,0 +1,99 @@
+import { UnauthorizedException } from "@nestjs/common";
+import { AuthService } from "./auth.service";
+import {
+  mockPrismaClient,
+  MockPrismaClient,
+} from "../../common/test/prisma-mock.service";
+
+/**
+ * deep-review C3 — Google Sign-In email_verified enforcement.
+ *
+ * Google permits tokens whose `email` claim is NOT verified (e.g. a
+ * Workspace/Cloud-Identity domain whose admin set an arbitrary primary
+ * email). Linking/logging-in by such an email is the canonical Google
+ * Sign-In account-takeover vector. googleAuth must reject before any
+ * user lookup or token issuance when email_verified is not true.
+ */
+describe("AuthService.googleAuth — email_verified gate (C3)", () => {
+  let prisma: MockPrismaClient;
+  let svc: AuthService;
+
+  function buildPayload(email_verified: unknown) {
+    return {
+      getPayload: () => ({
+        sub: "google-sub-1",
+        email: "victim@example.com",
+        given_name: "Vic",
+        family_name: "Tim",
+        email_verified,
+      }),
+    };
+  }
+
+  beforeEach(() => {
+    prisma = mockPrismaClient();
+    const jwtService = {
+      sign: jest.fn(),
+      verify: jest.fn(),
+      decode: jest.fn(),
+    };
+    const configService = { get: jest.fn(() => undefined) };
+    const emailService = {} as any;
+    const notificationsService = {} as any;
+    svc = new AuthService(
+      prisma as any,
+      jwtService as any,
+      configService as any,
+      emailService,
+      notificationsService,
+    );
+  });
+
+  it("rejects an unverified (email_verified=false) Google ID token without any user lookup", async () => {
+    (svc as any).googleClient = {
+      verifyIdToken: jest.fn().mockResolvedValue(buildPayload(false)),
+    };
+    const createSpy = jest
+      .spyOn(svc as any, "createSocialAuthUser")
+      .mockResolvedValue({ accessToken: "should-not-happen" } as any);
+
+    await expect(
+      svc.googleAuth({ credential: "id-token" } as any),
+    ).rejects.toBeInstanceOf(UnauthorizedException);
+
+    expect(prisma.user.findUnique).not.toHaveBeenCalled();
+    expect(createSpy).not.toHaveBeenCalled();
+  });
+
+  it("rejects when email_verified is missing (undefined) — strict === true", async () => {
+    (svc as any).googleClient = {
+      verifyIdToken: jest.fn().mockResolvedValue(buildPayload(undefined)),
+    };
+    const createSpy = jest
+      .spyOn(svc as any, "createSocialAuthUser")
+      .mockResolvedValue({ accessToken: "should-not-happen" } as any);
+
+    await expect(
+      svc.googleAuth({ credential: "id-token" } as any),
+    ).rejects.toBeInstanceOf(UnauthorizedException);
+    expect(prisma.user.findUnique).not.toHaveBeenCalled();
+    expect(createSpy).not.toHaveBeenCalled();
+  });
+
+  it("passes the gate when email_verified is true (proceeds to lookup/creation)", async () => {
+    (svc as any).googleClient = {
+      verifyIdToken: jest.fn().mockResolvedValue(buildPayload(true)),
+    };
+    (prisma.user.findUnique as any).mockResolvedValue(null); // no existing user
+    const createSpy = jest
+      .spyOn(svc as any, "createSocialAuthUser")
+      .mockResolvedValue({ accessToken: "ok" } as any);
+
+    const out = await svc.googleAuth({ credential: "id-token" } as any);
+
+    expect(out).toEqual({ accessToken: "ok" });
+    // Gate passed → googleId lookup ran and new-user creation was reached.
+    expect(prisma.user.findUnique).toHaveBeenCalled();
+    expect(createSpy).toHaveBeenCalled();
+  });
+});

--- a/backend/src/modules/auth/auth.service.ts
+++ b/backend/src/modules/auth/auth.service.ts
@@ -682,6 +682,15 @@ export class AuthService {
     let email: string;
     let firstName: string;
     let lastName: string;
+    // SECURITY (deep-review C3): Google permits accounts whose email is NOT
+    // verified (e.g. a Workspace/Cloud-Identity domain whose admin set an
+    // arbitrary primary email). Trusting payload.email for account linking
+    // without checking email_verified is the canonical Google Sign-In
+    // account-takeover vector. We capture the claim from whichever path
+    // (ID token / access-token userinfo) verifies the credential, then
+    // enforce it AFTER the try/catch below — never throw inside the inner
+    // ID-token try, or the access-token catch would swallow it.
+    let emailVerified = false;
 
     try {
       // Try to verify as ID token first
@@ -697,6 +706,9 @@ export class AuthService {
           email = payload.email;
           firstName = payload.given_name || "User";
           lastName = payload.family_name || "";
+          // payload.email_verified is boolean | undefined; strict === true
+          // rejects undefined too.
+          emailVerified = payload.email_verified === true;
         }
       } catch (idTokenError) {
         // If ID token verification fails, treat the credential as an access
@@ -733,10 +745,23 @@ export class AuthService {
         email = userInfo.email;
         firstName = userInfo.given_name || "User";
         lastName = userInfo.family_name || "";
+        // The /oauth2/v3/userinfo endpoint returns email_verified as either
+        // a boolean or the string "true"/"false" depending on path — coerce
+        // both. Anything else (including undefined) is treated as unverified.
+        emailVerified =
+          userInfo.email_verified === true ||
+          userInfo.email_verified === "true";
       }
 
       if (!email) {
         throw new BadRequestException("Email not provided by Google");
+      }
+
+      // SECURITY (deep-review C3): reject before any findUnique-by-email
+      // linking or new-user creation. An unverified Google email must not be
+      // trusted to identify a kds account.
+      if (!emailVerified) {
+        throw new UnauthorizedException("Google email is not verified");
       }
 
       // Check if user exists by googleId
@@ -870,6 +895,18 @@ export class AuthService {
 
       if (!email) {
         throw new BadRequestException("Email not provided by Apple");
+      }
+
+      // SECURITY (deep-review C3, Apple parity): Apple controls the email it
+      // issues (real Apple-ID address or a private relay), so it is verified
+      // by construction — unlike Google Workspace custom domains. We still
+      // refuse an explicitly-unverified email as defence in depth, but do NOT
+      // reject a missing claim (some Apple tokens omit it) to avoid breaking
+      // legitimate sign-ins. email_verified arrives as boolean or "true"/"false".
+      const appleEmailVerified = (applePayload as { email_verified?: unknown })
+        .email_verified;
+      if (appleEmailVerified === false || appleEmailVerified === "false") {
+        throw new UnauthorizedException("Apple email is not verified");
       }
 
       // Check if user exists by appleId

--- a/backend/src/modules/checkout/checkout-branch-snapshot.spec.ts
+++ b/backend/src/modules/checkout/checkout-branch-snapshot.spec.ts
@@ -101,7 +101,7 @@ describe("CheckoutService — branchId snapshot (v2.8.99.3)", () => {
         branchId: "branch-istanbul",
         shippingAddress: { line1: "Atatürk Cad. 12", city: "İstanbul" },
       },
-      "pay-ref-1",
+      null,
     );
 
     // Look-up was tenant-scoped + status=active.
@@ -130,7 +130,7 @@ describe("CheckoutService — branchId snapshot (v2.8.99.3)", () => {
           items: [] as any,
           branchId: "foreign-tenant-branch",
         },
-        "pay-ref-2",
+        null,
       ),
     ).rejects.toBeInstanceOf(BadRequestException);
     expect(createdOrder).toBeNull();
@@ -145,7 +145,7 @@ describe("CheckoutService — branchId snapshot (v2.8.99.3)", () => {
       svc.confirmAndProvision(
         "t-1",
         { items: [] as any, branchId: "archived-branch" },
-        "pay-ref-3",
+        null,
       ),
     ).rejects.toBeInstanceOf(BadRequestException);
   });
@@ -159,7 +159,7 @@ describe("CheckoutService — branchId snapshot (v2.8.99.3)", () => {
         items: [] as any,
         shippingAddress: { line1: "Custom address", city: "Bursa" },
       },
-      "pay-ref-4",
+      null,
     );
 
     // No branch lookup at all on the manual-address path.

--- a/backend/src/modules/checkout/checkout-branch-snapshot.spec.ts
+++ b/backend/src/modules/checkout/checkout-branch-snapshot.spec.ts
@@ -1,5 +1,5 @@
-import { BadRequestException } from '@nestjs/common';
-import { CheckoutService } from './checkout.service';
+import { BadRequestException } from "@nestjs/common";
+import { CheckoutService } from "./checkout.service";
 
 /**
  * v2.8.99.3 — `cart.branchId` is the "ship to my branch" snapshot the
@@ -19,7 +19,7 @@ import { CheckoutService } from './checkout.service';
  * is the snapshot. If Branch.address mutates after the order is placed,
  * the order row must not move.
  */
-describe('CheckoutService — branchId snapshot (v2.8.99.3)', () => {
+describe("CheckoutService — branchId snapshot (v2.8.99.3)", () => {
   let prisma: any;
   let outbox: any;
   let quoteSvc: any;
@@ -34,7 +34,7 @@ describe('CheckoutService — branchId snapshot (v2.8.99.3)', () => {
     const tx = {
       hardwareOrder: {
         create: jest.fn(async (args: any) => {
-          createdOrder = { id: 'hw-1', ...args.data };
+          createdOrder = { id: "hw-1", ...args.data };
           return createdOrder;
         }),
       },
@@ -43,6 +43,11 @@ describe('CheckoutService — branchId snapshot (v2.8.99.3)', () => {
       outboxEvent: { create: jest.fn() },
     };
     prisma = {
+      // C1 payment gate: a supplied paymentRef must resolve to a settled
+      // CheckoutIntent before provisioning.
+      checkoutIntent: {
+        findFirst: jest.fn().mockResolvedValue({ status: "succeeded" }),
+      },
       hardwareOrder: { findFirst: jest.fn().mockResolvedValue(null) },
       tenantAddOn: { findMany: jest.fn().mockResolvedValue([]) },
       branch: { findFirst: jest.fn() },
@@ -52,24 +57,30 @@ describe('CheckoutService — branchId snapshot (v2.8.99.3)', () => {
     catalog = { allocate: jest.fn().mockResolvedValue({ serials: [] }) };
     tenantMarketplace = { purchase: jest.fn() };
     quoteSvc = { quote: jest.fn() };
-    svc = new CheckoutService(prisma, outbox, quoteSvc, catalog, tenantMarketplace);
+    svc = new CheckoutService(
+      prisma,
+      outbox,
+      quoteSvc,
+      catalog,
+      tenantMarketplace,
+    );
   });
 
   function singleHardwareQuote() {
     quoteSvc.quote.mockResolvedValue({
       lines: [
         {
-          type: 'hardware',
-          code: 'yazarkasa-beko-300tr',
-          name: 'Beko 300TR',
+          type: "hardware",
+          code: "yazarkasa-beko-300tr",
+          name: "Beko 300TR",
           qty: 1,
           unitCents: 650000,
           subtotalCents: 650000,
-          cadence: 'oneTime',
-          meta: { productId: 'prod-1', acquisition: 'sell' },
+          cadence: "oneTime",
+          meta: { productId: "prod-1", acquisition: "sell" },
         },
       ],
-      currency: 'TRY',
+      currency: "TRY",
       subtotalCents: 650000,
       taxCents: 130000,
       shippingCents: 5000,
@@ -79,76 +90,76 @@ describe('CheckoutService — branchId snapshot (v2.8.99.3)', () => {
     });
   }
 
-  it('persists HardwareOrder.branchId when branchId is a tenant-owned active branch', async () => {
-    prisma.branch.findFirst.mockResolvedValue({ id: 'branch-istanbul' });
+  it("persists HardwareOrder.branchId when branchId is a tenant-owned active branch", async () => {
+    prisma.branch.findFirst.mockResolvedValue({ id: "branch-istanbul" });
     singleHardwareQuote();
 
     await svc.confirmAndProvision(
-      't-1',
+      "t-1",
       {
         items: [] as any,
-        branchId: 'branch-istanbul',
-        shippingAddress: { line1: 'Atatürk Cad. 12', city: 'İstanbul' },
+        branchId: "branch-istanbul",
+        shippingAddress: { line1: "Atatürk Cad. 12", city: "İstanbul" },
       },
-      'pay-ref-1',
+      "pay-ref-1",
     );
 
     // Look-up was tenant-scoped + status=active.
     expect(prisma.branch.findFirst).toHaveBeenCalledWith({
-      where: { id: 'branch-istanbul', tenantId: 't-1', status: 'active' },
+      where: { id: "branch-istanbul", tenantId: "t-1", status: "active" },
       select: { id: true },
     });
-    expect(createdOrder.branchId).toBe('branch-istanbul');
+    expect(createdOrder.branchId).toBe("branch-istanbul");
     // Address still copied as snapshot (the address is the source of
     // truth on the order; branchId is just the reference).
     expect(createdOrder.shippingAddress).toMatchObject({
-      line1: 'Atatürk Cad. 12',
-      city: 'İstanbul',
+      line1: "Atatürk Cad. 12",
+      city: "İstanbul",
     });
   });
 
-  it('rejects with BadRequest when branchId belongs to another tenant', async () => {
+  it("rejects with BadRequest when branchId belongs to another tenant", async () => {
     // findFirst returns null because the WHERE includes tenantId=t-1.
     prisma.branch.findFirst.mockResolvedValue(null);
     singleHardwareQuote();
 
     await expect(
       svc.confirmAndProvision(
-        't-1',
+        "t-1",
         {
           items: [] as any,
-          branchId: 'foreign-tenant-branch',
+          branchId: "foreign-tenant-branch",
         },
-        'pay-ref-2',
+        "pay-ref-2",
       ),
     ).rejects.toBeInstanceOf(BadRequestException);
     expect(createdOrder).toBeNull();
   });
 
-  it('rejects with BadRequest when the branch exists but is suspended/archived', async () => {
+  it("rejects with BadRequest when the branch exists but is suspended/archived", async () => {
     // Status filter excludes non-active branches, so findFirst returns null.
     prisma.branch.findFirst.mockResolvedValue(null);
     singleHardwareQuote();
 
     await expect(
       svc.confirmAndProvision(
-        't-1',
-        { items: [] as any, branchId: 'archived-branch' },
-        'pay-ref-3',
+        "t-1",
+        { items: [] as any, branchId: "archived-branch" },
+        "pay-ref-3",
       ),
     ).rejects.toBeInstanceOf(BadRequestException);
   });
 
-  it('leaves HardwareOrder.branchId null when the cart has no branchId (manual address mode)', async () => {
+  it("leaves HardwareOrder.branchId null when the cart has no branchId (manual address mode)", async () => {
     singleHardwareQuote();
 
     await svc.confirmAndProvision(
-      't-1',
+      "t-1",
       {
         items: [] as any,
-        shippingAddress: { line1: 'Custom address', city: 'Bursa' },
+        shippingAddress: { line1: "Custom address", city: "Bursa" },
       },
-      'pay-ref-4',
+      "pay-ref-4",
     );
 
     // No branch lookup at all on the manual-address path.

--- a/backend/src/modules/checkout/checkout-install-trigger.spec.ts
+++ b/backend/src/modules/checkout/checkout-install-trigger.spec.ts
@@ -1,4 +1,4 @@
-import { CheckoutService } from './checkout.service';
+import { CheckoutService } from "./checkout.service";
 
 /**
  * v2.8.87 — installation trigger now keyed on serviceMeta.serviceType.
@@ -27,7 +27,7 @@ import { CheckoutService } from './checkout.service';
  * Legacy code-prefix path stays as a fallback so the 2 hardcoded codes
  * still trigger installation (no serviceMeta on the legacy lines).
  */
-describe('CheckoutService — installation trigger (v2.8.87)', () => {
+describe("CheckoutService — installation trigger (v2.8.87)", () => {
   let prisma: any;
   let outbox: any;
   let quoteSvc: any;
@@ -45,7 +45,7 @@ describe('CheckoutService — installation trigger (v2.8.87)', () => {
     const tx = {
       hardwareOrder: {
         create: jest.fn(async (args: any) => {
-          createdOrder = { id: 'hw-1', ...args.data };
+          createdOrder = { id: "hw-1", ...args.data };
           return createdOrder;
         }),
       },
@@ -59,6 +59,11 @@ describe('CheckoutService — installation trigger (v2.8.87)', () => {
       outboxEvent: { create: jest.fn() },
     };
     prisma = {
+      // C1 payment gate: a supplied paymentRef must resolve to a settled
+      // CheckoutIntent before provisioning.
+      checkoutIntent: {
+        findFirst: jest.fn().mockResolvedValue({ status: "succeeded" }),
+      },
       hardwareOrder: { findFirst: jest.fn().mockResolvedValue(null) },
       tenantAddOn: { findMany: jest.fn().mockResolvedValue([]) },
       $transaction: jest.fn(async (cb: any) => cb(tx)),
@@ -67,42 +72,56 @@ describe('CheckoutService — installation trigger (v2.8.87)', () => {
     catalog = { allocate: jest.fn().mockResolvedValue({ serials: [] }) };
     tenantMarketplace = { purchase: jest.fn() };
     quoteSvc = { quote: jest.fn() };
-    svc = new CheckoutService(prisma, outbox, quoteSvc, catalog, tenantMarketplace);
+    svc = new CheckoutService(
+      prisma,
+      outbox,
+      quoteSvc,
+      catalog,
+      tenantMarketplace,
+    );
   });
 
-  it('mints an InstallationRequest with branchId + preferredDates + notes for each on-site service line', async () => {
+  it("mints an InstallationRequest with branchId + preferredDates + notes for each on-site service line", async () => {
     quoteSvc.quote.mockResolvedValue({
       lines: [
         {
-          type: 'service',
-          code: 'install-yazarkasa-gib',
-          name: 'Yazarkasa kurulum',
+          type: "service",
+          code: "install-yazarkasa-gib",
+          name: "Yazarkasa kurulum",
           qty: 1,
           unitCents: 350000,
           subtotalCents: 350000,
-          cadence: 'oneTime',
+          cadence: "oneTime",
           meta: {
-            branchId: 'branch-istanbul',
-            serviceMeta: { serviceType: 'onsite', durationHours: 4, requiresBranch: true },
-            preferredDates: ['2026-06-15', '2026-06-18'],
-            notes: 'Mesai dışı uygun',
+            branchId: "branch-istanbul",
+            serviceMeta: {
+              serviceType: "onsite",
+              durationHours: 4,
+              requiresBranch: true,
+            },
+            preferredDates: ["2026-06-15", "2026-06-18"],
+            notes: "Mesai dışı uygun",
           },
         },
         {
-          type: 'service',
-          code: 'wifi-site-survey',
-          name: 'WiFi survey',
+          type: "service",
+          code: "wifi-site-survey",
+          name: "WiFi survey",
           qty: 1,
           unitCents: 150000,
           subtotalCents: 150000,
-          cadence: 'oneTime',
+          cadence: "oneTime",
           meta: {
-            branchId: 'branch-ankara',
-            serviceMeta: { serviceType: 'onsite', durationHours: 2, requiresBranch: true },
+            branchId: "branch-ankara",
+            serviceMeta: {
+              serviceType: "onsite",
+              durationHours: 2,
+              requiresBranch: true,
+            },
           },
         },
       ],
-      currency: 'TRY',
+      currency: "TRY",
       subtotalCents: 500000,
       taxCents: 100000,
       shippingCents: 0,
@@ -111,51 +130,51 @@ describe('CheckoutService — installation trigger (v2.8.87)', () => {
       isPureRecurring: false,
     });
 
-    await svc.confirmAndProvision('t-1', { items: [] as any }, 'pay-ref-1');
+    await svc.confirmAndProvision("t-1", { items: [] as any }, "pay-ref-1");
 
-    expect(createdOrder.installation).toBe('requested');
+    expect(createdOrder.installation).toBe("requested");
     expect(createdInstallations).toHaveLength(2);
     const [ist, ank] = createdInstallations;
     expect(ist).toMatchObject({
-      tenantId: 't-1',
-      hwOrderId: 'hw-1',
-      branchId: 'branch-istanbul',
-      status: 'requested',
-      notes: 'Mesai dışı uygun',
+      tenantId: "t-1",
+      hwOrderId: "hw-1",
+      branchId: "branch-istanbul",
+      status: "requested",
+      notes: "Mesai dışı uygun",
     });
     expect(ist.preferredDates).toHaveLength(2);
     expect(ist.preferredDates[0]).toBeInstanceOf(Date);
-    expect(ank).toMatchObject({ branchId: 'branch-ankara' });
+    expect(ank).toMatchObject({ branchId: "branch-ankara" });
     // No buyer notes given on second line → fallback auto-message includes
     // the code so support can trace which line spawned the request.
-    expect(ank.notes).toContain('wifi-site-survey');
+    expect(ank.notes).toContain("wifi-site-survey");
   });
 
-  it('does NOT mint InstallationRequest for remote / consultation services', async () => {
+  it("does NOT mint InstallationRequest for remote / consultation services", async () => {
     quoteSvc.quote.mockResolvedValue({
       lines: [
         {
-          type: 'service',
-          code: 'integration-yemeksepeti',
-          name: 'Yemeksepeti entegrasyon',
+          type: "service",
+          code: "integration-yemeksepeti",
+          name: "Yemeksepeti entegrasyon",
           qty: 1,
           unitCents: 250000,
           subtotalCents: 250000,
-          cadence: 'oneTime',
-          meta: { serviceMeta: { serviceType: 'remote' } },
+          cadence: "oneTime",
+          meta: { serviceMeta: { serviceType: "remote" } },
         },
         {
-          type: 'service',
-          code: 'multibranch-rollout',
-          name: 'Multibranch rollout',
+          type: "service",
+          code: "multibranch-rollout",
+          name: "Multibranch rollout",
           qty: 1,
           unitCents: 500000,
           subtotalCents: 500000,
-          cadence: 'oneTime',
-          meta: { serviceMeta: { serviceType: 'consultation' } },
+          cadence: "oneTime",
+          meta: { serviceMeta: { serviceType: "consultation" } },
         },
       ],
-      currency: 'TRY',
+      currency: "TRY",
       subtotalCents: 750000,
       taxCents: 150000,
       shippingCents: 0,
@@ -164,27 +183,27 @@ describe('CheckoutService — installation trigger (v2.8.87)', () => {
       isPureRecurring: false,
     });
 
-    await svc.confirmAndProvision('t-1', { items: [] as any }, 'pay-ref-2');
+    await svc.confirmAndProvision("t-1", { items: [] as any }, "pay-ref-2");
 
     expect(createdOrder.installation).toBeNull();
     expect(createdInstallations).toHaveLength(0);
   });
 
-  it('legacy onsite_install_* prefix still triggers (no serviceMeta on the legacy line)', async () => {
+  it("legacy onsite_install_* prefix still triggers (no serviceMeta on the legacy line)", async () => {
     quoteSvc.quote.mockResolvedValue({
       lines: [
         {
-          type: 'service',
-          code: 'onsite_install_kds',
-          name: 'On-site KDS install',
+          type: "service",
+          code: "onsite_install_kds",
+          name: "On-site KDS install",
           qty: 1,
           unitCents: 250000,
           subtotalCents: 250000,
-          cadence: 'oneTime',
+          cadence: "oneTime",
           meta: {}, // no serviceMeta — legacy hardcoded line
         },
       ],
-      currency: 'TRY',
+      currency: "TRY",
       subtotalCents: 250000,
       taxCents: 50000,
       shippingCents: 0,
@@ -193,51 +212,51 @@ describe('CheckoutService — installation trigger (v2.8.87)', () => {
       isPureRecurring: false,
     });
 
-    await svc.confirmAndProvision('t-1', { items: [] as any }, 'pay-ref-3');
+    await svc.confirmAndProvision("t-1", { items: [] as any }, "pay-ref-3");
 
-    expect(createdOrder.installation).toBe('requested');
+    expect(createdOrder.installation).toBe("requested");
     expect(createdInstallations).toHaveLength(1);
   });
 
-  it('mixed cart (onsite + remote + hardware) creates exactly one InstallationRequest per on-site line', async () => {
+  it("mixed cart (onsite + remote + hardware) creates exactly one InstallationRequest per on-site line", async () => {
     quoteSvc.quote.mockResolvedValue({
       lines: [
         {
-          type: 'hardware',
-          code: 'yazarkasa-hugin-tiger-t300',
-          name: 'Hugin Tiger T300',
+          type: "hardware",
+          code: "yazarkasa-hugin-tiger-t300",
+          name: "Hugin Tiger T300",
           qty: 1,
           unitCents: 640000,
           subtotalCents: 640000,
-          cadence: 'oneTime',
-          meta: { productId: 'h-1', acquisition: 'sell' },
+          cadence: "oneTime",
+          meta: { productId: "h-1", acquisition: "sell" },
         },
         {
-          type: 'service',
-          code: 'install-yazarkasa-gib',
-          name: 'Yazarkasa kurulum',
+          type: "service",
+          code: "install-yazarkasa-gib",
+          name: "Yazarkasa kurulum",
           qty: 1,
           unitCents: 350000,
           subtotalCents: 350000,
-          cadence: 'oneTime',
+          cadence: "oneTime",
           meta: {
-            branchId: 'branch-1',
-            serviceMeta: { serviceType: 'onsite' },
-            preferredDates: ['2026-06-15'],
+            branchId: "branch-1",
+            serviceMeta: { serviceType: "onsite" },
+            preferredDates: ["2026-06-15"],
           },
         },
         {
-          type: 'service',
-          code: 'integration-yemeksepeti',
-          name: 'Yemeksepeti entegrasyon',
+          type: "service",
+          code: "integration-yemeksepeti",
+          name: "Yemeksepeti entegrasyon",
           qty: 1,
           unitCents: 250000,
           subtotalCents: 250000,
-          cadence: 'oneTime',
-          meta: { serviceMeta: { serviceType: 'remote' } },
+          cadence: "oneTime",
+          meta: { serviceMeta: { serviceType: "remote" } },
         },
       ],
-      currency: 'TRY',
+      currency: "TRY",
       subtotalCents: 1240000,
       taxCents: 248000,
       shippingCents: 5000,
@@ -246,11 +265,11 @@ describe('CheckoutService — installation trigger (v2.8.87)', () => {
       isPureRecurring: false,
     });
 
-    await svc.confirmAndProvision('t-1', { items: [] as any }, 'pay-ref-4');
+    await svc.confirmAndProvision("t-1", { items: [] as any }, "pay-ref-4");
 
-    expect(createdOrder.installation).toBe('requested');
+    expect(createdOrder.installation).toBe("requested");
     expect(createdInstallations).toHaveLength(1); // only the onsite line
-    expect(createdInstallations[0].branchId).toBe('branch-1');
+    expect(createdInstallations[0].branchId).toBe("branch-1");
     expect(createdInstallations[0].preferredDates).toHaveLength(1);
   });
 });

--- a/backend/src/modules/checkout/checkout-install-trigger.spec.ts
+++ b/backend/src/modules/checkout/checkout-install-trigger.spec.ts
@@ -62,7 +62,7 @@ describe("CheckoutService — installation trigger (v2.8.87)", () => {
       // C1 payment gate: a supplied paymentRef must resolve to a settled
       // CheckoutIntent before provisioning.
       checkoutIntent: {
-        findFirst: jest.fn().mockResolvedValue({ status: "succeeded" }),
+        findFirst: jest.fn().mockResolvedValue({ status: "succeeded", cartJson: { items: [] } }),
       },
       hardwareOrder: { findFirst: jest.fn().mockResolvedValue(null) },
       tenantAddOn: { findMany: jest.fn().mockResolvedValue([]) },

--- a/backend/src/modules/checkout/checkout-metrics.spec.ts
+++ b/backend/src/modules/checkout/checkout-metrics.spec.ts
@@ -37,7 +37,7 @@ describe("CheckoutService — checkout_provisions_total counter", () => {
       // CheckoutIntent before provisioning. These metric tests use a real
       // paymentRef, so default the intent to 'succeeded'.
       checkoutIntent: {
-        findFirst: jest.fn().mockResolvedValue({ status: "succeeded" }),
+        findFirst: jest.fn().mockResolvedValue({ status: "succeeded", cartJson: { items: [] } }),
       },
       hardwareOrder: { findFirst: jest.fn().mockResolvedValue(null) },
       tenantAddOn: { findMany: jest.fn().mockResolvedValue([]) },

--- a/backend/src/modules/checkout/checkout-metrics.spec.ts
+++ b/backend/src/modules/checkout/checkout-metrics.spec.ts
@@ -33,6 +33,12 @@ describe("CheckoutService — checkout_provisions_total counter", () => {
       outboxEvent: { create: jest.fn() },
     };
     prisma = {
+      // C1 payment gate: a supplied paymentRef must resolve to a settled
+      // CheckoutIntent before provisioning. These metric tests use a real
+      // paymentRef, so default the intent to 'succeeded'.
+      checkoutIntent: {
+        findFirst: jest.fn().mockResolvedValue({ status: "succeeded" }),
+      },
       hardwareOrder: { findFirst: jest.fn().mockResolvedValue(null) },
       tenantAddOn: { findMany: jest.fn().mockResolvedValue([]) },
       branch: { findFirst: jest.fn() },

--- a/backend/src/modules/checkout/checkout-payment-gate.spec.ts
+++ b/backend/src/modules/checkout/checkout-payment-gate.spec.ts
@@ -1,0 +1,98 @@
+import { ForbiddenException } from "@nestjs/common";
+import { CheckoutService } from "./checkout.service";
+
+/**
+ * deep-review C1 — confirmAndProvision payment gate.
+ *
+ * The tenant-facing POST /v1/checkout/confirm endpoint is reachable by any
+ * tenant ADMIN/MANAGER and forwards a client-supplied paymentRef. Without a
+ * server-side payment check a tenant could self-provision hardware/add-ons/
+ * plan-upgrades for free with any made-up ref. confirmAndProvision now
+ * REQUIRES a settled CheckoutIntent (status 'succeeded' | 'provisioned') for
+ * (tenantId, paymentRef) before provisioning anything.
+ */
+describe("CheckoutService — confirmAndProvision payment gate (C1)", () => {
+  let prisma: any;
+  let outbox: any;
+  let quoteSvc: any;
+  let catalog: any;
+  let tenantMarketplace: any;
+  let svc: CheckoutService;
+
+  beforeEach(() => {
+    const tx = {
+      hardwareOrder: {
+        create: jest.fn(async (args: any) => ({ id: "hw-1", ...args.data })),
+      },
+      hardwareOrderItem: { create: jest.fn() },
+      installationRequest: { create: jest.fn() },
+      outboxEvent: { create: jest.fn() },
+    };
+    prisma = {
+      checkoutIntent: { findFirst: jest.fn() },
+      hardwareOrder: { findFirst: jest.fn().mockResolvedValue(null) },
+      tenantAddOn: { findMany: jest.fn().mockResolvedValue([]) },
+      branch: { findFirst: jest.fn() },
+      $transaction: jest.fn(async (cb: any) => cb(tx)),
+    };
+    outbox = { append: jest.fn() };
+    catalog = { allocate: jest.fn().mockResolvedValue({ serials: [] }) };
+    tenantMarketplace = { purchase: jest.fn() };
+    quoteSvc = {
+      quote: jest.fn().mockResolvedValue({
+        lines: [],
+        currency: "TRY",
+        subtotalCents: 0,
+        taxCents: 0,
+        shippingCents: 0,
+        totalCents: 0,
+        warnings: [],
+        isPureRecurring: false,
+      }),
+    };
+    svc = new CheckoutService(
+      prisma,
+      outbox,
+      quoteSvc,
+      catalog,
+      tenantMarketplace,
+    );
+  });
+
+  it("rejects a forged paymentRef with no CheckoutIntent and provisions nothing", async () => {
+    prisma.checkoutIntent.findFirst.mockResolvedValue(null);
+
+    await expect(
+      svc.confirmAndProvision("t-1", { items: [] as any }, "forged-ref"),
+    ).rejects.toBeInstanceOf(ForbiddenException);
+
+    expect(prisma.$transaction).not.toHaveBeenCalled();
+    expect(prisma.hardwareOrder.findFirst).not.toHaveBeenCalled();
+  });
+
+  it("rejects a paymentRef whose intent is still pending (unpaid)", async () => {
+    prisma.checkoutIntent.findFirst.mockResolvedValue({ status: "pending" });
+
+    await expect(
+      svc.confirmAndProvision("t-1", { items: [] as any }, "CK-pending"),
+    ).rejects.toBeInstanceOf(ForbiddenException);
+    expect(prisma.$transaction).not.toHaveBeenCalled();
+  });
+
+  it("provisions when the CheckoutIntent is settled (succeeded)", async () => {
+    prisma.checkoutIntent.findFirst.mockResolvedValue({ status: "succeeded" });
+
+    await expect(
+      svc.confirmAndProvision("t-1", { items: [] as any }, "CK-ok"),
+    ).resolves.toBeDefined();
+    expect(prisma.$transaction).toHaveBeenCalledTimes(1);
+  });
+
+  it("allows the null-paymentRef internal comp path without an intent lookup", async () => {
+    await expect(
+      svc.confirmAndProvision("t-1", { items: [] as any }, null),
+    ).resolves.toBeDefined();
+    expect(prisma.checkoutIntent.findFirst).not.toHaveBeenCalled();
+    expect(prisma.$transaction).toHaveBeenCalledTimes(1);
+  });
+});

--- a/backend/src/modules/checkout/checkout-payment-gate.spec.ts
+++ b/backend/src/modules/checkout/checkout-payment-gate.spec.ts
@@ -80,12 +80,38 @@ describe("CheckoutService — confirmAndProvision payment gate (C1)", () => {
   });
 
   it("provisions when the CheckoutIntent is settled (succeeded)", async () => {
-    prisma.checkoutIntent.findFirst.mockResolvedValue({ status: "succeeded" });
+    prisma.checkoutIntent.findFirst.mockResolvedValue({
+      status: "succeeded",
+      cartJson: { items: [] },
+    });
 
     await expect(
       svc.confirmAndProvision("t-1", { items: [] as any }, "CK-ok"),
     ).resolves.toBeDefined();
     expect(prisma.$transaction).toHaveBeenCalledTimes(1);
+  });
+
+  // deep-review C1 verification follow-up — the cart-swap / amount-mismatch
+  // hole the status-only gate left open: pay for a cheap cart, then /confirm
+  // an expensive one under the SAME settled ref. The server must provision the
+  // cart that was actually paid for (intent.cartJson), never the client cart.
+  it("provisions intent.cartJson, not a swapped client cart, for a settled ref", async () => {
+    const paidCart = {
+      items: [{ type: "plan", code: "PRO", billingCycle: "MONTHLY" }],
+    };
+    prisma.checkoutIntent.findFirst.mockResolvedValue({
+      status: "succeeded",
+      cartJson: paidCart,
+    });
+
+    const swappedCart = {
+      items: [{ type: "hardware", sku: "EXPENSIVE", qty: 5 }],
+    };
+    await svc.confirmAndProvision("t-1", swappedCart as any, "CK-paid");
+
+    // Priced + provisioned the PAID cart, never the attacker's swapped cart.
+    expect(quoteSvc.quote).toHaveBeenCalledWith(paidCart);
+    expect(quoteSvc.quote).not.toHaveBeenCalledWith(swappedCart);
   });
 
   it("allows the null-paymentRef internal comp path without an intent lookup", async () => {

--- a/backend/src/modules/checkout/checkout.controller.ts
+++ b/backend/src/modules/checkout/checkout.controller.ts
@@ -94,10 +94,15 @@ export class CheckoutController {
   // v2.8.85: the production payment path is now /intent → PayTR iframe →
   // PaytrWebhookController dispatches CK- prefix → CheckoutSettlementService
   // → confirmAndProvision (so the user's browser never reaches /confirm
-  // with a free-text paymentRef). /confirm stays as the admin-comp /
-  // super-admin override path; the @Roles(ADMIN, MANAGER) gate keeps a
-  // forged paymentRef from a tenant user from succeeding because the
-  // matching CheckoutIntent row would not exist for arbitrary refs.
+  // with a free-text paymentRef).
+  //
+  // SECURITY (deep-review C1): @Roles(ADMIN, MANAGER) is NOT a payment
+  // control — ADMIN/MANAGER are ordinary tenant-realm roles any restaurant
+  // owner holds, so this endpoint is reachable by every tenant. A forged
+  // paymentRef is rejected because confirmAndProvision now REQUIRES a
+  // settled CheckoutIntent for (tenantId, paymentRef) before provisioning
+  // anything — see CheckoutService.confirmAndProvision. Do not rely on the
+  // role gate alone.
   @Post("confirm")
   @Roles(UserRole.ADMIN, UserRole.MANAGER)
   @ApiOperation({

--- a/backend/src/modules/checkout/checkout.service.ts
+++ b/backend/src/modules/checkout/checkout.service.ts
@@ -1,5 +1,6 @@
 import {
   BadRequestException,
+  ForbiddenException,
   Injectable,
   Logger,
   Optional,
@@ -56,6 +57,44 @@ export class CheckoutService {
     addOnIds: string[];
   }> {
     const quote = await this.quoteSvc.quote(cart);
+
+    // SECURITY (deep-review C1): a non-null paymentRef is NOT proof of
+    // payment on its own. The tenant-facing POST /v1/checkout/confirm
+    // endpoint is gated only by @Roles(ADMIN, MANAGER) — ordinary
+    // tenant-realm roles every restaurant owner holds — and forwards a
+    // client-supplied paymentRef straight here. Without this gate a tenant
+    // admin could POST an arbitrary cart with any made-up ref and have us
+    // allocate/ship hardware, grant paid add-on entitlements, and request a
+    // plan upgrade with ZERO money collected (repeatable with each new ref).
+    //
+    // The only legitimate way a paymentRef reaches provisioning is through
+    // CheckoutSettlementService.handleSuccess, which is driven by the
+    // HMAC-authenticated PayTR webhook and flips the CheckoutIntent
+    // 'pending' -> 'succeeded' BEFORE calling us. So we require a settled
+    // CheckoutIntent for (tenantId, paymentRef). A forged ref has no intent
+    // row -> rejected; an already-provisioned ref is allowed so idempotent
+    // replays still return the cached order below.
+    //
+    // paymentRef === null is the internal operator-comp path (no caller
+    // passes null today — the controller DTO forbids an empty ref — so this
+    // gate intentionally only fires for client-supplied refs).
+    if (paymentRef) {
+      const intent = await this.prisma.checkoutIntent.findFirst({
+        where: { tenantId, paymentRef },
+        select: { status: true },
+      });
+      if (
+        !intent ||
+        (intent.status !== "succeeded" && intent.status !== "provisioned")
+      ) {
+        this.logger.warn(
+          `Rejected confirmAndProvision for tenant=${tenantId} ref=${paymentRef}: no settled CheckoutIntent (status=${intent?.status ?? "none"})`,
+        );
+        throw new ForbiddenException(
+          "No settled payment was found for this reference",
+        );
+      }
+    }
 
     // Idempotency: webhook retries and double-clicks on the success page
     // both replay confirmAndProvision with the same paymentRef. Without

--- a/backend/src/modules/checkout/checkout.service.ts
+++ b/backend/src/modules/checkout/checkout.service.ts
@@ -56,32 +56,36 @@ export class CheckoutService {
     hardwareOrderId?: string;
     addOnIds: string[];
   }> {
-    const quote = await this.quoteSvc.quote(cart);
-
-    // SECURITY (deep-review C1): a non-null paymentRef is NOT proof of
-    // payment on its own. The tenant-facing POST /v1/checkout/confirm
-    // endpoint is gated only by @Roles(ADMIN, MANAGER) — ordinary
-    // tenant-realm roles every restaurant owner holds — and forwards a
-    // client-supplied paymentRef straight here. Without this gate a tenant
-    // admin could POST an arbitrary cart with any made-up ref and have us
-    // allocate/ship hardware, grant paid add-on entitlements, and request a
-    // plan upgrade with ZERO money collected (repeatable with each new ref).
+    // SECURITY (deep-review C1 + verification follow-up): a non-null
+    // paymentRef is NOT proof of payment, AND a settled ref must only
+    // provision the cart that was actually PAID FOR. The tenant-facing POST
+    // /v1/checkout/confirm endpoint is gated only by @Roles(ADMIN, MANAGER) —
+    // ordinary tenant-realm roles every restaurant owner holds — and forwards
+    // BOTH a client-supplied cart and paymentRef straight here. Two holes if
+    // we trust them:
+    //   1. Forged ref -> allocate/ship hardware, grant paid add-ons, request a
+    //      plan upgrade with ZERO money collected (repeatable per made-up ref).
+    //   2. Cart swap   -> pay for a cheap (e.g. plan-only) cart, then /confirm
+    //      an EXPENSIVE hardware+add-on cart under the same settled ref. A
+    //      plan-only purchase mints no HardwareOrder, so the idempotency guard
+    //      below does NOT early-return and the swapped hardware ships for free.
     //
     // The only legitimate way a paymentRef reaches provisioning is through
-    // CheckoutSettlementService.handleSuccess, which is driven by the
-    // HMAC-authenticated PayTR webhook and flips the CheckoutIntent
-    // 'pending' -> 'succeeded' BEFORE calling us. So we require a settled
-    // CheckoutIntent for (tenantId, paymentRef). A forged ref has no intent
-    // row -> rejected; an already-provisioned ref is allowed so idempotent
-    // replays still return the cached order below.
+    // CheckoutSettlementService.handleSuccess (HMAC-authenticated PayTR
+    // webhook), which flips the CheckoutIntent 'pending' -> 'succeeded' and
+    // passes intent.cartJson. So: require a settled CheckoutIntent for
+    // (tenantId, paymentRef), and provision THAT intent's persisted cart —
+    // ignoring whatever cart the client sent. A forged ref has no intent row
+    // -> rejected; an already-provisioned ref is allowed so idempotent replays
+    // still return the cached order below.
     //
-    // paymentRef === null is the internal operator-comp path (no caller
-    // passes null today — the controller DTO forbids an empty ref — so this
-    // gate intentionally only fires for client-supplied refs).
+    // paymentRef === null is the internal operator-comp path (no caller passes
+    // null today — the controller DTO forbids an empty ref).
+    let effectiveCart: Cart = cart;
     if (paymentRef) {
       const intent = await this.prisma.checkoutIntent.findFirst({
         where: { tenantId, paymentRef },
-        select: { status: true },
+        select: { status: true, cartJson: true },
       });
       if (
         !intent ||
@@ -94,7 +98,11 @@ export class CheckoutService {
           "No settled payment was found for this reference",
         );
       }
+      // Provision exactly what was paid for, never the client-supplied cart.
+      effectiveCart = intent.cartJson as unknown as Cart;
     }
+
+    const quote = await this.quoteSvc.quote(effectiveCart);
 
     // Idempotency: webhook retries and double-clicks on the success page
     // both replay confirmAndProvision with the same paymentRef. Without
@@ -134,21 +142,21 @@ export class CheckoutService {
 
     // v2.8.99.3 — tenant-scoped active-branch validation. The buyer
     // picked a branch in the shipping form; we trust the SPA to copy
-    // the branch's address into cart.shippingAddress (snapshot) but
+    // the branch's address into effectiveCart.shippingAddress (snapshot) but
     // re-validate the branchId here so a forged or stale request
     // can't stamp another tenant's branch onto this HardwareOrder.
     // Archived branches are rejected too — re-activating an archived
     // branch is a deliberate operator action, not something a
     // checkout flow should resurrect by proxy.
     let validatedBranchId: string | null = null;
-    if (cart.branchId) {
+    if (effectiveCart.branchId) {
       const branch = await this.prisma.branch.findFirst({
-        where: { id: cart.branchId, tenantId, status: "active" },
+        where: { id: effectiveCart.branchId, tenantId, status: "active" },
         select: { id: true },
       });
       if (!branch) {
         throw new BadRequestException(
-          `branchId ${cart.branchId} is not an active branch for this tenant`,
+          `branchId ${effectiveCart.branchId} is not an active branch for this tenant`,
         );
       }
       validatedBranchId = branch.id;
@@ -201,8 +209,8 @@ export class CheckoutService {
               hardwareLines.reduce((a, l) => a + l.subtotalCents, 0) +
               quote.shippingCents,
             currency: quote.currency,
-            shippingAddress: cart.shippingAddress as any,
-            billingAddress: cart.billingAddress as any,
+            shippingAddress: effectiveCart.shippingAddress as any,
+            billingAddress: effectiveCart.billingAddress as any,
             installation: onsiteServiceLines.length > 0 ? "requested" : null,
             paymentRef,
           },

--- a/backend/src/modules/customer-orders/services/customer-orders.createorder.spec.ts
+++ b/backend/src/modules/customer-orders/services/customer-orders.createorder.spec.ts
@@ -179,4 +179,61 @@ describe("CustomerOrdersService.createOrder — guards", () => {
       expect(arg.orderBy).toEqual({ createdAt: "asc" });
     });
   });
+
+  // deep-review H13/M14 — the public QR path must enforce
+  // modifier-belongs-to-product (parity with the staff path). A customer
+  // attaching a modifier defined for a DIFFERENT product (e.g. a free /
+  // negative-price add-on) must be rejected before pricing so it can't
+  // lower the line total or pollute the kitchen ticket.
+  describe("modifier-belongs-to-product guard (deep-review H13/M14)", () => {
+    it("rejects a foreign modifier not in any of the product's groups", async () => {
+      tenantNoGeo();
+      (prisma.table.findFirst as any).mockResolvedValue({
+        id: "tb-1",
+        branchId: "b1",
+      });
+      // Product "Cola" has a single active group whose only allowed
+      // modifier is "mod-allowed". The DTO attaches "mod-foreign", which
+      // belongs to another product entirely.
+      (prisma.product.findMany as any).mockResolvedValue([
+        {
+          id: "p-cola",
+          name: "Cola",
+          price: 10,
+          modifierGroups: [
+            {
+              group: {
+                isActive: true,
+                isRequired: false,
+                minSelections: 0,
+                maxSelections: 0,
+                displayName: "Extras",
+                modifiers: [{ id: "mod-allowed" }],
+              },
+            },
+          ],
+        },
+      ]);
+
+      await expect(
+        svc.createOrder({
+          ...baseDto,
+          tableId: "tb-1",
+          items: [
+            {
+              productId: "p-cola",
+              quantity: 1,
+              modifiers: [{ modifierId: "mod-foreign", quantity: 1 }],
+            },
+          ],
+        } as any),
+      ).rejects.toThrow(/Modifier mod-foreign is not allowed/);
+
+      // Guard fires before the pricing-pass modifier fetch — the foreign
+      // modifier's priceAdjustment never gets a chance to reach the total.
+      expect((prisma.modifier.findMany as any).mock.calls.length).toBe(0);
+      // And no order row is created.
+      expect((prisma.order.create as any).mock.calls.length).toBe(0);
+    });
+  });
 });

--- a/backend/src/modules/customer-orders/services/customer-orders.service.ts
+++ b/backend/src/modules/customer-orders/services/customer-orders.service.ts
@@ -835,6 +835,32 @@ export class CustomerOrdersService {
       if (!product) continue;
 
       const itemModifierIds = (item.modifiers || []).map((m) => m.modifierId);
+
+      // deep-review H13/M14 — enforce modifier-belongs-to-product on the
+      // public QR path, mirroring the staff guard in orders.service
+      // (createInner cross-references each modifier's group against the
+      // product's ProductModifierGroup). Without this a customer could
+      // attach a modifier defined for ANOTHER product (e.g. one with a
+      // negative/promo priceAdjustment, or a free add-on) to lower the
+      // line total — a direct underpay vector on the unauthenticated
+      // path — and produce wrong kitchen tickets. The product fetch
+      // already eager-loads active groups → modifiers{id} filtered by
+      // isAvailable:true (lines 808-820), so the allowed set costs no
+      // extra query and already excludes inactive groups / unavailable
+      // modifiers. Reject before the pricing pass at 887-899.
+      const allowedModifierIds = new Set<string>();
+      for (const pmg of product.modifierGroups) {
+        if (!pmg.group.isActive) continue;
+        for (const m of pmg.group.modifiers) allowedModifierIds.add(m.id);
+      }
+      for (const id of itemModifierIds) {
+        if (!allowedModifierIds.has(id)) {
+          throw new BadRequestException(
+            `Modifier ${id} is not allowed on product "${product.name}"`,
+          );
+        }
+      }
+
       for (const pmg of product.modifierGroups) {
         const group = pmg.group;
         if (!group.isActive) continue;

--- a/backend/src/modules/customer-orders/services/customer-self-pay.service.spec.ts
+++ b/backend/src/modules/customer-orders/services/customer-self-pay.service.spec.ts
@@ -12,6 +12,9 @@ import { CustomerSelfPayService } from "./customer-self-pay.service";
 // without redefining a frozen property.
 jest.mock("@sentry/node", () => ({
   captureException: jest.fn(),
+  // deep-review M12 — webhook success-path amount-drift alert uses
+  // captureMessage; stub it so the reconciliation branch never throws.
+  captureMessage: jest.fn(),
 }));
 import {
   mockPrismaClient,
@@ -178,9 +181,7 @@ describe("CustomerSelfPayService (characterization)", () => {
 
     it("requires exact (not substring/regex) origin match — phishing host falls back", () => {
       // The pre-v2.8.94 loose regex risk: attacker.com/.example.com#
-      expect(
-        call("https://attacker.com/.restaurant.hummytummy.com#"),
-      ).toEqual({
+      expect(call("https://attacker.com/.restaurant.hummytummy.com#")).toEqual({
         okUrl: "https://fallback.example.com/payment-result",
         failUrl: "https://fallback.example.com/payment-result",
       });
@@ -496,7 +497,12 @@ describe("CustomerSelfPayService (characterization)", () => {
     (prisma.pendingSelfPayment.update as any).mockResolvedValue({});
     wireTransaction();
 
-    return svc.createPayIntent(SESSION_ID, { items: dtoItems } as any, "1.2.3.4", returnOrigin);
+    return svc.createPayIntent(
+      SESSION_ID,
+      { items: dtoItems } as any,
+      "1.2.3.4",
+      returnOrigin,
+    );
   }
 
   describe("createPayIntent — happy path", () => {
@@ -508,8 +514,8 @@ describe("CustomerSelfPayService (characterization)", () => {
       // FOR UPDATE row lock issued for the touched order.
       expect(prisma.$queryRaw).toHaveBeenCalled();
       // Intent persisted PENDING with branchId + amount.
-      const created = (prisma.pendingSelfPayment.create as any).mock
-        .calls[0][0].data;
+      const created = (prisma.pendingSelfPayment.create as any).mock.calls[0][0]
+        .data;
       expect(created.status).toBe("PENDING");
       expect(created.branchId).toBe(BRANCH_ID);
       expect(created.tenantId).toBe(TENANT_ID);
@@ -522,8 +528,7 @@ describe("CustomerSelfPayService (characterization)", () => {
       });
       expect(res).toEqual({
         merchantOid: expect.stringMatching(/^SP/),
-        paymentLink:
-          "https://www.paytr.com/odeme/guvenli/paytr-token-xyz",
+        paymentLink: "https://www.paytr.com/odeme/guvenli/paytr-token-xyz",
         amount: "25.00", // 50 subtotal / 2 qty * 1 unit
         currency: "TRY",
       });
@@ -532,8 +537,7 @@ describe("CustomerSelfPayService (characterization)", () => {
     it("marks the intent FAILED and rethrows if PayTR token mint fails", async () => {
       paytrAdapter.getIframeToken.mockRejectedValue(new Error("paytr boom"));
       await expect(runHappyPathIntent()).rejects.toThrow("paytr boom");
-      const updateCalls = (prisma.pendingSelfPayment.update as any).mock
-        .calls;
+      const updateCalls = (prisma.pendingSelfPayment.update as any).mock.calls;
       const failUpdate = updateCalls.find(
         (c: any[]) => c[0].data.status === "FAILED",
       );
@@ -903,9 +907,9 @@ describe("CustomerSelfPayService (characterization)", () => {
         failureReason: null,
         expiresAt: new Date(Date.now() + 60_000),
       });
-      await expect(
-        svc.getPayStatus(SESSION_ID, "SPx"),
-      ).rejects.toBeInstanceOf(NotFoundException);
+      await expect(svc.getPayStatus(SESSION_ID, "SPx")).rejects.toBeInstanceOf(
+        NotFoundException,
+      );
     });
 
     it("lazily flips an expired PENDING intent to EXPIRED on read", async () => {
@@ -962,6 +966,10 @@ describe("CustomerSelfPayService (characterization)", () => {
     });
 
     it("settles every bucket via payByItems with per-order idempotency key, then flips PENDING→SUCCEEDED", async () => {
+      // deep-review M16 — pre-validate now runs inside a FOR-UPDATE
+      // $transaction; wire it to run against the mock and stub the
+      // row-lock query.
+      wireTransaction();
       (prisma.pendingSelfPayment.findUnique as any).mockResolvedValue({
         id: "intent-1",
         merchantOid: "SPx",
@@ -969,6 +977,7 @@ describe("CustomerSelfPayService (characterization)", () => {
         tenantId: TENANT_ID,
         sessionId: SESSION_ID,
         customerPhone: "+905551112233",
+        amount: new Prisma.Decimal("0"),
         itemsByOrder: [
           { orderId: "order-A", items: [{ orderItemId: "oi-1", quantity: 1 }] },
         ],
@@ -977,6 +986,10 @@ describe("CustomerSelfPayService (characterization)", () => {
       (prisma.orderItem.findMany as any).mockResolvedValue([
         { id: "oi-1", quantity: 2, orderItemPayments: [] },
       ]);
+      // deep-review M12 — booked-sum reconciliation read on the success path.
+      (prisma.payment.aggregate as any).mockResolvedValue({
+        _sum: { amount: new Prisma.Decimal("0") },
+      });
       (prisma.pendingSelfPayment.updateMany as any).mockResolvedValue({
         count: 1,
       });
@@ -992,17 +1005,20 @@ describe("CustomerSelfPayService (characterization)", () => {
       expect(body.transactionId).toBe("SPx");
       expect(body.method).toBe("CARD");
       expect(body.notes).toBe("Self-pay via PayTR (card)");
-      // TOCTOU-safe success write: compound WHERE on PENDING.
+      // TOCTOU-safe success write: compound WHERE on PENDING (and now also
+      // PARTIALLY_SETTLED so a healed retry is promoted — deep-review H10).
       const successWrite = (
         prisma.pendingSelfPayment.updateMany as any
       ).mock.calls.find((c: any[]) => c[0].data.status === "SUCCEEDED");
       expect(successWrite[0].where).toEqual({
         id: "intent-1",
-        status: "PENDING",
+        status: { in: ["PENDING", "PARTIALLY_SETTLED"] },
       });
     });
 
     it("pre-validate detects an item paid by someone else → marks intent FAILED, no payByItems", async () => {
+      // deep-review M16 — pre-validate runs inside a FOR-UPDATE tx.
+      wireTransaction();
       (prisma.pendingSelfPayment.findUnique as any).mockResolvedValue({
         id: "intent-1",
         merchantOid: "SPx",
@@ -1010,6 +1026,7 @@ describe("CustomerSelfPayService (characterization)", () => {
         tenantId: TENANT_ID,
         sessionId: SESSION_ID,
         customerPhone: null,
+        amount: new Prisma.Decimal("25.00"),
         itemsByOrder: [
           { orderId: "order-A", items: [{ orderItemId: "oi-1", quantity: 2 }] },
         ],
@@ -1022,6 +1039,11 @@ describe("CustomerSelfPayService (characterization)", () => {
           orderItemPayments: [{ quantity: 2 }],
         },
       ]);
+      // deep-review H10 — nothing was booked (pre-validate threw before any
+      // payByItems), so the failure-classifier sees 0 booked → FAILED.
+      (prisma.payment.aggregate as any).mockResolvedValue({
+        _sum: { amount: null },
+      });
       (prisma.pendingSelfPayment.updateMany as any).mockResolvedValue({
         count: 1,
       });
@@ -1040,6 +1062,57 @@ describe("CustomerSelfPayService (characterization)", () => {
       });
       expect(failWrite[0].data.failureReason).toBe("settlement_error");
       expect(Sentry.captureException).toHaveBeenCalled();
+    });
+
+    it("partial settlement (bucket #2 fails after bucket #1 booked) → PARTIALLY_SETTLED, not FAILED (deep-review H10)", async () => {
+      // deep-review H10/M16 — a transient failure on a later bucket after an
+      // earlier one already committed a Payment must leave the intent
+      // recoverable (PARTIALLY_SETTLED) so a PayTR retry re-enters and
+      // settles the remainder, instead of sticky-FAILED with a partial
+      // charge and no auto-recovery.
+      wireTransaction();
+      (prisma.pendingSelfPayment.findUnique as any).mockResolvedValue({
+        id: "intent-1",
+        merchantOid: "SPx",
+        status: "PENDING",
+        tenantId: TENANT_ID,
+        sessionId: SESSION_ID,
+        customerPhone: null,
+        amount: new Prisma.Decimal("50.00"),
+        itemsByOrder: [
+          { orderId: "order-A", items: [{ orderItemId: "oi-1", quantity: 1 }] },
+          { orderId: "order-B", items: [{ orderItemId: "oi-2", quantity: 1 }] },
+        ],
+      });
+      // Pre-validate passes for both buckets.
+      (prisma.orderItem.findMany as any).mockResolvedValue([
+        { id: "oi-1", quantity: 1, orderItemPayments: [] },
+        { id: "oi-2", quantity: 1, orderItemPayments: [] },
+      ]);
+      // Bucket #1 books fine; bucket #2 throws (e.g. waiter took cash).
+      paymentsService.payByItems
+        .mockResolvedValueOnce({ id: "pay-A" })
+        .mockRejectedValueOnce(new Error("transient settle failure"));
+      // 25 of the 50 actually booked → SOME booked → recoverable.
+      (prisma.payment.aggregate as any).mockResolvedValue({
+        _sum: { amount: new Prisma.Decimal("25.00") },
+      });
+      (prisma.pendingSelfPayment.updateMany as any).mockResolvedValue({
+        count: 1,
+      });
+
+      await svc.handleWebhookSuccess("SPx");
+
+      const partialWrite = (
+        prisma.pendingSelfPayment.updateMany as any
+      ).mock.calls.find((c: any[]) => c[0].data.status === "PARTIALLY_SETTLED");
+      expect(partialWrite).toBeDefined();
+      expect(partialWrite[0].data.failureReason).toBe("partial_settlement");
+      // It must NOT have flipped to a terminal FAILED.
+      const failWrite = (
+        prisma.pendingSelfPayment.updateMany as any
+      ).mock.calls.find((c: any[]) => c[0].data.status === "FAILED");
+      expect(failWrite).toBeUndefined();
     });
   });
 
@@ -1114,6 +1187,8 @@ describe("CustomerSelfPayService (characterization)", () => {
     });
 
     it("records result=success after a settled webhook success", async () => {
+      // deep-review M16/M12 — pre-validate FOR-UPDATE tx + booked-sum read.
+      wireTransaction();
       (prisma.pendingSelfPayment.findUnique as any).mockResolvedValue({
         id: "intent-1",
         merchantOid: "SPx",
@@ -1121,6 +1196,7 @@ describe("CustomerSelfPayService (characterization)", () => {
         tenantId: TENANT_ID,
         sessionId: SESSION_ID,
         customerPhone: null,
+        amount: new Prisma.Decimal("0"),
         itemsByOrder: [
           { orderId: "order-A", items: [{ orderItemId: "oi-1", quantity: 1 }] },
         ],
@@ -1128,6 +1204,9 @@ describe("CustomerSelfPayService (characterization)", () => {
       (prisma.orderItem.findMany as any).mockResolvedValue([
         { id: "oi-1", quantity: 2, orderItemPayments: [] },
       ]);
+      (prisma.payment.aggregate as any).mockResolvedValue({
+        _sum: { amount: new Prisma.Decimal("0") },
+      });
       (prisma.pendingSelfPayment.updateMany as any).mockResolvedValue({
         count: 1,
       });

--- a/backend/src/modules/customer-orders/services/self-pay-intent.service.ts
+++ b/backend/src/modules/customer-orders/services/self-pay-intent.service.ts
@@ -279,8 +279,19 @@ export class SelfPayIntentService {
         );
       }
 
+      // deep-review M12 — round each line to 2dp BEFORE summing
+      // (round-then-sum) so the charged amount matches what payByItems
+      // books per entry (it rounds each entry's amount toDecimalPlaces(2)
+      // — payments.service.ts:1289). Pre-fix this summed full-precision
+      // perUnit×qty and rounded once at the end, which for qty>1 /
+      // discounted lines could diverge from the per-entry-rounded booked
+      // total by a few kuruş, leaving PayTR payouts and KDS accounting
+      // out of sync (and occasionally an order a kuruş short of PAID).
+      // The webhook's reconciliation alert (sumBookedPayments vs amount)
+      // surfaces any residual divergence on the last-units residual path
+      // that this round-then-sum still can't fully predict.
       const perUnit = this.paymentsService.derivePerUnitNet(item, item.order);
-      const lineAmount = perUnit.mul(entry.quantity);
+      const lineAmount = perUnit.mul(entry.quantity).toDecimalPlaces(2);
       totalAmount = totalAmount.add(lineAmount);
 
       const bucket = itemsByOrder.get(item.orderId) ?? {

--- a/backend/src/modules/customer-orders/services/self-pay-webhook.service.ts
+++ b/backend/src/modules/customer-orders/services/self-pay-webhook.service.ts
@@ -7,6 +7,7 @@ import {
   forwardRef,
 } from "@nestjs/common";
 import * as Sentry from "@sentry/node";
+import { Prisma } from "@prisma/client";
 import { PrismaService } from "../../../prisma/prisma.service";
 import { PaymentsService } from "../../orders/services/payments.service";
 import { PaymentStatus } from "../../../common/constants/order-status.enum";
@@ -56,8 +57,14 @@ export class SelfPayWebhookService {
       this.logger.warn(`self-pay webhook: unknown merchantOid=${merchantOid}`);
       return;
     }
-    if (intent.status !== "PENDING") {
-      // Idempotent — PayTR retried; we already settled.
+    // deep-review H10 — PARTIALLY_SETTLED must re-enter the loop on a
+    // PayTR retry so the remaining (unbooked) buckets get a chance to
+    // settle. payByItems' idempotency fast-path turns already-booked
+    // buckets into no-ops, so a retry only books what's still missing
+    // and eventually reaches SUCCEEDED. Terminal states (SUCCEEDED /
+    // FAILED) still short-circuit.
+    if (intent.status !== "PENDING" && intent.status !== "PARTIALLY_SETTLED") {
+      // Idempotent — PayTR retried; we already settled (or gave up).
       return;
     }
 
@@ -72,36 +79,60 @@ export class SelfPayWebhookService {
     // (selfpay:<oid>:<orderId> key), so a partial book on retry
     // resolves to the existing row.
     try {
-      for (const bucket of itemsByOrder) {
-        const items = await this.prisma.orderItem.findMany({
-          where: {
-            id: { in: bucket.items.map((i) => i.orderItemId) },
-            order: { id: bucket.orderId, tenantId: intent.tenantId },
-          },
-          include: {
-            orderItemPayments: {
-              where: { payment: { status: PaymentStatus.COMPLETED } },
+      // deep-review M16 — pre-validate every order's remaining quantities
+      // under a FOR UPDATE lock on each referenced order, taken in sorted
+      // orderId order to mirror self-pay-intent.service.ts (avoids
+      // deadlocks against the create-time lock). Pre-fix the pre-validate
+      // read ran completely unlocked, so a waiter taking cash (payByItems
+      // / create) for the same units between this pass and the settle
+      // pass would only be caught inside each individual payByItems
+      // re-check — i.e. after earlier buckets already committed. Locking
+      // here makes a concurrent POS payment either lose the race cleanly
+      // (its own acquireOrderLock blocks until we release) or be visible
+      // to us before we book anything. NOTE: this lock is released when
+      // the pre-validate tx commits; the per-bucket payByItems calls
+      // below each open their own tx. True single-transaction atomicity
+      // across all buckets is deferred (it requires threading an injected
+      // tx client through payByItems) — the recoverable-retry handling in
+      // the catch below (H10) covers the residual partial-commit window.
+      const lockOrderIds = [...itemsByOrder.map((b) => b.orderId)].sort();
+      await this.prisma.$transaction(async (tx) => {
+        for (const oid of lockOrderIds) {
+          await tx.$queryRaw`
+            SELECT id FROM orders WHERE id = ${oid} AND "tenantId" = ${intent.tenantId} FOR UPDATE
+          `;
+        }
+        for (const bucket of itemsByOrder) {
+          const items = await tx.orderItem.findMany({
+            where: {
+              id: { in: bucket.items.map((i) => i.orderItemId) },
+              order: { id: bucket.orderId, tenantId: intent.tenantId },
             },
-          },
-        });
-        for (const entry of bucket.items) {
-          const dbItem = items.find((it) => it.id === entry.orderItemId);
-          if (!dbItem) {
-            throw new BadRequestException(
-              `Item ${entry.orderItemId} no longer exists or was cancelled`,
+            include: {
+              orderItemPayments: {
+                where: { payment: { status: PaymentStatus.COMPLETED } },
+              },
+            },
+          });
+          for (const entry of bucket.items) {
+            const dbItem = items.find((it) => it.id === entry.orderItemId);
+            if (!dbItem) {
+              throw new BadRequestException(
+                `Item ${entry.orderItemId} no longer exists or was cancelled`,
+              );
+            }
+            const alreadyPaid = dbItem.orderItemPayments.reduce(
+              (s, a) => s + a.quantity,
+              0,
             );
-          }
-          const alreadyPaid = dbItem.orderItemPayments.reduce(
-            (s, a) => s + a.quantity,
-            0,
-          );
-          if (alreadyPaid + entry.quantity > dbItem.quantity) {
-            throw new ConflictException(
-              `Item ${entry.orderItemId} was paid for by someone else after the intent was created`,
-            );
+            if (alreadyPaid + entry.quantity > dbItem.quantity) {
+              throw new ConflictException(
+                `Item ${entry.orderItemId} was paid for by someone else after the intent was created`,
+              );
+            }
           }
         }
-      }
+      });
 
       for (const bucket of itemsByOrder) {
         await this.paymentsService.payByItems(
@@ -122,13 +153,46 @@ export class SelfPayWebhookService {
           intent.tenantId,
         );
       }
+      // deep-review M12 — defensive reconciliation: assert the sum of
+      // booked Payment rows for this merchantOid equals the amount PayTR
+      // actually charged (intent.amount). The per-entry allocation in
+      // payByItems rounds differently than the intent's round-then-charge
+      // path, so a few-kuruş divergence is possible for qty>1 / discounted
+      // lines. We still flip to SUCCEEDED (the order-level finalizer is
+      // authoritative for PAID), but alert so any residual drift between
+      // PayTR payouts and KDS accounting is surfaced rather than silently
+      // corrupting revenue.
+      const bookedOnSuccess = await this.sumBookedPayments(
+        merchantOid,
+        intent.tenantId,
+      );
+      const intentAmount = new Prisma.Decimal(intent.amount);
+      if (!bookedOnSuccess.equals(intentAmount)) {
+        Sentry.captureMessage("SELF_PAY_AMOUNT_DRIFT", {
+          level: "warning",
+          tags: {
+            event: "SELF_PAY_AMOUNT_DRIFT",
+            tenantId: intent.tenantId,
+          },
+          extra: {
+            merchantOid,
+            charged: intentAmount.toFixed(2),
+            booked: bookedOnSuccess.toFixed(2),
+          },
+        });
+      }
+
       // Compound WHERE on the original PENDING status closes the
-      // TOCTOU between line 704's intent.status check and this write.
+      // TOCTOU between the intent.status check above and this write.
       // A concurrent retry from PayTR that already finished settlement
       // won't be overwritten; a concurrent failure path won't be
-      // downgraded to SUCCEEDED.
+      // downgraded to SUCCEEDED. A PARTIALLY_SETTLED row (deep-review
+      // H10) that reached this point on a retry is also promoted.
       await this.prisma.pendingSelfPayment.updateMany({
-        where: { id: intent.id, status: "PENDING" },
+        where: {
+          id: intent.id,
+          status: { in: ["PENDING", "PARTIALLY_SETTLED"] },
+        },
         data: { status: "SUCCEEDED", succeededAt: new Date() },
       });
     } catch (err: any) {
@@ -136,6 +200,69 @@ export class SelfPayWebhookService {
         `self-pay settlement failed for ${merchantOid}: ${err?.message ?? err}`,
         err?.stack,
       );
+
+      // deep-review H10 — distinguish "nothing booked" from "some buckets
+      // already committed" so a transient failure on bucket #N (e.g. a
+      // waiter took cash for one unit between pre-validate and settle, or
+      // a transient DB error) does not become a sticky-FAILED partial
+      // charge. PayTR has already charged the full intent.amount; if we
+      // flip to FAILED while bucket #1's Payment is durable, the PayTR
+      // retry early-returns and the remaining orders are NEVER settled.
+      // Instead: sum the committed Payments for this merchantOid.
+      //   - NOTHING booked  -> safe to flip FAILED (ops refunds in full).
+      //   - SOME booked      -> leave PARTIALLY_SETTLED so the next PayTR
+      //     retry re-enters the loop; payByItems' idempotency fast-path
+      //     makes booked buckets no-ops and only the remaining buckets
+      //     get booked, eventually reaching SUCCEEDED (self-healing).
+      let bookedOnFailure: Prisma.Decimal;
+      try {
+        bookedOnFailure = await this.sumBookedPayments(
+          merchantOid,
+          intent.tenantId,
+        );
+      } catch {
+        // If we can't even read the booked sum, fall back to the
+        // conservative legacy behaviour (treat as nothing booked).
+        bookedOnFailure = new Prisma.Decimal(0);
+      }
+      const someBooked = bookedOnFailure.gt(0);
+
+      if (someBooked) {
+        // Dedicated reconciliation alert distinct from the full-failure
+        // one, carrying how much settled vs. how much was charged so ops
+        // sees partial states even if PayTR retries eventually heal them.
+        Sentry.captureException(err, {
+          level: "warning",
+          tags: {
+            event: "SELF_PAY_PARTIAL_SETTLEMENT",
+            tenantId: intent.tenantId,
+          },
+          extra: {
+            merchantOid,
+            sessionId: intent.sessionId,
+            charged: new Prisma.Decimal(intent.amount).toFixed(2),
+            booked: bookedOnFailure.toFixed(2),
+            raw: err?.message,
+          },
+        });
+        // Leave recoverable: a PayTR retry resumes from PARTIALLY_SETTLED.
+        // NOTE: an explicit retry upper-bound (attemptCount column → escalate
+        // to FAILED-with-partial after N attempts) is deferred — it needs a
+        // schema migration outside this change set; the alert above already
+        // gives ops the signal to intervene if retries never heal it.
+        await this.prisma.pendingSelfPayment.updateMany({
+          where: {
+            id: intent.id,
+            status: { in: ["PENDING", "PARTIALLY_SETTLED"] },
+          },
+          data: {
+            status: "PARTIALLY_SETTLED",
+            failureReason: "partial_settlement",
+          },
+        });
+        return;
+      }
+
       Sentry.captureException(err, {
         tags: {
           event: "SELF_PAY_SETTLEMENT_FAILED",
@@ -144,13 +271,12 @@ export class SelfPayWebhookService {
         extra: { merchantOid, sessionId: intent.sessionId, raw: err?.message },
       });
       // Coded failureReason → frontend maps to localized message.
-      // PayTR charged the card but our settlement didn't book a
+      // PayTR charged the card but our settlement didn't book ANY
       // Payment row; this is the path that needs ops attention
-      // (manual refund or manual reconciliation). The Sentry alert
-      // carries the raw error; the customer sees a friendly string.
-      // Compound WHERE on PENDING: a concurrent retry that already
-      // succeeded must not be downgraded to FAILED. The Sentry alert
-      // above is still emitted regardless — ops gets the signal.
+      // (manual refund). The Sentry alert carries the raw error; the
+      // customer sees a friendly string. Compound WHERE on PENDING: a
+      // concurrent retry that already succeeded must not be downgraded
+      // to FAILED.
       await this.prisma.pendingSelfPayment.updateMany({
         where: { id: intent.id, status: "PENDING" },
         data: {
@@ -159,6 +285,29 @@ export class SelfPayWebhookService {
         },
       });
     }
+  }
+
+  /**
+   * deep-review H10/M12 — sum the COMPLETED Payment rows booked for a
+   * self-pay intent. payByItems books each bucket with
+   * transactionId=merchantOid and idempotencyKey=selfpay:<oid>:<orderId>,
+   * so transactionId is the stable join back to the intent. Used both to
+   * decide partial-vs-total failure and to reconcile the booked total
+   * against the amount PayTR actually charged.
+   */
+  private async sumBookedPayments(
+    merchantOid: string,
+    tenantId: string,
+  ): Promise<Prisma.Decimal> {
+    const agg = await this.prisma.payment.aggregate({
+      where: {
+        tenantId,
+        transactionId: merchantOid,
+        status: PaymentStatus.COMPLETED,
+      },
+      _sum: { amount: true },
+    });
+    return new Prisma.Decimal(agg._sum.amount ?? 0);
   }
 
   async handleWebhookFailure(

--- a/backend/src/modules/delivery-platforms/guards/webhook-auth.guard.spec.ts
+++ b/backend/src/modules/delivery-platforms/guards/webhook-auth.guard.spec.ts
@@ -1,13 +1,17 @@
-import { ExecutionContext, UnauthorizedException } from '@nestjs/common';
-import { ConfigService } from '@nestjs/config';
-import { Reflector } from '@nestjs/core';
-import { createHmac } from 'crypto';
-import { WebhookAuthGuard, WEBHOOK_PLATFORM_KEY } from './webhook-auth.guard';
+import { ExecutionContext, UnauthorizedException } from "@nestjs/common";
+import { ConfigService } from "@nestjs/config";
+import { Reflector } from "@nestjs/core";
+import { createHmac } from "crypto";
+import { WebhookAuthGuard, WEBHOOK_PLATFORM_KEY } from "./webhook-auth.guard";
 
-const YS_SECRET = 'test-yemeksepeti-secret';
+const YS_SECRET = "test-yemeksepeti-secret";
 
-function makeContext(platform: string, headers: Record<string, string>): ExecutionContext {
-  const req = { headers };
+function makeContext(
+  platform: string,
+  headers: Record<string, string>,
+  params: Record<string, string> = {},
+): ExecutionContext {
+  const req = { headers, params };
   return {
     switchToHttp: () => ({ getRequest: () => req }),
     getHandler: () => undefined,
@@ -18,108 +22,193 @@ function makeContext(platform: string, headers: Record<string, string>): Executi
 function makeGuard(): WebhookAuthGuard {
   const config = {
     get: (key: string) =>
-      key === 'YEMEKSEPETI_WEBHOOK_SECRET' ? YS_SECRET : undefined,
+      key === "YEMEKSEPETI_WEBHOOK_SECRET" ? YS_SECRET : undefined,
   } as ConfigService;
   const reflector = {
-    getAllAndOverride: (key: string) => (key === WEBHOOK_PLATFORM_KEY ? 'YEMEKSEPETI' : undefined),
+    getAllAndOverride: (key: string) =>
+      key === WEBHOOK_PLATFORM_KEY ? "YEMEKSEPETI" : undefined,
   } as any as Reflector;
   return new WebhookAuthGuard(config, reflector);
 }
 
 /** Build a Yemeksepeti-style JWT (HS512 over base64url-encoded header+payload). */
-function makeYsJwt(headerOverride: Record<string, any>, payloadOverride: Record<string, any>): string {
+function makeYsJwt(
+  headerOverride: Record<string, any>,
+  payloadOverride: Record<string, any>,
+): string {
   const header = Buffer.from(
-    JSON.stringify({ alg: 'HS512', typ: 'JWT', ...headerOverride }),
-  ).toString('base64url');
+    JSON.stringify({ alg: "HS512", typ: "JWT", ...headerOverride }),
+  ).toString("base64url");
   const payload = Buffer.from(
     JSON.stringify({
       iat: Math.floor(Date.now() / 1000),
       exp: Math.floor(Date.now() / 1000) + 60,
       ...payloadOverride,
     }),
-  ).toString('base64url');
-  const sig = createHmac('sha512', YS_SECRET)
+  ).toString("base64url");
+  const sig = createHmac("sha512", YS_SECRET)
     .update(`${header}.${payload}`)
-    .digest('base64url');
+    .digest("base64url");
   return `${header}.${payload}.${sig}`;
 }
 
-describe('WebhookAuthGuard — Yemeksepeti JWT (iter-27)', () => {
-  it('accepts a well-formed HS512 token within the freshness window', () => {
+describe("WebhookAuthGuard — Yemeksepeti JWT (iter-27)", () => {
+  it("accepts a well-formed HS512 token within the freshness window", () => {
     const guard = makeGuard();
     const token = makeYsJwt({}, {});
-    expect(guard.canActivate(makeContext('YEMEKSEPETI', { authorization: `Bearer ${token}` }))).toBe(true);
+    expect(
+      guard.canActivate(
+        makeContext("YEMEKSEPETI", { authorization: `Bearer ${token}` }),
+      ),
+    ).toBe(true);
   });
 
-  it('rejects a token with alg!=HS512 in the header (iter-27 — alg-confusion guard)', () => {
+  it("rejects a token with alg!=HS512 in the header (iter-27 — alg-confusion guard)", () => {
     const guard = makeGuard();
     // alg=none style: header claims `none`, sig is empty. The HMAC
     // compute would mismatch anyway, but pinning the header rejects
     // earlier and explicitly.
-    const headerB64 = Buffer.from(JSON.stringify({ alg: 'none', typ: 'JWT' })).toString('base64url');
+    const headerB64 = Buffer.from(
+      JSON.stringify({ alg: "none", typ: "JWT" }),
+    ).toString("base64url");
     const payloadB64 = Buffer.from(
-      JSON.stringify({ iat: Math.floor(Date.now() / 1000), exp: Math.floor(Date.now() / 1000) + 60 }),
-    ).toString('base64url');
+      JSON.stringify({
+        iat: Math.floor(Date.now() / 1000),
+        exp: Math.floor(Date.now() / 1000) + 60,
+      }),
+    ).toString("base64url");
     const token = `${headerB64}.${payloadB64}.`;
 
     expect(() =>
-      guard.canActivate(makeContext('YEMEKSEPETI', { authorization: `Bearer ${token}` })),
+      guard.canActivate(
+        makeContext("YEMEKSEPETI", { authorization: `Bearer ${token}` }),
+      ),
     ).toThrow(UnauthorizedException);
   });
 
-  it('rejects a token with alg=HS256 in the header (alg-confusion guard)', () => {
+  it("rejects a token with alg=HS256 in the header (alg-confusion guard)", () => {
     const guard = makeGuard();
     // Sign with HS256 + the correct secret — without alg pinning, a
     // naive verify could fall back to HMAC over the same secret with a
     // different alg and succeed. We refuse before computing.
-    const headerB64 = Buffer.from(JSON.stringify({ alg: 'HS256', typ: 'JWT' })).toString('base64url');
+    const headerB64 = Buffer.from(
+      JSON.stringify({ alg: "HS256", typ: "JWT" }),
+    ).toString("base64url");
     const payloadB64 = Buffer.from(
-      JSON.stringify({ iat: Math.floor(Date.now() / 1000), exp: Math.floor(Date.now() / 1000) + 60 }),
-    ).toString('base64url');
-    const sig = createHmac('sha256', YS_SECRET).update(`${headerB64}.${payloadB64}`).digest('base64url');
+      JSON.stringify({
+        iat: Math.floor(Date.now() / 1000),
+        exp: Math.floor(Date.now() / 1000) + 60,
+      }),
+    ).toString("base64url");
+    const sig = createHmac("sha256", YS_SECRET)
+      .update(`${headerB64}.${payloadB64}`)
+      .digest("base64url");
     const token = `${headerB64}.${payloadB64}.${sig}`;
 
     expect(() =>
-      guard.canActivate(makeContext('YEMEKSEPETI', { authorization: `Bearer ${token}` })),
+      guard.canActivate(
+        makeContext("YEMEKSEPETI", { authorization: `Bearer ${token}` }),
+      ),
     ).toThrow(UnauthorizedException);
   });
 
-  it('rejects a token with iat older than 5 minutes (iter-27 — freshness window)', () => {
+  it("rejects a token with iat older than 5 minutes (iter-27 — freshness window)", () => {
     const guard = makeGuard();
     const tenMinAgo = Math.floor(Date.now() / 1000) - 10 * 60;
     const token = makeYsJwt({}, { iat: tenMinAgo, exp: tenMinAgo + 3600 });
 
     expect(() =>
-      guard.canActivate(makeContext('YEMEKSEPETI', { authorization: `Bearer ${token}` })),
+      guard.canActivate(
+        makeContext("YEMEKSEPETI", { authorization: `Bearer ${token}` }),
+      ),
     ).toThrow(UnauthorizedException);
   });
 
-  it('rejects a token without iat (freshness gate cannot verify)', () => {
+  it("rejects a token without iat (freshness gate cannot verify)", () => {
     const guard = makeGuard();
-    const token = makeYsJwt({}, { iat: undefined, exp: Math.floor(Date.now() / 1000) + 60 });
+    const token = makeYsJwt(
+      {},
+      { iat: undefined, exp: Math.floor(Date.now() / 1000) + 60 },
+    );
 
     expect(() =>
-      guard.canActivate(makeContext('YEMEKSEPETI', { authorization: `Bearer ${token}` })),
+      guard.canActivate(
+        makeContext("YEMEKSEPETI", { authorization: `Bearer ${token}` }),
+      ),
     ).toThrow(UnauthorizedException);
   });
 
-  it('rejects a token with iat far in the future (clock-skew guard)', () => {
+  it("rejects a token with iat far in the future (clock-skew guard)", () => {
     const guard = makeGuard();
     const fiveMinFromNow = Math.floor(Date.now() / 1000) + 5 * 60;
-    const token = makeYsJwt({}, { iat: fiveMinFromNow, exp: fiveMinFromNow + 60 });
+    const token = makeYsJwt(
+      {},
+      { iat: fiveMinFromNow, exp: fiveMinFromNow + 60 },
+    );
 
     expect(() =>
-      guard.canActivate(makeContext('YEMEKSEPETI', { authorization: `Bearer ${token}` })),
+      guard.canActivate(
+        makeContext("YEMEKSEPETI", { authorization: `Bearer ${token}` }),
+      ),
     ).toThrow(UnauthorizedException);
   });
 
-  it('rejects an expired token (existing exp gate, regression coverage)', () => {
+  it("rejects an expired token (existing exp gate, regression coverage)", () => {
     const guard = makeGuard();
     const oneMinAgo = Math.floor(Date.now() / 1000) - 60;
     const token = makeYsJwt({}, { iat: oneMinAgo - 30, exp: oneMinAgo });
 
     expect(() =>
-      guard.canActivate(makeContext('YEMEKSEPETI', { authorization: `Bearer ${token}` })),
+      guard.canActivate(
+        makeContext("YEMEKSEPETI", { authorization: `Bearer ${token}` }),
+      ),
     ).toThrow(UnauthorizedException);
+  });
+
+  // deep-review H15 — cross-tenant binding: a JWT minted for tenant A
+  // (its `sub` names restaurant A) must not authorize tenant B's URL.
+  it("rejects a tenant-A JWT replayed against tenant-B URL (sub != remoteId)", () => {
+    const guard = makeGuard();
+    const token = makeYsJwt({}, { sub: "restaurant-A" });
+
+    expect(() =>
+      guard.canActivate(
+        makeContext(
+          "YEMEKSEPETI",
+          { authorization: `Bearer ${token}` },
+          { remoteId: "restaurant-B" },
+        ),
+      ),
+    ).toThrow(UnauthorizedException);
+  });
+
+  it("accepts a JWT whose sub claim matches the URL remoteId", () => {
+    const guard = makeGuard();
+    const token = makeYsJwt({}, { sub: "restaurant-A" });
+
+    expect(
+      guard.canActivate(
+        makeContext(
+          "YEMEKSEPETI",
+          { authorization: `Bearer ${token}` },
+          { remoteId: "restaurant-A" },
+        ),
+      ),
+    ).toBe(true);
+  });
+
+  it("accepts a claim-less JWT against any remoteId (no positive mismatch)", () => {
+    const guard = makeGuard();
+    const token = makeYsJwt({}, {});
+
+    expect(
+      guard.canActivate(
+        makeContext(
+          "YEMEKSEPETI",
+          { authorization: `Bearer ${token}` },
+          { remoteId: "restaurant-B" },
+        ),
+      ),
+    ).toBe(true);
   });
 });

--- a/backend/src/modules/delivery-platforms/guards/webhook-auth.guard.ts
+++ b/backend/src/modules/delivery-platforms/guards/webhook-auth.guard.ts
@@ -41,18 +41,32 @@ export class WebhookAuthGuard implements CanActivate {
       throw new UnauthorizedException("Webhook platform not declared");
     }
     const request = context.switchToHttp().getRequest();
+    // deep-review H15 — the per-platform secret is global, so a valid
+    // signature/JWT issued for one tenant must additionally be bound to
+    // the restaurant in the URL or it can be replayed against another
+    // tenant's webhook path (cross-tenant order spoofing / cancellation).
+    // The `:remoteId` path param identifies the target restaurant; we
+    // pass it down and reject when the signed material self-identifies a
+    // *different* restaurant.
+    const urlRemoteId =
+      typeof request.params?.remoteId === "string"
+        ? request.params.remoteId
+        : undefined;
     switch (platform) {
       case "YEMEKSEPETI":
-        return this.validateYemeksepetiWebhook(request);
+        return this.validateYemeksepetiWebhook(request, urlRemoteId);
       case "TRENDYOL":
-        return this.validateTrendyolWebhook(request);
+        return this.validateTrendyolWebhook(request, urlRemoteId);
       default:
         this.logger.warn(`Unknown webhook platform: ${platform}`);
         throw new UnauthorizedException("Unknown webhook platform");
     }
   }
 
-  private validateYemeksepetiWebhook(request: any): boolean {
+  private validateYemeksepetiWebhook(
+    request: any,
+    urlRemoteId?: string,
+  ): boolean {
     const authHeader = request.headers["authorization"];
     if (!authHeader) {
       throw new UnauthorizedException("Missing authorization header");
@@ -133,6 +147,31 @@ export class WebhookAuthGuard implements CanActivate {
         throw new Error("Token issued-at in the future");
       }
 
+      // deep-review H15 — bind the JWT to the restaurant in the URL.
+      // The secret is global across tenants, so a JWT minted for tenant A
+      // must not be replayable against tenant B's `/yemeksepeti/:remoteId`
+      // path. Yemeksepeti tokens carry the chain/vendor/restaurant in a
+      // subject-style claim; when such a claim is present it MUST equal
+      // the path `remoteId`. We only reject on a *positive mismatch* so a
+      // token that legitimately omits the claim is not broken — the
+      // attack we close is a captured/issued-for-A token retargeted at B,
+      // where the token's own claim still names A.
+      if (urlRemoteId) {
+        const claimedRestaurant =
+          decoded.sub ??
+          decoded.restaurantId ??
+          decoded.chainId ??
+          decoded.chainCode ??
+          decoded.vendor ??
+          decoded.vendorId;
+        if (
+          claimedRestaurant != null &&
+          String(claimedRestaurant) !== urlRemoteId
+        ) {
+          throw new Error("Token restaurant claim does not match URL");
+        }
+      }
+
       return true;
     } catch (error: any) {
       this.logger.warn(`Yemeksepeti webhook auth failed: ${error.message}`);
@@ -140,7 +179,7 @@ export class WebhookAuthGuard implements CanActivate {
     }
   }
 
-  private validateTrendyolWebhook(request: any): boolean {
+  private validateTrendyolWebhook(request: any, urlRemoteId?: string): boolean {
     const webhookSecret = this.configService.get<string>(
       "TRENDYOL_WEBHOOK_SECRET",
     );
@@ -203,6 +242,35 @@ export class WebhookAuthGuard implements CanActivate {
     const expBuf = Buffer.from(expectedSignature, "utf8");
     if (sigBuf.length !== expBuf.length || !timingSafeEqual(sigBuf, expBuf)) {
       throw new UnauthorizedException("Invalid webhook signature");
+    }
+
+    // deep-review H15 — bind the verified body to the restaurant in the
+    // URL. The HMAC only covers `${timestamp}.${body}` with a global
+    // secret, so a signature captured within the freshness window could
+    // otherwise be replayed against a *different* tenant's
+    // `/trendyol/order/:remoteId` path. Changing the signed contract to
+    // include the remoteId would require sender coordination and would
+    // break all live senders, so we instead assert the restaurant
+    // identifier carried inside the (now signature-verified) body matches
+    // the path param. We reject only on a positive mismatch so bodies
+    // that don't self-identify the restaurant are not broken.
+    if (urlRemoteId) {
+      let parsedBody: any;
+      try {
+        parsedBody = JSON.parse(body);
+      } catch {
+        parsedBody = undefined;
+      }
+      const bodyRestaurant =
+        parsedBody?.restaurantId ??
+        parsedBody?.supplierId ??
+        parsedBody?.storeId ??
+        parsedBody?.restaurant?.id;
+      if (bodyRestaurant != null && String(bodyRestaurant) !== urlRemoteId) {
+        throw new UnauthorizedException(
+          "Webhook body restaurant does not match URL",
+        );
+      }
     }
 
     return true;

--- a/backend/src/modules/device-mesh/command-queue.service.spec.ts
+++ b/backend/src/modules/device-mesh/command-queue.service.spec.ts
@@ -1,5 +1,8 @@
-import { CommandQueueService } from './command-queue.service';
-import { mockPrismaClient, MockPrismaClient } from '../../common/test/prisma-mock.service';
+import { CommandQueueService } from "./command-queue.service";
+import {
+  mockPrismaClient,
+  MockPrismaClient,
+} from "../../common/test/prisma-mock.service";
 
 /** Minimal ConfigService stub honouring the (key, default) signature. */
 function makeConfig(overrides: Record<string, unknown> = {}) {
@@ -15,51 +18,63 @@ function makeConfig(overrides: Record<string, unknown> = {}) {
  * on the idempotency-on-create branch and the ack state machine, which sit
  * on top of regular Prisma calls and are amenable to mocking.
  */
-describe('CommandQueueService', () => {
+describe("CommandQueueService", () => {
   let prisma: MockPrismaClient;
   let outbox: { append: jest.Mock };
   let svc: CommandQueueService;
 
   beforeEach(() => {
     prisma = mockPrismaClient();
-    outbox = { append: jest.fn().mockResolvedValue('ok') };
+    outbox = { append: jest.fn().mockResolvedValue("ok") };
     svc = new CommandQueueService(prisma as any, outbox as any, makeConfig());
   });
 
-  describe('DEFAULT_TTL config', () => {
+  describe("DEFAULT_TTL config", () => {
     const THIRTY_MIN_MS = 30 * 60 * 1000;
 
-    it('defaults to 30m when DEVICE_COMMAND_TTL_MS is unset', async () => {
-      prisma.device.findFirst.mockResolvedValue({ id: 'dev', status: 'online', branchId: 'b' } as any);
+    it("defaults to 30m when DEVICE_COMMAND_TTL_MS is unset", async () => {
+      prisma.device.findFirst.mockResolvedValue({
+        id: "dev",
+        status: "online",
+        branchId: "b",
+      } as any);
       let captured: any = null;
-      (prisma.deviceCommand.create as any).mockImplementation(async ({ data }: any) => {
-        captured = data;
-        return { id: 'c-1', ...data };
-      });
+      (prisma.deviceCommand.create as any).mockImplementation(
+        async ({ data }: any) => {
+          captured = data;
+          return { id: "c-1", ...data };
+        },
+      );
 
       const before = Date.now();
-      await svc.enqueue('t', 'dev', { kind: 'print', payload: {} });
+      await svc.enqueue("t", "dev", { kind: "print", payload: {} });
       const ttl = captured.expiresAt.getTime() - before;
       expect(ttl).toBeGreaterThanOrEqual(THIRTY_MIN_MS - 1000);
       expect(ttl).toBeLessThanOrEqual(THIRTY_MIN_MS + 5000);
     });
 
-    it('honours a DEVICE_COMMAND_TTL_MS override', async () => {
+    it("honours a DEVICE_COMMAND_TTL_MS override", async () => {
       const override = 5 * 60 * 1000;
       svc = new CommandQueueService(
         prisma as any,
         outbox as any,
         makeConfig({ DEVICE_COMMAND_TTL_MS: override }),
       );
-      prisma.device.findFirst.mockResolvedValue({ id: 'dev', status: 'online', branchId: 'b' } as any);
+      prisma.device.findFirst.mockResolvedValue({
+        id: "dev",
+        status: "online",
+        branchId: "b",
+      } as any);
       let captured: any = null;
-      (prisma.deviceCommand.create as any).mockImplementation(async ({ data }: any) => {
-        captured = data;
-        return { id: 'c-1', ...data };
-      });
+      (prisma.deviceCommand.create as any).mockImplementation(
+        async ({ data }: any) => {
+          captured = data;
+          return { id: "c-1", ...data };
+        },
+      );
 
       const before = Date.now();
-      await svc.enqueue('t', 'dev', { kind: 'print', payload: {} });
+      await svc.enqueue("t", "dev", { kind: "print", payload: {} });
       const ttl = captured.expiresAt.getTime() - before;
       expect(ttl).toBeGreaterThanOrEqual(override - 1000);
       expect(ttl).toBeLessThanOrEqual(override + 5000);
@@ -75,26 +90,34 @@ describe('CommandQueueService', () => {
    * device id is bound as a parameter (not string-spliced — SQLi guard)
    * and that the lock/skip semantics are present in the SQL text.
    */
-  describe('claimNext (raw atomic claim)', () => {
-    it('binds deviceId as a parameter and returns the first claimed row', async () => {
+  describe("claimNext (raw atomic claim)", () => {
+    it("binds deviceId as a parameter and returns the first claimed row", async () => {
       const claimed = {
-        id: 'cmd-1', tenantId: 't', kind: 'print', payload: {}, priority: 0, attempts: 1, idempotencyKey: 'k',
+        id: "cmd-1",
+        tenantId: "t",
+        kind: "print",
+        payload: {},
+        priority: 0,
+        attempts: 1,
+        idempotencyKey: "k",
       };
       let strings: TemplateStringsArray | null = null;
       let values: any[] = [];
-      (prisma.$queryRaw as any).mockImplementation(async (s: TemplateStringsArray, ...v: any[]) => {
-        strings = s;
-        values = v;
-        return [claimed];
-      });
+      (prisma.$queryRaw as any).mockImplementation(
+        async (s: TemplateStringsArray, ...v: any[]) => {
+          strings = s;
+          values = v;
+          return [claimed];
+        },
+      );
 
-      const out = await svc.claimNext('dev-42');
+      const out = await svc.claimNext("dev-42");
 
       expect(out).toEqual(claimed);
       // deviceId is bound as a parameter, never interpolated into the SQL.
-      expect(values).toContain('dev-42');
+      expect(values).toContain("dev-42");
       // The SQL carries the concurrency-safe claim shape.
-      const sql = (strings as unknown as string[]).join('?');
+      const sql = (strings as unknown as string[]).join("?");
       expect(sql).toMatch(/UPDATE "device_commands"/);
       expect(sql).toMatch(/'inflight'/);
       expect(sql).toMatch(/FOR UPDATE SKIP LOCKED/);
@@ -104,98 +127,146 @@ describe('CommandQueueService', () => {
       expect(sql).toMatch(/"expiresAt" IS NULL OR "expiresAt" > NOW/);
     });
 
-    it('returns null when the queue is empty (zero rows)', async () => {
+    it("returns null when the queue is empty (zero rows)", async () => {
       (prisma.$queryRaw as any).mockResolvedValue([]);
-      expect(await svc.claimNext('dev-42')).toBeNull();
+      expect(await svc.claimNext("dev-42")).toBeNull();
     });
   });
 
-  it('enqueue dedupes on (deviceId, idempotencyKey)', async () => {
-    prisma.device.findFirst.mockResolvedValue({ id: 'dev', status: 'online' } as any);
+  it("enqueue dedupes on (deviceId, idempotencyKey)", async () => {
+    prisma.device.findFirst.mockResolvedValue({
+      id: "dev",
+      status: "online",
+    } as any);
 
-    const { Prisma } = await import('@prisma/client');
+    const { Prisma } = await import("@prisma/client");
     let attempt = 0;
     (prisma.deviceCommand.create as any).mockImplementation(async () => {
       attempt += 1;
       if (attempt === 1) {
-        return { id: 'c-1', tenantId: 't', deviceId: 'dev', kind: 'print_receipt' };
+        return {
+          id: "c-1",
+          tenantId: "t",
+          deviceId: "dev",
+          kind: "print_receipt",
+        };
       }
       // Real Prisma error so the `instanceof` check the service does walks
       // the dedup branch.
-      throw new Prisma.PrismaClientKnownRequestError('Unique constraint failed', {
-        code: 'P2002',
-        clientVersion: '6.x',
-      } as any);
+      throw new Prisma.PrismaClientKnownRequestError(
+        "Unique constraint failed",
+        {
+          code: "P2002",
+          clientVersion: "6.x",
+        } as any,
+      );
     });
-    (prisma.deviceCommand.findUnique as any).mockResolvedValue({ id: 'c-1' });
+    (prisma.deviceCommand.findUnique as any).mockResolvedValue({ id: "c-1" });
 
-    const first = await svc.enqueue('t', 'dev', {
-      kind: 'print_receipt', payload: {}, idempotencyKey: 'fixed',
+    const first = await svc.enqueue("t", "dev", {
+      kind: "print_receipt",
+      payload: {},
+      idempotencyKey: "fixed",
     });
-    const second = await svc.enqueue('t', 'dev', {
-      kind: 'print_receipt', payload: {}, idempotencyKey: 'fixed',
+    const second = await svc.enqueue("t", "dev", {
+      kind: "print_receipt",
+      payload: {},
+      idempotencyKey: "fixed",
     });
-    expect(first.id).toBe('c-1');
-    expect(second.id).toBe('c-1');
+    expect(first.id).toBe("c-1");
+    expect(second.id).toBe("c-1");
   });
 
-  it('ack(failed) requeues until MAX_ATTEMPTS, then marks failed', async () => {
+  it("ack(failed) requeues until MAX_ATTEMPTS, then marks failed", async () => {
     // iter-28: ack now uses findFirst + updateMany + findUniqueOrThrow.
+    // deep-review M21: kind must be an IDEMPOTENT one here — the generic
+    // retry path is only taken for safe kinds (`print_receipt` is now
+    // non-retryable; side-effecting kinds are covered by their own spec).
     prisma.deviceCommand.findFirst.mockResolvedValue({
-      id: 'c-1', deviceId: 'dev', tenantId: 't', status: 'inflight', attempts: 2, kind: 'print_receipt',
+      id: "c-1",
+      deviceId: "dev",
+      tenantId: "t",
+      status: "inflight",
+      attempts: 2,
+      kind: "show_order",
     } as any);
     let capturedFirst: any = null;
-    (prisma.deviceCommand.updateMany as any).mockImplementation(async ({ data }: any) => {
-      capturedFirst = data;
-      return { count: 1 };
-    });
+    (prisma.deviceCommand.updateMany as any).mockImplementation(
+      async ({ data }: any) => {
+        capturedFirst = data;
+        return { count: 1 };
+      },
+    );
     (prisma.deviceCommand.findUniqueOrThrow as any).mockResolvedValue({
-      id: 'c-1', deviceId: 'dev', tenantId: 't', status: 'queued',
+      id: "c-1",
+      deviceId: "dev",
+      tenantId: "t",
+      status: "queued",
     });
 
-    await svc.ack('dev', 'c-1', { status: 'failed', error: 'printer offline' });
-    expect(capturedFirst.status).toBe('queued');
+    await svc.ack("dev", "c-1", { status: "failed", error: "printer offline" });
+    expect(capturedFirst.status).toBe("queued");
 
     prisma.deviceCommand.findFirst.mockResolvedValue({
-      id: 'c-1', deviceId: 'dev', tenantId: 't', status: 'inflight', attempts: 5, kind: 'print_receipt',
+      id: "c-1",
+      deviceId: "dev",
+      tenantId: "t",
+      status: "inflight",
+      attempts: 5,
+      kind: "show_order",
     } as any);
     let capturedSecond: any = null;
-    (prisma.deviceCommand.updateMany as any).mockImplementation(async ({ data }: any) => {
-      capturedSecond = data;
-      return { count: 1 };
-    });
+    (prisma.deviceCommand.updateMany as any).mockImplementation(
+      async ({ data }: any) => {
+        capturedSecond = data;
+        return { count: 1 };
+      },
+    );
     (prisma.deviceCommand.findUniqueOrThrow as any).mockResolvedValue({
-      id: 'c-1', deviceId: 'dev', tenantId: 't', status: 'failed',
+      id: "c-1",
+      deviceId: "dev",
+      tenantId: "t",
+      status: "failed",
     });
-    await svc.ack('dev', 'c-1', { status: 'failed', error: 'printer offline' });
-    expect(capturedSecond.status).toBe('failed');
+    await svc.ack("dev", "c-1", { status: "failed", error: "printer offline" });
+    expect(capturedSecond.status).toBe("failed");
   });
 
-  it('ack rejects when command does not belong to the device (iter-28: scope at DB layer)', async () => {
+  it("ack rejects when command does not belong to the device (iter-28: scope at DB layer)", async () => {
     // The findFirst's compound WHERE now returns null when deviceId
     // doesn't match — no in-JS post-fetch comparison. A future
     // refactor that drops the WHERE clause would surface as this test
     // returning the row and the assertion below failing.
     prisma.deviceCommand.findFirst.mockResolvedValue(null);
-    await expect(svc.ack('dev', 'c-1', { status: 'done' })).rejects.toThrow(/not found/i);
+    await expect(svc.ack("dev", "c-1", { status: "done" })).rejects.toThrow(
+      /not found/i,
+    );
 
     // Pin the compound WHERE shape so the DB-layer scope can't silently
     // regress to in-JS filtering.
-    const where = (prisma.deviceCommand.findFirst as any).mock.calls[0][0].where;
-    expect(where).toEqual({ id: 'c-1', deviceId: 'dev' });
+    const where = (prisma.deviceCommand.findFirst as any).mock.calls[0][0]
+      .where;
+    expect(where).toEqual({ id: "c-1", deviceId: "dev" });
   });
 
-  it('ack throws on concurrent transition when updateMany claims zero rows (iter-28)', async () => {
+  it("ack throws on concurrent transition when updateMany claims zero rows (iter-28)", async () => {
     // Inflight when read, but a sweepStuck cron raced ahead and flipped
     // it to queued/failed between read and write. The compound-WHERE
     // updateMany returns count=0; service must surface that rather
     // than silently no-op.
     prisma.deviceCommand.findFirst.mockResolvedValue({
-      id: 'c-1', deviceId: 'dev', tenantId: 't', status: 'inflight', attempts: 1, kind: 'print_receipt',
+      id: "c-1",
+      deviceId: "dev",
+      tenantId: "t",
+      status: "inflight",
+      attempts: 1,
+      kind: "print_receipt",
     } as any);
     (prisma.deviceCommand.updateMany as any).mockResolvedValue({ count: 0 });
 
-    await expect(svc.ack('dev', 'c-1', { status: 'done' })).rejects.toThrow(/concurrent/i);
+    await expect(svc.ack("dev", "c-1", { status: "done" })).rejects.toThrow(
+      /concurrent/i,
+    );
   });
 
   /**
@@ -206,8 +277,8 @@ describe('CommandQueueService', () => {
    * $transaction (one per attempts-vs-MAX branch) regardless of how
    * many rows are stuck.
    */
-  describe('sweepStuck batching (iter-72)', () => {
-    it('issues exactly two updateMany calls inside one $transaction', async () => {
+  describe("sweepStuck batching (iter-72)", () => {
+    it("issues exactly two updateMany calls inside one $transaction", async () => {
       (prisma.$transaction as any).mockImplementation(async (ops: any[]) => {
         // The test mock passes through each updateMany call so we can
         // measure how many statements the service issued. In production
@@ -219,41 +290,230 @@ describe('CommandQueueService', () => {
       await svc.sweepStuck();
 
       expect((prisma.$transaction as any).mock.calls.length).toBe(1);
-      // The first $transaction call's first arg is the array of three
-      // updateMany prismas (v2.8.97 added the expired-queued sweep
-      // alongside the requeue + fail branches) — length must be 3
-      // regardless of how many rows are stale.
+      // The first $transaction call's first arg is the array of updateMany
+      // prismas: requeue + fail + (deep-review M19/M21) side-effecting-fail
+      // + expired-queued sweep — length must be 4 regardless of how many
+      // rows are stale.
       const txArgs = (prisma.$transaction as any).mock.calls[0][0];
       expect(Array.isArray(txArgs)).toBe(true);
-      expect(txArgs.length).toBe(3);
+      expect(txArgs.length).toBe(4);
       // findMany must NOT fire — that was the N+1 starting point.
       expect((prisma.deviceCommand.findMany as any).mock.calls.length).toBe(0);
     });
 
-    it('returns the combined requeue+fail+expired count', async () => {
-      (prisma.$transaction as any).mockResolvedValue([{ count: 3 }, { count: 2 }, { count: 4 }]);
+    it("returns the combined requeue+fail+sideEffectFail+expired count", async () => {
+      (prisma.$transaction as any).mockResolvedValue([
+        { count: 3 },
+        { count: 2 },
+        { count: 1 },
+        { count: 4 },
+      ]);
 
       const total = await svc.sweepStuck();
 
-      expect(total).toBe(9);
+      expect(total).toBe(10);
     });
 
-    it('predicate splits on attempts vs MAX_ATTEMPTS', async () => {
+    it("predicate splits on attempts vs MAX_ATTEMPTS", async () => {
       const captured: any[] = [];
-      (prisma.deviceCommand.updateMany as any).mockImplementation(async (args: any) => {
-        captured.push(args);
-        return { count: 0 };
-      });
-      (prisma.$transaction as any).mockImplementation(async (ops: any[]) => Promise.all(ops));
+      (prisma.deviceCommand.updateMany as any).mockImplementation(
+        async (args: any) => {
+          captured.push(args);
+          return { count: 0 };
+        },
+      );
+      (prisma.$transaction as any).mockImplementation(async (ops: any[]) =>
+        Promise.all(ops),
+      );
 
       await svc.sweepStuck();
 
       // First call requeues (status=queued, attempts < MAX).
-      expect(captured[0].data.status).toBe('queued');
+      expect(captured[0].data.status).toBe("queued");
       expect(captured[0].where.attempts).toEqual({ lt: 5 });
+      // deep-review M19/M21 — the requeue branch must exclude
+      // side-effecting kinds so a stuck inflight charge is never put back
+      // on the queue.
+      expect(captured[0].where.kind).toEqual({
+        notIn: expect.arrayContaining(["charge_card"]),
+      });
       // Second call fails (status=failed, attempts >= MAX).
-      expect(captured[1].data.status).toBe('failed');
+      expect(captured[1].data.status).toBe("failed");
       expect(captured[1].where.attempts).toEqual({ gte: 5 });
+    });
+
+    /**
+     * deep-review M19/M21. A stuck inflight side-effecting command
+     * (charge_card / fiscal_receipt / open_drawer …) must be terminated
+     * in `failed` by the sweeper REGARDLESS of attempts — never put back
+     * on the queue, where claimNext would redeliver it and double-charge
+     * the customer. The third updateMany matches `kind: { in: [...] }`
+     * with no attempts predicate and sets status=failed.
+     */
+    it("routes stuck inflight side-effecting kinds to failed, never requeued (M19/M21)", async () => {
+      const captured: any[] = [];
+      (prisma.deviceCommand.updateMany as any).mockImplementation(
+        async (args: any) => {
+          captured.push(args);
+          return { count: 0 };
+        },
+      );
+      (prisma.$transaction as any).mockImplementation(async (ops: any[]) =>
+        Promise.all(ops),
+      );
+
+      await svc.sweepStuck();
+
+      // Third updateMany is the side-effecting branch.
+      const sideEffect = captured[2];
+      expect(sideEffect.where.status).toBe("inflight");
+      expect(sideEffect.where.kind).toEqual({
+        in: expect.arrayContaining([
+          "charge_card",
+          "fiscal_receipt",
+          "open_drawer",
+        ]),
+      });
+      // No attempts predicate — failed regardless of remaining retries.
+      expect(sideEffect.where.attempts).toBeUndefined();
+      expect(sideEffect.data.status).toBe("failed");
+      expect(sideEffect.data.error).toMatch(/side-effecting/i);
+      // And the requeue branch must NOT touch these kinds.
+      expect(captured[0].where.kind).toEqual({
+        notIn: expect.arrayContaining([
+          "charge_card",
+          "fiscal_receipt",
+          "open_drawer",
+        ]),
+      });
+    });
+  });
+
+  /**
+   * deep-review M21. A failed ack on a side-effecting (non-idempotent)
+   * kind must terminate directly in `failed` — NOT requeue — even with
+   * retries remaining. The device may already have charged the acquirer
+   * and lost only the result; re-delivery double-charges.
+   */
+  describe("ack failed on side-effecting kinds never requeues (M21)", () => {
+    it.each(["charge_card", "fiscal_receipt", "fiscal_cancel", "open_drawer"])(
+      "%s goes straight to failed despite attempts < MAX",
+      async (kind) => {
+        prisma.deviceCommand.findFirst.mockResolvedValue({
+          id: "c-1",
+          deviceId: "dev",
+          tenantId: "t",
+          status: "inflight",
+          attempts: 1,
+          kind,
+        } as any);
+        let captured: any = null;
+        (prisma.deviceCommand.updateMany as any).mockImplementation(
+          async ({ data }: any) => {
+            captured = data;
+            return { count: 1 };
+          },
+        );
+        (prisma.deviceCommand.findUniqueOrThrow as any).mockResolvedValue({
+          id: "c-1",
+          deviceId: "dev",
+          tenantId: "t",
+          status: "failed",
+        });
+
+        await svc.ack("dev", "c-1", { status: "failed", error: "lost result" });
+
+        // Terminal failed, not requeued — and ackedAt is set so it won't
+        // be re-swept either.
+        expect(captured.status).toBe("failed");
+        expect(captured.ackedAt).toBeInstanceOf(Date);
+      },
+    );
+
+    it("still requeues an idempotent kind (print/show_order) on failed ack with retries left", async () => {
+      prisma.deviceCommand.findFirst.mockResolvedValue({
+        id: "c-1",
+        deviceId: "dev",
+        tenantId: "t",
+        status: "inflight",
+        attempts: 1,
+        kind: "show_order",
+      } as any);
+      let captured: any = null;
+      (prisma.deviceCommand.updateMany as any).mockImplementation(
+        async ({ data }: any) => {
+          captured = data;
+          return { count: 1 };
+        },
+      );
+      (prisma.deviceCommand.findUniqueOrThrow as any).mockResolvedValue({
+        id: "c-1",
+        deviceId: "dev",
+        tenantId: "t",
+        status: "queued",
+      });
+
+      await svc.ack("dev", "c-1", { status: "failed", error: "screen busy" });
+
+      expect(captured.status).toBe("queued");
+    });
+  });
+
+  /**
+   * deep-review H14. enqueue() and listForDevice() accept an optional
+   * branch-scope constraint. When a non-wildcard branchId is passed, the
+   * device lookup is constrained to that branch so a branch-restricted
+   * manager can't target a device in another branch.
+   */
+  describe("branch-scope constraint (H14)", () => {
+    it("enqueue constrains the device lookup to the passed branchId", async () => {
+      prisma.device.findFirst.mockResolvedValue(null);
+
+      await expect(
+        svc.enqueue(
+          "t",
+          "dev-in-branch-B",
+          { kind: "show_order", payload: {} },
+          "branch-A",
+        ),
+      ).rejects.toThrow(/not found/i);
+
+      const where = (prisma.device.findFirst as any).mock.calls[0][0].where;
+      expect(where).toEqual({
+        id: "dev-in-branch-B",
+        tenantId: "t",
+        branchId: "branch-A",
+      });
+    });
+
+    it("enqueue stays tenant-wide when no branchId is passed (ADMIN wildcard)", async () => {
+      prisma.device.findFirst.mockResolvedValue({
+        id: "dev",
+        status: "online",
+        branchId: "b",
+      } as any);
+      (prisma.deviceCommand.create as any).mockImplementation(
+        async ({ data }: any) => ({ id: "c-1", ...data }),
+      );
+
+      await svc.enqueue("t", "dev", { kind: "show_order", payload: {} });
+
+      const where = (prisma.device.findFirst as any).mock.calls[0][0].where;
+      expect(where).toEqual({ id: "dev", tenantId: "t" });
+    });
+
+    it("listForDevice constrains the query to the passed branchId", async () => {
+      (prisma.deviceCommand.findMany as any).mockResolvedValue([]);
+
+      await svc.listForDevice("t", "dev", undefined, "branch-A");
+
+      const where = (prisma.deviceCommand.findMany as any).mock.calls[0][0]
+        .where;
+      expect(where).toMatchObject({
+        tenantId: "t",
+        deviceId: "dev",
+        branchId: "branch-A",
+      });
     });
   });
 });

--- a/backend/src/modules/device-mesh/command-queue.service.ts
+++ b/backend/src/modules/device-mesh/command-queue.service.ts
@@ -25,6 +25,43 @@ import { captureSwallowedEmit } from "../../common/observability/capture-swallow
 export class CommandQueueService {
   private readonly logger = new Logger(CommandQueueService.name);
   private static readonly MAX_ATTEMPTS = 5;
+
+  /**
+   * deep-review M19/M21 — side-effecting, NON-idempotent command kinds.
+   *
+   * These move real-world money or produce legally-binding artefacts:
+   *   - charge_card    → contacts the acquirer; a re-delivery double-charges.
+   *   - fiscal_receipt → prints a yazarkasa fiscal receipt; a duplicate is a
+   *                      tax/legal exposure.
+   *   - fiscal_cancel  → fiscal void; double-void corrupts the fiscal journal.
+   *   - open_drawer    → physically re-opens the cash drawer.
+   *   - print_receipt  → emits a customer receipt (cosmetic but undesirable
+   *                      to duplicate; included so the agent gets a stable
+   *                      no-auto-retry contract for all paper-emitting kinds).
+   *
+   * For these, the server NEVER auto-redelivers after a failed/lost ack: the
+   * device may already have executed the side effect with no surviving ack
+   * (terminal charged → app crashed → no result reached us). Re-queuing would
+   * charge the customer / print the receipt a second time. Instead they
+   * terminate in `failed` and an operator reconciles with an explicit
+   * compensating command. Safe/idempotent kinds (show_order, clear_order,
+   * capability_probe, reboot, noop, …) keep the normal retry path.
+   *
+   * NOTE: kinds use the DTO's dot/underscore identifier space; we match the
+   * canonical forms the bridge dispatcher actually executes today. New
+   * side-effecting kinds MUST be added here.
+   */
+  private static readonly NON_RETRYABLE_KINDS = new Set<string>([
+    "charge_card",
+    "fiscal_receipt",
+    "fiscal_cancel",
+    "open_drawer",
+    "print_receipt",
+  ]);
+
+  private static isNonRetryableKind(kind: string): boolean {
+    return CommandQueueService.NON_RETRYABLE_KINDS.has(kind);
+  }
   // 30 minutes — long enough for slow ESC/POS prints + occasional yazarkasa
   // network blips, short enough that operators see stuck commands cleared.
   // Override via DEVICE_COMMAND_TTL_MS.
@@ -50,9 +87,23 @@ export class CommandQueueService {
       priority?: number;
       idempotencyKey?: string;
     },
+    // deep-review H14 — branch-scope constraint on the device lookup.
+    // When the caller passes a `branchId` (non-wildcard, e.g. a MANAGER
+    // limited to a single branch), the target device MUST live in that
+    // branch or the lookup returns null → 404. ADMINs acting tenant-wide
+    // pass `undefined` and retain the tenant-wide reach. Omitting the
+    // arg preserves the pre-fix behaviour (tenant-wide) so existing
+    // callers compile unchanged; the controller is expected to forward
+    // the branch scope so a branch-restricted manager can't drive payment
+    // terminals / cash drawers / fiscal printers in another branch.
+    branchId?: string,
   ) {
     const device = await this.prisma.device.findFirst({
-      where: { id: deviceId, tenantId },
+      where: {
+        id: deviceId,
+        tenantId,
+        ...(branchId ? { branchId } : {}),
+      },
       select: { id: true, status: true, branchId: true },
     });
     if (!device) throw new NotFoundException("Device not found");
@@ -162,10 +213,19 @@ export class CommandQueueService {
 
     // Failed commands with retries remaining go back to `queued`; otherwise
     // they terminate in `failed`. Done commands are terminal regardless.
+    //
+    // deep-review M21 — side-effecting (non-idempotent) kinds are NEVER
+    // auto-requeued on a failed/lost ack. A terminal that charged the
+    // acquirer then lost its result on the way back must NOT be re-issued
+    // — that double-charges the customer / duplicates the fiscal receipt.
+    // Such commands terminate directly in `failed` (ackedAt set, error
+    // surfaced) and emit device.command.failed.v1 for an operator to
+    // reconcile with an explicit compensating command.
     let nextStatus: "done" | "failed" | "queued" = input.status;
     if (
       input.status === "failed" &&
-      cmd.attempts < CommandQueueService.MAX_ATTEMPTS
+      cmd.attempts < CommandQueueService.MAX_ATTEMPTS &&
+      !CommandQueueService.isNonRetryableKind(cmd.kind)
     ) {
       nextStatus = "queued";
     }
@@ -233,12 +293,13 @@ export class CommandQueueService {
    * would sweep a slow-claim queue: a command created an hour ago that
    * JUST went inflight 10s ago would be wrongly marked stuck.
    *
-   * Implemented as two updateMany calls — one per attempts branch —
-   * rather than the previous findMany + per-row update loop. The old
-   * shape was an N+1 (one round-trip per stuck command), so a sweep
-   * with 10K stale rows held the connection for as many serialised
-   * writes; the new shape is two statements regardless of N and lets
-   * Postgres pick the index path it likes.
+   * Implemented as a fixed set of updateMany calls (one per branch:
+   * requeue / give-up / side-effecting-fail / expired) rather than the
+   * previous findMany + per-row update loop. The old shape was an N+1
+   * (one round-trip per stuck command), so a sweep with 10K stale rows
+   * held the connection for as many serialised writes; the new shape is
+   * a constant number of statements regardless of N and lets Postgres
+   * pick the index path it likes.
    */
   async sweepStuck(): Promise<number> {
     const cutoff = new Date(Date.now() - 5 * 60 * 1000);
@@ -248,35 +309,69 @@ export class CommandQueueService {
     // in `queued` status with expiresAt in the past (where claimNext
     // silently skips them and nobody is alerted). The `expired` row
     // still carries the original payload for forensic review.
-    const [requeue, fail, expired] = await this.prisma.$transaction([
-      this.prisma.deviceCommand.updateMany({
-        where: {
-          status: "inflight",
-          updatedAt: { lt: cutoff },
-          attempts: { lt: CommandQueueService.MAX_ATTEMPTS },
-        },
-        data: { status: "queued", error: "No ack received; requeued" },
-      }),
-      this.prisma.deviceCommand.updateMany({
-        where: {
-          status: "inflight",
-          updatedAt: { lt: cutoff },
-          attempts: { gte: CommandQueueService.MAX_ATTEMPTS },
-        },
-        data: { status: "failed", error: "No ack received; giving up" },
-      }),
-      this.prisma.deviceCommand.updateMany({
-        where: {
-          status: "queued",
-          expiresAt: { lt: now, not: null },
-        },
-        data: { status: "expired", error: "TTL expired before device claimed" },
-      }),
-    ]);
-    const total = requeue.count + fail.count + expired.count;
+    // deep-review M19/M21 — the sweeper is the MORE dangerous redelivery
+    // path (crash-after-charge with no surviving ack), so the kind guard
+    // applied in ack() MUST also apply here or the TTL sweeper silently
+    // bypasses it. The inflight-requeue branch therefore excludes the
+    // non-idempotent kinds (`kind: { notIn }`); those are routed instead
+    // to a terminal `failed` state regardless of attempts — a stuck
+    // inflight charge_card/fiscal_receipt is never put back on the queue.
+    // Operators see the `failed` row + device.command.failed.v1 (emitted
+    // by the ack path / surfaced via the admin view) and reconcile with an
+    // explicit compensating command rather than the server blindly
+    // re-charging.
+    const nonRetryable = [...CommandQueueService.NON_RETRYABLE_KINDS];
+    const [requeue, fail, sideEffectFail, expired] =
+      await this.prisma.$transaction([
+        this.prisma.deviceCommand.updateMany({
+          where: {
+            status: "inflight",
+            updatedAt: { lt: cutoff },
+            attempts: { lt: CommandQueueService.MAX_ATTEMPTS },
+            kind: { notIn: nonRetryable },
+          },
+          data: { status: "queued", error: "No ack received; requeued" },
+        }),
+        this.prisma.deviceCommand.updateMany({
+          where: {
+            status: "inflight",
+            updatedAt: { lt: cutoff },
+            attempts: { gte: CommandQueueService.MAX_ATTEMPTS },
+            kind: { notIn: nonRetryable },
+          },
+          data: { status: "failed", error: "No ack received; giving up" },
+        }),
+        // Side-effecting kinds: terminate in `failed` regardless of
+        // attempts. Never auto-retried — the device may already have
+        // moved real money / printed a fiscal receipt.
+        this.prisma.deviceCommand.updateMany({
+          where: {
+            status: "inflight",
+            updatedAt: { lt: cutoff },
+            kind: { in: nonRetryable },
+          },
+          data: {
+            status: "failed",
+            error:
+              "No ack received; not auto-retried (side-effecting) — requires manual compensating command",
+          },
+        }),
+        this.prisma.deviceCommand.updateMany({
+          where: {
+            status: "queued",
+            expiresAt: { lt: now, not: null },
+          },
+          data: {
+            status: "expired",
+            error: "TTL expired before device claimed",
+          },
+        }),
+      ]);
+    const total =
+      requeue.count + fail.count + sideEffectFail.count + expired.count;
     if (total > 0) {
       this.logger.warn(
-        `Swept ${total} stuck device commands (requeued=${requeue.count} failed=${fail.count} expired=${expired.count})`,
+        `Swept ${total} stuck device commands (requeued=${requeue.count} failed=${fail.count} sideEffectFailed=${sideEffectFail.count} expired=${expired.count})`,
       );
     }
     return total;
@@ -286,11 +381,18 @@ export class CommandQueueService {
     tenantId: string,
     deviceId: string,
     filters?: { status?: string; limit?: number },
+    // deep-review H14 — same branch-scope guard as enqueue(). A
+    // branch-restricted caller (non-wildcard `branchId`) can only inspect
+    // command queues for devices in their own branch; a cross-branch
+    // deviceId yields an empty list rather than leaking another branch's
+    // command history. ADMINs acting tenant-wide pass undefined.
+    branchId?: string,
   ) {
     return this.prisma.deviceCommand.findMany({
       where: {
         tenantId,
         deviceId,
+        ...(branchId ? { branchId } : {}),
         ...(filters?.status ? { status: filters.status } : {}),
       },
       orderBy: { createdAt: "desc" },

--- a/backend/src/modules/device-mesh/devices.controller.spec.ts
+++ b/backend/src/modules/device-mesh/devices.controller.spec.ts
@@ -12,7 +12,10 @@ describe("DevicesController", () => {
   let devices: Record<string, jest.Mock>;
   let queue: Record<string, jest.Mock>;
   let ctrl: DevicesController;
-  const userReq = { user: { tenantId: "t1" } };
+  // deep-review H14: branch-scoped surface — the global BranchGuard sets
+  // req.scope.branchId, which the controller forwards so device commands stay
+  // within the caller's validated branch.
+  const userReq = { user: { tenantId: "t1" }, scope: { branchId: "branch-a" } };
   const deviceReq = { device: { id: "dev-1" } };
 
   beforeEach(() => {
@@ -53,15 +56,21 @@ describe("DevicesController", () => {
   it("enqueueCommand threads tenantId, device id and dto", () => {
     const dto = { kind: "print.receipt", payload: {} } as any;
     ctrl.enqueueCommand(userReq, "dev-9", dto);
-    expect(queue.enqueue).toHaveBeenCalledWith("t1", "dev-9", dto);
+    // H14: branch scope (branch-a) threaded through as the 4th arg.
+    expect(queue.enqueue).toHaveBeenCalledWith("t1", "dev-9", dto, "branch-a");
   });
 
   it("listCommands parses the limit to int", () => {
     ctrl.listCommands(userReq, "dev-9", "queued", "20");
-    expect(queue.listForDevice).toHaveBeenCalledWith("t1", "dev-9", {
-      status: "queued",
-      limit: 20,
-    });
+    expect(queue.listForDevice).toHaveBeenCalledWith(
+      "t1",
+      "dev-9",
+      {
+        status: "queued",
+        limit: 20,
+      },
+      "branch-a",
+    );
   });
 
   it("pair forwards the dto (public, device not yet known)", () => {

--- a/backend/src/modules/device-mesh/devices.controller.ts
+++ b/backend/src/modules/device-mesh/devices.controller.ts
@@ -90,7 +90,13 @@ export class DevicesController {
     @Param("id") id: string,
     @Body() dto: EnqueueCommandDto,
   ) {
-    return this.queue.enqueue(req.user.tenantId, id, dto);
+    // deep-review H14: /v1/devices is a branch-scoped surface, so the global
+    // BranchGuard has already validated req.scope.branchId ∈ the caller's
+    // allowed branches. Forward it so a branch-restricted MANAGER can only
+    // drive devices in the branch they are scoped to — closing the
+    // cross-branch "enqueue charge_card/open_drawer/fiscal_receipt to another
+    // branch's terminal" vector. A device outside the scoped branch 404s.
+    return this.queue.enqueue(req.user.tenantId, id, dto, req.scope?.branchId);
   }
 
   @UseGuards(JwtAuthGuard, RolesGuard)
@@ -104,10 +110,17 @@ export class DevicesController {
     @Query("status") status?: string,
     @Query("limit") limit?: string,
   ) {
-    return this.queue.listForDevice(req.user.tenantId, id, {
-      status,
-      limit: limit ? parseInt(limit, 10) : undefined,
-    });
+    return this.queue.listForDevice(
+      req.user.tenantId,
+      id,
+      {
+        status,
+        limit: limit ? parseInt(limit, 10) : undefined,
+      },
+      // deep-review H14: scope command-queue inspection to the caller's
+      // validated branch (same rationale as enqueueCommand above).
+      req.scope?.branchId,
+    );
   }
 
   // -- Device-side (device-token auth) endpoints ---------------------------

--- a/backend/src/modules/fiscal-core/adapters/efatura-fiscal-provider.spec.ts
+++ b/backend/src/modules/fiscal-core/adapters/efatura-fiscal-provider.spec.ts
@@ -13,7 +13,9 @@ import { FiscalReceiptRequest } from "../fiscal-provider.interface";
  */
 describe("EfaturaFiscalProvider", () => {
   function makeProvider(createImpl: jest.Mock) {
-    const registry = { register: jest.fn() } as unknown as FiscalProviderRegistry;
+    const registry = {
+      register: jest.fn(),
+    } as unknown as FiscalProviderRegistry;
     const prisma = {
       salesInvoice: { create: createImpl },
     } as unknown as PrismaService;
@@ -54,8 +56,15 @@ describe("EfaturaFiscalProvider", () => {
     expect(data.tenantId).toBe("t1");
     expect(data.currency).toBe("TRY");
     expect(data.status).toBe("pending");
-    // 2 * 5000 cents = 10000 cents = 100.00 TRY
-    expect(data.subtotal).toBe(100);
+    // deep-review H9/M9: prices are KDV-inclusive, so 2 * 5000 = 10000 cents =
+    // 100.00 TRY is the GROSS (totalAmount). The taxable base (subtotal) is
+    // net = gross - extracted KDV; at 20% that is 100 - round(100*20/120) =
+    // 100 - 16.67 = 83.33. The row now writes the real SalesInvoice columns
+    // (subtotal/taxAmount/totalAmount), not the non-existent `kind`/`total`.
+    expect(data.totalAmount).toBe(100);
+    expect(data.subtotal).toBeCloseTo(83.33, 2);
+    expect(data.taxAmount).toBeCloseTo(16.67, 2);
+    expect(data.type).toBe("SALES");
     expect(data.items.create).toHaveLength(1);
   });
 
@@ -71,10 +80,9 @@ describe("EfaturaFiscalProvider", () => {
     const registry = {
       register: jest.fn(),
     } as unknown as FiscalProviderRegistry;
-    const provider = new EfaturaFiscalProvider(
-      registry,
-      { salesInvoice: { create: jest.fn() } } as unknown as PrismaService,
-    );
+    const provider = new EfaturaFiscalProvider(registry, {
+      salesInvoice: { create: jest.fn() },
+    } as unknown as PrismaService);
     provider.onModuleInit();
     expect(registry.register).toHaveBeenCalledWith(provider);
   });

--- a/backend/src/modules/fiscal-core/adapters/efatura-fiscal-provider.ts
+++ b/backend/src/modules/fiscal-core/adapters/efatura-fiscal-provider.ts
@@ -46,15 +46,21 @@ export class EfaturaFiscalProvider implements FiscalProvider, OnModuleInit {
     // Translate the line items into the existing SalesInvoice shape. The
     // accounting module owns finalisation/GİB submission; we are only the
     // bridge that turns "fiscal issuance request" into one of its rows.
-    const subtotal = req.lines.reduce(
+    // Prices are KDV-inclusive, so each line's (qty*unitPrice - discount) is
+    // the GROSS amount actually charged. deep-review H9: the invoice's
+    // `subtotal` must be the taxable BASE (net = gross - extracted KDV), not
+    // the gross — previously subtotal was set to the tax-inclusive amount,
+    // overstating the taxable base on every e-Arşiv invoice.
+    const grossCents = req.lines.reduce(
       (acc, l) =>
         acc + Math.round(l.qty * l.unitPriceCents) - (l.discountCents ?? 0),
       0,
     );
-    const taxAmount = req.lines.reduce((acc, l) => {
-      const lineNet = l.qty * l.unitPriceCents - (l.discountCents ?? 0);
-      return acc + Math.round((lineNet * l.vatRate) / (100 + l.vatRate));
+    const taxCents = req.lines.reduce((acc, l) => {
+      const lineGross = l.qty * l.unitPriceCents - (l.discountCents ?? 0);
+      return acc + Math.round((lineGross * l.vatRate) / (100 + l.vatRate));
     }, 0);
+    const netCents = grossCents - taxCents;
 
     // Invoice numbers were previously `EARS-${year}-${Date.now().slice(-8)}`.
     // Two issuances in the same millisecond produced an identical number,
@@ -71,34 +77,45 @@ export class EfaturaFiscalProvider implements FiscalProvider, OnModuleInit {
     // so the caller marks the receipt 'failed' and the ops manual-recovery
     // panel picks it up.
     try {
-      await (this.prisma as any).salesInvoice.create({
+      // deep-review M9: write the ACTUAL SalesInvoice columns. The model has
+      // no `kind` and no `total` field and `totalAmount` is required (no
+      // default) — the previous shape made EVERY e-Arşiv issuance throw an
+      // "Unknown arg"/"missing totalAmount" Prisma error (masked by the
+      // `as any` cast), so every receipt fell into manual-recovery. The
+      // e-Arşiv vs e-Fatura `kind` is recorded via externalProvider/type
+      // rather than a non-existent column.
+      await this.prisma.salesInvoice.create({
         data: {
           id: uuidv7(),
           tenantId: req.tenantId,
           orderId: req.orderId,
           invoiceNumber: fiscalNo,
-          kind: req.kind ?? "earsiv",
+          type: "SALES",
+          externalProvider: this.id,
           issueDate: new Date(),
-          subtotal: subtotal / 100,
-          taxAmount: taxAmount / 100,
-          total: subtotal / 100,
+          subtotal: netCents / 100,
+          taxAmount: taxCents / 100,
+          totalAmount: grossCents / 100,
           currency: "TRY",
           status: "pending",
           items: {
-            create: req.lines.map((l) => ({
-              description: l.name,
-              quantity: l.qty,
-              unitPrice: l.unitPriceCents / 100,
-              taxRate: l.vatRate,
-              taxAmount:
-                ((l.qty * l.unitPriceCents - (l.discountCents ?? 0)) *
-                  l.vatRate) /
-                (100 + l.vatRate) /
-                100,
-              subtotal:
-                (l.qty * l.unitPriceCents - (l.discountCents ?? 0)) / 100,
-              total: (l.qty * l.unitPriceCents - (l.discountCents ?? 0)) / 100,
-            })),
+            create: req.lines.map((l) => {
+              const lineGross =
+                l.qty * l.unitPriceCents - (l.discountCents ?? 0);
+              const lineTax = Math.round(
+                (lineGross * l.vatRate) / (100 + l.vatRate),
+              );
+              return {
+                description: l.name,
+                quantity: l.qty,
+                unitPrice: l.unitPriceCents / 100,
+                taxRate: l.vatRate,
+                taxAmount: lineTax / 100,
+                // subtotal = taxable base (net); total = gross charged.
+                subtotal: (lineGross - lineTax) / 100,
+                total: lineGross / 100,
+              };
+            }),
           },
         },
       });

--- a/backend/src/modules/integration-gateway/integration.service.spec.ts
+++ b/backend/src/modules/integration-gateway/integration.service.spec.ts
@@ -1,5 +1,9 @@
-import { IntegrationService } from './integration.service';
-import { mockPrismaClient, MockPrismaClient } from '../../common/test/prisma-mock.service';
+import { Prisma } from "@prisma/client";
+import { IntegrationService } from "./integration.service";
+import {
+  mockPrismaClient,
+  MockPrismaClient,
+} from "../../common/test/prisma-mock.service";
 
 // Fake adapter implementations for unit tests — small enough to inline,
 // keeps tests independent of the real adapter shells. Each behaves as
@@ -8,7 +12,7 @@ import { mockPrismaClient, MockPrismaClient } from '../../common/test/prisma-moc
 function fakeAdapter(id: string) {
   return {
     id,
-    kind: 'delivery' as const,
+    kind: "delivery" as const,
     configSchema: {},
     init: jest.fn().mockResolvedValue(undefined),
     healthCheck: jest.fn().mockResolvedValue({ ok: true }),
@@ -20,9 +24,9 @@ function buildSvc(prisma: MockPrismaClient, outbox: { append: jest.Mock }) {
   return new IntegrationService(
     prisma as any,
     outbox as any,
-    fakeAdapter('yemeksepeti') as any,
-    fakeAdapter('getir') as any,
-    fakeAdapter('trendyol_yemek') as any,
+    fakeAdapter("yemeksepeti") as any,
+    fakeAdapter("getir") as any,
+    fakeAdapter("trendyol_yemek") as any,
   );
 }
 
@@ -31,42 +35,42 @@ function buildSvc(prisma: MockPrismaClient, outbox: { append: jest.Mock }) {
  * a regression here would mean leaked tenant credentials. These tests pin
  * down per-tenant key derivation + AES-256-GCM round-trip.
  */
-describe('IntegrationService crypto', () => {
+describe("IntegrationService crypto", () => {
   let prisma: MockPrismaClient;
   let outbox: { append: jest.Mock };
   let svc: IntegrationService;
 
   beforeEach(() => {
     prisma = mockPrismaClient();
-    outbox = { append: jest.fn().mockResolvedValue('outbox') };
+    outbox = { append: jest.fn().mockResolvedValue("outbox") };
     svc = buildSvc(prisma, outbox);
-    process.env.INTEGRATION_KEY = 'test-key-1234';
+    process.env.INTEGRATION_KEY = "test-key-1234";
   });
 
-  it('encrypts and decrypts a payload back to itself', () => {
+  it("encrypts and decrypts a payload back to itself", () => {
     // encrypt + decrypt are private — `as any` is the established pattern
     // for unit-testing internal helpers without exporting them.
-    const enc = (svc as any).encrypt('tenant-1', 'super-secret-token');
-    const dec = (svc as any).decrypt('tenant-1', enc);
-    expect(dec).toBe('super-secret-token');
+    const enc = (svc as any).encrypt("tenant-1", "super-secret-token");
+    const dec = (svc as any).decrypt("tenant-1", enc);
+    expect(dec).toBe("super-secret-token");
   });
 
-  it('uses a different ciphertext on every encryption (random IV)', () => {
-    const a = (svc as any).encrypt('tenant-1', 'same');
-    const b = (svc as any).encrypt('tenant-1', 'same');
+  it("uses a different ciphertext on every encryption (random IV)", () => {
+    const a = (svc as any).encrypt("tenant-1", "same");
+    const b = (svc as any).encrypt("tenant-1", "same");
     expect(Buffer.compare(a, b)).not.toBe(0);
   });
 
-  it('refuses to decrypt with a different tenant key', () => {
-    const enc = (svc as any).encrypt('tenant-1', 'super-secret-token');
-    expect(() => (svc as any).decrypt('tenant-2', enc)).toThrow();
+  it("refuses to decrypt with a different tenant key", () => {
+    const enc = (svc as any).encrypt("tenant-1", "super-secret-token");
+    expect(() => (svc as any).decrypt("tenant-2", enc)).toThrow();
   });
 
-  it('refuses to decrypt when ciphertext has been tampered with', () => {
-    const enc = (svc as any).encrypt('tenant-1', 'super-secret-token');
+  it("refuses to decrypt when ciphertext has been tampered with", () => {
+    const enc = (svc as any).encrypt("tenant-1", "super-secret-token");
     // Flip a byte deep in the ciphertext (after iv+tag).
     enc[40] = enc[40] ^ 0x01;
-    expect(() => (svc as any).decrypt('tenant-1', enc)).toThrow();
+    expect(() => (svc as any).decrypt("tenant-1", enc)).toThrow();
   });
 });
 
@@ -85,188 +89,292 @@ describe('IntegrationService crypto', () => {
  * envelope contains an `ignored: true` flag visible only to internal
  * callers (this test), and ops sees the actual reason via the logger.
  */
-describe('IntegrationService.ingestWebhook (iter-16 storage-DoS guards)', () => {
+describe("IntegrationService.ingestWebhook (iter-16 storage-DoS guards)", () => {
   let prisma: MockPrismaClient;
   let outbox: { append: jest.Mock };
   let svc: IntegrationService;
 
   beforeEach(() => {
     prisma = mockPrismaClient();
-    outbox = { append: jest.fn().mockResolvedValue('outbox') };
+    outbox = { append: jest.fn().mockResolvedValue("outbox") };
     svc = buildSvc(prisma, outbox);
-    process.env.INTEGRATION_KEY = 'test-key-1234';
+    process.env.INTEGRATION_KEY = "test-key-1234";
+    // deep-review M20 wrapped the replay dup-check + the event create in a
+    // Serializable $transaction. The deep-mocked prisma's $transaction
+    // doesn't forward the callback by default — wire it through so the
+    // inner tx.integrationWebhookEvent.* calls land on the same mock
+    // surface the tests already poke. Default the dup-check findFirst to
+    // null so the happy path doesn't have to set it on every test.
+    (prisma.$transaction as any).mockImplementation(async (fn: any) =>
+      fn(prisma),
+    );
+    (prisma.integrationWebhookEvent.findFirst as any).mockResolvedValue(null);
   });
 
-  it('drops the webhook when tenantId is missing entirely', async () => {
-    const out = await svc.ingestWebhook('yemeksepeti', null, {}, Buffer.from('{}'));
+  it("drops the webhook when tenantId is missing entirely", async () => {
+    const out = await svc.ingestWebhook(
+      "yemeksepeti",
+      null,
+      {},
+      Buffer.from("{}"),
+    );
 
-    expect(out).toEqual({ ignored: true, reason: 'missing tenant' });
+    expect(out).toEqual({ ignored: true, reason: "missing tenant" });
     // No DB writes. The load-bearing assertion — a row created here is
     // the storage-flood hole this iter-16 fix closed.
-    expect((prisma.integrationWebhookEvent.create as any).mock.calls.length).toBe(0);
+    expect(
+      (prisma.integrationWebhookEvent.create as any).mock.calls.length,
+    ).toBe(0);
     expect(outbox.append).not.toHaveBeenCalled();
   });
 
-  it('drops the webhook when the tenant does not exist', async () => {
+  it("drops the webhook when the tenant does not exist", async () => {
     prisma.tenant.findUnique.mockResolvedValue(null);
-    prisma.integrationProviderDef.findUnique.mockResolvedValue({ id: 'yemeksepeti' } as any);
+    prisma.integrationProviderDef.findUnique.mockResolvedValue({
+      id: "yemeksepeti",
+    } as any);
 
-    const out = await svc.ingestWebhook('yemeksepeti', 'bogus-tenant', {}, Buffer.from('{}'));
+    const out = await svc.ingestWebhook(
+      "yemeksepeti",
+      "bogus-tenant",
+      {},
+      Buffer.from("{}"),
+    );
 
-    expect(out).toEqual({ ignored: true, reason: 'unknown tenant' });
-    expect((prisma.integrationWebhookEvent.create as any).mock.calls.length).toBe(0);
+    expect(out).toEqual({ ignored: true, reason: "unknown tenant" });
+    expect(
+      (prisma.integrationWebhookEvent.create as any).mock.calls.length,
+    ).toBe(0);
   });
 
-  it('drops the webhook when the provider does not exist', async () => {
-    prisma.tenant.findUnique.mockResolvedValue({ id: 't1' } as any);
+  it("drops the webhook when the provider does not exist", async () => {
+    prisma.tenant.findUnique.mockResolvedValue({ id: "t1" } as any);
     prisma.integrationProviderDef.findUnique.mockResolvedValue(null);
 
-    const out = await svc.ingestWebhook('bogus-provider', 't1', {}, Buffer.from('{}'));
+    const out = await svc.ingestWebhook(
+      "bogus-provider",
+      "t1",
+      {},
+      Buffer.from("{}"),
+    );
 
-    expect(out).toEqual({ ignored: true, reason: 'unknown provider' });
-    expect((prisma.integrationWebhookEvent.create as any).mock.calls.length).toBe(0);
+    expect(out).toEqual({ ignored: true, reason: "unknown provider" });
+    expect(
+      (prisma.integrationWebhookEvent.create as any).mock.calls.length,
+    ).toBe(0);
   });
 
-  it('rejects oversized bodies before JSON.parse (CPU + storage DoS guard)', async () => {
-    prisma.tenant.findUnique.mockResolvedValue({ id: 't1' } as any);
-    prisma.integrationProviderDef.findUnique.mockResolvedValue({ id: 'yemeksepeti' } as any);
+  it("rejects oversized bodies before JSON.parse (CPU + storage DoS guard)", async () => {
+    prisma.tenant.findUnique.mockResolvedValue({ id: "t1" } as any);
+    prisma.integrationProviderDef.findUnique.mockResolvedValue({
+      id: "yemeksepeti",
+    } as any);
     // 64KB cap + 1 byte → over the limit.
     const oversized = Buffer.alloc(64 * 1024 + 1, 0x7b);
 
-    const out = await svc.ingestWebhook('yemeksepeti', 't1', {}, oversized);
+    const out = await svc.ingestWebhook("yemeksepeti", "t1", {}, oversized);
 
-    expect(out).toEqual({ ignored: true, reason: 'payload too large' });
+    expect(out).toEqual({ ignored: true, reason: "payload too large" });
     // Crucially the body never gets JSON.parsed — pulling a 100MB
     // alleged-JSON apart only to drop the row would still be a CPU DoS.
     // We can't directly assert "JSON.parse was not called" without spying
     // on a global, but the create-call check covers the observable
     // outcome.
-    expect((prisma.integrationWebhookEvent.create as any).mock.calls.length).toBe(0);
+    expect(
+      (prisma.integrationWebhookEvent.create as any).mock.calls.length,
+    ).toBe(0);
   });
 
-  it('writes the row and appends to outbox on the happy path', async () => {
-    prisma.tenant.findUnique.mockResolvedValue({ id: 't1' } as any);
-    prisma.integrationProviderDef.findUnique.mockResolvedValue({ id: 'yemeksepeti' } as any);
+  it("writes the row and appends to outbox on the happy path", async () => {
+    prisma.tenant.findUnique.mockResolvedValue({ id: "t1" } as any);
+    prisma.integrationProviderDef.findUnique.mockResolvedValue({
+      id: "yemeksepeti",
+    } as any);
 
     // The new HMAC-verification gate (iter-11) needs:
     //   1. a `connected` IntegrationConnection row with non-null
     //      credentialsEnc, decryptable with the test INTEGRATION_KEY.
     //   2. the adapter's parseWebhook to resolve (fake adapter does).
-    const credsBlob = (svc as any).encrypt('t1', JSON.stringify({ secret: 's' }));
+    const credsBlob = (svc as any).encrypt(
+      "t1",
+      JSON.stringify({ secret: "s" }),
+    );
     prisma.integrationConnection.findFirst.mockResolvedValue({
-      id: 'conn-1',
-      tenantId: 't1',
-      providerId: 'yemeksepeti',
-      status: 'connected',
+      id: "conn-1",
+      tenantId: "t1",
+      providerId: "yemeksepeti",
+      status: "connected",
       credentialsEnc: credsBlob,
     } as any);
 
     let createArgs: any = null;
-    (prisma.integrationWebhookEvent.create as any).mockImplementation(async ({ data }: any) => {
-      createArgs = data;
-      return { id: 'wh-1', ...data };
-    });
+    (prisma.integrationWebhookEvent.create as any).mockImplementation(
+      async ({ data }: any) => {
+        createArgs = data;
+        return { id: "wh-1", ...data };
+      },
+    );
 
     const out: any = await svc.ingestWebhook(
-      'yemeksepeti',
-      't1',
-      { 'x-signature': 'sig-value' },
+      "yemeksepeti",
+      "t1",
+      { "x-signature": "sig-value" },
       Buffer.from('{"type":"order.created"}'),
     );
 
     // id is a server-side UUIDv7 (the `wh-1` in the mock gets overwritten
     // by the spread). The actual debugging hook is the createArgs shape.
     expect(out.id).toMatch(/^[0-9a-f-]{36}$/);
-    expect(createArgs.tenantId).toBe('t1');
-    expect(createArgs.providerId).toBe('yemeksepeti');
-    expect(createArgs.connectionId).toBe('conn-1');
-    expect(createArgs.type).toBe('order.created');
-    expect(createArgs.signature).toBe('sig-value');
+    expect(createArgs.tenantId).toBe("t1");
+    expect(createArgs.providerId).toBe("yemeksepeti");
+    expect(createArgs.connectionId).toBe("conn-1");
+    expect(createArgs.type).toBe("order.created");
+    expect(createArgs.signature).toBe("sig-value");
     expect(outbox.append).toHaveBeenCalledWith(
       expect.objectContaining({
-        type: 'integration.webhook.yemeksepeti.received.v1',
-        tenantId: 't1',
+        type: "integration.webhook.yemeksepeti.received.v1",
+        tenantId: "t1",
       }),
     );
   });
 
-  it('drops the webhook when no IntegrationConnection exists for the tenant', async () => {
+  it("drops the webhook when no IntegrationConnection exists for the tenant", async () => {
     // Critical iter-11 invariant: URL-only tenant routing is not enough.
     // Without a connected row, an attacker could land arbitrary "verified"
     // payloads under any real tenant by guessing the URL — we refuse here.
-    prisma.tenant.findUnique.mockResolvedValue({ id: 't1' } as any);
-    prisma.integrationProviderDef.findUnique.mockResolvedValue({ id: 'yemeksepeti' } as any);
+    prisma.tenant.findUnique.mockResolvedValue({ id: "t1" } as any);
+    prisma.integrationProviderDef.findUnique.mockResolvedValue({
+      id: "yemeksepeti",
+    } as any);
     prisma.integrationConnection.findFirst.mockResolvedValue(null);
 
     const out = await svc.ingestWebhook(
-      'yemeksepeti',
-      't1',
-      { 'x-signature': 'sig-value' },
-      Buffer.from('{}'),
+      "yemeksepeti",
+      "t1",
+      { "x-signature": "sig-value" },
+      Buffer.from("{}"),
     );
 
-    expect(out).toEqual({ ignored: true, reason: 'no connection' });
-    expect((prisma.integrationWebhookEvent.create as any).mock.calls.length).toBe(0);
+    expect(out).toEqual({ ignored: true, reason: "no connection" });
+    expect(
+      (prisma.integrationWebhookEvent.create as any).mock.calls.length,
+    ).toBe(0);
     expect(outbox.append).not.toHaveBeenCalled();
   });
 
-  it('rejects a duplicate signature within the replay window (iter-17)', async () => {
+  it("rejects a duplicate signature within the replay window (iter-17)", async () => {
     // HMAC verify proves the body+sig was signed by the provider's secret.
     // It does NOT prevent capture-and-replay. If a captured body+sig is
     // POSTed twice, the second one must short-circuit so we don't double-
     // process the same order/event downstream.
-    prisma.tenant.findUnique.mockResolvedValue({ id: 't1' } as any);
-    prisma.integrationProviderDef.findUnique.mockResolvedValue({ id: 'yemeksepeti' } as any);
-    const credsBlob = (svc as any).encrypt('t1', JSON.stringify({ secret: 's' }));
+    prisma.tenant.findUnique.mockResolvedValue({ id: "t1" } as any);
+    prisma.integrationProviderDef.findUnique.mockResolvedValue({
+      id: "yemeksepeti",
+    } as any);
+    const credsBlob = (svc as any).encrypt(
+      "t1",
+      JSON.stringify({ secret: "s" }),
+    );
     prisma.integrationConnection.findFirst.mockResolvedValue({
-      id: 'conn-1',
-      tenantId: 't1',
-      providerId: 'yemeksepeti',
-      status: 'connected',
+      id: "conn-1",
+      tenantId: "t1",
+      providerId: "yemeksepeti",
+      status: "connected",
       credentialsEnc: credsBlob,
     } as any);
     prisma.integrationWebhookEvent.findFirst.mockResolvedValue({
-      id: 'prev-event-id',
-      receivedAt: new Date('2026-05-25T10:00:00Z'),
+      id: "prev-event-id",
+      receivedAt: new Date("2026-05-25T10:00:00Z"),
     } as any);
 
     const out = await svc.ingestWebhook(
-      'yemeksepeti',
-      't1',
-      { 'x-signature': 'replayed-sig' },
+      "yemeksepeti",
+      "t1",
+      { "x-signature": "replayed-sig" },
       Buffer.from('{"type":"order.created"}'),
     );
 
-    expect(out).toEqual({ ignored: true, reason: 'duplicate' });
-    expect((prisma.integrationWebhookEvent.create as any).mock.calls.length).toBe(0);
+    expect(out).toEqual({ ignored: true, reason: "duplicate" });
+    expect(
+      (prisma.integrationWebhookEvent.create as any).mock.calls.length,
+    ).toBe(0);
     expect(outbox.append).not.toHaveBeenCalled();
   });
 
-  it('drops the webhook when the adapter rejects the signature', async () => {
-    prisma.tenant.findUnique.mockResolvedValue({ id: 't1' } as any);
-    prisma.integrationProviderDef.findUnique.mockResolvedValue({ id: 'yemeksepeti' } as any);
-    const credsBlob = (svc as any).encrypt('t1', JSON.stringify({ secret: 's' }));
+  it("rejects a CONCURRENT duplicate via serialization abort (deep-review M20)", async () => {
+    // The sequential gate above only catches a duplicate whose first row has
+    // already committed. Two identical webhooks racing each other both ran
+    // findFirst before either committed, so neither saw the peer and BOTH
+    // created an event + emitted to the outbox — double-firing downstream.
+    // The dup-check + create now run in one Serializable txn; the loser of
+    // the race aborts with Postgres 40001 → Prisma P2034, which we map to
+    // the same { ignored, reason: "duplicate" } WITHOUT touching the outbox.
+    prisma.tenant.findUnique.mockResolvedValue({ id: "t1" } as any);
+    prisma.integrationProviderDef.findUnique.mockResolvedValue({
+      id: "yemeksepeti",
+    } as any);
+    const credsBlob = (svc as any).encrypt(
+      "t1",
+      JSON.stringify({ secret: "s" }),
+    );
     prisma.integrationConnection.findFirst.mockResolvedValue({
-      id: 'conn-1',
-      tenantId: 't1',
-      providerId: 'yemeksepeti',
-      status: 'connected',
+      id: "conn-1",
+      tenantId: "t1",
+      providerId: "yemeksepeti",
+      status: "connected",
+      credentialsEnc: credsBlob,
+    } as any);
+    // The serialization failure surfaces from the $transaction itself.
+    (prisma.$transaction as any).mockRejectedValueOnce(
+      new Prisma.PrismaClientKnownRequestError("could not serialize access", {
+        code: "P2034",
+        clientVersion: "test",
+      }),
+    );
+
+    const out = await svc.ingestWebhook(
+      "yemeksepeti",
+      "t1",
+      { "x-signature": "racing-sig" },
+      Buffer.from('{"type":"order.created"}'),
+    );
+
+    expect(out).toEqual({ ignored: true, reason: "duplicate" });
+    expect(outbox.append).not.toHaveBeenCalled();
+  });
+
+  it("drops the webhook when the adapter rejects the signature", async () => {
+    prisma.tenant.findUnique.mockResolvedValue({ id: "t1" } as any);
+    prisma.integrationProviderDef.findUnique.mockResolvedValue({
+      id: "yemeksepeti",
+    } as any);
+    const credsBlob = (svc as any).encrypt(
+      "t1",
+      JSON.stringify({ secret: "s" }),
+    );
+    prisma.integrationConnection.findFirst.mockResolvedValue({
+      id: "conn-1",
+      tenantId: "t1",
+      providerId: "yemeksepeti",
+      status: "connected",
       credentialsEnc: credsBlob,
     } as any);
 
     // Reach into the adapter and make parseWebhook reject.
-    const adapter = (svc as any).adapters.get('yemeksepeti');
-    adapter.parseWebhook.mockRejectedValueOnce(new Error('invalid signature'));
+    const adapter = (svc as any).adapters.get("yemeksepeti");
+    adapter.parseWebhook.mockRejectedValueOnce(new Error("invalid signature"));
 
     const out = await svc.ingestWebhook(
-      'yemeksepeti',
-      't1',
-      { 'x-signature': 'bad' },
-      Buffer.from('{}'),
+      "yemeksepeti",
+      "t1",
+      { "x-signature": "bad" },
+      Buffer.from("{}"),
     );
 
-    expect(out).toEqual({ ignored: true, reason: 'verify failed' });
-    expect((prisma.integrationWebhookEvent.create as any).mock.calls.length).toBe(0);
+    expect(out).toEqual({ ignored: true, reason: "verify failed" });
+    expect(
+      (prisma.integrationWebhookEvent.create as any).mock.calls.length,
+    ).toBe(0);
     expect(outbox.append).not.toHaveBeenCalled();
   });
 });

--- a/backend/src/modules/integration-gateway/integration.service.ts
+++ b/backend/src/modules/integration-gateway/integration.service.ts
@@ -11,6 +11,7 @@ import {
   createHash,
 } from "node:crypto";
 import { v7 as uuidv7 } from "uuid";
+import { Prisma } from "@prisma/client";
 import { PrismaService } from "../../prisma/prisma.service";
 import { OutboxService } from "../outbox/outbox.service";
 import { captureSwallowedEmit } from "../../common/observability/capture-swallowed-emit";
@@ -307,26 +308,23 @@ export class IntegrationService {
     // requiring a schema change. 24h window is conservative; providers
     // that legitimately resend identical bodies more than a day apart
     // (e.g. daily heartbeats) won't trip the gate.
-    if (signature) {
-      const recentDuplicate =
-        await this.prisma.integrationWebhookEvent.findFirst({
-          where: {
-            tenantId,
-            providerId,
-            signature,
-            receivedAt: { gte: new Date(Date.now() - 24 * 60 * 60_000) },
-          },
-          select: { id: true, receivedAt: true },
-        });
-      if (recentDuplicate) {
-        this.logger.warn(
-          `Replay rejected: duplicate signature for provider=${providerId} tenant=${tenantId} ` +
-            `— original event ${recentDuplicate.id} received at ${recentDuplicate.receivedAt.toISOString()}`,
-        );
-        return { ignored: true, reason: "duplicate" };
-      }
-    }
-
+    //
+    // deep-review M20: the dedup used to be a bare findFirst followed by a
+    // separate create — a read-then-write TOCTOU. Two identical webhooks
+    // arriving concurrently (provider retry storm / attacker replay) each
+    // ran findFirst before the other committed, so neither saw the peer's
+    // row and BOTH created an event + emitted to the outbox, double-firing
+    // downstream order/payment consumers. A plain @@unique can't fix this
+    // cleanly here: signature is nullable (null-sig rows are intentionally
+    // never deduped — Postgres treats NULLs as distinct anyway) and a full
+    // unique index would also kill the deliberate 24h-resend escape hatch
+    // for daily-heartbeat bodies. Instead we run the dup-check + create in
+    // a single Serializable transaction (same pattern as Iter-68 in
+    // tenant-marketplace). Postgres detects the overlapping read/write
+    // predicate sets and aborts one of the two concurrent transactions;
+    // the loser surfaces as a serialization failure (40001 / P2034), which
+    // we map to the same { ignored, reason: "duplicate" } the sequential
+    // path returns — so only the winner ever appends to the outbox.
     let parsed: any = {};
     try {
       parsed = JSON.parse(raw.toString("utf8"));
@@ -335,18 +333,71 @@ export class IntegrationService {
       parsed = { _raw: raw.toString("utf8") };
     }
 
-    const row = await this.prisma.integrationWebhookEvent.create({
-      data: {
-        id: uuidv7(),
-        tenantId,
-        connectionId: connection.id,
-        providerId,
-        type: parsed?.type ?? parsed?.event ?? "unknown",
-        signature,
-        payload: parsed as any,
-        result: "received",
-      },
-    });
+    // `null` is the in-txn sentinel for a sequential-duplicate hit (the txn
+    // unwinds without writing); the non-null branch is the created row.
+    let row: Awaited<
+      ReturnType<typeof this.prisma.integrationWebhookEvent.create>
+    > | null;
+    try {
+      row = await this.prisma.$transaction(
+        async (tx) => {
+          if (signature) {
+            const recentDuplicate = await tx.integrationWebhookEvent.findFirst({
+              where: {
+                tenantId,
+                providerId,
+                signature,
+                receivedAt: { gte: new Date(Date.now() - 24 * 60 * 60_000) },
+              },
+              select: { id: true, receivedAt: true },
+            });
+            if (recentDuplicate) {
+              this.logger.warn(
+                `Replay rejected: duplicate signature for provider=${providerId} tenant=${tenantId} ` +
+                  `— original event ${recentDuplicate.id} received at ${recentDuplicate.receivedAt.toISOString()}`,
+              );
+              // Sentinel: unwind the txn without writing, distinguished from
+              // a real serialization abort by the P2034 check below.
+              return null;
+            }
+          }
+
+          return tx.integrationWebhookEvent.create({
+            data: {
+              id: uuidv7(),
+              tenantId,
+              connectionId: connection.id,
+              providerId,
+              type: parsed?.type ?? parsed?.event ?? "unknown",
+              signature,
+              payload: parsed as any,
+              result: "received",
+            },
+          });
+        },
+        { isolationLevel: Prisma.TransactionIsolationLevel.Serializable },
+      );
+    } catch (err) {
+      // deep-review M20: the loser of a concurrent dup race aborts here with
+      // a Postgres serialization failure (40001 → Prisma P2034). Treat it as
+      // a duplicate so the loser neither retries nor touches the outbox.
+      if (
+        err instanceof Prisma.PrismaClientKnownRequestError &&
+        err.code === "P2034"
+      ) {
+        this.logger.warn(
+          `Replay rejected (serialization conflict): concurrent duplicate ` +
+            `signature for provider=${providerId} tenant=${tenantId}`,
+        );
+        return { ignored: true, reason: "duplicate" };
+      }
+      throw err;
+    }
+
+    // Sequential duplicate caught inside the txn (recentDuplicate hit).
+    if (row === null) {
+      return { ignored: true, reason: "duplicate" };
+    }
 
     await this.outbox
       .append({

--- a/backend/src/modules/kds/kds.service.spec.ts
+++ b/backend/src/modules/kds/kds.service.spec.ts
@@ -1,8 +1,8 @@
-import { KdsService } from './kds.service';
+import { KdsService } from "./kds.service";
 import {
   mockPrismaClient,
   MockPrismaClient,
-} from '../../common/test/prisma-mock.service';
+} from "../../common/test/prisma-mock.service";
 
 /**
  * Track-1 branch-scope hardening (Task 3).
@@ -15,7 +15,7 @@ import {
  * These specs pin the compound (tenantId, branchId) predicate at the DB
  * boundary for the read path and the mutating claim paths.
  */
-describe('KdsService branch scope', () => {
+describe("KdsService branch scope", () => {
   let prisma: MockPrismaClient;
   let svc: KdsService;
   // Light jest.fn() collaborator mocks matching the real ctor arg order:
@@ -27,10 +27,10 @@ describe('KdsService branch scope', () => {
   };
 
   const scope = {
-    tenantId: 't-1',
-    branchId: 'b-1',
-    userId: 'u-1',
-    role: 'KITCHEN',
+    tenantId: "t-1",
+    branchId: "b-1",
+    userId: "u-1",
+    role: "KITCHEN",
   } as any;
 
   beforeEach(() => {
@@ -43,95 +43,229 @@ describe('KdsService branch scope', () => {
     svc = new KdsService(prisma as any, gateway as any);
   });
 
-  it('getKitchenOrders filters by branchId AND tenantId', async () => {
+  it("getKitchenOrders filters by branchId AND tenantId", async () => {
     (prisma.order.findMany as any).mockResolvedValue([]);
 
     await svc.getKitchenOrders(scope);
 
     const where = (prisma.order.findMany as any).mock.calls[0][0].where;
-    expect(where.branchId).toBe('b-1');
-    expect(where.tenantId).toBe('t-1');
+    expect(where.branchId).toBe("b-1");
+    expect(where.tenantId).toBe("t-1");
   });
 
-  it('updateOrderStatus scopes the lookup AND the compound updateMany claim by branchId', async () => {
+  it("updateOrderStatus scopes the lookup AND the compound updateMany claim by branchId", async () => {
     (prisma.order.findFirst as any).mockResolvedValue({
-      id: 'o-1',
-      tenantId: 't-1',
-      branchId: 'b-1',
-      status: 'PENDING',
+      id: "o-1",
+      tenantId: "t-1",
+      branchId: "b-1",
+      status: "PENDING",
       requiresApproval: false,
     });
     (prisma.order.updateMany as any).mockResolvedValue({ count: 1 });
     (prisma.order.findUniqueOrThrow as any).mockResolvedValue({
-      id: 'o-1',
-      branchId: 'b-1',
+      id: "o-1",
+      branchId: "b-1",
       orderItems: [],
     });
 
-    await svc.updateOrderStatus(scope, 'o-1', 'PREPARING' as any);
+    await svc.updateOrderStatus(scope, "o-1", "PREPARING" as any);
 
     // The tenant+branch-bound lookup
     const findWhere = (prisma.order.findFirst as any).mock.calls[0][0].where;
-    expect(findWhere.tenantId).toBe('t-1');
-    expect(findWhere.branchId).toBe('b-1');
+    expect(findWhere.tenantId).toBe("t-1");
+    expect(findWhere.branchId).toBe("b-1");
     // The compound TOCTOU claim must also carry the branch predicate so a
     // cross-branch order id can never be claimed.
     const claimWhere = (prisma.order.updateMany as any).mock.calls[0][0].where;
-    expect(claimWhere.tenantId).toBe('t-1');
-    expect(claimWhere.branchId).toBe('b-1');
+    expect(claimWhere.tenantId).toBe("t-1");
+    expect(claimWhere.branchId).toBe("b-1");
   });
 
-  it('cancelOrder scopes the lookup AND the compound cancel claim by branchId', async () => {
+  it("cancelOrder scopes the lookup AND the compound cancel claim by branchId", async () => {
     (prisma.order.findFirst as any).mockResolvedValue({
-      id: 'o-1',
-      tenantId: 't-1',
-      branchId: 'b-1',
-      status: 'PENDING',
+      id: "o-1",
+      tenantId: "t-1",
+      branchId: "b-1",
+      status: "PENDING",
     });
     (prisma.order.updateMany as any).mockResolvedValue({ count: 1 });
     (prisma.order.findUniqueOrThrow as any).mockResolvedValue({
-      id: 'o-1',
-      branchId: 'b-1',
+      id: "o-1",
+      branchId: "b-1",
       orderItems: [],
     });
 
-    await svc.cancelOrder(scope, 'o-1');
+    await svc.cancelOrder(scope, "o-1");
 
     const findWhere = (prisma.order.findFirst as any).mock.calls[0][0].where;
-    expect(findWhere.tenantId).toBe('t-1');
-    expect(findWhere.branchId).toBe('b-1');
+    expect(findWhere.tenantId).toBe("t-1");
+    expect(findWhere.branchId).toBe("b-1");
     const claimWhere = (prisma.order.updateMany as any).mock.calls[0][0].where;
-    expect(claimWhere.tenantId).toBe('t-1');
-    expect(claimWhere.branchId).toBe('b-1');
+    expect(claimWhere.tenantId).toBe("t-1");
+    expect(claimWhere.branchId).toBe("b-1");
   });
 
-  it('updateOrderItemStatus scopes the item lookup by branch via the order relation', async () => {
+  it("updateOrderItemStatus scopes the item lookup by branch via the order relation", async () => {
     (prisma.orderItem.findFirst as any).mockResolvedValue({
-      id: 'i-1',
-      orderId: 'o-1',
-      status: 'PENDING',
+      id: "i-1",
+      orderId: "o-1",
+      status: "PENDING",
       order: {
-        id: 'o-1',
-        status: 'PREPARING',
+        id: "o-1",
+        status: "PREPARING",
         requiresApproval: false,
-        branchId: 'b-1',
+        branchId: "b-1",
       },
     });
     (prisma.orderItem.updateMany as any).mockResolvedValue({ count: 1 });
     (prisma.orderItem.findUniqueOrThrow as any).mockResolvedValue({
-      id: 'i-1',
-      order: { id: 'o-1', branchId: 'b-1' },
+      id: "i-1",
+      order: { id: "o-1", branchId: "b-1" },
     });
     (prisma.orderItem.findMany as any).mockResolvedValue([
-      { status: 'PREPARING' },
+      { status: "PREPARING" },
     ]);
 
-    await svc.updateOrderItemStatus(scope, 'i-1', 'PREPARING' as any);
+    await svc.updateOrderItemStatus(scope, "i-1", "PREPARING" as any);
 
-    const findWhere = (prisma.orderItem.findFirst as any).mock.calls[0][0].where;
+    const findWhere = (prisma.orderItem.findFirst as any).mock.calls[0][0]
+      .where;
     // Relation filter must spread the full branch scope, not just tenantId.
-    expect(findWhere.order.tenantId).toBe('t-1');
-    expect(findWhere.order.branchId).toBe('b-1');
+    expect(findWhere.order.tenantId).toBe("t-1");
+    expect(findWhere.order.branchId).toBe("b-1");
+  });
+});
+
+/**
+ * deep-review H11/M17 — bumping the LAST item to READY on a still-PENDING
+ * ticket must auto-promote the order to READY by bridging the intermediate
+ * PREPARING hop (the state machine forbids PENDING→READY), WITHOUT throwing
+ * a 400 after the item write already committed, and the item-status WS emit
+ * must still fire.
+ */
+describe("KdsService item-bump auto-promotion (H11/M17)", () => {
+  let prisma: MockPrismaClient;
+  let gateway: {
+    emitOrderStatusChange: jest.Mock;
+    emitOrderItemStatusChange: jest.Mock;
+    emitLowStockAlert: jest.Mock;
+  };
+  let svc: KdsService;
+
+  const scope = {
+    tenantId: "t-1",
+    branchId: "b-1",
+    userId: "u-1",
+    role: "KITCHEN",
+  } as any;
+
+  beforeEach(() => {
+    prisma = mockPrismaClient();
+    gateway = {
+      emitOrderStatusChange: jest.fn(),
+      emitOrderItemStatusChange: jest.fn(),
+      emitLowStockAlert: jest.fn(),
+    };
+    svc = new KdsService(prisma as any, gateway as any);
+  });
+
+  it("PENDING order, last item bumped READY → order ends READY via PREPARING, item READY, no throw, WS emit fires", async () => {
+    // The item being bumped, on a PENDING order.
+    (prisma.orderItem.findFirst as any).mockResolvedValue({
+      id: "i-1",
+      orderId: "o-1",
+      status: "PREPARING",
+      order: {
+        id: "o-1",
+        status: "PENDING",
+        requiresApproval: false,
+        branchId: "b-1",
+      },
+    });
+    (prisma.orderItem.updateMany as any).mockResolvedValue({ count: 1 });
+    (prisma.orderItem.findUniqueOrThrow as any).mockResolvedValue({
+      id: "i-1",
+      status: "READY",
+      order: { id: "o-1", branchId: "b-1" },
+    });
+    // Every item is now READY → promotion should run.
+    (prisma.orderItem.findMany as any).mockResolvedValue([{ status: "READY" }]);
+
+    // The recursive updateOrderStatus reads the order via findFirst. First
+    // call sees PENDING (→ PREPARING hop), second call sees PREPARING (→ READY).
+    (prisma.order.findFirst as any)
+      .mockResolvedValueOnce({
+        id: "o-1",
+        tenantId: "t-1",
+        branchId: "b-1",
+        status: "PENDING",
+        requiresApproval: false,
+      })
+      .mockResolvedValueOnce({
+        id: "o-1",
+        tenantId: "t-1",
+        branchId: "b-1",
+        status: "PREPARING",
+        requiresApproval: false,
+      });
+    (prisma.order.updateMany as any).mockResolvedValue({ count: 1 });
+    (prisma.order.findUniqueOrThrow as any).mockResolvedValue({
+      id: "o-1",
+      tenantId: "t-1",
+      branchId: "b-1",
+      status: "READY",
+      finalAmount: null,
+      orderItems: [],
+    });
+    // The "fresh" re-read between the PREPARING hop and the READY promotion
+    // must report PREPARING so canTransition(PREPARING, READY) is true.
+    (prisma.order.findUnique as any).mockResolvedValue({ status: "PREPARING" });
+
+    await expect(
+      svc.updateOrderItemStatus(scope, "i-1", "READY" as any),
+    ).resolves.toBeDefined();
+
+    // Two order-status writes: PENDING→PREPARING, then PREPARING→READY.
+    const statuses = (prisma.order.updateMany as any).mock.calls.map(
+      (c: any) => c[0].data.status,
+    );
+    expect(statuses).toEqual(["PREPARING", "READY"]);
+    // Item-status WS emit must still fire (it did not, in the old throwing path).
+    expect(gateway.emitOrderItemStatusChange).toHaveBeenCalledWith(
+      "t-1",
+      "b-1",
+      "i-1",
+      "READY",
+    );
+  });
+
+  it("PENDING_APPROVAL order with all items READY does not auto-promote and does not throw", async () => {
+    (prisma.orderItem.findFirst as any).mockResolvedValue({
+      id: "i-1",
+      orderId: "o-1",
+      status: "PREPARING",
+      order: {
+        id: "o-1",
+        status: "PENDING_APPROVAL",
+        requiresApproval: true,
+        branchId: "b-1",
+      },
+    });
+    (prisma.orderItem.updateMany as any).mockResolvedValue({ count: 1 });
+    (prisma.orderItem.findUniqueOrThrow as any).mockResolvedValue({
+      id: "i-1",
+      status: "READY",
+      order: { id: "o-1", branchId: "b-1" },
+    });
+    (prisma.orderItem.findMany as any).mockResolvedValue([{ status: "READY" }]);
+
+    await expect(
+      svc.updateOrderItemStatus(scope, "i-1", "READY" as any),
+    ).resolves.toBeDefined();
+
+    // No order-status write may happen for a PENDING_APPROVAL ticket.
+    expect(prisma.order.updateMany).not.toHaveBeenCalled();
+    expect(gateway.emitOrderItemStatusChange).toHaveBeenCalled();
   });
 });
 
@@ -145,7 +279,7 @@ describe('KdsService branch scope', () => {
  * injected last in the ctor, increment AFTER the committed DB write, and
  * ?.-guarded so a missing collaborator can never break the business write.
  */
-describe('KdsService metrics', () => {
+describe("KdsService metrics", () => {
   let prisma: MockPrismaClient;
   let gateway: {
     emitOrderStatusChange: jest.Mock;
@@ -156,10 +290,10 @@ describe('KdsService metrics', () => {
   let svc: KdsService;
 
   const scope = {
-    tenantId: 't-1',
-    branchId: 'b-1',
-    userId: 'u-1',
-    role: 'KITCHEN',
+    tenantId: "t-1",
+    branchId: "b-1",
+    userId: "u-1",
+    role: "KITCHEN",
   } as any;
 
   beforeEach(() => {
@@ -181,80 +315,80 @@ describe('KdsService metrics', () => {
     );
   });
 
-  it('updateOrderStatus records kds_ticket_status_total labeled by status', async () => {
+  it("updateOrderStatus records kds_ticket_status_total labeled by status", async () => {
     (prisma.order.findFirst as any).mockResolvedValue({
-      id: 'o-1',
-      tenantId: 't-1',
-      branchId: 'b-1',
-      status: 'PENDING',
+      id: "o-1",
+      tenantId: "t-1",
+      branchId: "b-1",
+      status: "PENDING",
       requiresApproval: false,
     });
     (prisma.order.updateMany as any).mockResolvedValue({ count: 1 });
     (prisma.order.findUniqueOrThrow as any).mockResolvedValue({
-      id: 'o-1',
-      branchId: 'b-1',
+      id: "o-1",
+      branchId: "b-1",
       orderItems: [],
     });
 
-    await svc.updateOrderStatus(scope, 'o-1', 'PREPARING' as any);
+    await svc.updateOrderStatus(scope, "o-1", "PREPARING" as any);
 
     expect(metrics.incCounter).toHaveBeenCalledWith(
-      'kds_ticket_status_total',
+      "kds_ticket_status_total",
       expect.any(String),
-      { status: 'PREPARING' },
+      { status: "PREPARING" },
     );
   });
 
-  it('updateOrderItemStatus records kds_ticket_item_status_total labeled by status', async () => {
+  it("updateOrderItemStatus records kds_ticket_item_status_total labeled by status", async () => {
     (prisma.orderItem.findFirst as any).mockResolvedValue({
-      id: 'i-1',
-      orderId: 'o-1',
-      status: 'PENDING',
+      id: "i-1",
+      orderId: "o-1",
+      status: "PENDING",
       order: {
-        id: 'o-1',
-        status: 'PREPARING',
+        id: "o-1",
+        status: "PREPARING",
         requiresApproval: false,
-        branchId: 'b-1',
+        branchId: "b-1",
       },
     });
     (prisma.orderItem.updateMany as any).mockResolvedValue({ count: 1 });
     (prisma.orderItem.findUniqueOrThrow as any).mockResolvedValue({
-      id: 'i-1',
-      order: { id: 'o-1', branchId: 'b-1' },
+      id: "i-1",
+      order: { id: "o-1", branchId: "b-1" },
     });
     // Not all items READY → updateOrderStatus is NOT recursively triggered,
     // so the only emit is the item-status one.
     (prisma.orderItem.findMany as any).mockResolvedValue([
-      { status: 'PREPARING' },
+      { status: "PREPARING" },
     ]);
 
-    await svc.updateOrderItemStatus(scope, 'i-1', 'PREPARING' as any);
+    await svc.updateOrderItemStatus(scope, "i-1", "PREPARING" as any);
 
     expect(metrics.incCounter).toHaveBeenCalledWith(
-      'kds_ticket_item_status_total',
+      "kds_ticket_item_status_total",
       expect.any(String),
-      { status: 'PREPARING' },
+      { status: "PREPARING" },
     );
   });
 
-  it('does not throw when no MetricsService is injected (optional dep)', async () => {
+  it("does not throw when no MetricsService is injected (optional dep)", async () => {
     const bare = new KdsService(prisma as any, gateway as any);
     (prisma.order.findFirst as any).mockResolvedValue({
-      id: 'o-1',
-      tenantId: 't-1',
-      branchId: 'b-1',
-      status: 'PENDING',
+      id: "o-1",
+      tenantId: "t-1",
+      branchId: "b-1",
+      status: "PENDING",
       requiresApproval: false,
     });
     (prisma.order.updateMany as any).mockResolvedValue({ count: 1 });
     (prisma.order.findUniqueOrThrow as any).mockResolvedValue({
-      id: 'o-1',
-      branchId: 'b-1',
+      id: "o-1",
+      branchId: "b-1",
       orderItems: [],
     });
 
     await expect(
-      bare.updateOrderStatus(scope, 'o-1', 'PREPARING' as any),
+      bare.updateOrderStatus(scope, "o-1", "PREPARING" as any),
     ).resolves.toBeDefined();
   });
 });
@@ -273,7 +407,7 @@ describe('KdsService metrics', () => {
  * fires alongside it (the durable emit augments, never replaces, the UI
  * signal).
  */
-describe('KdsService durable outbox events', () => {
+describe("KdsService durable outbox events", () => {
   let prisma: MockPrismaClient;
   let gateway: {
     emitOrderStatusChange: jest.Mock;
@@ -284,10 +418,10 @@ describe('KdsService durable outbox events', () => {
   let svc: KdsService;
 
   const scope = {
-    tenantId: 't-1',
-    branchId: 'b-1',
-    userId: 'u-1',
-    role: 'KITCHEN',
+    tenantId: "t-1",
+    branchId: "b-1",
+    userId: "u-1",
+    role: "KITCHEN",
   } as any;
 
   beforeEach(() => {
@@ -297,7 +431,7 @@ describe('KdsService durable outbox events', () => {
       emitOrderItemStatusChange: jest.fn(),
       emitLowStockAlert: jest.fn(),
     };
-    outbox = { append: jest.fn().mockResolvedValue('outbox-id') };
+    outbox = { append: jest.fn().mockResolvedValue("outbox-id") };
     // ctor arg order: (prisma, kdsGateway, deliveryStatusSync?,
     // stockDeductionService?, metrics?, outbox?)
     svc = new KdsService(
@@ -310,80 +444,80 @@ describe('KdsService durable outbox events', () => {
     );
   });
 
-  it('updateOrderStatus → READY appends a durable order.updated.v1 AND still WS-broadcasts', async () => {
+  it("updateOrderStatus → READY appends a durable order.updated.v1 AND still WS-broadcasts", async () => {
     (prisma.order.findFirst as any).mockResolvedValue({
-      id: 'o-1',
-      tenantId: 't-1',
-      branchId: 'b-1',
-      status: 'PREPARING',
+      id: "o-1",
+      tenantId: "t-1",
+      branchId: "b-1",
+      status: "PREPARING",
       requiresApproval: false,
     });
     (prisma.order.updateMany as any).mockResolvedValue({ count: 1 });
     (prisma.order.findUniqueOrThrow as any).mockResolvedValue({
-      id: 'o-1',
-      tenantId: 't-1',
-      branchId: 'b-1',
-      tableId: 'tbl-9',
-      status: 'READY',
+      id: "o-1",
+      tenantId: "t-1",
+      branchId: "b-1",
+      tableId: "tbl-9",
+      status: "READY",
       // Prisma.Decimal-like: exposes toFixed (non-number) so toIntCents
       // routes through the string path, never the IEEE-754 float boundary.
       finalAmount: { toFixed: (n: number) => (123.45).toFixed(n) },
       orderItems: [],
     });
 
-    await svc.updateOrderStatus(scope, 'o-1', 'READY' as any);
+    await svc.updateOrderStatus(scope, "o-1", "READY" as any);
 
     // Live WS broadcast must STILL fire alongside the durable emit.
     expect(gateway.emitOrderStatusChange).toHaveBeenCalledWith(
-      't-1',
-      'b-1',
-      'o-1',
-      'READY',
+      "t-1",
+      "b-1",
+      "o-1",
+      "READY",
     );
     // Durable append: matching OrdersService event payload shape +
     // integer-cents money convention.
     expect(outbox.append).toHaveBeenCalledWith({
-      type: 'order.updated.v1',
-      tenantId: 't-1',
+      type: "order.updated.v1",
+      tenantId: "t-1",
       payload: {
-        orderId: 'o-1',
-        tenantId: 't-1',
-        branchId: 'b-1',
-        tableId: 'tbl-9',
-        status: 'READY',
+        orderId: "o-1",
+        tenantId: "t-1",
+        branchId: "b-1",
+        tableId: "tbl-9",
+        status: "READY",
         totalCents: 12345,
       },
     });
   });
 
-  it('updateOrderStatus → SERVED appends order.completed.v1', async () => {
+  it("updateOrderStatus → SERVED appends order.completed.v1", async () => {
     (prisma.order.findFirst as any).mockResolvedValue({
-      id: 'o-1',
-      tenantId: 't-1',
-      branchId: 'b-1',
-      status: 'READY',
+      id: "o-1",
+      tenantId: "t-1",
+      branchId: "b-1",
+      status: "READY",
       requiresApproval: false,
     });
     (prisma.order.updateMany as any).mockResolvedValue({ count: 1 });
     (prisma.order.findUniqueOrThrow as any).mockResolvedValue({
-      id: 'o-1',
-      tenantId: 't-1',
-      branchId: 'b-1',
+      id: "o-1",
+      tenantId: "t-1",
+      branchId: "b-1",
       tableId: null,
-      status: 'SERVED',
+      status: "SERVED",
       finalAmount: null,
       orderItems: [],
     });
 
-    await svc.updateOrderStatus(scope, 'o-1', 'SERVED' as any);
+    await svc.updateOrderStatus(scope, "o-1", "SERVED" as any);
 
     expect(outbox.append).toHaveBeenCalledWith(
       expect.objectContaining({
-        type: 'order.completed.v1',
-        tenantId: 't-1',
+        type: "order.completed.v1",
+        tenantId: "t-1",
         payload: expect.objectContaining({
-          orderId: 'o-1',
-          status: 'SERVED',
+          orderId: "o-1",
+          status: "SERVED",
           tableId: null,
           // null finalAmount → totalCents undefined (mirrors OrdersService).
           totalCents: undefined,
@@ -392,94 +526,94 @@ describe('KdsService durable outbox events', () => {
     );
   });
 
-  it('cancelOrder appends a durable order.cancelled.v1 AND still WS-broadcasts', async () => {
+  it("cancelOrder appends a durable order.cancelled.v1 AND still WS-broadcasts", async () => {
     (prisma.order.findFirst as any).mockResolvedValue({
-      id: 'o-1',
-      tenantId: 't-1',
-      branchId: 'b-1',
-      status: 'PENDING',
+      id: "o-1",
+      tenantId: "t-1",
+      branchId: "b-1",
+      status: "PENDING",
     });
     (prisma.order.updateMany as any).mockResolvedValue({ count: 1 });
     (prisma.order.findUniqueOrThrow as any).mockResolvedValue({
-      id: 'o-1',
-      tenantId: 't-1',
-      branchId: 'b-1',
-      tableId: 'tbl-3',
-      status: 'CANCELLED',
-      finalAmount: '50.00',
+      id: "o-1",
+      tenantId: "t-1",
+      branchId: "b-1",
+      tableId: "tbl-3",
+      status: "CANCELLED",
+      finalAmount: "50.00",
       orderItems: [],
     });
 
-    await svc.cancelOrder(scope, 'o-1');
+    await svc.cancelOrder(scope, "o-1");
 
     expect(gateway.emitOrderStatusChange).toHaveBeenCalledWith(
-      't-1',
-      'b-1',
-      'o-1',
-      'CANCELLED',
+      "t-1",
+      "b-1",
+      "o-1",
+      "CANCELLED",
     );
     expect(outbox.append).toHaveBeenCalledWith({
-      type: 'order.cancelled.v1',
-      tenantId: 't-1',
+      type: "order.cancelled.v1",
+      tenantId: "t-1",
       payload: {
-        orderId: 'o-1',
-        tenantId: 't-1',
-        branchId: 'b-1',
-        tableId: 'tbl-3',
-        status: 'CANCELLED',
+        orderId: "o-1",
+        tenantId: "t-1",
+        branchId: "b-1",
+        tableId: "tbl-3",
+        status: "CANCELLED",
         // string finalAmount → integer cents.
         totalCents: 5000,
       },
     });
   });
 
-  it('does not throw and still WS-broadcasts when no OutboxService is injected (optional dep)', async () => {
+  it("does not throw and still WS-broadcasts when no OutboxService is injected (optional dep)", async () => {
     const bare = new KdsService(prisma as any, gateway as any);
     (prisma.order.findFirst as any).mockResolvedValue({
-      id: 'o-1',
-      tenantId: 't-1',
-      branchId: 'b-1',
-      status: 'PENDING',
+      id: "o-1",
+      tenantId: "t-1",
+      branchId: "b-1",
+      status: "PENDING",
       requiresApproval: false,
     });
     (prisma.order.updateMany as any).mockResolvedValue({ count: 1 });
     (prisma.order.findUniqueOrThrow as any).mockResolvedValue({
-      id: 'o-1',
-      tenantId: 't-1',
-      branchId: 'b-1',
-      status: 'PREPARING',
+      id: "o-1",
+      tenantId: "t-1",
+      branchId: "b-1",
+      status: "PREPARING",
       orderItems: [],
     });
 
     await expect(
-      bare.updateOrderStatus(scope, 'o-1', 'PREPARING' as any),
+      bare.updateOrderStatus(scope, "o-1", "PREPARING" as any),
     ).resolves.toBeDefined();
     // The durable emit no-ops without an outbox, but the live WS broadcast
     // must still fire so the KDS UI keeps updating.
     expect(gateway.emitOrderStatusChange).toHaveBeenCalled();
   });
 
-  it('swallows an outbox append rejection without breaking the status write', async () => {
-    outbox.append.mockRejectedValueOnce(new Error('outbox down'));
+  it("swallows an outbox append rejection without breaking the status write", async () => {
+    outbox.append.mockRejectedValueOnce(new Error("outbox down"));
     (prisma.order.findFirst as any).mockResolvedValue({
-      id: 'o-1',
-      tenantId: 't-1',
-      branchId: 'b-1',
-      status: 'PREPARING',
+      id: "o-1",
+      tenantId: "t-1",
+      branchId: "b-1",
+      status: "PREPARING",
       requiresApproval: false,
     });
     (prisma.order.updateMany as any).mockResolvedValue({ count: 1 });
     (prisma.order.findUniqueOrThrow as any).mockResolvedValue({
-      id: 'o-1',
-      tenantId: 't-1',
-      branchId: 'b-1',
-      status: 'READY',
+      id: "o-1",
+      tenantId: "t-1",
+      branchId: "b-1",
+      status: "READY",
       finalAmount: null,
       orderItems: [],
     });
 
     await expect(
-      svc.updateOrderStatus(scope, 'o-1', 'READY' as any),
+      svc.updateOrderStatus(scope, "o-1", "READY" as any),
     ).resolves.toBeDefined();
     expect(outbox.append).toHaveBeenCalled();
   });

--- a/backend/src/modules/kds/kds.service.ts
+++ b/backend/src/modules/kds/kds.service.ts
@@ -9,7 +9,10 @@ import {
 } from "@nestjs/common";
 import { PrismaService } from "../../prisma/prisma.service";
 import { OrderStatus } from "../../common/constants/order-status.enum";
-import { validateTransition } from "../../common/utils/order-state-machine";
+import {
+  validateTransition,
+  canTransition,
+} from "../../common/utils/order-state-machine";
 import { OrderItemStatus } from "./dto/update-order-item-status.dto";
 import { KdsGateway } from "./kds.gateway";
 import { DeliveryStatusSyncService } from "../delivery-platforms/services/delivery-status-sync.service";
@@ -314,15 +317,58 @@ export class KdsService {
     const allReady = allItems.every(
       (item) => item.status === OrderItemStatus.READY,
     );
-    if (allReady && orderItem.order.status !== OrderStatus.READY) {
-      if (
-        !orderItem.order.requiresApproval ||
-        orderItem.order.status !== OrderStatus.PENDING_APPROVAL
-      ) {
-        await this.updateOrderStatus(
-          scope,
-          orderItem.orderId,
-          OrderStatus.READY,
+    // deep-review H11/M17: when the kitchen bumps the LAST item to READY,
+    // auto-promote the ticket — but the state machine forbids PENDING→READY
+    // directly, and the item write above is ALREADY committed (no enclosing
+    // $transaction). The old code called updateOrderStatus(PENDING→READY)
+    // unconditionally, which threw a 400 from validateTransition AFTER the
+    // item committed, leaving the ticket stuck/lost on the KDS even though
+    // every item is done. Two fixes:
+    //   1) Bridge the intermediate hop: PENDING needs a PREPARING step first
+    //      so READY becomes reachable (driven by canTransition, not hardcoded).
+    //   2) Make the promotion fault-tolerant — guard with canTransition AND
+    //      swallow a still-invalid transition so the item bump itself always
+    //      succeeds (the WS emit below must fire) instead of bubbling a 400.
+    // An order in PENDING_APPROVAL must NEVER auto-promote, regardless of the
+    // requiresApproval flag.
+    const cur = orderItem.order.status as OrderStatus;
+    if (
+      allReady &&
+      cur !== OrderStatus.READY &&
+      cur !== OrderStatus.PENDING_APPROVAL
+    ) {
+      try {
+        // PENDING has no direct edge to READY — hop through PREPARING first.
+        if (cur === OrderStatus.PENDING) {
+          await this.updateOrderStatus(
+            scope,
+            orderItem.orderId,
+            OrderStatus.PREPARING,
+          );
+        }
+        // Only promote if READY is now reachable from the order's CURRENT
+        // (post-hop) status; otherwise skip silently rather than throw.
+        const fresh = await this.prisma.order.findUnique({
+          where: { id: orderItem.orderId },
+          select: { status: true },
+        });
+        if (
+          fresh &&
+          canTransition(fresh.status as OrderStatus, OrderStatus.READY)
+        ) {
+          await this.updateOrderStatus(
+            scope,
+            orderItem.orderId,
+            OrderStatus.READY,
+          );
+        }
+      } catch (error: any) {
+        // The item bump itself succeeded and is committed; a failed/raced
+        // auto-promotion (invalid transition, concurrent-change claim, etc.)
+        // must not surface a 400 to the KDS — log and let the WS emit fire so
+        // the screen still updates. A waiter/kitchen can advance the ticket.
+        this.logger.warn(
+          `KDS auto-promotion to READY skipped for order ${orderItem.orderId}: ${error?.message}`,
         );
       }
     }

--- a/backend/src/modules/marketplace/marketplace.controller.spec.ts
+++ b/backend/src/modules/marketplace/marketplace.controller.spec.ts
@@ -47,13 +47,11 @@ describe("MarketplaceController", () => {
     expect(tenant.listMine).toHaveBeenCalledWith("t1");
   });
 
-  it("purchase forwards tenantId + the destructured purchase fields", () => {
-    ctrl.purchase(req, { addOnCode: "x", quantity: 2, branchId: "b1" } as any);
-    expect(tenant.purchase).toHaveBeenCalledWith("t1", {
-      addOnCode: "x",
-      quantity: 2,
-      branchId: "b1",
-    });
+  it("does NOT expose a free-grant purchase endpoint (deep-review C2)", () => {
+    // The tenant-facing POST /addons/purchase free-grant endpoint was
+    // removed — it let any tenant ADMIN activate paid add-ons without
+    // payment. All purchases now flow through the PayTR checkout rail.
+    expect((ctrl as any).purchase).toBeUndefined();
   });
 
   it("cancel parses immediate=true into a boolean", () => {

--- a/backend/src/modules/marketplace/marketplace.controller.ts
+++ b/backend/src/modules/marketplace/marketplace.controller.ts
@@ -1,10 +1,8 @@
 import {
-  Body,
   Controller,
   Delete,
   Get,
   Param,
-  Post,
   Query,
   Req,
   UseGuards,
@@ -17,7 +15,6 @@ import { UserRole } from "../../common/constants/roles.enum";
 import { Public } from "../auth/decorators/public.decorator";
 import { AddOnCatalogService } from "./addon-catalog.service";
 import { TenantMarketplaceService } from "./tenant-marketplace.service";
-import { PurchaseAddOnDto } from "./dto/addon.dto";
 
 @ApiTags("Marketplace")
 @Controller("v1/marketplace")
@@ -57,20 +54,17 @@ export class MarketplaceController {
     return this.tenant.listMine(req.user.tenantId);
   }
 
-  @UseGuards(JwtAuthGuard, RolesGuard)
-  @Roles(UserRole.ADMIN)
-  @ApiBearerAuth()
-  @Post("addons/purchase")
-  @ApiOperation({
-    summary: "Purchase / activate an add-on (ADMIN only — billing event)",
-  })
-  purchase(@Req() req: any, @Body() dto: PurchaseAddOnDto) {
-    return this.tenant.purchase(req.user.tenantId, {
-      addOnCode: dto.addOnCode,
-      quantity: dto.quantity,
-      branchId: dto.branchId,
-    });
-  }
+  // SECURITY (deep-review C2): the tenant-facing free-grant endpoint
+  // POST /v1/marketplace/addons/purchase has been REMOVED. It was guarded
+  // only by @Roles(ADMIN) (an ordinary tenant-realm role) and called
+  // tenant.purchase() with no paymentRef, so any restaurant owner could
+  // activate a paid add-on (capacity packs, integrations) for free via
+  // curl, bypassing the PayTR checkout rail wired in v3.2.11. Tenant-
+  // initiated purchases now go ONLY through POST /v1/checkout/intent →
+  // PayTR webhook → CheckoutSettlementService → tenant.purchase(paymentRef).
+  // tenant.purchase() additionally refuses any priceCents>0 grant without a
+  // paymentRef as defence in depth. Operator comps belong on the SuperAdmin
+  // surface, not here.
 
   @UseGuards(JwtAuthGuard, RolesGuard)
   @Roles(UserRole.ADMIN)

--- a/backend/src/modules/marketplace/tenant-marketplace.service.spec.ts
+++ b/backend/src/modules/marketplace/tenant-marketplace.service.spec.ts
@@ -1,24 +1,27 @@
-import { TenantMarketplaceService } from './tenant-marketplace.service';
-import { AddOnCatalogService } from './addon-catalog.service';
-import { mockPrismaClient, MockPrismaClient } from '../../common/test/prisma-mock.service';
+import { TenantMarketplaceService } from "./tenant-marketplace.service";
+import { AddOnCatalogService } from "./addon-catalog.service";
+import {
+  mockPrismaClient,
+  MockPrismaClient,
+} from "../../common/test/prisma-mock.service";
 
 /**
  * Tenant-side marketplace purchase paths. The dependency-check matrix is
  * the security-relevant part — a tenant must not be able to buy something
  * whose entitlements would clash with a missing prerequisite.
  */
-describe('TenantMarketplaceService.purchase', () => {
+describe("TenantMarketplaceService.purchase", () => {
   let prisma: MockPrismaClient;
   let catalog: jest.Mocked<AddOnCatalogService>;
   let outbox: { append: jest.Mock };
   let svc: TenantMarketplaceService;
 
-  const TENANT = 't1';
+  const TENANT = "t1";
 
   beforeEach(() => {
     prisma = mockPrismaClient();
     catalog = { findByCodeOrThrow: jest.fn() } as any;
-    outbox = { append: jest.fn().mockResolvedValue('ok') };
+    outbox = { append: jest.fn().mockResolvedValue("ok") };
     svc = new TenantMarketplaceService(prisma as any, catalog, outbox as any);
     // Iter-68 wrapped the dup-check + create in a Serializable
     // $transaction. The deep-mocked prisma's $transaction doesn't
@@ -26,48 +29,93 @@ describe('TenantMarketplaceService.purchase', () => {
     // tx.tenantAddOn.* calls land on the same mock surface the tests
     // already poke. We also default the dup-check findFirst to null so
     // the happy path doesn't have to set it on every test.
-    (prisma.$transaction as any).mockImplementation(async (fn: any) => fn(prisma));
+    (prisma.$transaction as any).mockImplementation(async (fn: any) =>
+      fn(prisma),
+    );
     (prisma.tenantAddOn.findFirst as any).mockResolvedValue(null);
   });
 
-  it('rejects purchase of draft or archived add-ons', async () => {
-    catalog.findByCodeOrThrow.mockResolvedValueOnce({ id: 'a-1', code: 'x', status: 'draft', deps: [], billing: 'recurring' } as any);
-    await expect(svc.purchase(TENANT, { addOnCode: 'x' })).rejects.toThrow(/not yet published/);
+  it("rejects purchase of draft or archived add-ons", async () => {
+    catalog.findByCodeOrThrow.mockResolvedValueOnce({
+      id: "a-1",
+      code: "x",
+      status: "draft",
+      deps: [],
+      billing: "recurring",
+    } as any);
+    await expect(svc.purchase(TENANT, { addOnCode: "x" })).rejects.toThrow(
+      /not yet published/,
+    );
 
-    catalog.findByCodeOrThrow.mockResolvedValueOnce({ id: 'a-2', code: 'x', status: 'archived', deps: [], billing: 'recurring' } as any);
-    await expect(svc.purchase(TENANT, { addOnCode: 'x' })).rejects.toThrow(/no longer available/);
+    catalog.findByCodeOrThrow.mockResolvedValueOnce({
+      id: "a-2",
+      code: "x",
+      status: "archived",
+      deps: [],
+      billing: "recurring",
+    } as any);
+    await expect(svc.purchase(TENANT, { addOnCode: "x" })).rejects.toThrow(
+      /no longer available/,
+    );
   });
 
-  it('rejects when a plan dep is unmet', async () => {
+  it("rejects when a plan dep is unmet", async () => {
     catalog.findByCodeOrThrow.mockResolvedValue({
-      id: 'a-3', code: 'fiscal_hugin', status: 'published', deps: ['plan:PRO'], billing: 'recurring',
+      id: "a-3",
+      code: "fiscal_hugin",
+      status: "published",
+      deps: ["plan:PRO"],
+      billing: "recurring",
     } as any);
-    prisma.tenant.findUnique.mockResolvedValue({ id: TENANT, currentPlan: { name: 'BASIC' } } as any);
+    prisma.tenant.findUnique.mockResolvedValue({
+      id: TENANT,
+      currentPlan: { name: "BASIC" },
+    } as any);
     prisma.tenantAddOn.findMany.mockResolvedValue([]);
 
-    await expect(svc.purchase(TENANT, { addOnCode: 'fiscal_hugin' })).rejects.toThrow(/requires.*plan:PRO/i);
+    await expect(
+      svc.purchase(TENANT, { addOnCode: "fiscal_hugin" }),
+    ).rejects.toThrow(/requires.*plan:PRO/i);
   });
 
-  it('rejects when an addon dep is unmet', async () => {
+  it("rejects when an addon dep is unmet", async () => {
     catalog.findByCodeOrThrow.mockResolvedValue({
-      id: 'a-4', code: 'delivery_yemeksepeti', status: 'published', deps: ['delivery_hub'], billing: 'recurring',
+      id: "a-4",
+      code: "delivery_yemeksepeti",
+      status: "published",
+      deps: ["delivery_hub"],
+      billing: "recurring",
     } as any);
-    prisma.tenant.findUnique.mockResolvedValue({ id: TENANT, currentPlan: { name: 'PRO' } } as any);
+    prisma.tenant.findUnique.mockResolvedValue({
+      id: TENANT,
+      currentPlan: { name: "PRO" },
+    } as any);
     prisma.tenantAddOn.findMany.mockResolvedValue([] as any);
 
-    await expect(svc.purchase(TENANT, { addOnCode: 'delivery_yemeksepeti' })).rejects.toThrow(/delivery_hub/);
+    await expect(
+      svc.purchase(TENANT, { addOnCode: "delivery_yemeksepeti" }),
+    ).rejects.toThrow(/delivery_hub/);
   });
 
-  it('purchases happily when deps are met and emits AddOnPurchased', async () => {
+  it("purchases happily when deps are met and emits AddOnPurchased", async () => {
     catalog.findByCodeOrThrow.mockResolvedValue({
-      id: 'a-5', code: 'kds_extra_screen', status: 'published', deps: [], billing: 'recurring',
+      id: "a-5",
+      code: "kds_extra_screen",
+      status: "published",
+      deps: [],
+      billing: "recurring",
     } as any);
-    (prisma.tenantAddOn.create as any).mockImplementation(async ({ data }: any) => ({ id: 't-a-1', ...data }));
+    (prisma.tenantAddOn.create as any).mockImplementation(
+      async ({ data }: any) => ({ id: "t-a-1", ...data }),
+    );
 
-    const out = await svc.purchase(TENANT, { addOnCode: 'kds_extra_screen', quantity: 3 });
+    const out = await svc.purchase(TENANT, {
+      addOnCode: "kds_extra_screen",
+      quantity: 3,
+    });
     expect(out.quantity).toBe(3);
     expect(outbox.append).toHaveBeenCalledWith(
-      expect.objectContaining({ type: 'addon.purchased.v1' }),
+      expect.objectContaining({ type: "addon.purchased.v1" }),
     );
   });
 
@@ -81,24 +129,32 @@ describe('TenantMarketplaceService.purchase', () => {
    *    Postgres's serialization-failure (P2034) surfaces as a 409 the
    *    client can retry — never a double-grant.
    */
-  describe('iter-68 hardening', () => {
-    it('refuses an addon with an unknown status (default-deny)', async () => {
+  describe("iter-68 hardening", () => {
+    it("refuses an addon with an unknown status (default-deny)", async () => {
       catalog.findByCodeOrThrow.mockResolvedValue({
-        id: 'a-x', code: 'experimental', status: 'beta', deps: [], billing: 'recurring',
+        id: "a-x",
+        code: "experimental",
+        status: "beta",
+        deps: [],
+        billing: "recurring",
       } as any);
-      await expect(svc.purchase(TENANT, { addOnCode: 'experimental' })).rejects.toThrow(
-        /not available for purchase.*beta/i,
-      );
+      await expect(
+        svc.purchase(TENANT, { addOnCode: "experimental" }),
+      ).rejects.toThrow(/not available for purchase.*beta/i);
       expect((prisma.tenantAddOn.create as any).mock.calls.length).toBe(0);
     });
 
-    it('runs the dup-check + create inside a $transaction (atomicity envelope)', async () => {
+    it("runs the dup-check + create inside a $transaction (atomicity envelope)", async () => {
       catalog.findByCodeOrThrow.mockResolvedValue({
-        id: 'a-5', code: 'kds_extra_screen', status: 'published', deps: [], billing: 'recurring',
+        id: "a-5",
+        code: "kds_extra_screen",
+        status: "published",
+        deps: [],
+        billing: "recurring",
       } as any);
-      (prisma.tenantAddOn.create as any).mockResolvedValue({ id: 'ta-1' });
+      (prisma.tenantAddOn.create as any).mockResolvedValue({ id: "ta-1" });
 
-      await svc.purchase(TENANT, { addOnCode: 'kds_extra_screen' });
+      await svc.purchase(TENANT, { addOnCode: "kds_extra_screen" });
 
       // Single $transaction call wraps the whole critical section.
       expect((prisma.$transaction as any).mock.calls.length).toBe(1);
@@ -106,22 +162,94 @@ describe('TenantMarketplaceService.purchase', () => {
       // load-bearing knob, since lower isolations would let the
       // double-grant race through.
       const txCallArgs = (prisma.$transaction as any).mock.calls[0];
-      expect(txCallArgs[1]).toEqual(expect.objectContaining({ isolationLevel: 'Serializable' }));
+      expect(txCallArgs[1]).toEqual(
+        expect.objectContaining({ isolationLevel: "Serializable" }),
+      );
     });
 
-    it('returns the existing row when paymentRef has already been provisioned (idempotency)', async () => {
+    it("returns the existing row when paymentRef has already been provisioned (idempotency)", async () => {
       catalog.findByCodeOrThrow.mockResolvedValue({
-        id: 'a-5', code: 'kds_extra_screen', status: 'published', deps: [], billing: 'recurring',
+        id: "a-5",
+        code: "kds_extra_screen",
+        status: "published",
+        deps: [],
+        billing: "recurring",
       } as any);
-      const existing = { id: 'ta-existing', tenantId: TENANT, paymentRef: 'pay-1' };
+      const existing = {
+        id: "ta-existing",
+        tenantId: TENANT,
+        paymentRef: "pay-1",
+      };
       (prisma.tenantAddOn.findFirst as any).mockResolvedValue(existing);
 
       const out = await svc.purchase(TENANT, {
-        addOnCode: 'kds_extra_screen',
-        paymentRef: 'pay-1',
+        addOnCode: "kds_extra_screen",
+        paymentRef: "pay-1",
       });
       expect(out).toBe(existing);
       expect((prisma.tenantAddOn.create as any).mock.calls.length).toBe(0);
+    });
+  });
+
+  /**
+   * deep-review C2: a PAID add-on (priceCents > 0) must never be granted
+   * without a settled paymentRef. The free tenant-facing /addons/purchase
+   * endpoint was removed; this service-layer guard is the defence in depth
+   * that protects every caller.
+   */
+  describe("deep-review C2: payment required for paid add-ons", () => {
+    it("refuses a paid add-on with no paymentRef and never writes a row", async () => {
+      catalog.findByCodeOrThrow.mockResolvedValue({
+        id: "a-paid",
+        code: "pos_pro",
+        status: "published",
+        deps: [],
+        billing: "recurring",
+        priceCents: 99900,
+      } as any);
+
+      await expect(
+        svc.purchase(TENANT, { addOnCode: "pos_pro" }),
+      ).rejects.toThrow(/requires payment/i);
+      expect((prisma.tenantAddOn.create as any).mock.calls.length).toBe(0);
+    });
+
+    it("allows a paid add-on when a paymentRef is supplied (checkout/settlement path)", async () => {
+      catalog.findByCodeOrThrow.mockResolvedValue({
+        id: "a-paid",
+        code: "pos_pro",
+        status: "published",
+        deps: [],
+        billing: "recurring",
+        priceCents: 99900,
+      } as any);
+      (prisma.tenantAddOn.create as any).mockImplementation(
+        async ({ data }: any) => ({ id: "ta-paid", ...data }),
+      );
+
+      const out = await svc.purchase(TENANT, {
+        addOnCode: "pos_pro",
+        paymentRef: "CK-abc",
+      });
+      expect(out.id).toBe("ta-paid");
+      expect(out.paymentRef).toBe("CK-abc");
+    });
+
+    it("allows a free add-on (priceCents 0) without a paymentRef", async () => {
+      catalog.findByCodeOrThrow.mockResolvedValue({
+        id: "a-free",
+        code: "free_trial_pack",
+        status: "published",
+        deps: [],
+        billing: "recurring",
+        priceCents: 0,
+      } as any);
+      (prisma.tenantAddOn.create as any).mockImplementation(
+        async ({ data }: any) => ({ id: "ta-free", ...data }),
+      );
+
+      const out = await svc.purchase(TENANT, { addOnCode: "free_trial_pack" });
+      expect(out.id).toBe("ta-free");
     });
   });
 });

--- a/backend/src/modules/marketplace/tenant-marketplace.service.ts
+++ b/backend/src/modules/marketplace/tenant-marketplace.service.ts
@@ -1,6 +1,7 @@
 import {
   BadRequestException,
   ConflictException,
+  ForbiddenException,
   Injectable,
   Logger,
   NotFoundException,
@@ -16,10 +17,13 @@ import { AddOnCatalogService } from "./addon-catalog.service";
  *
  * Purchase is **provisioning-only** here — it creates the TenantAddOn row,
  * emits AddOnPurchased on the outbox, and trusts the entitlement projector
- * to fold in the new grants. The *payment* side of the transaction is
- * separate (Phase 5 cart flow); for MVP we accept that admins can create
- * comp add-ons via this endpoint and treat paid purchases as the same call
- * after PaymentCompleted.
+ * to fold in the new grants. Payment is collected upstream: the only
+ * caller that grants a PAID add-on is CheckoutService.confirmAndProvision,
+ * which runs after the PayTR webhook settles and passes the settled
+ * paymentRef. As a hard guard (deep-review C2) purchase() refuses to grant
+ * any add-on with priceCents > 0 unless a paymentRef is supplied, so a
+ * free grant cannot be minted even if a future caller forgets to route
+ * through checkout. Only zero-priced add-ons may be provisioned for free.
  *
  * Dependency check rule: every entry in `deps` must currently apply to the
  * tenant. Plan deps (`plan:PRO`) match Tenant.currentPlan.name. Add-on deps
@@ -57,6 +61,20 @@ export class TenantMarketplaceService {
           : addOn.status === "draft"
             ? "This add-on is not yet published"
             : `Add-on is not available for purchase (status=${addOn.status})`,
+      );
+    }
+
+    // SECURITY (deep-review C2): never mint a PAID add-on without proof of
+    // payment. The only legitimate caller that grants a paid add-on is the
+    // checkout/PayTR settlement path (CheckoutService.confirmAndProvision),
+    // which always passes the settled paymentRef. A paid add-on with no
+    // paymentRef is a free grant — reject it here so the service is safe
+    // regardless of which controller calls it (defence in depth behind the
+    // removal of the tenant-facing free /addons/purchase endpoint). Free
+    // add-ons (priceCents === 0) may still be provisioned without payment.
+    if (addOn.priceCents > 0 && !input.paymentRef) {
+      throw new ForbiddenException(
+        `Add-on "${addOn.code}" requires payment; purchase it through checkout.`,
       );
     }
 

--- a/backend/src/modules/orders/services/payments.service.spec.ts
+++ b/backend/src/modules/orders/services/payments.service.spec.ts
@@ -1,8 +1,14 @@
-import { BadRequestException, NotFoundException } from '@nestjs/common';
-import { Prisma } from '@prisma/client';
-import { PaymentsService } from './payments.service';
-import { mockPrismaClient, MockPrismaClient } from '../../../common/test/prisma-mock.service';
-import { OrderStatus, PaymentStatus } from '../../../common/constants/order-status.enum';
+import { BadRequestException, NotFoundException } from "@nestjs/common";
+import { Prisma } from "@prisma/client";
+import { PaymentsService } from "./payments.service";
+import {
+  mockPrismaClient,
+  MockPrismaClient,
+} from "../../../common/test/prisma-mock.service";
+import {
+  OrderStatus,
+  PaymentStatus,
+} from "../../../common/constants/order-status.enum";
 
 /**
  * Unit tests for the progressive ("Dutch-style") per-item payment path
@@ -12,10 +18,10 @@ import { OrderStatus, PaymentStatus } from '../../../common/constants/order-stat
  * exercise the real code path. Atomicity / isolation aren't simulated
  * — separate concerns covered by e2e.
  */
-describe('PaymentsService — progressive per-item payments', () => {
-  const TENANT_ID = 'tenant-1';
-  const ORDER_ID = 'order-1';
-  const TABLE_ID = 'table-1';
+describe("PaymentsService — progressive per-item payments", () => {
+  const TENANT_ID = "tenant-1";
+  const ORDER_ID = "order-1";
+  const TABLE_ID = "table-1";
 
   let prisma: MockPrismaClient;
   let ordersService: { findOne: jest.Mock; findOneByTenant: jest.Mock };
@@ -36,7 +42,7 @@ describe('PaymentsService — progressive per-item payments', () => {
   function wireTransaction() {
     (prisma.$transaction as unknown as jest.Mock).mockImplementation(
       async (fn: any) => {
-        if (typeof fn === 'function') return fn(prisma);
+        if (typeof fn === "function") return fn(prisma);
         return Promise.all(fn);
       },
     );
@@ -51,14 +57,14 @@ describe('PaymentsService — progressive per-item payments', () => {
   function makeOrder(overrides: Partial<any> = {}) {
     return {
       id: ORDER_ID,
-      orderNumber: 'ORD-001',
+      orderNumber: "ORD-001",
       tenantId: TENANT_ID,
       tableId: TABLE_ID,
-      type: 'DINE_IN',
+      type: "DINE_IN",
       status: OrderStatus.SERVED,
-      totalAmount: new Prisma.Decimal('100.00'),
-      discount: new Prisma.Decimal('0'),
-      finalAmount: new Prisma.Decimal('100.00'),
+      totalAmount: new Prisma.Decimal("100.00"),
+      discount: new Prisma.Decimal("0"),
+      finalAmount: new Prisma.Decimal("100.00"),
       customerId: null,
       customerPhone: null,
       requiresApproval: false,
@@ -66,7 +72,12 @@ describe('PaymentsService — progressive per-item payments', () => {
     };
   }
 
-  function makeItem(id: string, qty: number, unitPrice: string | number, opts: Partial<any> = {}) {
+  function makeItem(
+    id: string,
+    qty: number,
+    unitPrice: string | number,
+    opts: Partial<any> = {},
+  ) {
     const subtotal = new Prisma.Decimal(unitPrice).mul(qty);
     return {
       id,
@@ -75,11 +86,11 @@ describe('PaymentsService — progressive per-item payments', () => {
       quantity: qty,
       unitPrice: new Prisma.Decimal(unitPrice),
       subtotal,
-      modifierTotal: new Prisma.Decimal(opts.modifierTotal ?? '0'),
-      taxAmount: new Prisma.Decimal(opts.taxAmount ?? '0'),
+      modifierTotal: new Prisma.Decimal(opts.modifierTotal ?? "0"),
+      taxAmount: new Prisma.Decimal(opts.taxAmount ?? "0"),
       taxRate: 10,
       notes: null,
-      status: 'READY',
+      status: "READY",
       ...opts,
     };
   }
@@ -102,7 +113,10 @@ describe('PaymentsService — progressive per-item payments', () => {
       buildReceiptSnapshot: jest.fn().mockReturnValue({}),
       buildKitchenTicketSnapshot: jest.fn().mockReturnValue({}),
     };
-    salesInvoice = { createFromOrder: jest.fn().mockResolvedValue(undefined), createFromPayment: jest.fn().mockResolvedValue(undefined) };
+    salesInvoice = {
+      createFromOrder: jest.fn().mockResolvedValue(undefined),
+      createFromPayment: jest.fn().mockResolvedValue(undefined),
+    };
     accountingSettings = {
       findByTenant: jest.fn().mockResolvedValue({ autoGenerateInvoice: false }),
     };
@@ -133,39 +147,45 @@ describe('PaymentsService — progressive per-item payments', () => {
     wireTransaction();
     // Default: no pending self-pay intents reserve items in any test.
     // Specific specs can override to test the reservation block.
-    (prisma.pendingSelfPayment.findMany as unknown as jest.Mock).mockResolvedValue([]);
+    (
+      prisma.pendingSelfPayment.findMany as unknown as jest.Mock
+    ).mockResolvedValue([]);
   });
 
   // ──────────────────────────────────────────────────────────────────
   // payByItems — happy path / closing payment / overpayment / dupes
   // ──────────────────────────────────────────────────────────────────
 
-  describe('payByItems', () => {
-    it('settles a single unit, leaves order open, writes the allocation row', async () => {
+  describe("payByItems", () => {
+    it("settles a single unit, leaves order open, writes the allocation row", async () => {
       const order = makeOrder({
-        finalAmount: new Prisma.Decimal('100.00'),
-        totalAmount: new Prisma.Decimal('100.00'),
+        finalAmount: new Prisma.Decimal("100.00"),
+        totalAmount: new Prisma.Decimal("100.00"),
       });
-      const itemA = makeItem('item-A', 2, '25.00');
-      const itemB = makeItem('item-B', 1, '50.00');
+      const itemA = makeItem("item-A", 2, "25.00");
+      const itemB = makeItem("item-B", 1, "50.00");
       (order as any).orderItems = [itemA, itemB];
 
       (prisma.order.findFirst as unknown as jest.Mock).mockResolvedValue(order);
-      (prisma.orderItemPayment.groupBy as unknown as jest.Mock).mockResolvedValue([]);
+      (
+        prisma.orderItemPayment.groupBy as unknown as jest.Mock
+      ).mockResolvedValue([]);
       (prisma.payment.create as unknown as jest.Mock).mockResolvedValue({
-        id: 'payment-1',
-        amount: new Prisma.Decimal('25.00'),
-        method: 'CASH',
+        id: "payment-1",
+        amount: new Prisma.Decimal("25.00"),
+        method: "CASH",
         status: PaymentStatus.COMPLETED,
         orderId: ORDER_ID,
         tenantId: TENANT_ID,
-        notes: 'Ali',
+        notes: "Ali",
         paidAt: new Date(),
       });
-      (prisma.orderItemPayment.createMany as unknown as jest.Mock).mockResolvedValue({ count: 1 });
+      (
+        prisma.orderItemPayment.createMany as unknown as jest.Mock
+      ).mockResolvedValue({ count: 1 });
       // After insert, sum-of-completed remains < finalAmount → no PAID transition.
       (prisma.payment.aggregate as unknown as jest.Mock).mockResolvedValue({
-        _sum: { amount: new Prisma.Decimal('25.00') },
+        _sum: { amount: new Prisma.Decimal("25.00") },
       });
       // getPayableItems re-fetch at the end:
       (prisma.order.findFirst as unknown as jest.Mock)
@@ -173,17 +193,39 @@ describe('PaymentsService — progressive per-item payments', () => {
         .mockResolvedValueOnce({
           ...order,
           orderItems: [
-            { ...itemA, product: { name: 'Cola' }, modifiers: [], orderItemPayments: [{ quantity: 1, paymentId: 'payment-1', amount: new Prisma.Decimal('25.00') }] },
-            { ...itemB, product: { name: 'Burger' }, modifiers: [], orderItemPayments: [] },
+            {
+              ...itemA,
+              product: { name: "Cola" },
+              modifiers: [],
+              orderItemPayments: [
+                {
+                  quantity: 1,
+                  paymentId: "payment-1",
+                  amount: new Prisma.Decimal("25.00"),
+                },
+              ],
+            },
+            {
+              ...itemB,
+              product: { name: "Burger" },
+              modifiers: [],
+              orderItemPayments: [],
+            },
           ],
           payments: [
             {
-              id: 'payment-1',
-              amount: new Prisma.Decimal('25.00'),
-              method: 'CASH',
-              notes: 'Ali',
+              id: "payment-1",
+              amount: new Prisma.Decimal("25.00"),
+              method: "CASH",
+              notes: "Ali",
               paidAt: new Date(),
-              orderItemPayments: [{ orderItemId: 'item-A', quantity: 1, amount: new Prisma.Decimal('25.00') }],
+              orderItemPayments: [
+                {
+                  orderItemId: "item-A",
+                  quantity: 1,
+                  amount: new Prisma.Decimal("25.00"),
+                },
+              ],
             },
           ],
         });
@@ -191,9 +233,9 @@ describe('PaymentsService — progressive per-item payments', () => {
       const result = await svc.payByItems(
         ORDER_ID,
         {
-          items: [{ orderItemId: 'item-A', quantity: 1 }],
-          method: 'CASH' as any,
-          notes: 'Ali',
+          items: [{ orderItemId: "item-A", quantity: 1 }],
+          method: "CASH" as any,
+          notes: "Ali",
         },
         TENANT_ID,
       );
@@ -201,19 +243,19 @@ describe('PaymentsService — progressive per-item payments', () => {
       expect(prisma.payment.create).toHaveBeenCalledWith(
         expect.objectContaining({
           data: expect.objectContaining({
-            method: 'CASH',
+            method: "CASH",
             status: PaymentStatus.COMPLETED,
             orderId: ORDER_ID,
             tenantId: TENANT_ID,
-            notes: 'Ali',
+            notes: "Ali",
           }),
         }),
       );
       expect(prisma.orderItemPayment.createMany).toHaveBeenCalledWith({
         data: [
           expect.objectContaining({
-            paymentId: 'payment-1',
-            orderItemId: 'item-A',
+            paymentId: "payment-1",
+            orderItemId: "item-A",
             quantity: 1,
             tenantId: TENANT_ID,
           }),
@@ -221,52 +263,77 @@ describe('PaymentsService — progressive per-item payments', () => {
       });
       // Not fully paid yet → no PAID transition.
       expect(prisma.order.update).not.toHaveBeenCalledWith(
-        expect.objectContaining({ data: expect.objectContaining({ status: OrderStatus.PAID }) }),
+        expect.objectContaining({
+          data: expect.objectContaining({ status: OrderStatus.PAID }),
+        }),
       );
       expect(result.orderFullyPaid).toBe(false);
     });
 
-    it('closes the order, releases the table when last unit is paid', async () => {
+    it("closes the order, releases the table when last unit is paid", async () => {
       const order = makeOrder({
-        finalAmount: new Prisma.Decimal('50.00'),
-        totalAmount: new Prisma.Decimal('50.00'),
+        finalAmount: new Prisma.Decimal("50.00"),
+        totalAmount: new Prisma.Decimal("50.00"),
       });
-      const itemA = makeItem('item-A', 1, '50.00');
+      const itemA = makeItem("item-A", 1, "50.00");
       (order as any).orderItems = [itemA];
 
       (prisma.order.findFirst as unknown as jest.Mock).mockResolvedValue(order);
-      (prisma.orderItemPayment.groupBy as unknown as jest.Mock).mockResolvedValue([]);
-      (prisma.orderItemPayment.aggregate as unknown as jest.Mock).mockResolvedValue({
-        _sum: { amount: new Prisma.Decimal('0') },
+      (
+        prisma.orderItemPayment.groupBy as unknown as jest.Mock
+      ).mockResolvedValue([]);
+      (
+        prisma.orderItemPayment.aggregate as unknown as jest.Mock
+      ).mockResolvedValue({
+        _sum: { amount: new Prisma.Decimal("0") },
       });
       (prisma.payment.create as unknown as jest.Mock).mockResolvedValue({
-        id: 'payment-1',
-        amount: new Prisma.Decimal('50.00'),
-        method: 'CASH',
+        id: "payment-1",
+        amount: new Prisma.Decimal("50.00"),
+        method: "CASH",
         status: PaymentStatus.COMPLETED,
         orderId: ORDER_ID,
         tenantId: TENANT_ID,
       });
       (prisma.payment.aggregate as unknown as jest.Mock).mockResolvedValue({
-        _sum: { amount: new Prisma.Decimal('50.00') },
+        _sum: { amount: new Prisma.Decimal("50.00") },
       });
       (prisma.order.count as unknown as jest.Mock).mockResolvedValue(0);
-      (prisma.customer.findUnique as unknown as jest.Mock).mockResolvedValue(null);
+      (prisma.customer.findUnique as unknown as jest.Mock).mockResolvedValue(
+        null,
+      );
       // getPayableItems final read:
       (prisma.order.findFirst as unknown as jest.Mock)
         .mockResolvedValueOnce(order)
         .mockResolvedValueOnce({
           ...order,
           status: OrderStatus.PAID,
-          orderItems: [{ ...itemA, product: { name: 'Burger' }, modifiers: [], orderItemPayments: [{ quantity: 1 }] }],
+          orderItems: [
+            {
+              ...itemA,
+              product: { name: "Burger" },
+              modifiers: [],
+              orderItemPayments: [{ quantity: 1 }],
+            },
+          ],
           payments: [
-            { id: 'payment-1', amount: new Prisma.Decimal('50.00'), method: 'CASH', notes: null, paidAt: new Date(), orderItemPayments: [] },
+            {
+              id: "payment-1",
+              amount: new Prisma.Decimal("50.00"),
+              method: "CASH",
+              notes: null,
+              paidAt: new Date(),
+              orderItemPayments: [],
+            },
           ],
         });
 
       const result = await svc.payByItems(
         ORDER_ID,
-        { items: [{ orderItemId: 'item-A', quantity: 1 }], method: 'CASH' as any },
+        {
+          items: [{ orderItemId: "item-A", quantity: 1 }],
+          method: "CASH" as any,
+        },
         TENANT_ID,
       );
 
@@ -283,49 +350,148 @@ describe('PaymentsService — progressive per-item payments', () => {
       expect(prisma.table.updateMany).toHaveBeenCalledWith(
         expect.objectContaining({
           where: { id: TABLE_ID, tenantId: TENANT_ID },
-          data: { status: 'AVAILABLE' },
+          data: { status: "AVAILABLE" },
         }),
       );
       expect(result.orderFullyPaid).toBe(true);
     });
 
-    it('rejects when requested quantity exceeds remaining', async () => {
-      const order = makeOrder({ finalAmount: new Prisma.Decimal('50.00') });
-      const itemA = makeItem('item-A', 2, '25.00'); // qty 2 max
+    it("flips to PAID when all units are allocated even if totalPaid is a kuruş short (deep-review M13)", async () => {
+      // Cross-item rounding residual: every unit is paid (remaining 0) but
+      // the SUM of the independently-2dp-rounded per-item totals lands at
+      // 9.99 against a 10.00 finalAmount. Pre-fix the strict `gte` left the
+      // order stranded SERVED forever (table held OCCUPIED, no invoice /
+      // loyalty) while the response said orderFullyPaid:true. The PAID
+      // transition must now trigger off ±PAYMENT_TOLERANCE / all-units.
+      const order = makeOrder({
+        finalAmount: new Prisma.Decimal("10.00"),
+        totalAmount: new Prisma.Decimal("30.00"),
+        discount: new Prisma.Decimal("20.00"),
+      });
+      const itemA = makeItem("item-A", 3, "10.00");
+      (order as any).orderItems = [itemA];
+
+      (prisma.order.findFirst as unknown as jest.Mock).mockResolvedValue(order);
+      (
+        prisma.orderItemPayment.groupBy as unknown as jest.Mock
+      ).mockResolvedValue([]);
+      (
+        prisma.orderItemPayment.aggregate as unknown as jest.Mock
+      ).mockResolvedValue({
+        _sum: { amount: new Prisma.Decimal("0") },
+      });
+      (prisma.payment.create as unknown as jest.Mock).mockResolvedValue({
+        id: "payment-1",
+        amount: new Prisma.Decimal("9.99"),
+        method: "CASH",
+        status: PaymentStatus.COMPLETED,
+        orderId: ORDER_ID,
+        tenantId: TENANT_ID,
+      });
+      (
+        prisma.orderItemPayment.createMany as unknown as jest.Mock
+      ).mockResolvedValue({ count: 1 });
+      // The sum-of-completed lands a kuruş short of finalAmount.
+      (prisma.payment.aggregate as unknown as jest.Mock).mockResolvedValue({
+        _sum: { amount: new Prisma.Decimal("9.99") },
+      });
+      (prisma.order.count as unknown as jest.Mock).mockResolvedValue(0);
+      (prisma.customer.findUnique as unknown as jest.Mock).mockResolvedValue(
+        null,
+      );
+      (prisma.order.findFirst as unknown as jest.Mock)
+        .mockResolvedValueOnce(order)
+        .mockResolvedValueOnce({
+          ...order,
+          status: OrderStatus.PAID,
+          orderItems: [
+            {
+              ...itemA,
+              product: { name: "Mezze" },
+              modifiers: [],
+              orderItemPayments: [{ quantity: 3 }],
+            },
+          ],
+          payments: [
+            {
+              id: "payment-1",
+              amount: new Prisma.Decimal("9.99"),
+              method: "CASH",
+              notes: null,
+              paidAt: new Date(),
+              orderItemPayments: [],
+            },
+          ],
+        });
+
+      const result = await svc.payByItems(
+        ORDER_ID,
+        {
+          items: [{ orderItemId: "item-A", quantity: 3 }],
+          method: "CASH" as any,
+        },
+        TENANT_ID,
+      );
+
+      // PAID transition must fire despite totalPaid (9.99) < finalAmount (10.00).
+      expect(prisma.order.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: ORDER_ID },
+          data: expect.objectContaining({ status: OrderStatus.PAID }),
+        }),
+      );
+      expect(prisma.table.updateMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: TABLE_ID, tenantId: TENANT_ID },
+          data: { status: "AVAILABLE" },
+        }),
+      );
+      expect(result.orderFullyPaid).toBe(true);
+    });
+
+    it("rejects when requested quantity exceeds remaining", async () => {
+      const order = makeOrder({ finalAmount: new Prisma.Decimal("50.00") });
+      const itemA = makeItem("item-A", 2, "25.00"); // qty 2 max
       (order as any).orderItems = [itemA];
       (prisma.order.findFirst as unknown as jest.Mock).mockResolvedValue(order);
       // Already paid 1 unit:
-      (prisma.orderItemPayment.groupBy as unknown as jest.Mock).mockResolvedValue([
-        { orderItemId: 'item-A', _sum: { quantity: 1 } },
-      ]);
+      (
+        prisma.orderItemPayment.groupBy as unknown as jest.Mock
+      ).mockResolvedValue([{ orderItemId: "item-A", _sum: { quantity: 1 } }]);
 
       await expect(
         svc.payByItems(
           ORDER_ID,
-          { items: [{ orderItemId: 'item-A', quantity: 2 }], method: 'CASH' as any },
+          {
+            items: [{ orderItemId: "item-A", quantity: 2 }],
+            method: "CASH" as any,
+          },
           TENANT_ID,
         ),
       ).rejects.toBeInstanceOf(BadRequestException);
       expect(prisma.payment.create).not.toHaveBeenCalled();
     });
 
-    it('rejects items not belonging to the order', async () => {
+    it("rejects items not belonging to the order", async () => {
       const order = makeOrder();
-      (order as any).orderItems = [makeItem('item-A', 1, '50.00')];
+      (order as any).orderItems = [makeItem("item-A", 1, "50.00")];
       (prisma.order.findFirst as unknown as jest.Mock).mockResolvedValue(order);
 
       await expect(
         svc.payByItems(
           ORDER_ID,
-          { items: [{ orderItemId: 'item-NOT-MINE', quantity: 1 }], method: 'CASH' as any },
+          {
+            items: [{ orderItemId: "item-NOT-MINE", quantity: 1 }],
+            method: "CASH" as any,
+          },
           TENANT_ID,
         ),
       ).rejects.toBeInstanceOf(BadRequestException);
     });
 
-    it('rejects duplicate orderItemIds in the same request', async () => {
+    it("rejects duplicate orderItemIds in the same request", async () => {
       const order = makeOrder();
-      const itemA = makeItem('item-A', 2, '25.00');
+      const itemA = makeItem("item-A", 2, "25.00");
       (order as any).orderItems = [itemA];
       (prisma.order.findFirst as unknown as jest.Mock).mockResolvedValue(order);
 
@@ -334,76 +500,88 @@ describe('PaymentsService — progressive per-item payments', () => {
           ORDER_ID,
           {
             items: [
-              { orderItemId: 'item-A', quantity: 1 },
-              { orderItemId: 'item-A', quantity: 1 },
+              { orderItemId: "item-A", quantity: 1 },
+              { orderItemId: "item-A", quantity: 1 },
             ],
-            method: 'CASH' as any,
+            method: "CASH" as any,
           },
           TENANT_ID,
         ),
       ).rejects.toThrow(/[Dd]uplicate/);
     });
 
-    it('rejects paying for a cancelled order', async () => {
+    it("rejects paying for a cancelled order", async () => {
       const order = makeOrder({ status: OrderStatus.CANCELLED });
-      (order as any).orderItems = [makeItem('item-A', 1, '50.00')];
+      (order as any).orderItems = [makeItem("item-A", 1, "50.00")];
       (prisma.order.findFirst as unknown as jest.Mock).mockResolvedValue(order);
 
       await expect(
         svc.payByItems(
           ORDER_ID,
-          { items: [{ orderItemId: 'item-A', quantity: 1 }], method: 'CASH' as any },
+          {
+            items: [{ orderItemId: "item-A", quantity: 1 }],
+            method: "CASH" as any,
+          },
           TENANT_ID,
         ),
       ).rejects.toThrow(/cancelled/i);
     });
 
-    it('rejects paying for an order in PENDING_APPROVAL with requiresApproval', async () => {
+    it("rejects paying for an order in PENDING_APPROVAL with requiresApproval", async () => {
       const order = makeOrder({
         status: OrderStatus.PENDING_APPROVAL,
         requiresApproval: true,
       });
-      (order as any).orderItems = [makeItem('item-A', 1, '50.00')];
+      (order as any).orderItems = [makeItem("item-A", 1, "50.00")];
       (prisma.order.findFirst as unknown as jest.Mock).mockResolvedValue(order);
 
       await expect(
         svc.payByItems(
           ORDER_ID,
-          { items: [{ orderItemId: 'item-A', quantity: 1 }], method: 'CASH' as any },
+          {
+            items: [{ orderItemId: "item-A", quantity: 1 }],
+            method: "CASH" as any,
+          },
           TENANT_ID,
         ),
       ).rejects.toThrow(/approval/i);
     });
 
-    it('returns the cached payment on idempotency replay without re-creating', async () => {
+    it("returns the cached payment on idempotency replay without re-creating", async () => {
       const cached = {
-        id: 'payment-existing',
-        amount: new Prisma.Decimal('25.00'),
-        method: 'CASH',
+        id: "payment-existing",
+        amount: new Prisma.Decimal("25.00"),
+        method: "CASH",
         status: PaymentStatus.COMPLETED,
         orderId: ORDER_ID,
         tenantId: TENANT_ID,
         orderItemPayments: [
-          { orderItemId: 'item-A', quantity: 1, amount: new Prisma.Decimal('25.00') },
+          {
+            orderItemId: "item-A",
+            quantity: 1,
+            amount: new Prisma.Decimal("25.00"),
+          },
         ],
       };
-      (prisma.payment.findFirst as unknown as jest.Mock).mockResolvedValueOnce(cached);
+      (prisma.payment.findFirst as unknown as jest.Mock).mockResolvedValueOnce(
+        cached,
+      );
       // getPayableItems still runs to build the remaining summary:
       (prisma.order.findFirst as unknown as jest.Mock).mockResolvedValueOnce({
         ...makeOrder(),
         orderItems: [
           {
-            ...makeItem('item-A', 2, '25.00'),
-            product: { name: 'Cola' },
+            ...makeItem("item-A", 2, "25.00"),
+            product: { name: "Cola" },
             modifiers: [],
             orderItemPayments: [{ quantity: 1 }],
           },
         ],
         payments: [
           {
-            id: 'payment-existing',
-            amount: new Prisma.Decimal('25.00'),
-            method: 'CASH',
+            id: "payment-existing",
+            amount: new Prisma.Decimal("25.00"),
+            method: "CASH",
             notes: null,
             paidAt: new Date(),
             orderItemPayments: [],
@@ -414,9 +592,9 @@ describe('PaymentsService — progressive per-item payments', () => {
       const result = await svc.payByItems(
         ORDER_ID,
         {
-          items: [{ orderItemId: 'item-A', quantity: 1 }],
-          method: 'CASH' as any,
-          idempotencyKey: 'idem-key-12345',
+          items: [{ orderItemId: "item-A", quantity: 1 }],
+          method: "CASH" as any,
+          idempotencyKey: "idem-key-12345",
         },
         TENANT_ID,
       );
@@ -427,7 +605,7 @@ describe('PaymentsService — progressive per-item payments', () => {
       expect(prisma.orderItemPayment.createMany).not.toHaveBeenCalled();
     });
 
-    it('does NOT double-count tax (subtotal is already KDV-inclusive)', async () => {
+    it("does NOT double-count tax (subtotal is already KDV-inclusive)", async () => {
       // Regression for the original perUnitGross bug: orders are stored
       // with KDV-inclusive subtotals (orders.service.ts extracts tax
       // FROM subtotal, doesn't add to it). order.totalAmount = sum of
@@ -435,126 +613,167 @@ describe('PaymentsService — progressive per-item payments', () => {
       // overcharges by the embedded tax and the order silently flips
       // to PAID at totalPaid > finalAmount.
       const order = makeOrder({
-        totalAmount: new Prisma.Decimal('11.00'),
-        discount: new Prisma.Decimal('0'),
-        finalAmount: new Prisma.Decimal('11.00'),
+        totalAmount: new Prisma.Decimal("11.00"),
+        discount: new Prisma.Decimal("0"),
+        finalAmount: new Prisma.Decimal("11.00"),
       });
       // 10% KDV is *already inside* the 11.00 subtotal; taxAmount of
       // 1.00 is just the extracted-portion bookkeeping, not an addition.
-      const item = makeItem('item-A', 1, '11.00', {
-        subtotal: new Prisma.Decimal('11.00'),
-        taxAmount: new Prisma.Decimal('1.00'),
+      const item = makeItem("item-A", 1, "11.00", {
+        subtotal: new Prisma.Decimal("11.00"),
+        taxAmount: new Prisma.Decimal("1.00"),
       });
       (order as any).orderItems = [item];
 
       (prisma.order.findFirst as unknown as jest.Mock).mockResolvedValue(order);
-      (prisma.orderItemPayment.groupBy as unknown as jest.Mock).mockResolvedValue([]);
-      (prisma.orderItemPayment.aggregate as unknown as jest.Mock).mockResolvedValue({
-        _sum: { amount: new Prisma.Decimal('0') },
+      (
+        prisma.orderItemPayment.groupBy as unknown as jest.Mock
+      ).mockResolvedValue([]);
+      (
+        prisma.orderItemPayment.aggregate as unknown as jest.Mock
+      ).mockResolvedValue({
+        _sum: { amount: new Prisma.Decimal("0") },
       });
       (prisma.payment.create as unknown as jest.Mock).mockImplementation(
         async ({ data }: any) => ({
-          id: 'payment-1',
+          id: "payment-1",
           ...data,
           status: PaymentStatus.COMPLETED,
           paidAt: new Date(),
         }),
       );
       (prisma.payment.aggregate as unknown as jest.Mock).mockResolvedValue({
-        _sum: { amount: new Prisma.Decimal('11.00') },
+        _sum: { amount: new Prisma.Decimal("11.00") },
       });
       (prisma.order.count as unknown as jest.Mock).mockResolvedValue(0);
       (prisma.order.findFirst as unknown as jest.Mock)
         .mockResolvedValueOnce(order)
         .mockResolvedValueOnce({
           ...order,
-          orderItems: [{ ...item, product: { name: 'X' }, modifiers: [], orderItemPayments: [{ quantity: 1 }] }],
+          orderItems: [
+            {
+              ...item,
+              product: { name: "X" },
+              modifiers: [],
+              orderItemPayments: [{ quantity: 1 }],
+            },
+          ],
           payments: [],
         });
 
       await svc.payByItems(
         ORDER_ID,
-        { items: [{ orderItemId: 'item-A', quantity: 1 }], method: 'CASH' as any },
+        {
+          items: [{ orderItemId: "item-A", quantity: 1 }],
+          method: "CASH" as any,
+        },
         TENANT_ID,
       );
 
-      const create = (prisma.payment.create as unknown as jest.Mock).mock.calls[0][0];
+      const create = (prisma.payment.create as unknown as jest.Mock).mock
+        .calls[0][0];
       // 11.00 — NOT 12.00. Old buggy formula would have summed
       // subtotal(11) + modifierTotal(0) + taxAmount(1) = 12.
-      expect(new Prisma.Decimal(create.data.amount).toFixed(2)).toBe('11.00');
+      expect(new Prisma.Decimal(create.data.amount).toFixed(2)).toBe("11.00");
     });
 
-    it('does NOT double-count modifier value (already inside subtotal)', async () => {
+    it("does NOT double-count modifier value (already inside subtotal)", async () => {
       // orders.service.ts:190 stores `subtotal = qty * (price + modifierTotal)`.
       // modifierTotal is bookkeeping for receipt rendering, not a
       // value to add on top of subtotal.
       const order = makeOrder({
-        totalAmount: new Prisma.Decimal('30.00'),
-        finalAmount: new Prisma.Decimal('30.00'),
+        totalAmount: new Prisma.Decimal("30.00"),
+        finalAmount: new Prisma.Decimal("30.00"),
       });
-      const item = makeItem('item-A', 2, '15.00', {
-        subtotal: new Prisma.Decimal('30.00'), // 2 × (10 base + 5 modifier)
-        modifierTotal: new Prisma.Decimal('5.00'),
+      const item = makeItem("item-A", 2, "15.00", {
+        subtotal: new Prisma.Decimal("30.00"), // 2 × (10 base + 5 modifier)
+        modifierTotal: new Prisma.Decimal("5.00"),
       });
       (order as any).orderItems = [item];
 
       (prisma.order.findFirst as unknown as jest.Mock).mockResolvedValue(order);
-      (prisma.orderItemPayment.groupBy as unknown as jest.Mock).mockResolvedValue([]);
-      (prisma.orderItemPayment.aggregate as unknown as jest.Mock).mockResolvedValue({
-        _sum: { amount: new Prisma.Decimal('0') },
+      (
+        prisma.orderItemPayment.groupBy as unknown as jest.Mock
+      ).mockResolvedValue([]);
+      (
+        prisma.orderItemPayment.aggregate as unknown as jest.Mock
+      ).mockResolvedValue({
+        _sum: { amount: new Prisma.Decimal("0") },
       });
       (prisma.payment.create as unknown as jest.Mock).mockImplementation(
-        async ({ data }: any) => ({ id: 'p1', ...data, status: PaymentStatus.COMPLETED, paidAt: new Date() }),
+        async ({ data }: any) => ({
+          id: "p1",
+          ...data,
+          status: PaymentStatus.COMPLETED,
+          paidAt: new Date(),
+        }),
       );
       (prisma.payment.aggregate as unknown as jest.Mock).mockResolvedValue({
-        _sum: { amount: new Prisma.Decimal('15.00') },
+        _sum: { amount: new Prisma.Decimal("15.00") },
       });
       (prisma.order.findFirst as unknown as jest.Mock)
         .mockResolvedValueOnce(order)
         .mockResolvedValueOnce({
           ...order,
-          orderItems: [{ ...item, product: { name: 'X' }, modifiers: [], orderItemPayments: [] }],
+          orderItems: [
+            {
+              ...item,
+              product: { name: "X" },
+              modifiers: [],
+              orderItemPayments: [],
+            },
+          ],
           payments: [],
         });
 
       await svc.payByItems(
         ORDER_ID,
-        { items: [{ orderItemId: 'item-A', quantity: 1 }], method: 'CASH' as any },
+        {
+          items: [{ orderItemId: "item-A", quantity: 1 }],
+          method: "CASH" as any,
+        },
         TENANT_ID,
       );
 
-      const create = (prisma.payment.create as unknown as jest.Mock).mock.calls[0][0];
+      const create = (prisma.payment.create as unknown as jest.Mock).mock
+        .calls[0][0];
       // 15.00 (subtotal/qty = 30/2), NOT 20.00 (would be 30/2 + 5).
-      expect(new Prisma.Decimal(create.data.amount).toFixed(2)).toBe('15.00');
+      expect(new Prisma.Decimal(create.data.amount).toFixed(2)).toBe("15.00");
     });
 
-    it('idempotency replay re-derives orderFullyPaid from current state', async () => {
+    it("idempotency replay re-derives orderFullyPaid from current state", async () => {
       // The in-tx P2002 branch returns isFullyPaid=false by design;
       // the outer code must re-derive from getPayableItems so a retry
       // after the closing payment still tells the caller orderFullyPaid=true.
       const cached = {
-        id: 'payment-existing',
-        amount: new Prisma.Decimal('50.00'),
+        id: "payment-existing",
+        amount: new Prisma.Decimal("50.00"),
         status: PaymentStatus.COMPLETED,
-        method: 'CASH',
+        method: "CASH",
         notes: null,
         orderId: ORDER_ID,
         tenantId: TENANT_ID,
         orderItemPayments: [
-          { orderItemId: 'item-A', quantity: 1, amount: new Prisma.Decimal('50.00') },
+          {
+            orderItemId: "item-A",
+            quantity: 1,
+            amount: new Prisma.Decimal("50.00"),
+          },
         ],
       };
-      (prisma.payment.findFirst as unknown as jest.Mock).mockResolvedValueOnce(cached);
+      (prisma.payment.findFirst as unknown as jest.Mock).mockResolvedValueOnce(
+        cached,
+      );
       // getPayableItems read: item paid in full → remainingQuantity=0
       (prisma.order.findFirst as unknown as jest.Mock).mockResolvedValueOnce({
         ...makeOrder({
-          finalAmount: new Prisma.Decimal('50.00'),
+          finalAmount: new Prisma.Decimal("50.00"),
           status: OrderStatus.PAID,
         }),
         orderItems: [
           {
-            ...makeItem('item-A', 1, '50.00'),
-            product: { name: 'X' },
+            ...makeItem("item-A", 1, "50.00"),
+            product: { name: "X" },
             modifiers: [],
             orderItemPayments: [{ quantity: 1 }],
           },
@@ -565,9 +784,9 @@ describe('PaymentsService — progressive per-item payments', () => {
       const result = await svc.payByItems(
         ORDER_ID,
         {
-          items: [{ orderItemId: 'item-A', quantity: 1 }],
-          method: 'CASH' as any,
-          idempotencyKey: 'idem-replay-fp',
+          items: [{ orderItemId: "item-A", quantity: 1 }],
+          method: "CASH" as any,
+          idempotencyKey: "idem-replay-fp",
         },
         TENANT_ID,
       );
@@ -576,27 +795,31 @@ describe('PaymentsService — progressive per-item payments', () => {
       expect(prisma.payment.create).not.toHaveBeenCalled();
     });
 
-    it('applies discount pro-rata so closing payment hits exactly finalAmount', async () => {
+    it("applies discount pro-rata so closing payment hits exactly finalAmount", async () => {
       // 100 TL pre-discount, 10 TL discount → 90 TL final. Two equal items.
       // Each item per-unit = 50, after 10% discount factor = 45. Two items
       // sum to 90; the last unit paid eats any rounding residual.
       const order = makeOrder({
-        totalAmount: new Prisma.Decimal('100.00'),
-        discount: new Prisma.Decimal('10.00'),
-        finalAmount: new Prisma.Decimal('90.00'),
+        totalAmount: new Prisma.Decimal("100.00"),
+        discount: new Prisma.Decimal("10.00"),
+        finalAmount: new Prisma.Decimal("90.00"),
       });
-      const itemA = makeItem('item-A', 1, '50.00');
-      const itemB = makeItem('item-B', 1, '50.00');
+      const itemA = makeItem("item-A", 1, "50.00");
+      const itemB = makeItem("item-B", 1, "50.00");
       (order as any).orderItems = [itemA, itemB];
 
       (prisma.order.findFirst as unknown as jest.Mock).mockResolvedValue(order);
-      (prisma.orderItemPayment.groupBy as unknown as jest.Mock).mockResolvedValue([]);
-      (prisma.orderItemPayment.aggregate as unknown as jest.Mock).mockResolvedValue({
-        _sum: { amount: new Prisma.Decimal('0') },
+      (
+        prisma.orderItemPayment.groupBy as unknown as jest.Mock
+      ).mockResolvedValue([]);
+      (
+        prisma.orderItemPayment.aggregate as unknown as jest.Mock
+      ).mockResolvedValue({
+        _sum: { amount: new Prisma.Decimal("0") },
       });
       (prisma.payment.create as unknown as jest.Mock).mockImplementation(
         async ({ data }: any) => ({
-          id: 'payment-1',
+          id: "payment-1",
           ...data,
           status: PaymentStatus.COMPLETED,
           paidAt: new Date(),
@@ -604,7 +827,7 @@ describe('PaymentsService — progressive per-item payments', () => {
       );
       // After both items paid, aggregate returns full 90.
       (prisma.payment.aggregate as unknown as jest.Mock).mockResolvedValue({
-        _sum: { amount: new Prisma.Decimal('90.00') },
+        _sum: { amount: new Prisma.Decimal("90.00") },
       });
       (prisma.order.count as unknown as jest.Mock).mockResolvedValue(0);
       (prisma.order.findFirst as unknown as jest.Mock)
@@ -613,8 +836,18 @@ describe('PaymentsService — progressive per-item payments', () => {
           ...order,
           status: OrderStatus.PAID,
           orderItems: [
-            { ...itemA, product: { name: 'A' }, modifiers: [], orderItemPayments: [{ quantity: 1 }] },
-            { ...itemB, product: { name: 'B' }, modifiers: [], orderItemPayments: [{ quantity: 1 }] },
+            {
+              ...itemA,
+              product: { name: "A" },
+              modifiers: [],
+              orderItemPayments: [{ quantity: 1 }],
+            },
+            {
+              ...itemB,
+              product: { name: "B" },
+              modifiers: [],
+              orderItemPayments: [{ quantity: 1 }],
+            },
           ],
           payments: [],
         });
@@ -623,115 +856,149 @@ describe('PaymentsService — progressive per-item payments', () => {
         ORDER_ID,
         {
           items: [
-            { orderItemId: 'item-A', quantity: 1 },
-            { orderItemId: 'item-B', quantity: 1 },
+            { orderItemId: "item-A", quantity: 1 },
+            { orderItemId: "item-B", quantity: 1 },
           ],
-          method: 'CARD' as any,
-          transactionId: 'TX-123',
+          method: "CARD" as any,
+          transactionId: "TX-123",
         },
         TENANT_ID,
       );
 
       // Verify the derived payment.amount equals exactly 90.00.
-      const createCall = (prisma.payment.create as unknown as jest.Mock).mock.calls[0][0];
-      expect(new Prisma.Decimal(createCall.data.amount).toFixed(2)).toBe('90.00');
-      expect(createCall.data.transactionId).toBe('TX-123');
+      const createCall = (prisma.payment.create as unknown as jest.Mock).mock
+        .calls[0][0];
+      expect(new Prisma.Decimal(createCall.data.amount).toFixed(2)).toBe(
+        "90.00",
+      );
+      expect(createCall.data.transactionId).toBe("TX-123");
       expect(result.orderFullyPaid).toBe(true);
     });
 
-    it('last-unit residual eats sub-kuruş rounding (3 units totaling 10.01)', async () => {
+    it("last-unit residual eats sub-kuruş rounding (3 units totaling 10.01)", async () => {
       // 10.01 TL split across 3 units → per-unit ≈ 3.336666… Each rounds
       // to 3.34 (HALF_UP) but the third (last) entry is set as
       // total - sum(prior) so the order closes at exactly 10.01.
       const order = makeOrder({
-        totalAmount: new Prisma.Decimal('10.01'),
-        discount: new Prisma.Decimal('0'),
-        finalAmount: new Prisma.Decimal('10.01'),
+        totalAmount: new Prisma.Decimal("10.01"),
+        discount: new Prisma.Decimal("0"),
+        finalAmount: new Prisma.Decimal("10.01"),
       });
-      const itemA = makeItem('item-A', 3, '3.336666666');
+      const itemA = makeItem("item-A", 3, "3.336666666");
       // Force the subtotal/taxAmount sum to exactly 10.01 regardless of
       // unitPrice rounding so the helper math has a clean target.
-      itemA.subtotal = new Prisma.Decimal('10.01');
-      itemA.modifierTotal = new Prisma.Decimal('0');
-      itemA.taxAmount = new Prisma.Decimal('0');
+      itemA.subtotal = new Prisma.Decimal("10.01");
+      itemA.modifierTotal = new Prisma.Decimal("0");
+      itemA.taxAmount = new Prisma.Decimal("0");
       (order as any).orderItems = [itemA];
 
       // Three sequential calls — track running prior allocations.
-      let priorSum = new Prisma.Decimal('0');
+      let priorSum = new Prisma.Decimal("0");
       let paidQty = 0;
 
-      (prisma.order.findFirst as unknown as jest.Mock).mockImplementation(async () => ({
-        ...order,
-        orderItems: [itemA],
-      }));
-      (prisma.orderItemPayment.groupBy as unknown as jest.Mock).mockImplementation(async () => [
-        { orderItemId: 'item-A', _sum: { quantity: paidQty } },
+      (prisma.order.findFirst as unknown as jest.Mock).mockImplementation(
+        async () => ({
+          ...order,
+          orderItems: [itemA],
+        }),
+      );
+      (
+        prisma.orderItemPayment.groupBy as unknown as jest.Mock
+      ).mockImplementation(async () => [
+        { orderItemId: "item-A", _sum: { quantity: paidQty } },
       ]);
-      (prisma.orderItemPayment.aggregate as unknown as jest.Mock).mockImplementation(async () => ({
+      (
+        prisma.orderItemPayment.aggregate as unknown as jest.Mock
+      ).mockImplementation(async () => ({
         _sum: { amount: priorSum },
       }));
-      (prisma.payment.create as unknown as jest.Mock).mockImplementation(async ({ data }: any) => {
-        priorSum = priorSum.add(new Prisma.Decimal(data.amount));
-        return { id: `payment-${paidQty + 1}`, ...data, status: PaymentStatus.COMPLETED, paidAt: new Date() };
-      });
-      (prisma.orderItemPayment.createMany as unknown as jest.Mock).mockImplementation(
+      (prisma.payment.create as unknown as jest.Mock).mockImplementation(
         async ({ data }: any) => {
-          paidQty += data[0].quantity;
-          return { count: data.length };
+          priorSum = priorSum.add(new Prisma.Decimal(data.amount));
+          return {
+            id: `payment-${paidQty + 1}`,
+            ...data,
+            status: PaymentStatus.COMPLETED,
+            paidAt: new Date(),
+          };
         },
       );
-      (prisma.payment.aggregate as unknown as jest.Mock).mockImplementation(async () => ({
-        _sum: { amount: priorSum },
-      }));
+      (
+        prisma.orderItemPayment.createMany as unknown as jest.Mock
+      ).mockImplementation(async ({ data }: any) => {
+        paidQty += data[0].quantity;
+        return { count: data.length };
+      });
+      (prisma.payment.aggregate as unknown as jest.Mock).mockImplementation(
+        async () => ({
+          _sum: { amount: priorSum },
+        }),
+      );
       (prisma.order.count as unknown as jest.Mock).mockResolvedValue(0);
       // Stub getPayableItems read.
       const stubPayableRead = () => ({
         ...order,
-        orderItems: [{ ...itemA, product: { name: 'X' }, modifiers: [], orderItemPayments: [] }],
+        orderItems: [
+          {
+            ...itemA,
+            product: { name: "X" },
+            modifiers: [],
+            orderItemPayments: [],
+          },
+        ],
         payments: [],
       });
-      (prisma.order.findFirst as unknown as jest.Mock).mockImplementation(async () => stubPayableRead());
+      (prisma.order.findFirst as unknown as jest.Mock).mockImplementation(
+        async () => stubPayableRead(),
+      );
 
       for (let i = 0; i < 3; i++) {
         await svc.payByItems(
           ORDER_ID,
-          { items: [{ orderItemId: 'item-A', quantity: 1 }], method: 'CASH' as any },
+          {
+            items: [{ orderItemId: "item-A", quantity: 1 }],
+            method: "CASH" as any,
+          },
           TENANT_ID,
         );
       }
 
       // After three single-unit payments, prior sum must equal exactly 10.01.
-      expect(priorSum.toFixed(2)).toBe('10.01');
+      expect(priorSum.toFixed(2)).toBe("10.01");
     });
-    it('payByItems emits payment:success with initiatedByUserId (waiter)', async () => {
+    it("payByItems emits payment:success with initiatedByUserId (waiter)", async () => {
       // The frontend de-dups its own auto-print on the originating
       // tablet by comparing payment:success.initiatedByUserId to the
       // logged-in user's id. If the service forgets to forward the
       // userId, every waiter cash payment double-prints. Locking
       // this in with a spec so a future refactor can't regress it.
       const order = makeOrder({
-        finalAmount: new Prisma.Decimal('100.00'),
-        totalAmount: new Prisma.Decimal('100.00'),
+        finalAmount: new Prisma.Decimal("100.00"),
+        totalAmount: new Prisma.Decimal("100.00"),
       });
-      const itemA = makeItem('item-A', 1, '50.00');
-      const itemB = makeItem('item-B', 1, '50.00');
+      const itemA = makeItem("item-A", 1, "50.00");
+      const itemB = makeItem("item-B", 1, "50.00");
       (order as any).orderItems = [itemA, itemB];
 
       (prisma.order.findFirst as unknown as jest.Mock).mockResolvedValue(order);
-      (prisma.orderItemPayment.groupBy as unknown as jest.Mock).mockResolvedValue([]);
-      (prisma.orderItemPayment.aggregate as unknown as jest.Mock).mockResolvedValue({
-        _sum: { amount: new Prisma.Decimal('0') },
+      (
+        prisma.orderItemPayment.groupBy as unknown as jest.Mock
+      ).mockResolvedValue([]);
+      (
+        prisma.orderItemPayment.aggregate as unknown as jest.Mock
+      ).mockResolvedValue({
+        _sum: { amount: new Prisma.Decimal("0") },
       });
       (prisma.payment.create as unknown as jest.Mock).mockResolvedValue({
-        id: 'payment-1',
+        id: "payment-1",
         orderId: ORDER_ID,
-        amount: new Prisma.Decimal('50.00'),
-        method: 'CASH',
+        amount: new Prisma.Decimal("50.00"),
+        method: "CASH",
         status: PaymentStatus.COMPLETED,
         receiptSnapshot: null,
       });
       (prisma.payment.aggregate as unknown as jest.Mock).mockResolvedValue({
-        _sum: { amount: new Prisma.Decimal('50.00') },
+        _sum: { amount: new Prisma.Decimal("50.00") },
       });
       // getPayableItems read at the end of payByItems.
       (prisma.order.findFirst as unknown as jest.Mock)
@@ -739,16 +1006,29 @@ describe('PaymentsService — progressive per-item payments', () => {
         .mockResolvedValueOnce({
           ...order,
           orderItems: [
-            { ...itemA, product: { name: 'A' }, modifiers: [], orderItemPayments: [{ quantity: 1 }] },
-            { ...itemB, product: { name: 'B' }, modifiers: [], orderItemPayments: [] },
+            {
+              ...itemA,
+              product: { name: "A" },
+              modifiers: [],
+              orderItemPayments: [{ quantity: 1 }],
+            },
+            {
+              ...itemB,
+              product: { name: "B" },
+              modifiers: [],
+              orderItemPayments: [],
+            },
           ],
           payments: [],
         });
 
-      const WAITER_USER_ID = 'waiter-jwt-id';
+      const WAITER_USER_ID = "waiter-jwt-id";
       await svc.payByItems(
         ORDER_ID,
-        { items: [{ orderItemId: 'item-A', quantity: 1 }], method: 'CASH' as any },
+        {
+          items: [{ orderItemId: "item-A", quantity: 1 }],
+          method: "CASH" as any,
+        },
         TENANT_ID,
         WAITER_USER_ID,
       );
@@ -760,50 +1040,64 @@ describe('PaymentsService — progressive per-item payments', () => {
       const [emitTenantId, , emitPayment, emitUserId] =
         kdsGateway.emitPaymentSuccess.mock.calls[0];
       expect(emitTenantId).toBe(TENANT_ID);
-      expect(emitPayment.id).toBe('payment-1');
+      expect(emitPayment.id).toBe("payment-1");
       expect(emitUserId).toBe(WAITER_USER_ID);
     });
 
-    it('payByItems emits with initiatedByUserId=null on webhook origin', async () => {
+    it("payByItems emits with initiatedByUserId=null on webhook origin", async () => {
       // Customer self-pay path: CustomerSelfPayService.handleWebhookSuccess
       // calls payByItems without a userId. The emit must echo null so
       // EVERY tablet (no logged-in user matches) prints the receipt.
       const order = makeOrder({
-        finalAmount: new Prisma.Decimal('50.00'),
-        totalAmount: new Prisma.Decimal('50.00'),
+        finalAmount: new Prisma.Decimal("50.00"),
+        totalAmount: new Prisma.Decimal("50.00"),
       });
-      const itemA = makeItem('item-A', 1, '50.00');
+      const itemA = makeItem("item-A", 1, "50.00");
       (order as any).orderItems = [itemA];
 
       (prisma.order.findFirst as unknown as jest.Mock).mockResolvedValue(order);
-      (prisma.orderItemPayment.groupBy as unknown as jest.Mock).mockResolvedValue([]);
-      (prisma.orderItemPayment.aggregate as unknown as jest.Mock).mockResolvedValue({
-        _sum: { amount: new Prisma.Decimal('0') },
+      (
+        prisma.orderItemPayment.groupBy as unknown as jest.Mock
+      ).mockResolvedValue([]);
+      (
+        prisma.orderItemPayment.aggregate as unknown as jest.Mock
+      ).mockResolvedValue({
+        _sum: { amount: new Prisma.Decimal("0") },
       });
       (prisma.payment.create as unknown as jest.Mock).mockResolvedValue({
-        id: 'payment-webhook-1',
+        id: "payment-webhook-1",
         orderId: ORDER_ID,
-        amount: new Prisma.Decimal('50.00'),
-        method: 'CARD',
+        amount: new Prisma.Decimal("50.00"),
+        method: "CARD",
         status: PaymentStatus.COMPLETED,
         receiptSnapshot: null,
       });
       (prisma.payment.aggregate as unknown as jest.Mock).mockResolvedValue({
-        _sum: { amount: new Prisma.Decimal('50.00') },
+        _sum: { amount: new Prisma.Decimal("50.00") },
       });
       (prisma.order.count as unknown as jest.Mock).mockResolvedValue(0);
       (prisma.order.findFirst as unknown as jest.Mock)
         .mockResolvedValueOnce(order)
         .mockResolvedValueOnce({
           ...order,
-          orderItems: [{ ...itemA, product: { name: 'A' }, modifiers: [], orderItemPayments: [{ quantity: 1 }] }],
+          orderItems: [
+            {
+              ...itemA,
+              product: { name: "A" },
+              modifiers: [],
+              orderItemPayments: [{ quantity: 1 }],
+            },
+          ],
           payments: [],
         });
 
       // No userId passed (mimics CustomerSelfPayService.handleWebhookSuccess).
       await svc.payByItems(
         ORDER_ID,
-        { items: [{ orderItemId: 'item-A', quantity: 1 }], method: 'CARD' as any },
+        {
+          items: [{ orderItemId: "item-A", quantity: 1 }],
+          method: "CARD" as any,
+        },
         TENANT_ID,
       );
 
@@ -819,74 +1113,82 @@ describe('PaymentsService — progressive per-item payments', () => {
   // getPayableItems — paid/remaining shape
   // ──────────────────────────────────────────────────────────────────
 
-  describe('getPayableItems', () => {
-    it('reports paid and remaining quantities per item', async () => {
-      const itemA = makeItem('item-A', 2, '25.00');
-      const itemB = makeItem('item-B', 1, '50.00');
+  describe("getPayableItems", () => {
+    it("reports paid and remaining quantities per item", async () => {
+      const itemA = makeItem("item-A", 2, "25.00");
+      const itemB = makeItem("item-B", 1, "50.00");
 
       (prisma.order.findFirst as unknown as jest.Mock).mockResolvedValue({
-        ...makeOrder({ finalAmount: new Prisma.Decimal('100.00') }),
+        ...makeOrder({ finalAmount: new Prisma.Decimal("100.00") }),
         orderItems: [
           {
             ...itemA,
-            product: { name: 'Cola' },
+            product: { name: "Cola" },
             modifiers: [],
-            orderItemPayments: [{ quantity: 1, paymentId: 'p1' }],
+            orderItemPayments: [{ quantity: 1, paymentId: "p1" }],
           },
           {
             ...itemB,
-            product: { name: 'Burger' },
+            product: { name: "Burger" },
             modifiers: [],
             orderItemPayments: [],
           },
         ],
         payments: [
           {
-            id: 'p1',
-            amount: new Prisma.Decimal('25.00'),
-            method: 'CASH',
-            notes: 'Ali',
+            id: "p1",
+            amount: new Prisma.Decimal("25.00"),
+            method: "CASH",
+            notes: "Ali",
             paidAt: new Date(),
-            orderItemPayments: [{ orderItemId: 'item-A', quantity: 1, amount: new Prisma.Decimal('25.00') }],
+            orderItemPayments: [
+              {
+                orderItemId: "item-A",
+                quantity: 1,
+                amount: new Prisma.Decimal("25.00"),
+              },
+            ],
           },
         ],
       });
 
       const summary = await svc.getPayableItems(ORDER_ID, TENANT_ID);
 
-      expect(summary.finalAmount).toBe('100.00');
-      expect(summary.paidAmount).toBe('25.00');
-      expect(summary.remainingAmount).toBe('75.00');
+      expect(summary.finalAmount).toBe("100.00");
+      expect(summary.paidAmount).toBe("25.00");
+      expect(summary.remainingAmount).toBe("75.00");
       expect(summary.remainingQuantity).toBe(2); // itemA:1 + itemB:1
-      const a = summary.items.find((i) => i.orderItemId === 'item-A')!;
+      const a = summary.items.find((i) => i.orderItemId === "item-A")!;
       expect(a.paidQuantity).toBe(1);
       expect(a.remainingQuantity).toBe(1);
-      expect(a.unitTotal).toBe('25.00');
-      expect(a.itemTotal).toBe('50.00'); // server-authoritative discount-adjusted line total
-      const b = summary.items.find((i) => i.orderItemId === 'item-B')!;
+      expect(a.unitTotal).toBe("25.00");
+      expect(a.itemTotal).toBe("50.00"); // server-authoritative discount-adjusted line total
+      const b = summary.items.find((i) => i.orderItemId === "item-B")!;
       expect(b.paidQuantity).toBe(0);
       expect(b.remainingQuantity).toBe(1);
-      expect(b.itemTotal).toBe('50.00');
+      expect(b.itemTotal).toBe("50.00");
     });
 
-    it('writeOff: closes order via HOUSE payment, no CRM stat bump', async () => {
+    it("writeOff: closes order via HOUSE payment, no CRM stat bump", async () => {
       // 2/3 paid via progressive; manager writes off the rest. Expected:
       // - one HOUSE Payment with remaining amount
       // - order → PAID, table → AVAILABLE
       // - no customer.totalSpent bump (it's not real revenue)
       const order = makeOrder({
-        finalAmount: new Prisma.Decimal('100.00'),
-        totalAmount: new Prisma.Decimal('100.00'),
+        finalAmount: new Prisma.Decimal("100.00"),
+        totalAmount: new Prisma.Decimal("100.00"),
       });
       (prisma.order.findFirst as unknown as jest.Mock).mockResolvedValue(order);
       // Already paid 60 of 100 → 40 to be written off.
       (prisma.payment.aggregate as unknown as jest.Mock).mockResolvedValue({
-        _sum: { amount: new Prisma.Decimal('60.00') },
+        _sum: { amount: new Prisma.Decimal("60.00") },
       });
-      (prisma.payment.findFirst as unknown as jest.Mock).mockResolvedValueOnce(null); // no prior idempotent match
+      (prisma.payment.findFirst as unknown as jest.Mock).mockResolvedValueOnce(
+        null,
+      ); // no prior idempotent match
       (prisma.payment.create as unknown as jest.Mock).mockImplementation(
         async ({ data }: any) => ({
-          id: 'payment-house-1',
+          id: "payment-house-1",
           ...data,
           status: PaymentStatus.COMPLETED,
           paidAt: new Date(),
@@ -896,14 +1198,17 @@ describe('PaymentsService — progressive per-item payments', () => {
 
       const result = await (svc as any).writeOff(
         ORDER_ID,
-        { reason: 'no-show' },
+        { reason: "no-show" },
         TENANT_ID,
       );
 
-      const createCall = (prisma.payment.create as unknown as jest.Mock).mock.calls[0][0];
-      expect(createCall.data.method).toBe('HOUSE');
-      expect(new Prisma.Decimal(createCall.data.amount).toFixed(2)).toBe('40.00');
-      expect(createCall.data.notes).toBe('no-show');
+      const createCall = (prisma.payment.create as unknown as jest.Mock).mock
+        .calls[0][0];
+      expect(createCall.data.method).toBe("HOUSE");
+      expect(new Prisma.Decimal(createCall.data.amount).toFixed(2)).toBe(
+        "40.00",
+      );
+      expect(createCall.data.notes).toBe("no-show");
       // No customer stat bump.
       expect(prisma.customer.update).not.toHaveBeenCalled();
       // Order flipped to PAID.
@@ -915,53 +1220,69 @@ describe('PaymentsService — progressive per-item payments', () => {
       expect(result.orderFullyPaid).toBe(true);
     });
 
-    it('per-payment customer linkage bumps stats by THIS payment only', async () => {
+    it("per-payment customer linkage bumps stats by THIS payment only", async () => {
       // Customer A pays 25, customer B pays 75 with their own phone.
       // Each gets their own Customer record bumped by their own slice.
       const order = makeOrder({
-        finalAmount: new Prisma.Decimal('100.00'),
-        totalAmount: new Prisma.Decimal('100.00'),
+        finalAmount: new Prisma.Decimal("100.00"),
+        totalAmount: new Prisma.Decimal("100.00"),
       });
-      const itemA = makeItem('item-A', 1, '25.00');
-      const itemB = makeItem('item-B', 1, '75.00');
+      const itemA = makeItem("item-A", 1, "25.00");
+      const itemB = makeItem("item-B", 1, "75.00");
       (order as any).orderItems = [itemA, itemB];
 
       (prisma.order.findFirst as unknown as jest.Mock).mockResolvedValue(order);
-      (prisma.orderItemPayment.groupBy as unknown as jest.Mock).mockResolvedValue([]);
-      (prisma.orderItemPayment.aggregate as unknown as jest.Mock).mockResolvedValue({
-        _sum: { amount: new Prisma.Decimal('0') },
+      (
+        prisma.orderItemPayment.groupBy as unknown as jest.Mock
+      ).mockResolvedValue([]);
+      (
+        prisma.orderItemPayment.aggregate as unknown as jest.Mock
+      ).mockResolvedValue({
+        _sum: { amount: new Prisma.Decimal("0") },
       });
       (prisma.payment.create as unknown as jest.Mock).mockImplementation(
         async ({ data }: any) => ({
-          id: 'p-A',
+          id: "p-A",
           ...data,
           status: PaymentStatus.COMPLETED,
           paidAt: new Date(),
         }),
       );
-      (prisma.customer.findFirst as unknown as jest.Mock).mockResolvedValue(null);
+      (prisma.customer.findFirst as unknown as jest.Mock).mockResolvedValue(
+        null,
+      );
       (prisma.customer.create as unknown as jest.Mock).mockResolvedValue({
-        id: 'cust-A',
-        phone: '+905551112233',
+        id: "cust-A",
+        phone: "+905551112233",
         totalOrders: 0,
-        totalSpent: new Prisma.Decimal('0'),
+        totalSpent: new Prisma.Decimal("0"),
       });
       (prisma.customer.findUnique as unknown as jest.Mock).mockResolvedValue({
-        id: 'cust-A',
+        id: "cust-A",
         totalOrders: 0,
-        totalSpent: new Prisma.Decimal('0'),
+        totalSpent: new Prisma.Decimal("0"),
       });
       (prisma.payment.count as unknown as jest.Mock).mockResolvedValue(0);
       (prisma.payment.aggregate as unknown as jest.Mock).mockResolvedValue({
-        _sum: { amount: new Prisma.Decimal('25.00') },
+        _sum: { amount: new Prisma.Decimal("25.00") },
       });
       (prisma.order.findFirst as unknown as jest.Mock)
         .mockResolvedValueOnce(order)
         .mockResolvedValueOnce({
           ...order,
           orderItems: [
-            { ...itemA, product: { name: 'A' }, modifiers: [], orderItemPayments: [{ quantity: 1 }] },
-            { ...itemB, product: { name: 'B' }, modifiers: [], orderItemPayments: [] },
+            {
+              ...itemA,
+              product: { name: "A" },
+              modifiers: [],
+              orderItemPayments: [{ quantity: 1 }],
+            },
+            {
+              ...itemB,
+              product: { name: "B" },
+              modifiers: [],
+              orderItemPayments: [],
+            },
           ],
           payments: [],
         });
@@ -969,39 +1290,42 @@ describe('PaymentsService — progressive per-item payments', () => {
       await svc.payByItems(
         ORDER_ID,
         {
-          items: [{ orderItemId: 'item-A', quantity: 1 }],
-          method: 'CASH' as any,
-          customerPhone: '+905551112233',
+          items: [{ orderItemId: "item-A", quantity: 1 }],
+          method: "CASH" as any,
+          customerPhone: "+905551112233",
         },
         TENANT_ID,
       );
 
       // Stats bump = payment.amount (25), not order.finalAmount (100).
-      const updateCalls = (prisma.customer.update as unknown as jest.Mock).mock.calls;
+      const updateCalls = (prisma.customer.update as unknown as jest.Mock).mock
+        .calls;
       const bumpCall = updateCalls.find((c) => c[0]?.data?.totalSpent);
       expect(bumpCall).toBeDefined();
-      expect(new Prisma.Decimal(bumpCall[0].data.totalSpent).toFixed(2)).toBe('25.00');
+      expect(new Prisma.Decimal(bumpCall[0].data.totalSpent).toFixed(2)).toBe(
+        "25.00",
+      );
     });
 
-    it('itemTotal applies discount pro-rata', async () => {
+    it("itemTotal applies discount pro-rata", async () => {
       // 100 TL total, 10 TL discount → 90 TL final. 50 TL line gets
       // 90% factor = 45.00 itemTotal.
       (prisma.order.findFirst as unknown as jest.Mock).mockResolvedValue({
         ...makeOrder({
-          totalAmount: new Prisma.Decimal('100.00'),
-          discount: new Prisma.Decimal('10.00'),
-          finalAmount: new Prisma.Decimal('90.00'),
+          totalAmount: new Prisma.Decimal("100.00"),
+          discount: new Prisma.Decimal("10.00"),
+          finalAmount: new Prisma.Decimal("90.00"),
         }),
         orderItems: [
           {
-            ...makeItem('item-A', 1, '50.00'),
-            product: { name: 'A' },
+            ...makeItem("item-A", 1, "50.00"),
+            product: { name: "A" },
             modifiers: [],
             orderItemPayments: [],
           },
           {
-            ...makeItem('item-B', 1, '50.00'),
-            product: { name: 'B' },
+            ...makeItem("item-B", 1, "50.00"),
+            product: { name: "B" },
             modifiers: [],
             orderItemPayments: [],
           },
@@ -1010,7 +1334,7 @@ describe('PaymentsService — progressive per-item payments', () => {
       });
 
       const summary = await svc.getPayableItems(ORDER_ID, TENANT_ID);
-      expect(summary.items.every((i) => i.itemTotal === '45.00')).toBe(true);
+      expect(summary.items.every((i) => i.itemTotal === "45.00")).toBe(true);
     });
   });
 });

--- a/backend/src/modules/orders/services/payments.service.ts
+++ b/backend/src/modules/orders/services/payments.service.ts
@@ -1405,7 +1405,31 @@ export class PaymentsService {
               totalPaid._sum.amount ?? 0,
             );
             const orderAmount = new Prisma.Decimal(order.finalAmount);
-            const fullyPaid = totalPaidAmount.gte(orderAmount);
+            // deep-review M13 — drive the PAID transition off the same
+            // ±PAYMENT_TOLERANCE the rest of the module uses (and an
+            // explicit all-units-allocated check), not a strict gte.
+            // Each per-entry amount is independently rounded to 2dp, so
+            // the SUM of the closing per-item totals can fall a sub-kuruş
+            // short of finalAmount even when every unit is paid. A strict
+            // gte left such an order stranded in SERVED forever (table
+            // never released, no invoice/loyalty) while the response said
+            // orderFullyPaid:true. We compute allUnitsAllocated inside the
+            // tx from the already-loaded order.orderItems + paidByItem
+            // (folding in this payment's allocations) so the authoritative
+            // "all units paid" signal also flips the order.
+            const allocatedByItem = new Map<string, number>(paidByItem);
+            for (const row of allocationRows) {
+              allocatedByItem.set(
+                row.orderItemId,
+                (allocatedByItem.get(row.orderItemId) ?? 0) + row.quantity,
+              );
+            }
+            const allUnitsAllocated = order.orderItems.every(
+              (oi) => (allocatedByItem.get(oi.id) ?? 0) >= oi.quantity,
+            );
+            const fullyPaid =
+              totalPaidAmount.gte(orderAmount.sub(PAYMENT_TOLERANCE)) ||
+              allUnitsAllocated;
 
             if (fullyPaid) {
               // bumpCustomerStats:false because each progressive

--- a/backend/src/modules/outbox/outbox-worker.service.spec.ts
+++ b/backend/src/modules/outbox/outbox-worker.service.spec.ts
@@ -26,6 +26,7 @@ describe("OutboxWorkerService — drainOnce", () => {
 
   let prisma: {
     $queryRaw: jest.Mock;
+    $executeRaw: jest.Mock;
     outboxEvent: { update: jest.Mock };
   };
   let bus: { dispatch: jest.Mock };
@@ -41,6 +42,7 @@ describe("OutboxWorkerService — drainOnce", () => {
   beforeEach(() => {
     prisma = {
       $queryRaw: jest.fn().mockResolvedValue([row()]),
+      $executeRaw: jest.fn().mockResolvedValue(0),
       outboxEvent: { update: jest.fn().mockResolvedValue({}) },
     };
     bus = { dispatch: jest.fn().mockResolvedValue(undefined) };
@@ -146,6 +148,31 @@ describe("OutboxWorkerService — drainOnce", () => {
       const { data } = prisma.outboxEvent.update.mock.calls[0][0];
       expect(data.status).toBe("failed");
       expect(data.nextAttemptAt).toBeNull();
+    });
+  });
+
+  // deep-review H16: rows orphaned in 'dispatching' by a worker crash must be
+  // reclaimed back to 'queued' so the events (payment.succeeded.v1 commission
+  // crediting, entitlement reprojection, …) aren't lost forever.
+  describe("reclaimStuck (worker-crash recovery)", () => {
+    const reclaimStuck = () =>
+      (worker as unknown as { reclaimStuck(): Promise<number> }).reclaimStuck();
+
+    it("re-queues orphaned 'dispatching' rows aged past the timeout", async () => {
+      // Simulate a crash: a prior tick claimed a batch (flipping rows to
+      // 'dispatching') and died before the terminal write. The next tick's
+      // reclaim pass runs the reaper UPDATE, which reports 2 affected rows.
+      prisma.$executeRaw.mockResolvedValue(2);
+
+      await expect(reclaimStuck()).resolves.toBe(2);
+      expect(prisma.$executeRaw).toHaveBeenCalledTimes(1);
+    });
+
+    it("is a no-op when nothing is stuck (returns 0, no terminal writes)", async () => {
+      prisma.$executeRaw.mockResolvedValue(0);
+
+      await expect(reclaimStuck()).resolves.toBe(0);
+      expect(prisma.outboxEvent.update).not.toHaveBeenCalled();
     });
   });
 });

--- a/backend/src/modules/outbox/outbox-worker.service.ts
+++ b/backend/src/modules/outbox/outbox-worker.service.ts
@@ -45,6 +45,15 @@ export class OutboxWorkerService implements OnModuleInit, OnModuleDestroy {
   // re-dispatches, short enough that configuring the URL drains the
   // backlog within half an hour.
   private readonly UNCONFIGURED_PARK_MS = 30 * 60_000;
+  // deep-review H16 — how long a row may sit in 'dispatching' before we
+  // treat it as orphaned (worker crashed/OOM/SIGKILL between claiming the
+  // batch and writing the terminal status) and reclaim it to 'queued'.
+  // Comfortably above the worst-case single-dispatch + marketing-relay HTTP
+  // latency so we never race a still-live in-flight dispatch. Re-dispatch is
+  // safe: consumers dedupe on idempotencyKey (documented at-least-once
+  // contract). The claim already burned an attempt, so a reclaimed crash
+  // counts as one attempt — poison pills still converge on the DLQ.
+  private readonly STUCK_TIMEOUT_MS = 5 * 60_000;
 
   private timer: NodeJS.Timeout | null = null;
   private pruneTimer: NodeJS.Timeout | null = null;
@@ -155,6 +164,11 @@ export class OutboxWorkerService implements OnModuleInit, OnModuleDestroy {
     }
     this.running = true;
     try {
+      // deep-review H16: reclaim orphaned 'dispatching' rows before draining
+      // so a crashed-worker's in-flight batch re-enters the queue on the very
+      // next poll of whichever replica picks it up. Cheap (indexed status
+      // predicate, almost always a no-op) and idempotent across replicas.
+      await this.reclaimStuck();
       const drained = await this.drainOnce();
       // If we drained a full batch, immediately try again — backlog catch-up.
       // Otherwise sleep until the next poll cycle.
@@ -165,6 +179,58 @@ export class OutboxWorkerService implements OnModuleInit, OnModuleDestroy {
     } finally {
       this.running = false;
     }
+  }
+
+  /**
+   * deep-review H16 — reclaim outbox rows orphaned in status='dispatching'.
+   *
+   * If the worker process dies (OOM, SIGKILL during a deploy/rollout, pod
+   * eviction) after the claim UPDATE flips a batch to 'dispatching' but
+   * before each row's terminal write, those rows would otherwise stay
+   * 'dispatching' forever: drainOnce() only selects 'queued', pruneOnce()
+   * only deletes 'dispatched', and the superadmin requeue only targets
+   * 'failed'. The events — including payment.succeeded.v1 (commission
+   * crediting) and subscription/entitlement reprojection — would be silently
+   * lost. This reaper flips any 'dispatching' row whose claim timestamp
+   * (stamped into nextAttemptAt by the claim UPDATE) has aged past
+   * STUCK_TIMEOUT_MS back to 'queued'.
+   *
+   * We deliberately do NOT decrement attempts: the claim already burned one,
+   * and counting the crash as an attempt keeps a genuine poison pill (one
+   * that reliably kills the worker mid-dispatch) converging on the DLQ
+   * instead of looping forever. Re-dispatch is safe under the at-least-once
+   * contract — consumers dedupe on idempotencyKey.
+   */
+  private async reclaimStuck(): Promise<number> {
+    const cutoff = new Date(Date.now() - this.STUCK_TIMEOUT_MS);
+    const reclaimed = await this.prisma.$executeRaw`
+      UPDATE "outbox_events"
+         SET "status" = 'queued',
+             "nextAttemptAt" = NULL,
+             "lastError" = 'reclaimed: stuck in dispatching past timeout (worker likely crashed)'
+       WHERE "status" = 'dispatching'
+         AND "nextAttemptAt" IS NOT NULL
+         AND "nextAttemptAt" < ${cutoff}
+    `;
+    if (reclaimed > 0) {
+      // Loud on purpose: a non-zero reclaim means a worker died mid-dispatch.
+      // Ops should correlate with a crash/OOM/eviction around this time.
+      this.logger.warn(
+        `outbox reclaim: re-queued ${reclaimed} row(s) orphaned in 'dispatching' past ${this.STUCK_TIMEOUT_MS}ms (worker likely crashed)`,
+      );
+      // deep-review H16: expose reclaims to Prometheus so an alert can fire
+      // when this is non-zero (the existing outbox_dlq_depth gauge only ever
+      // catches status='failed' and would never have surfaced this state).
+      // A counter is used because MetricsService has a generic incCounter but
+      // no generic gauge setter; a sustained non-zero rate is the alert
+      // signal. (A dedicated `outbox_dispatching_depth` gauge would need a
+      // MetricsService change — out of scope for this file; see deviations.)
+      this.metrics?.incCounter(
+        "outbox_events_reclaimed_total",
+        "Outbox events reclaimed from a stuck 'dispatching' state (worker crash recovery)",
+      );
+    }
+    return reclaimed;
   }
 
   private async drainOnce(): Promise<number> {
@@ -185,7 +251,16 @@ export class OutboxWorkerService implements OnModuleInit, OnModuleDestroy {
       }>
     >`
       UPDATE "outbox_events"
-         SET "status" = 'dispatching', "attempts" = "attempts" + 1
+         SET "status" = 'dispatching',
+             "attempts" = "attempts" + 1,
+             -- deep-review H16: stamp the claim time onto the row (reusing
+             -- nextAttemptAt, the only mutable timestamp column on
+             -- OutboxEvent) so reclaimStuck() can detect rows orphaned in
+             -- 'dispatching' by a worker crash. A clean terminal write
+             -- below overwrites/clears this; a crash leaves it as the claim
+             -- instant, and once it ages past STUCK_TIMEOUT_MS the reaper
+             -- re-queues the row.
+             "nextAttemptAt" = ${now}
        WHERE "id" IN (
          SELECT "id" FROM "outbox_events"
           WHERE "status" = 'queued'

--- a/backend/src/modules/personnel/services/attendance.service.spec.ts
+++ b/backend/src/modules/personnel/services/attendance.service.spec.ts
@@ -1,20 +1,35 @@
-import { AttendanceService } from './attendance.service';
-import { mockPrismaClient, MockPrismaClient } from '../../../common/test/prisma-mock.service';
-import { getTenantMidnight } from '../../../common/helpers/timezone.helper';
+import { AttendanceService } from "./attendance.service";
+import {
+  mockPrismaClient,
+  MockPrismaClient,
+} from "../../../common/test/prisma-mock.service";
 
 /**
- * Iter-52 regression: attendance day boundaries use tenant timezone
- * (via getTenantMidnight helper, same as z-reports iter-35), not
- * server-local midnight. For non-UTC tenants on a UTC API container,
- * clocking in at 02:00 TR (=23:00 UTC previous day) previously
- * stamped the attendance with the previous server date — which then
- * broke payroll export day boundaries and the shift-late calculation
- * against shiftTemplate.startTime.
+ * deep-review H6/M7 regression: the Attendance.date column is `@db.Date`,
+ * which truncates the stored instant to its UTC calendar date. Stamping
+ * the `getTenantMidnight` *instant* (Istanbul midnight = the previous
+ * UTC day for a UTC+3 tenant) truncated the row to the PREVIOUS calendar
+ * day for every positive-offset tenant — corrupting payroll day
+ * boundaries AND breaking the clockIn->shiftAssignment join (schedule
+ * stores the true calendar day), so isLate/lateMinutes/overtime were
+ * silently always 0.
+ *
+ * The `date` column is now a tenant-local YYYY-MM-DD anchored at
+ * UTC-midnight, so `@db.Date` truncation reflects the tenant's real day.
  */
-describe('AttendanceService.tenantToday (iter-52)', () => {
+describe("AttendanceService date-only handling (deep-review H6/M7)", () => {
   let prisma: MockPrismaClient;
   let kdsGateway: any;
   let svc: AttendanceService;
+
+  // Compute the tenant-local YYYY-MM-DD the same way the service does.
+  const tenantYmd = (tz: string) =>
+    new Intl.DateTimeFormat("en-CA", {
+      timeZone: tz,
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+    }).format(new Date());
 
   beforeEach(() => {
     prisma = mockPrismaClient();
@@ -22,41 +37,100 @@ describe('AttendanceService.tenantToday (iter-52)', () => {
     svc = new AttendanceService(prisma as any, kdsGateway);
   });
 
-  it('clockIn looks up today using tenant timezone via getTenantMidnight', async () => {
-    const TR = 'Europe/Istanbul';
+  it("clockIn stamps date as the tenant-local calendar day at UTC-midnight", async () => {
+    const TR = "Europe/Istanbul";
     prisma.tenant.findUnique.mockResolvedValue({ timezone: TR } as any);
     prisma.attendance.findFirst.mockResolvedValue(null);
     prisma.shiftAssignment.findFirst.mockResolvedValue(null);
-    prisma.user.findUnique.mockResolvedValue({ primaryBranchId: 'branch-1' } as any);
-    (prisma.attendance.create as any).mockResolvedValue({ id: 'a-1', branchId: 'branch-1', user: {} });
+    prisma.user.findUnique.mockResolvedValue({
+      primaryBranchId: "branch-1",
+    } as any);
+    (prisma.attendance.create as any).mockResolvedValue({
+      id: "a-1",
+      branchId: "branch-1",
+      user: {},
+    });
 
-    await svc.clockIn('tenant-1', 'user-1');
+    await svc.clockIn("tenant-1", "user-1");
 
-    // The date attribute on the attendance.findFirst lookup should
-    // equal the tenant-midnight instant, not server-local midnight.
+    // The lookup date and the created date must both equal the tenant's
+    // local calendar day anchored at UTC-midnight (so @db.Date keeps it).
+    const expected = new Date(`${tenantYmd(TR)}T00:00:00.000Z`);
     const lookupArgs = (prisma.attendance.findFirst as any).mock.calls[0][0];
-    const expectedToday = getTenantMidnight(new Date(), TR);
-    expect((lookupArgs.where.date as Date).getTime()).toBe(expectedToday.getTime());
+    expect((lookupArgs.where.date as Date).getTime()).toBe(expected.getTime());
+    expect((lookupArgs.where.date as Date).toISOString()).toBe(
+      `${tenantYmd(TR)}T00:00:00.000Z`,
+    );
+
+    const createArgs = (prisma.attendance.create as any).mock.calls[0][0];
+    expect((createArgs.data.date as Date).getTime()).toBe(expected.getTime());
+
     // v3.0.0: gateway emit takes explicit branchId as 2nd arg.
     expect(kdsGateway.emitAttendanceUpdate).toHaveBeenCalledWith(
-      'tenant-1',
-      'branch-1',
-      expect.objectContaining({ id: 'a-1', branchId: 'branch-1' }),
+      "tenant-1",
+      "branch-1",
+      expect.objectContaining({ id: "a-1", branchId: "branch-1" }),
     );
   });
 
-  it('falls back to UTC when tenant.timezone is null', async () => {
+  it("clockIn matches the shiftAssignment join and records isLate/lateMinutes for a UTC+3 tenant", async () => {
+    const TR = "Europe/Istanbul";
+    prisma.tenant.findUnique.mockResolvedValue({ timezone: TR } as any);
+    prisma.attendance.findFirst.mockResolvedValue(null);
+    prisma.user.findUnique.mockResolvedValue({
+      primaryBranchId: "branch-1",
+    } as any);
+
+    // Shift started 00:00 tenant-local with no grace, so any clock-in
+    // later in the tenant's day is "late" — this exercises the tenant-tz
+    // shiftStart computation (deep-review H6 secondary) deterministically
+    // regardless of the wall-clock time the test runs at.
+    prisma.shiftAssignment.findFirst.mockResolvedValue({
+      id: "sa-1",
+      branchId: "branch-1",
+      shiftTemplate: {
+        startTime: "00:00",
+        endTime: "08:00",
+        gracePeriodMinutes: 0,
+      },
+    } as any);
+
+    let captured: any;
+    (prisma.attendance.create as any).mockImplementation((args: any) => {
+      captured = args.data;
+      return Promise.resolve({ id: "a-1", branchId: "branch-1", user: {} });
+    });
+
+    await svc.clockIn("tenant-1", "user-1");
+
+    // The shiftAssignment lookup uses the same tenant-local date as the
+    // assignment writer, so the join is non-null and lateness is recorded.
+    const saLookup = (prisma.shiftAssignment.findFirst as any).mock.calls[0][0];
+    const expected = new Date(`${tenantYmd(TR)}T00:00:00.000Z`);
+    expect((saLookup.where.date as Date).getTime()).toBe(expected.getTime());
+    expect(captured.shiftAssignmentId).toBe("sa-1");
+    expect(captured.isLate).toBe(true);
+    expect(captured.lateMinutes).toBeGreaterThan(0);
+  });
+
+  it("falls back to UTC when tenant.timezone is null", async () => {
     prisma.tenant.findUnique.mockResolvedValue({ timezone: null } as any);
     prisma.attendance.findFirst.mockResolvedValue(null);
     prisma.shiftAssignment.findFirst.mockResolvedValue(null);
-    prisma.user.findUnique.mockResolvedValue({ primaryBranchId: 'branch-1' } as any);
-    (prisma.attendance.create as any).mockResolvedValue({ id: 'a-1', branchId: 'branch-1', user: {} });
+    prisma.user.findUnique.mockResolvedValue({
+      primaryBranchId: "branch-1",
+    } as any);
+    (prisma.attendance.create as any).mockResolvedValue({
+      id: "a-1",
+      branchId: "branch-1",
+      user: {},
+    });
 
-    await svc.clockIn('tenant-1', 'user-1');
+    await svc.clockIn("tenant-1", "user-1");
 
     const lookupArgs = (prisma.attendance.findFirst as any).mock.calls[0][0];
-    const expectedToday = getTenantMidnight(new Date(), 'UTC');
-    expect((lookupArgs.where.date as Date).getTime()).toBe(expectedToday.getTime());
+    const expected = new Date(`${tenantYmd("UTC")}T00:00:00.000Z`);
+    expect((lookupArgs.where.date as Date).getTime()).toBe(expected.getTime());
   });
 });
 
@@ -66,63 +140,66 @@ describe('AttendanceService.tenantToday (iter-52)', () => {
  * branch B's attendance rows. Self-scoped reads (my-status) still pin
  * the branch so a user only sees their record within the active branch.
  */
-describe('AttendanceService branch-scope reads (track-1)', () => {
+describe("AttendanceService branch-scope reads (track-1)", () => {
   let prisma: MockPrismaClient;
   let kdsGateway: any;
   let svc: AttendanceService;
   const scope = {
-    tenantId: 't-1',
-    branchId: 'b-1',
-    userId: 'u-1',
-    role: 'MANAGER',
+    tenantId: "t-1",
+    branchId: "b-1",
+    userId: "u-1",
+    role: "MANAGER",
   } as any;
 
   beforeEach(() => {
     prisma = mockPrismaClient();
     kdsGateway = { emitAttendanceUpdate: jest.fn() };
     svc = new AttendanceService(prisma as any, kdsGateway);
-    prisma.tenant.findUnique.mockResolvedValue({ timezone: 'UTC' } as any);
+    prisma.tenant.findUnique.mockResolvedValue({ timezone: "UTC" } as any);
   });
 
-  it('getTodayAttendance filters by branchId + tenantId', async () => {
+  it("getTodayAttendance filters by branchId + tenantId", async () => {
     (prisma.attendance.findMany as any).mockResolvedValue([]);
 
     await svc.getTodayAttendance(scope);
 
     const where = (prisma.attendance.findMany as any).mock.calls[0][0].where;
-    expect(where.branchId).toBe('b-1');
-    expect(where.tenantId).toBe('t-1');
+    expect(where.branchId).toBe("b-1");
+    expect(where.tenantId).toBe("t-1");
   });
 
-  it('getAttendanceHistory filters by branchId + tenantId', async () => {
+  it("getAttendanceHistory filters by branchId + tenantId", async () => {
     (prisma.attendance.findMany as any).mockResolvedValue([]);
     (prisma.attendance.count as any).mockResolvedValue(0);
 
     await svc.getAttendanceHistory(scope, {} as any);
 
     const where = (prisma.attendance.findMany as any).mock.calls[0][0].where;
-    expect(where.branchId).toBe('b-1');
-    expect(where.tenantId).toBe('t-1');
+    expect(where.branchId).toBe("b-1");
+    expect(where.tenantId).toBe("t-1");
   });
 
-  it('getAttendanceSummary filters by branchId + tenantId', async () => {
+  it("getAttendanceSummary filters by branchId + tenantId", async () => {
     (prisma.attendance.findMany as any).mockResolvedValue([]);
 
     await svc.getAttendanceSummary(scope, {} as any);
 
     const where = (prisma.attendance.findMany as any).mock.calls[0][0].where;
-    expect(where.branchId).toBe('b-1');
-    expect(where.tenantId).toBe('t-1');
+    expect(where.branchId).toBe("b-1");
+    expect(where.tenantId).toBe("t-1");
   });
 
-  it('getMyStatus pins the active branch for the self-scoped read', async () => {
+  it("getMyStatus self-scopes by tenant+user+date WITHOUT pinning the active branch (deep-review M8)", async () => {
     (prisma.attendance.findFirst as any).mockResolvedValue(null);
 
     await svc.getMyStatus(scope);
 
     const where = (prisma.attendance.findFirst as any).mock.calls[0][0].where;
-    expect(where.branchId).toBe('b-1');
-    expect(where.tenantId).toBe('t-1');
-    expect(where.userId).toBe('u-1');
+    // A roaming ADMIN/MANAGER whose active branch != their primary branch
+    // must still see their own row (which lives under their primary
+    // branch), so the self-status read drops the active-branch predicate.
+    expect(where.branchId).toBeUndefined();
+    expect(where.tenantId).toBe("t-1");
+    expect(where.userId).toBe("u-1");
   });
 });

--- a/backend/src/modules/personnel/services/attendance.service.ts
+++ b/backend/src/modules/personnel/services/attendance.service.ts
@@ -22,23 +22,82 @@ export class AttendanceService {
   ) {}
 
   /**
-   * Resolve the tenant-local-midnight UTC instant for "today". Same
-   * helper z-reports uses (iter-35). Without this, server-local
-   * midnight diverges from the tenant's "today" — a user clocking
-   * in at 02:00 TR on a UTC container gets stamped with the previous
-   * server date, which then breaks payroll-export day boundaries
-   * and the shift-late calculation against shiftTemplate.startTime.
+   * Resolve the tenant-local calendar day for "today" as a date-only
+   * value anchored at UTC-midnight (YYYY-MM-DDT00:00:00Z).
+   *
+   * deep-review H6/M7: the `date` columns on Attendance and
+   * ShiftAssignment are `@db.Date`, which truncates the stored instant
+   * to its UTC calendar date. The previous implementation stamped the
+   * `getTenantMidnight` *instant* (e.g. Istanbul 2026-06-17 00:00 =
+   * 2026-06-16T21:00Z) which `@db.Date`-truncates to the PREVIOUS day
+   * for every positive-offset tenant (TR is UTC+3, the primary market).
+   * That stored the row one day early AND broke the clockIn ->
+   * shiftAssignment join (schedule.service writes its `@db.Date` from
+   * `new Date(dto.date)` which truncates to the true calendar day), so
+   * isLate / lateMinutes / overtimeMinutes were silently always 0.
+   *
+   * By anchoring the tenant-local YYYY-MM-DD at UTC-midnight, the
+   * `@db.Date` truncation yields exactly the tenant's real calendar day
+   * and the round-trip stays symmetric with the schedule writer.
    */
-  private async tenantToday(tenantId: string): Promise<Date> {
+  private async tenantTimezone(tenantId: string): Promise<string> {
     const tenant = await this.prisma.tenant.findUnique({
       where: { id: tenantId },
       select: { timezone: true },
     });
-    return getTenantMidnight(new Date(), tenant?.timezone || "UTC");
+    return tenant?.timezone || "UTC";
+  }
+
+  /**
+   * Tenant-local calendar day for `now`, anchored at UTC-midnight so the
+   * `@db.Date` column stores the tenant's actual day (deep-review H6/M7).
+   */
+  private tenantDateOnly(now: Date, timezone: string): Date {
+    try {
+      const ymd = new Intl.DateTimeFormat("en-CA", {
+        timeZone: timezone,
+        year: "numeric",
+        month: "2-digit",
+        day: "2-digit",
+      }).format(now);
+      return new Date(`${ymd}T00:00:00.000Z`);
+    } catch {
+      // Unknown tz: fall back to the server-local calendar day at
+      // UTC-midnight (still date-only correct on a UTC container).
+      const fallback = new Date(
+        Date.UTC(now.getFullYear(), now.getMonth(), now.getDate()),
+      );
+      return fallback;
+    }
+  }
+
+  /**
+   * The UTC instant for a tenant-local wall-clock HH:MM on the calendar
+   * day represented by `dateOnly` (a UTC-anchored date-only value).
+   *
+   * deep-review H6 (secondary): shift template start/end times are
+   * tenant-local wall clock ("09:00"). The old code built shiftStart via
+   * `new Date(today); setHours(...)` using SERVER-local hours, so even
+   * once the join matched the late/grace comparison was tz-skewed. We
+   * anchor on the tenant midnight (via the shared helper, DST-safe) and
+   * add the wall-clock offset.
+   */
+  private tenantWallClockInstant(
+    dateOnly: Date,
+    hour: number,
+    minute: number,
+    timezone: string,
+  ): Date {
+    // Anchor at noon so a DST jump (which happens at night) cannot push
+    // getTenantMidnight onto the adjacent day — mirrors getTenantDayBounds.
+    const noonUtc = new Date(dateOnly.getTime() + 12 * 60 * 60 * 1000);
+    const midnight = getTenantMidnight(noonUtc, timezone);
+    return new Date(midnight.getTime() + (hour * 60 + minute) * 60000);
   }
 
   async clockIn(tenantId: string, userId: string, notes?: string) {
-    const today = await this.tenantToday(tenantId);
+    const timezone = await this.tenantTimezone(tenantId);
+    const today = this.tenantDateOnly(new Date(), timezone);
 
     // Check no existing active record for today
     const existing = await this.prisma.attendance.findFirst({
@@ -71,8 +130,14 @@ export class AttendanceService {
         .map(Number);
       const gracePeriod = shiftAssignment.shiftTemplate.gracePeriodMinutes;
 
-      const shiftStart = new Date(today);
-      shiftStart.setHours(shiftHour, shiftMin, 0, 0);
+      // deep-review H6: build shiftStart in the TENANT timezone, not
+      // server-local, so isLate/lateMinutes are accurate on a UTC pod.
+      const shiftStart = this.tenantWallClockInstant(
+        today,
+        shiftHour,
+        shiftMin,
+        timezone,
+      );
 
       const graceEnd = new Date(shiftStart.getTime() + gracePeriod * 60000);
 
@@ -133,7 +198,10 @@ export class AttendanceService {
   }
 
   async clockOut(tenantId: string, userId: string) {
-    const today = await this.tenantToday(tenantId);
+    const today = this.tenantDateOnly(
+      new Date(),
+      await this.tenantTimezone(tenantId),
+    );
 
     const attendance = await this.prisma.attendance.findFirst({
       where: { userId, date: today, tenantId },
@@ -206,7 +274,10 @@ export class AttendanceService {
   }
 
   async breakStart(tenantId: string, userId: string) {
-    const today = await this.tenantToday(tenantId);
+    const today = this.tenantDateOnly(
+      new Date(),
+      await this.tenantTimezone(tenantId),
+    );
 
     const attendance = await this.prisma.attendance.findFirst({
       where: { userId, date: today, tenantId },
@@ -251,7 +322,10 @@ export class AttendanceService {
   }
 
   async breakEnd(tenantId: string, userId: string) {
-    const today = await this.tenantToday(tenantId);
+    const today = this.tenantDateOnly(
+      new Date(),
+      await this.tenantTimezone(tenantId),
+    );
 
     const attendance = await this.prisma.attendance.findFirst({
       where: { userId, date: today, tenantId },
@@ -308,13 +382,22 @@ export class AttendanceService {
   }
 
   async getMyStatus(scope: BranchScope) {
-    const today = await this.tenantToday(scope.tenantId);
+    const today = this.tenantDateOnly(
+      new Date(),
+      await this.tenantTimezone(scope.tenantId),
+    );
 
-    // Self-scoped to the acting user, but still pinned to the active
-    // branch: a user only sees their record within the branch they are
-    // operating in (matches the v3.0.0 branch-scope design).
+    // deep-review M8: the self-status read is intentionally NOT pinned
+    // to the active branch. Attendance is one-row-per-user-per-day
+    // (@@unique([userId, date])) and clockIn pins the row to the user's
+    // PRIMARY branch. A roaming ADMIN/MANAGER whose active branch != their
+    // primary branch would otherwise see themselves as NOT_CLOCKED_IN,
+    // be blocked from clocking in again, and break clock-out/break. This
+    // stays safe from IDOR: it is still self-scoped (userId) AND
+    // tenant-scoped. (Roster reads below remain branch-scoped by design;
+    // worked-branch vs home-branch attribution is a deferred product call.)
     const attendance = await this.prisma.attendance.findFirst({
-      where: { ...branchScope(scope), userId: scope.userId, date: today },
+      where: { tenantId: scope.tenantId, userId: scope.userId, date: today },
       include: {
         shiftAssignment: { include: { shiftTemplate: true } },
         user: {
@@ -327,7 +410,10 @@ export class AttendanceService {
   }
 
   async getTodayAttendance(scope: BranchScope) {
-    const today = await this.tenantToday(scope.tenantId);
+    const today = this.tenantDateOnly(
+      new Date(),
+      await this.tenantTimezone(scope.tenantId),
+    );
 
     return this.prisma.attendance.findMany({
       where: { ...branchScope(scope), date: today },

--- a/backend/src/modules/provisioning/tenant-provisioning.service.spec.ts
+++ b/backend/src/modules/provisioning/tenant-provisioning.service.spec.ts
@@ -1,16 +1,21 @@
-import { Prisma } from '@prisma/client';
-import { TenantProvisioningService } from './tenant-provisioning.service';
-import { mockPrismaClient, MockPrismaClient } from '../../common/test/prisma-mock.service';
+import { Prisma } from "@prisma/client";
+import { TenantProvisioningService } from "./tenant-provisioning.service";
+import {
+  mockPrismaClient,
+  MockPrismaClient,
+} from "../../common/test/prisma-mock.service";
 import {
   CoreProvisioningEmailInUseError,
   CoreProvisioningPlanInvalidError,
   ProvisionTenantForLeadCommand,
-} from '../../core-contracts/provisioning/tenant-provisioning.types';
+} from "../../core-contracts/provisioning/tenant-provisioning.types";
 
-jest.mock('bcryptjs', () => ({ hash: jest.fn().mockResolvedValue('$hashed$') }));
-jest.mock('../../common/helpers/subdomain.helper', () => ({
+jest.mock("bcryptjs", () => ({
+  hash: jest.fn().mockResolvedValue("$hashed$"),
+}));
+jest.mock("../../common/helpers/subdomain.helper", () => ({
   isSubdomainQuarantined: jest.fn().mockResolvedValue(false),
-  randomSubdomainSuffix: jest.fn().mockReturnValue('abc123'),
+  randomSubdomainSuffix: jest.fn().mockReturnValue("abc123"),
 }));
 
 /**
@@ -19,17 +24,17 @@ jest.mock('../../common/helpers/subdomain.helper', () => ({
  * idempotency (one tenant per lead, even under retry/race) and the typed
  * port errors that keep the caller framework-neutral.
  */
-describe('TenantProvisioningService', () => {
+describe("TenantProvisioningService", () => {
   let prisma: MockPrismaClient;
   let config: { get: jest.Mock };
   let svc: TenantProvisioningService;
 
   const command: ProvisionTenantForLeadCommand = {
-    leadId: 'lead-1',
-    idempotencyKey: 'lead-convert:lead-1',
-    tenantName: 'Test Bistro',
-    admin: { email: 'owner@test.com', firstName: 'Ada', lastName: 'Lovelace' },
-    plan: { planId: 'plan-pro', amountOverride: null, trialDaysOverride: null },
+    leadId: "lead-1",
+    idempotencyKey: "lead-convert:lead-1",
+    tenantName: "Test Bistro",
+    admin: { email: "owner@test.com", firstName: "Ada", lastName: "Lovelace" },
+    plan: { planId: "plan-pro", amountOverride: null, trialDaysOverride: null },
   };
 
   beforeEach(() => {
@@ -38,107 +43,157 @@ describe('TenantProvisioningService', () => {
     svc = new TenantProvisioningService(prisma as any, config as any);
 
     // Forward the $transaction callback onto the same mock surface.
-    (prisma.$transaction as any).mockImplementation(async (fn: any) => fn(prisma));
+    (prisma.$transaction as any).mockImplementation(async (fn: any) =>
+      fn(prisma),
+    );
 
     // Happy-path defaults (individual tests override as needed).
     prisma.tenantProvisioningLog.findUnique.mockResolvedValue(null as any);
     prisma.subscriptionPlan.findUnique.mockResolvedValue({
-      id: 'plan-pro',
-      name: 'PRO',
+      id: "plan-pro",
+      name: "PRO",
       isActive: true,
       monthlyPrice: new Prisma.Decimal(1299),
-      currency: 'TRY',
+      currency: "TRY",
       trialDays: 14,
       commissionRate: new Prisma.Decimal(0.15),
     } as any);
     prisma.user.findUnique.mockResolvedValue(null as any); // no email collision
     prisma.tenant.findUnique.mockResolvedValue(null as any); // subdomain free
-    prisma.tenant.create.mockResolvedValue({ id: 'tenant-1', subdomain: 'test-bistro' } as any);
-    prisma.user.create.mockResolvedValue({ id: 'admin-1' } as any);
-    prisma.subscription.create.mockResolvedValue({ id: 'sub-1' } as any);
+    prisma.tenant.create.mockResolvedValue({
+      id: "tenant-1",
+      subdomain: "test-bistro",
+    } as any);
+    // deep-review H7: provisioning now seeds a Main branch and points the
+    // admin's primaryBranchId at it (new-tenant parity), so mock branch.create.
+    prisma.branch.create.mockResolvedValue({ id: "branch-main" } as any);
+    prisma.user.create.mockResolvedValue({ id: "admin-1" } as any);
+    prisma.subscription.create.mockResolvedValue({ id: "sub-1" } as any);
     prisma.tenantProvisioningLog.create.mockResolvedValue({} as any);
   });
 
-  it('provisions tenant + admin + subscription + ledger and returns plan facts (created)', async () => {
+  it("provisions tenant + admin + subscription + ledger and returns plan facts (created)", async () => {
     const res = await svc.provisionTenantForLead(command);
 
     expect(res.created).toBe(true);
-    expect(res).toMatchObject({ tenantId: 'tenant-1', adminUserId: 'admin-1', subscriptionId: 'sub-1' });
-    expect(res.adminTempPassword).not.toBe('');
-    expect(res.planFacts).toEqual({ monthlyPrice: 1299, commissionRate: 0.15, planCode: 'PRO' });
+    expect(res).toMatchObject({
+      tenantId: "tenant-1",
+      adminUserId: "admin-1",
+      subscriptionId: "sub-1",
+    });
+    expect(res.adminTempPassword).not.toBe("");
+    expect(res.planFacts).toEqual({
+      monthlyPrice: 1299,
+      commissionRate: 0.15,
+      planCode: "PRO",
+    });
     expect(prisma.tenant.create).toHaveBeenCalledTimes(1);
+    // H7: a Main branch is seeded and the admin's primaryBranchId points at it
+    // so the converted tenant isn't bricked (null primaryBranchId).
+    expect(prisma.branch.create).toHaveBeenCalledTimes(1);
+    expect(prisma.user.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ primaryBranchId: "branch-main" }),
+      }),
+    );
     expect(prisma.user.create).toHaveBeenCalledTimes(1);
     expect(prisma.subscription.create).toHaveBeenCalledTimes(1);
     expect(prisma.tenantProvisioningLog.create).toHaveBeenCalledWith(
       expect.objectContaining({
-        data: expect.objectContaining({ leadId: 'lead-1', tenantId: 'tenant-1', idempotencyKey: 'lead-convert:lead-1' }),
+        data: expect.objectContaining({
+          leadId: "lead-1",
+          tenantId: "tenant-1",
+          idempotencyKey: "lead-convert:lead-1",
+        }),
       }),
     );
   });
 
-  it('is idempotent: a prior ledger row returns the same tenant without writing', async () => {
+  it("is idempotent: a prior ledger row returns the same tenant without writing", async () => {
     prisma.tenantProvisioningLog.findUnique.mockResolvedValue({
-      leadId: 'lead-1',
-      tenantId: 'tenant-1',
-      adminUserId: 'admin-1',
-      subscriptionId: 'sub-1',
+      leadId: "lead-1",
+      tenantId: "tenant-1",
+      adminUserId: "admin-1",
+      subscriptionId: "sub-1",
     } as any);
-    prisma.tenant.findUnique.mockResolvedValue({ subdomain: 'test-bistro' } as any);
+    prisma.tenant.findUnique.mockResolvedValue({
+      subdomain: "test-bistro",
+    } as any);
     prisma.subscription.findUnique.mockResolvedValue({
-      plan: { monthlyPrice: new Prisma.Decimal(1299), commissionRate: new Prisma.Decimal(0.15), name: 'PRO' },
+      plan: {
+        monthlyPrice: new Prisma.Decimal(1299),
+        commissionRate: new Prisma.Decimal(0.15),
+        name: "PRO",
+      },
     } as any);
 
     const res = await svc.provisionTenantForLead(command);
 
     expect(res.created).toBe(false);
-    expect(res.tenantId).toBe('tenant-1');
-    expect(res.adminTempPassword).toBe(''); // password already delivered on first call
-    expect(res.planFacts).toEqual({ monthlyPrice: 1299, commissionRate: 0.15, planCode: 'PRO' });
+    expect(res.tenantId).toBe("tenant-1");
+    expect(res.adminTempPassword).toBe(""); // password already delivered on first call
+    expect(res.planFacts).toEqual({
+      monthlyPrice: 1299,
+      commissionRate: 0.15,
+      planCode: "PRO",
+    });
     expect(prisma.tenant.create).not.toHaveBeenCalled();
     expect(prisma.$transaction).not.toHaveBeenCalled();
   });
 
-  it('throws CoreProvisioningEmailInUseError when the admin email collides', async () => {
-    prisma.user.findUnique.mockResolvedValue({ id: 'existing' } as any);
-    await expect(svc.provisionTenantForLead(command)).rejects.toBeInstanceOf(CoreProvisioningEmailInUseError);
+  it("throws CoreProvisioningEmailInUseError when the admin email collides", async () => {
+    prisma.user.findUnique.mockResolvedValue({ id: "existing" } as any);
+    await expect(svc.provisionTenantForLead(command)).rejects.toBeInstanceOf(
+      CoreProvisioningEmailInUseError,
+    );
     expect(prisma.tenant.create).not.toHaveBeenCalled();
   });
 
-  it('throws CoreProvisioningPlanInvalidError for an inactive plan', async () => {
-    prisma.subscriptionPlan.findUnique.mockResolvedValue({ id: 'plan-pro', isActive: false } as any);
-    await expect(svc.provisionTenantForLead(command)).rejects.toBeInstanceOf(CoreProvisioningPlanInvalidError);
+  it("throws CoreProvisioningPlanInvalidError for an inactive plan", async () => {
+    prisma.subscriptionPlan.findUnique.mockResolvedValue({
+      id: "plan-pro",
+      isActive: false,
+    } as any);
+    await expect(svc.provisionTenantForLead(command)).rejects.toBeInstanceOf(
+      CoreProvisioningPlanInvalidError,
+    );
     expect(prisma.tenant.create).not.toHaveBeenCalled();
   });
 
-  it('converges on the winner when a concurrent provision wins the ledger unique (P2002)', async () => {
-    const p2002 = new Prisma.PrismaClientKnownRequestError('unique violation', {
-      code: 'P2002',
-      clientVersion: 'test',
+  it("converges on the winner when a concurrent provision wins the ledger unique (P2002)", async () => {
+    const p2002 = new Prisma.PrismaClientKnownRequestError("unique violation", {
+      code: "P2002",
+      clientVersion: "test",
     } as any);
     (prisma.$transaction as any).mockRejectedValueOnce(p2002);
     prisma.tenantProvisioningLog.findUnique
       .mockResolvedValueOnce(null as any) // fast-path: not yet provisioned
       .mockResolvedValueOnce({
-        leadId: 'lead-1',
-        tenantId: 'tenant-9',
-        adminUserId: 'admin-9',
-        subscriptionId: 'sub-9',
+        leadId: "lead-1",
+        tenantId: "tenant-9",
+        adminUserId: "admin-9",
+        subscriptionId: "sub-9",
       } as any); // re-read after the race
     // findUnique by subdomain (allocation) → free; by id (replay) → the tenant.
-    prisma.tenant.findUnique.mockImplementation((args: any) =>
-      (args?.where?.id ? { subdomain: 'test-bistro' } : null) as any,
+    prisma.tenant.findUnique.mockImplementation(
+      (args: any) =>
+        (args?.where?.id ? { subdomain: "test-bistro" } : null) as any,
     );
     prisma.subscription.findUnique.mockResolvedValue({
-      plan: { monthlyPrice: new Prisma.Decimal(1299), commissionRate: new Prisma.Decimal(0.15), name: 'PRO' },
+      plan: {
+        monthlyPrice: new Prisma.Decimal(1299),
+        commissionRate: new Prisma.Decimal(0.15),
+        name: "PRO",
+      },
     } as any);
 
     const res = await svc.provisionTenantForLead(command);
 
     expect(res.created).toBe(false);
-    expect(res.tenantId).toBe('tenant-9'); // the winner's tenant, not a second one
+    expect(res.tenantId).toBe("tenant-9"); // the winner's tenant, not a second one
   });
 
-  it('no-plan conversion creates tenant + admin only, no subscription, no plan read', async () => {
+  it("no-plan conversion creates tenant + admin only, no subscription, no plan read", async () => {
     const res = await svc.provisionTenantForLead({ ...command, plan: null });
 
     expect(res.subscriptionId).toBeNull();
@@ -149,21 +204,21 @@ describe('TenantProvisioningService', () => {
     expect(prisma.user.create).toHaveBeenCalledTimes(1);
   });
 
-  it('describePlan returns display facts for a known plan, null for unknown', async () => {
+  it("describePlan returns display facts for a known plan, null for unknown", async () => {
     prisma.subscriptionPlan.findUnique.mockResolvedValueOnce({
-      name: 'PRO',
-      displayName: 'Profesyonel',
+      name: "PRO",
+      displayName: "Profesyonel",
       monthlyPrice: new Prisma.Decimal(1299),
-      currency: 'TRY',
+      currency: "TRY",
     } as any);
-    await expect(svc.describePlan('plan-pro')).resolves.toEqual({
-      planCode: 'PRO',
-      planName: 'Profesyonel',
+    await expect(svc.describePlan("plan-pro")).resolves.toEqual({
+      planCode: "PRO",
+      planName: "Profesyonel",
       monthlyPrice: 1299,
-      currency: 'TRY',
+      currency: "TRY",
     });
 
     prisma.subscriptionPlan.findUnique.mockResolvedValueOnce(null as any);
-    await expect(svc.describePlan('nope')).resolves.toBeNull();
+    await expect(svc.describePlan("nope")).resolves.toBeNull();
   });
 });

--- a/backend/src/modules/provisioning/tenant-provisioning.service.spec.ts
+++ b/backend/src/modules/provisioning/tenant-provisioning.service.spec.ts
@@ -205,6 +205,56 @@ describe("TenantProvisioningService", () => {
     expect(prisma.subscription.create).not.toHaveBeenCalled();
   });
 
+  // deep-review H8 verification follow-up #2 — the RESIDUAL grant-before-pay
+  // vector: an unbounded caller-supplied trialDaysOverride fakes a multi-year
+  // free TRIALING subscription on a paid plan. A plan that offers NO trial
+  // (trialDays=0) must not become trialable via the override.
+  it("refuses a faked trial via trialDaysOverride on a no-trial paid plan", async () => {
+    prisma.subscriptionPlan.findUnique.mockResolvedValue({
+      id: "plan-pro",
+      name: "PRO",
+      isActive: true,
+      monthlyPrice: new Prisma.Decimal(1299),
+      currency: "TRY",
+      trialDays: 0, // plan offers no trial
+      commissionRate: new Prisma.Decimal(0.15),
+    } as any);
+
+    await expect(
+      svc.provisionTenantForLead({
+        ...command,
+        plan: { planId: "plan-pro", amountOverride: null, trialDaysOverride: 3650 },
+      }),
+    ).rejects.toBeInstanceOf(CoreProvisioningPlanInvalidError);
+    expect(prisma.subscription.create).not.toHaveBeenCalled();
+  });
+
+  // The override may shorten a trial but never extend it past the plan's own.
+  it("clamps trialDaysOverride to the plan's server-owned trial length", async () => {
+    prisma.subscriptionPlan.findUnique.mockResolvedValue({
+      id: "plan-pro",
+      name: "PRO",
+      isActive: true,
+      monthlyPrice: new Prisma.Decimal(1299),
+      currency: "TRY",
+      trialDays: 14,
+      commissionRate: new Prisma.Decimal(0.15),
+    } as any);
+
+    await svc.provisionTenantForLead({
+      ...command,
+      plan: { planId: "plan-pro", amountOverride: null, trialDaysOverride: 3650 },
+    });
+
+    const data = (prisma.subscription.create as jest.Mock).mock.calls[0][0].data;
+    expect(data.status).toBe("TRIALING");
+    const span =
+      (new Date(data.trialEnd).getTime() -
+        new Date(data.currentPeriodStart).getTime()) /
+      86_400_000;
+    expect(Math.round(span)).toBe(14); // clamped to the plan's 14, not 3650
+  });
+
   it("converges on the winner when a concurrent provision wins the ledger unique (P2002)", async () => {
     const p2002 = new Prisma.PrismaClientKnownRequestError("unique violation", {
       code: "P2002",

--- a/backend/src/modules/provisioning/tenant-provisioning.service.spec.ts
+++ b/backend/src/modules/provisioning/tenant-provisioning.service.spec.ts
@@ -160,6 +160,51 @@ describe("TenantProvisioningService", () => {
     expect(prisma.tenant.create).not.toHaveBeenCalled();
   });
 
+  // deep-review H8 verification follow-up — the grant-before-pay bypass. The
+  // amount-based guard (`subscriptionAmount > 0`) is defeated by a marketing
+  // offer.customPrice of 0 (or negative) on a PAID, no-trial plan: it mints a
+  // free ACTIVE paid subscription. The guard must key on the PLAN's real price.
+  it("refuses a free ACTIVE paid sub via amountOverride=0 on a no-trial plan (H8 bypass)", async () => {
+    prisma.subscriptionPlan.findUnique.mockResolvedValue({
+      id: "plan-pro",
+      name: "PRO",
+      isActive: true,
+      monthlyPrice: new Prisma.Decimal(1299),
+      currency: "TRY",
+      trialDays: 0, // no trial
+      commissionRate: new Prisma.Decimal(0.15),
+    } as any);
+
+    await expect(
+      svc.provisionTenantForLead({
+        ...command,
+        plan: { planId: "plan-pro", amountOverride: 0, trialDaysOverride: null },
+      }),
+    ).rejects.toBeInstanceOf(CoreProvisioningPlanInvalidError);
+    expect(prisma.subscription.create).not.toHaveBeenCalled();
+    expect(prisma.tenant.create).not.toHaveBeenCalled();
+  });
+
+  it("refuses a negative amountOverride on a paid plan", async () => {
+    prisma.subscriptionPlan.findUnique.mockResolvedValue({
+      id: "plan-pro",
+      name: "PRO",
+      isActive: true,
+      monthlyPrice: new Prisma.Decimal(1299),
+      currency: "TRY",
+      trialDays: 14,
+      commissionRate: new Prisma.Decimal(0.15),
+    } as any);
+
+    await expect(
+      svc.provisionTenantForLead({
+        ...command,
+        plan: { planId: "plan-pro", amountOverride: -1, trialDaysOverride: null },
+      }),
+    ).rejects.toBeInstanceOf(CoreProvisioningPlanInvalidError);
+    expect(prisma.subscription.create).not.toHaveBeenCalled();
+  });
+
   it("converges on the winner when a concurrent provision wins the ledger unique (P2002)", async () => {
     const p2002 = new Prisma.PrismaClientKnownRequestError("unique violation", {
       code: "P2002",

--- a/backend/src/modules/provisioning/tenant-provisioning.service.ts
+++ b/backend/src/modules/provisioning/tenant-provisioning.service.ts
@@ -105,7 +105,22 @@ export class TenantProvisioningService implements CoreProvisioningPort {
     // offer a trial or be collected through real PayTR checkout — mirror the
     // register/social loadBusinessPlanOrThrow `trialDays <= 0` guard. FREE
     // plans (amount 0) are unaffected and provision ACTIVE as before.
-    if (planRow && !canTrial && Number(subscriptionAmount ?? 0) > 0) {
+    // The guard keys on the PLAN's real price, NOT the caller-supplied
+    // amountOverride (deep-review H8 + verification follow-up). amountOverride
+    // is a marketing-owned offer term (offer.customPrice) with no positivity
+    // validation; an amountOverride of 0 — or a negative value — would slip a
+    // paid plan past an `amount > 0` check and mint a free (or negative) ACTIVE
+    // paid subscription, which plan-projector grants full entitlements for.
+    const planIsPaid = !!planRow && Number(planRow.monthlyPrice) > 0;
+    if (planIsPaid && !canTrial) {
+      throw new CoreProvisioningPlanInvalidError(planRow!.id);
+    }
+    // A negative override is never valid (no negative-amount subscriptions).
+    if (
+      planRow &&
+      command.plan?.amountOverride != null &&
+      Number(command.plan.amountOverride) < 0
+    ) {
       throw new CoreProvisioningPlanInvalidError(planRow.id);
     }
 

--- a/backend/src/modules/provisioning/tenant-provisioning.service.ts
+++ b/backend/src/modules/provisioning/tenant-provisioning.service.ts
@@ -97,6 +97,18 @@ export class TenantProvisioningService implements CoreProvisioningPort {
       ? (command.plan!.amountOverride ?? planRow.monthlyPrice)
       : null;
 
+    // SECURITY (deep-review H8): never mint a paid, immediately-ACTIVE
+    // subscription here — that is grant-before-pay. If a lead is converted
+    // onto a paid plan with no trial (canTrial=false) and a positive amount,
+    // the tenant would get full paid access for free until the next renewal
+    // cycle (PlanFeatureGuard treats ACTIVE as live). A paid plan must either
+    // offer a trial or be collected through real PayTR checkout — mirror the
+    // register/social loadBusinessPlanOrThrow `trialDays <= 0` guard. FREE
+    // plans (amount 0) are unaffected and provision ACTIVE as before.
+    if (planRow && !canTrial && Number(subscriptionAmount ?? 0) > 0) {
+      throw new CoreProvisioningPlanInvalidError(planRow.id);
+    }
+
     const baseSubdomain = command.tenantName
       .toLowerCase()
       .replace(/[^a-z0-9]+/g, "-")
@@ -126,6 +138,23 @@ export class TenantProvisioningService implements CoreProvisioningPort {
           },
         });
 
+        // deep-review H7: every signup path MUST seed a Main branch and
+        // point the ADMIN's primaryBranchId at it (new-tenant provisioning
+        // parity). Without this the converted tenant has zero branches and a
+        // null primaryBranchId, so resolve-primary-branch returns null, the
+        // SPA resolves branchId=null, and the api interceptor hard-rejects
+        // every branch-scoped request — the documented "null primaryBranchId
+        // bricked the app" state. Mirror AuthProvisioningService exactly.
+        const mainBranch = await tx.branch.create({
+          data: {
+            tenantId: tenant.id,
+            name: "Main",
+            status: "active",
+            timezone: "UTC",
+          },
+          select: { id: true },
+        });
+
         const adminUser = await tx.user.create({
           data: {
             email: command.admin.email,
@@ -136,6 +165,7 @@ export class TenantProvisioningService implements CoreProvisioningPort {
             status: "ACTIVE",
             emailVerified: true,
             tenantId: tenant.id,
+            primaryBranchId: mainBranch.id,
           },
         });
 

--- a/backend/src/modules/provisioning/tenant-provisioning.service.ts
+++ b/backend/src/modules/provisioning/tenant-provisioning.service.ts
@@ -82,8 +82,24 @@ export class TenantProvisioningService implements CoreProvisioningPort {
     }
 
     const now = new Date();
+    // SECURITY (deep-review H8 + verification follow-up #2): a caller-supplied
+    // trialDaysOverride (a marketing offer term, unvalidated upstream) may only
+    // REDUCE the plan's server-defined trial — NEVER extend it. Left unbounded
+    // it was a grant-before-pay vector: trialDaysOverride=3650 on a paid plan
+    // mints a ~10-year free TRIALING subscription (TRIALING grants full paid
+    // entitlements). This mirrors auth-provisioning, which trusts only the
+    // server-owned plan.trialDays. A plan offering no trial (trialDays=0) can
+    // never become trialable via the override -> trialDays clamps to 0 -> the
+    // paid-plan guard below rejects the grant-before-pay.
+    const planTrialDays = Number(planRow?.trialDays ?? 0);
     const trialDays = planRow
-      ? (command.plan!.trialDaysOverride ?? planRow.trialDays ?? 0)
+      ? Math.max(
+          0,
+          Math.min(
+            Number(command.plan!.trialDaysOverride ?? planTrialDays),
+            planTrialDays,
+          ),
+        )
       : 0;
     const canTrial = !!planRow && trialDays > 0 && planRow.name !== "FREE";
     const trialStart = canTrial ? now : null;

--- a/backend/src/modules/reservations/services/reservations.service.ts
+++ b/backend/src/modules/reservations/services/reservations.service.ts
@@ -542,6 +542,32 @@ export class ReservationsService {
   async update(scope: BranchScope, id: string, dto: UpdateReservationDto) {
     const reservation = await this.findOne(scope, id);
 
+    // [M22] Validate any incoming tableId against the caller's scope before
+    // writing, mirroring createPublicReservation. The table FK is
+    // tenant-agnostic, so without this an ADMIN/MANAGER scoped to branch A
+    // could PATCH tableId to a table belonging to branch B / another tenant —
+    // the write would succeed (leaving branchId stale/inconsistent) and the
+    // include:{table:true} response would leak the foreign table's fields.
+    // branchScope(scope) pins (tenantId, branchId), so a found table is
+    // guaranteed in the SAME tenant AND branch as the reservation — no
+    // branchId rewrite is needed (and must NOT be allowed, lest a foreign
+    // branchId leak in). This also keeps the overlap query (which already
+    // filters by branchScope) accurate.
+    if (dto.tableId && dto.tableId !== reservation.tableId) {
+      const table = await this.prisma.table.findFirst({
+        where: { id: dto.tableId, ...branchScope(scope) },
+      });
+      if (!table) {
+        throw new NotFoundException("Table not found");
+      }
+      // Keep guestCount within the new table's capacity, using the effective
+      // guest count (incoming dto value, else the existing row).
+      const effectiveGuestCount = dto.guestCount ?? reservation.guestCount;
+      if (effectiveGuestCount > table.capacity) {
+        throw new BadRequestException(`Table capacity is ${table.capacity}`);
+      }
+    }
+
     const data: any = { ...dto };
     if (dto.date) {
       data.date = new Date(dto.date);

--- a/backend/src/modules/reservations/services/reservations.update-table-scope.spec.ts
+++ b/backend/src/modules/reservations/services/reservations.update-table-scope.spec.ts
@@ -1,0 +1,96 @@
+import { NotFoundException } from "@nestjs/common";
+import { ReservationsService } from "./reservations.service";
+import {
+  mockPrismaClient,
+  MockPrismaClient,
+} from "../../../common/test/prisma-mock.service";
+
+/**
+ * [M22] Reservation admin update() must validate any incoming tableId against
+ * the caller's branch scope before writing. The table FK is tenant-agnostic,
+ * so without the guard an ADMIN/MANAGER scoped to branch A could PATCH the
+ * reservation's tableId to a table belonging to branch B / another tenant —
+ * the write would succeed (stale branchId) and include:{table:true} would
+ * leak the foreign table's fields.
+ */
+describe("ReservationsService.update — tableId branch-scope guard (M22)", () => {
+  let prisma: MockPrismaClient;
+  let svc: ReservationsService;
+
+  const scope = { tenantId: "t-1", branchId: "b-1" } as any;
+
+  const existingReservation = {
+    id: "r-1",
+    tenantId: "t-1",
+    branchId: "b-1",
+    tableId: "table-a",
+    guestCount: 2,
+    date: new Date("2026-07-01"),
+    startTime: "19:00",
+    endTime: "21:00",
+    status: "CONFIRMED",
+  };
+
+  beforeEach(() => {
+    prisma = mockPrismaClient();
+    svc = new ReservationsService(
+      prisma as any,
+      { notifyAdmins: jest.fn() } as any,
+      { getOrCreate: jest.fn() } as any,
+      { notify: jest.fn() } as any,
+      { resolvePublicBranchId: jest.fn() } as any,
+    );
+
+    // findOne()
+    (prisma.reservation.findFirst as any).mockResolvedValue(existingReservation);
+    (prisma.reservation.update as any).mockResolvedValue({
+      ...existingReservation,
+    });
+  });
+
+  it("rejects a tableId that is not in the caller's scope (no foreign-table write/leak)", async () => {
+    // Scoped lookup finds nothing => foreign / cross-branch table.
+    (prisma.table.findFirst as any).mockResolvedValue(null);
+
+    await expect(
+      svc.update(scope, "r-1", { tableId: "table-foreign" } as any),
+    ).rejects.toBeInstanceOf(NotFoundException);
+
+    // The scoped lookup must be tenant+branch pinned.
+    const tableWhere = (prisma.table.findFirst as any).mock.calls[0][0].where;
+    expect(tableWhere.id).toBe("table-foreign");
+    expect(tableWhere.tenantId).toBe("t-1");
+    expect(tableWhere.branchId).toBe("b-1");
+
+    // Nothing was written.
+    expect(prisma.reservation.update).not.toHaveBeenCalled();
+  });
+
+  it("accepts an in-scope tableId and writes the update", async () => {
+    (prisma.table.findFirst as any).mockResolvedValue({
+      id: "table-b",
+      tenantId: "t-1",
+      branchId: "b-1",
+      capacity: 4,
+    });
+    (prisma.reservation.findMany as any).mockResolvedValue([]);
+
+    await svc.update(scope, "r-1", { tableId: "table-b" } as any);
+
+    expect(prisma.reservation.update).toHaveBeenCalledTimes(1);
+    const data = (prisma.reservation.update as any).mock.calls[0][0].data;
+    expect(data.tableId).toBe("table-b");
+    // The reservation's branchId must NOT be rewritten from the table lookup.
+    expect(data.branchId).toBeUndefined();
+  });
+
+  it("does not re-validate when tableId is unchanged", async () => {
+    (prisma.reservation.findMany as any).mockResolvedValue([]);
+
+    await svc.update(scope, "r-1", { tableId: "table-a" } as any);
+
+    // Same tableId => no scoped table lookup, just the overlap read.
+    expect(prisma.table.findFirst).not.toHaveBeenCalled();
+    expect(prisma.reservation.update).toHaveBeenCalledTimes(1);
+  });
+});

--- a/backend/src/modules/stock-management/services/purchase-orders.service.spec.ts
+++ b/backend/src/modules/stock-management/services/purchase-orders.service.spec.ts
@@ -1,7 +1,10 @@
-import { BadRequestException } from '@nestjs/common';
-import { PurchaseOrdersService } from './purchase-orders.service';
-import { mockPrismaClient, MockPrismaClient } from '../../../common/test/prisma-mock.service';
-import { PurchaseOrderStatus } from '../../../common/constants/stock-management.enum';
+import { BadRequestException } from "@nestjs/common";
+import { PurchaseOrdersService } from "./purchase-orders.service";
+import {
+  mockPrismaClient,
+  MockPrismaClient,
+} from "../../../common/test/prisma-mock.service";
+import { PurchaseOrderStatus } from "../../../common/constants/stock-management.enum";
 
 /**
  * Iter-34 regression: the per-line poItem read in receive() MUST
@@ -11,7 +14,7 @@ import { PurchaseOrderStatus } from '../../../common/constants/stock-management.
  * `alreadyReceived=N`, both computed `N+their_qty`, and the second
  * UPDATE clobbered the first (lost update). Pin the query shape.
  */
-describe('PurchaseOrdersService.receive (iter-34)', () => {
+describe("PurchaseOrdersService.receive (iter-34)", () => {
   let prisma: MockPrismaClient;
   let svc: PurchaseOrdersService;
 
@@ -19,10 +22,10 @@ describe('PurchaseOrdersService.receive (iter-34)', () => {
   // branchScope(scope) fences the PO read on (tenantId, branchId), so a
   // cross-branch PO id can never be received/cancelled (stock mutated).
   const SCOPE = {
-    tenantId: 't1',
-    branchId: 'b1',
-    userId: 'user-1',
-    role: 'ADMIN',
+    tenantId: "t1",
+    branchId: "b1",
+    userId: "user-1",
+    role: "ADMIN",
   } as const;
 
   beforeEach(() => {
@@ -30,21 +33,21 @@ describe('PurchaseOrdersService.receive (iter-34)', () => {
     svc = new PurchaseOrdersService(prisma as any);
   });
 
-  it('re-reads poItem on the txn client inside the transaction', async () => {
+  it("re-reads poItem on the txn client inside the transaction", async () => {
     // Outside-txn findOne (pre-flight status check)
     (prisma.purchaseOrder.findFirst as any).mockResolvedValue({
-      id: 'po-1',
-      tenantId: 't1',
+      id: "po-1",
+      tenantId: "t1",
       status: PurchaseOrderStatus.SUBMITTED,
-      orderNumber: 'PO-00001',
+      orderNumber: "PO-00001",
       items: [
         {
-          id: 'poi-1',
-          stockItemId: 'stock-1',
-          stockItem: { name: 'Flour' },
-          quantityReceived: '0',
-          quantityOrdered: '10',
-          unitPrice: '5',
+          id: "poi-1",
+          stockItemId: "stock-1",
+          stockItem: { name: "Flour" },
+          quantityReceived: "0",
+          quantityOrdered: "10",
+          unitPrice: "5",
         },
       ],
     });
@@ -53,23 +56,25 @@ describe('PurchaseOrdersService.receive (iter-34)', () => {
       purchaseOrderItem: {
         // In-txn re-read — load-bearing for the lost-update fix.
         findFirst: jest.fn().mockResolvedValue({
-          id: 'poi-1',
-          stockItemId: 'stock-1',
-          stockItem: { name: 'Flour' },
-          quantityReceived: '0',
-          quantityOrdered: '10',
-          unitPrice: '5',
+          id: "poi-1",
+          stockItemId: "stock-1",
+          stockItem: { name: "Flour" },
+          quantityReceived: "0",
+          quantityOrdered: "10",
+          unitPrice: "5",
         }),
         update: jest.fn().mockResolvedValue({}),
-        findMany: jest.fn().mockResolvedValue([
-          { quantityReceived: '5', quantityOrdered: '10' },
-        ]),
+        findMany: jest
+          .fn()
+          .mockResolvedValue([
+            { quantityReceived: "5", quantityOrdered: "10" },
+          ]),
       },
       stockItem: {
         findUnique: jest.fn().mockResolvedValue({
-          id: 'stock-1',
-          currentStock: '0',
-          costPerUnit: '0',
+          id: "stock-1",
+          currentStock: "0",
+          costPerUnit: "0",
         }),
         update: jest.fn().mockResolvedValue({}),
       },
@@ -77,13 +82,15 @@ describe('PurchaseOrdersService.receive (iter-34)', () => {
       ingredientMovement: { create: jest.fn().mockResolvedValue({}) },
       purchaseOrder: { update: jest.fn().mockResolvedValue({}) },
     };
-    (prisma.$transaction as any).mockImplementation(async (cb: any, _opts: any) => cb(txMock));
+    (prisma.$transaction as any).mockImplementation(
+      async (cb: any, _opts: any) => cb(txMock),
+    );
 
     await svc.receive(
-      'po-1',
-      { items: [{ purchaseOrderItemId: 'poi-1', quantityReceived: 5 }] } as any,
+      "po-1",
+      { items: [{ purchaseOrderItemId: "poi-1", quantityReceived: 5 }] } as any,
       SCOPE,
-      'user-1',
+      "user-1",
     );
 
     // Load-bearing assertion: the second findFirst (per-line) lands on
@@ -92,8 +99,8 @@ describe('PurchaseOrdersService.receive (iter-34)', () => {
     expect(txMock.purchaseOrderItem.findFirst).toHaveBeenCalledWith(
       expect.objectContaining({
         where: expect.objectContaining({
-          id: 'poi-1',
-          purchaseOrderId: 'po-1',
+          id: "poi-1",
+          purchaseOrderId: "po-1",
         }),
       }),
     );
@@ -102,50 +109,52 @@ describe('PurchaseOrdersService.receive (iter-34)', () => {
     // from branchScope(scope), so receive can only mutate stock for a PO
     // that belongs to the caller's (tenantId, branchId).
     expect(prisma.purchaseOrder.findFirst.mock.calls[0][0].where).toEqual({
-      id: 'po-1',
-      tenantId: 't1',
-      branchId: 'b1',
+      id: "po-1",
+      tenantId: "t1",
+      branchId: "b1",
     });
     // Stock + movement writes carry the scope's branchId (not re-derived).
-    expect(txMock.stockBatch.create.mock.calls[0][0].data.branchId).toBe('b1');
+    expect(txMock.stockBatch.create.mock.calls[0][0].data.branchId).toBe("b1");
     expect(
       txMock.ingredientMovement.create.mock.calls[0][0].data.branchId,
-    ).toBe('b1');
+    ).toBe("b1");
   });
 
-  it('does NOT receive (mutate stock for) a cross-branch PO id', async () => {
+  it("does NOT receive (mutate stock for) a cross-branch PO id", async () => {
     // findOne is branch-fenced; a PO that lives in another branch is not
     // visible, so findFirst returns null → NotFound before any txn.
     (prisma.purchaseOrder.findFirst as any).mockResolvedValue(null);
-    const { NotFoundException } = require('@nestjs/common');
+    const { NotFoundException } = require("@nestjs/common");
 
     await expect(
       svc.receive(
-        'cross-branch-po',
-        { items: [{ purchaseOrderItemId: 'poi-1', quantityReceived: 5 }] } as any,
+        "cross-branch-po",
+        {
+          items: [{ purchaseOrderItemId: "poi-1", quantityReceived: 5 }],
+        } as any,
         SCOPE,
-        'user-1',
+        "user-1",
       ),
     ).rejects.toBeInstanceOf(NotFoundException);
     // No stock-mutating transaction may run for a cross-branch PO.
     expect(prisma.$transaction).not.toHaveBeenCalled();
   });
 
-  it('rejects over-receive based on the FRESHLY-READ alreadyReceived (not the stale snapshot)', async () => {
+  it("rejects over-receive based on the FRESHLY-READ alreadyReceived (not the stale snapshot)", async () => {
     // Outside-txn snapshot says quantityReceived=0 (the stale view).
     (prisma.purchaseOrder.findFirst as any).mockResolvedValue({
-      id: 'po-1',
-      tenantId: 't1',
+      id: "po-1",
+      tenantId: "t1",
       status: PurchaseOrderStatus.SUBMITTED,
-      orderNumber: 'PO-00001',
+      orderNumber: "PO-00001",
       items: [
         {
-          id: 'poi-1',
-          stockItemId: 'stock-1',
-          stockItem: { name: 'Flour' },
-          quantityReceived: '0',
-          quantityOrdered: '10',
-          unitPrice: '5',
+          id: "poi-1",
+          stockItemId: "stock-1",
+          stockItem: { name: "Flour" },
+          quantityReceived: "0",
+          quantityOrdered: "10",
+          unitPrice: "5",
         },
       ],
     });
@@ -155,12 +164,12 @@ describe('PurchaseOrdersService.receive (iter-34)', () => {
         // In-txn fresh read says we ALREADY received 8 (a concurrent
         // call landed). New attempt of 5 would push us to 13 > 10.
         findFirst: jest.fn().mockResolvedValue({
-          id: 'poi-1',
-          stockItemId: 'stock-1',
-          stockItem: { name: 'Flour' },
-          quantityReceived: '8',
-          quantityOrdered: '10',
-          unitPrice: '5',
+          id: "poi-1",
+          stockItemId: "stock-1",
+          stockItem: { name: "Flour" },
+          quantityReceived: "8",
+          quantityOrdered: "10",
+          unitPrice: "5",
         }),
         update: jest.fn(),
         findMany: jest.fn(),
@@ -170,12 +179,16 @@ describe('PurchaseOrdersService.receive (iter-34)', () => {
       ingredientMovement: { create: jest.fn() },
       purchaseOrder: { update: jest.fn() },
     };
-    (prisma.$transaction as any).mockImplementation(async (cb: any, _opts: any) => cb(txMock));
+    (prisma.$transaction as any).mockImplementation(
+      async (cb: any, _opts: any) => cb(txMock),
+    );
 
     await expect(
       svc.receive(
-        'po-1',
-        { items: [{ purchaseOrderItemId: 'poi-1', quantityReceived: 5 }] } as any,
+        "po-1",
+        {
+          items: [{ purchaseOrderItemId: "poi-1", quantityReceived: 5 }],
+        } as any,
         SCOPE,
       ),
     ).rejects.toThrow(BadRequestException);
@@ -184,5 +197,159 @@ describe('PurchaseOrdersService.receive (iter-34)', () => {
     // mutation, so the over-receive race is properly closed.
     expect(txMock.stockItem.update).not.toHaveBeenCalled();
     expect(txMock.stockBatch.create).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * deep-review M18 regression: cancel() must run under Serializable, re-read
+ * the PO/items/batches INSIDE the txn, and reverse only the un-consumed
+ * batch remainder — NOT the gross quantityReceived from the outside-txn
+ * findOne snapshot. The prior code zeroed all batches and decremented by the
+ * gross received qty, double-counting any stock FIFO had already consumed
+ * (and missing receives that committed after findOne).
+ */
+describe("PurchaseOrdersService.cancel (deep-review M18)", () => {
+  let prisma: MockPrismaClient;
+  let svc: PurchaseOrdersService;
+
+  const SCOPE = {
+    tenantId: "t1",
+    branchId: "b1",
+    userId: "user-1",
+    role: "ADMIN",
+  } as const;
+
+  beforeEach(() => {
+    prisma = mockPrismaClient();
+    svc = new PurchaseOrdersService(prisma as any);
+  });
+
+  it("reverses only the un-consumed batch remainder, not the gross received qty", async () => {
+    // Pre-flight findOne snapshot: 5 received.
+    (prisma.purchaseOrder.findFirst as any).mockResolvedValue({
+      id: "po-1",
+      tenantId: "t1",
+      branchId: "b1",
+      status: PurchaseOrderStatus.PARTIALLY_RECEIVED,
+      orderNumber: "PO-00001",
+      items: [
+        {
+          id: "poi-1",
+          stockItemId: "stock-1",
+          quantityReceived: "5",
+          unitPrice: "5",
+        },
+      ],
+    });
+
+    const txMock: any = {
+      // In-txn re-claim — load-bearing for the M18 fix.
+      purchaseOrder: {
+        findFirst: jest.fn().mockResolvedValue({
+          id: "po-1",
+          status: PurchaseOrderStatus.PARTIALLY_RECEIVED,
+          orderNumber: "PO-00001",
+          items: [
+            {
+              id: "poi-1",
+              stockItemId: "stock-1",
+              quantityReceived: "5",
+              unitPrice: "5",
+            },
+          ],
+        }),
+        update: jest.fn().mockResolvedValue({}),
+      },
+      // FIFO already consumed 2 of the 5 → only 3 remain on hand.
+      stockBatch: {
+        findMany: jest
+          .fn()
+          .mockResolvedValue([{ id: "batch-1", quantity: "3" }]),
+        updateMany: jest.fn().mockResolvedValue({ count: 1 }),
+      },
+      stockItem: { update: jest.fn().mockResolvedValue({}) },
+      ingredientMovement: { create: jest.fn().mockResolvedValue({}) },
+      purchaseOrderItem: { update: jest.fn().mockResolvedValue({}) },
+    };
+    (prisma.$transaction as any).mockImplementation(
+      async (cb: any, _opts: any) => cb(txMock),
+    );
+
+    await svc.cancel("po-1", SCOPE, "user-1");
+
+    // The PO is re-claimed inside the txn (not trusting the outer snapshot).
+    expect(txMock.purchaseOrder.findFirst).toHaveBeenCalledTimes(1);
+
+    // Stock is decremented by the REMAINING 3, never the gross 5.
+    expect(
+      txMock.stockItem.update.mock.calls[0][0].data.currentStock.decrement.toString(),
+    ).toBe("3");
+
+    // The reversal movement records the actual reversed qty (-3).
+    expect(
+      txMock.ingredientMovement.create.mock.calls[0][0].data.quantity.toString(),
+    ).toBe("-3");
+
+    // Serializable isolation is requested (write-vs-write race → 40001).
+    const opts = (prisma.$transaction as any).mock.calls[0][1];
+    expect(opts.isolationLevel).toBe("Serializable");
+  });
+
+  it("skips stock reversal entirely when no batch quantity remains", async () => {
+    (prisma.purchaseOrder.findFirst as any).mockResolvedValue({
+      id: "po-1",
+      tenantId: "t1",
+      branchId: "b1",
+      status: PurchaseOrderStatus.PARTIALLY_RECEIVED,
+      orderNumber: "PO-00001",
+      items: [
+        {
+          id: "poi-1",
+          stockItemId: "stock-1",
+          quantityReceived: "5",
+          unitPrice: "5",
+        },
+      ],
+    });
+
+    const txMock: any = {
+      purchaseOrder: {
+        findFirst: jest.fn().mockResolvedValue({
+          id: "po-1",
+          status: PurchaseOrderStatus.PARTIALLY_RECEIVED,
+          orderNumber: "PO-00001",
+          items: [
+            {
+              id: "poi-1",
+              stockItemId: "stock-1",
+              quantityReceived: "5",
+              unitPrice: "5",
+            },
+          ],
+        }),
+        update: jest.fn().mockResolvedValue({}),
+      },
+      // Fully consumed by FIFO — nothing left to reverse.
+      stockBatch: {
+        findMany: jest
+          .fn()
+          .mockResolvedValue([{ id: "batch-1", quantity: "0" }]),
+        updateMany: jest.fn(),
+      },
+      stockItem: { update: jest.fn() },
+      ingredientMovement: { create: jest.fn() },
+      purchaseOrderItem: { update: jest.fn().mockResolvedValue({}) },
+    };
+    (prisma.$transaction as any).mockImplementation(
+      async (cb: any, _opts: any) => cb(txMock),
+    );
+
+    await svc.cancel("po-1", SCOPE, "user-1");
+
+    // No phantom decrement / movement when remaining is zero.
+    expect(txMock.stockItem.update).not.toHaveBeenCalled();
+    expect(txMock.ingredientMovement.create).not.toHaveBeenCalled();
+    // quantityReceived is still cleared so the PO can't be re-cancelled into stock.
+    expect(txMock.purchaseOrderItem.update).toHaveBeenCalled();
   });
 });

--- a/backend/src/modules/stock-management/services/purchase-orders.service.ts
+++ b/backend/src/modules/stock-management/services/purchase-orders.service.ts
@@ -402,6 +402,10 @@ export class PurchaseOrdersService {
    * warning and left stock inflated forever.
    */
   async cancel(id: string, scope: BranchScope, userId?: string) {
+    // Cheap pre-flight rejection so the obvious "wrong status" case
+    // doesn't burn a Serializable txn — the in-txn re-claim below is
+    // what actually guards the race. findOne is branch-fenced, so a
+    // cross-branch PO id is rejected before any stock is mutated.
     const po = await this.findOne(id, scope);
     if (
       po.status === PurchaseOrderStatus.RECEIVED ||
@@ -412,51 +416,103 @@ export class PurchaseOrdersService {
       );
     }
 
-    return this.prisma.$transaction(async (tx) => {
-      for (const item of po.items) {
-        const received = new Prisma.Decimal(item.quantityReceived);
-        if (received.lte(0)) continue;
+    // deep-review M18: mirror receive(). The prior implementation
+    // reversed stock from the OUTSIDE-txn findOne snapshot under the
+    // default READ COMMITTED isolation. Two failure modes:
+    //   (1) a receive() that committed between findOne and this txn was
+    //       invisible — cancel decremented currentStock by the stale
+    //       (smaller) quantityReceived yet zeroed ALL batches, leaving
+    //       stock inflated / batches wrongly nulled; and
+    //   (2) even with no concurrency, batches already partially consumed
+    //       by FIFO deduction were force-zeroed and the gross
+    //       quantityReceived was decremented — double-counting the
+    //       consumption and potentially driving stock negative.
+    // Fix: run under Serializable, re-read the PO/items/batches INSIDE
+    // the txn, and reverse only the un-consumed batch remainder.
+    return this.prisma.$transaction(
+      async (tx) => {
+        // Re-claim the PO inside the txn so a receive that committed
+        // after the outer findOne is observed, and a concurrent cancel
+        // can't double-reverse.
+        const claimed = await tx.purchaseOrder.findFirst({
+          where: { id, ...branchScope(scope) },
+          include: { items: true },
+        });
+        if (!claimed) throw new NotFoundException("Purchase order not found");
+        if (
+          claimed.status === PurchaseOrderStatus.RECEIVED ||
+          claimed.status === PurchaseOrderStatus.CANCELLED
+        ) {
+          throw new BadRequestException(
+            `Cannot cancel a purchase order with status "${claimed.status}".`,
+          );
+        }
 
-        await tx.stockItem.update({
-          where: { id: item.stockItemId },
-          data: { currentStock: { decrement: received as any } },
-        });
-        await tx.stockBatch.updateMany({
-          where: { purchaseOrderItemId: item.id },
-          data: { quantity: 0 as any },
-        });
-        await tx.ingredientMovement.create({
-          data: {
-            type: IngredientMovementType.PO_CANCEL_REVERSAL,
-            quantity: received.neg() as any,
-            costPerUnit: item.unitPrice,
-            notes: `PO ${po.orderNumber} cancelled — reversing received stock`,
-            referenceType: "PURCHASE_ORDER",
-            referenceId: po.id,
-            stockItemId: item.stockItemId,
-            branchId: scope.branchId,
-            tenantId: scope.tenantId,
-            createdById: userId,
-          },
-        });
-        await tx.purchaseOrderItem.update({
-          where: { id: item.id },
-          data: { quantityReceived: 0 as any },
-        });
-      }
+        for (const item of claimed.items) {
+          const received = new Prisma.Decimal(item.quantityReceived);
+          if (received.lte(0)) continue;
 
-      return tx.purchaseOrder.update({
-        where: { id },
-        data: { status: PurchaseOrderStatus.CANCELLED },
-        include: {
-          supplier: { select: { id: true, name: true } },
-          items: {
-            include: {
-              stockItem: { select: { id: true, name: true, unit: true } },
+          // Reverse only what is still on hand in this PO's batches —
+          // FIFO may have already consumed part of them. Sum the
+          // remaining batch quantity and zero only that, so currentStock
+          // is decremented by the actually-reversible amount, never
+          // below what consumption already removed.
+          const batches = await tx.stockBatch.findMany({
+            where: { purchaseOrderItemId: item.id },
+          });
+          const remaining = batches.reduce(
+            (acc, b) => acc.add(new Prisma.Decimal(b.quantity)),
+            new Prisma.Decimal(0),
+          );
+          if (remaining.gt(0)) {
+            await tx.stockItem.update({
+              where: { id: item.stockItemId },
+              data: { currentStock: { decrement: remaining as any } },
+            });
+            await tx.stockBatch.updateMany({
+              where: { purchaseOrderItemId: item.id },
+              data: { quantity: 0 as any },
+            });
+            await tx.ingredientMovement.create({
+              data: {
+                type: IngredientMovementType.PO_CANCEL_REVERSAL,
+                // Record the actual reversed qty, not the gross received.
+                quantity: remaining.neg() as any,
+                costPerUnit: item.unitPrice,
+                notes: `PO ${claimed.orderNumber} cancelled — reversing un-consumed received stock`,
+                referenceType: "PURCHASE_ORDER",
+                referenceId: claimed.id,
+                stockItemId: item.stockItemId,
+                branchId: scope.branchId,
+                tenantId: scope.tenantId,
+                createdById: userId,
+              },
+            });
+          }
+          await tx.purchaseOrderItem.update({
+            where: { id: item.id },
+            data: { quantityReceived: 0 as any },
+          });
+        }
+
+        return tx.purchaseOrder.update({
+          where: { id },
+          data: { status: PurchaseOrderStatus.CANCELLED },
+          include: {
+            supplier: { select: { id: true, name: true } },
+            items: {
+              include: {
+                stockItem: { select: { id: true, name: true, unit: true } },
+              },
             },
           },
-        },
-      });
-    });
+        });
+      },
+      // Mirrors receive(): the reversal's read-modify-write on
+      // quantityReceived / currentStock / batches races a concurrent
+      // receive. Serializable promotes the write-vs-write race into a
+      // 40001 that Prisma retries against a fresh snapshot.
+      { isolationLevel: Prisma.TransactionIsolationLevel.Serializable },
+    );
   }
 }

--- a/backend/src/modules/stock-management/services/recipes.service.spec.ts
+++ b/backend/src/modules/stock-management/services/recipes.service.spec.ts
@@ -1,5 +1,5 @@
-import { BadRequestException } from '@nestjs/common';
-import { RecipesService } from './recipes.service';
+import { BadRequestException } from "@nestjs/common";
+import { RecipesService } from "./recipes.service";
 
 /**
  * Iter-93 regression for the recipes service. Pre-fix:
@@ -18,86 +18,95 @@ import { RecipesService } from './recipes.service';
  * "first wins") and paginates findAll behind a default-500, cap-2000
  * window.
  */
-describe('RecipesService (iter-93)', () => {
+describe("RecipesService (iter-93)", () => {
   // v3 branch-scope: read/update/remove/checkStock take a BranchScope.
   // branchScope(scope) fences every where on (tenantId, branchId).
   const SCOPE = {
-    tenantId: 't1',
-    branchId: 'b1',
-    userId: 'u1',
-    role: 'ADMIN',
+    tenantId: "t1",
+    branchId: "b1",
+    userId: "u1",
+    role: "ADMIN",
   } as const;
   const validIngredient = (stockItemId: string, qty: number = 1) => ({
     stockItemId,
     quantity: qty,
   });
 
-  describe('create — duplicate-ingredient guard', () => {
+  describe("create — duplicate-ingredient guard", () => {
     let prisma: any;
     let svc: RecipesService;
 
     beforeEach(() => {
       prisma = {
-        product: { findFirst: jest.fn().mockResolvedValue({ id: 'p1', tenantId: 't1', name: 'Burger' }) },
+        product: {
+          findFirst: jest
+            .fn()
+            .mockResolvedValue({ id: "p1", tenantId: "t1", name: "Burger" }),
+        },
         // v3 branch-scope: the existing-recipe guard now keys on the
         // compound (productId, branchId) via findUnique, so the mock must
         // expose findUnique (null = no recipe yet for this product+branch).
-        recipe: { findUnique: jest.fn().mockResolvedValue(null), create: jest.fn() },
+        recipe: {
+          findUnique: jest.fn().mockResolvedValue(null),
+          create: jest.fn(),
+        },
         stockItem: { findMany: jest.fn() },
       };
       svc = new RecipesService(prisma);
     });
 
-    it('rejects two ingredient entries for the same stockItemId', async () => {
+    it("rejects two ingredient entries for the same stockItemId", async () => {
       await expect(
         svc.create(
           {
-            productId: 'p1',
+            productId: "p1",
             ingredients: [
-              validIngredient('flour-uuid', 200),
-              validIngredient('flour-uuid', 100),
+              validIngredient("flour-uuid", 200),
+              validIngredient("flour-uuid", 100),
             ],
           } as any,
-          't1',
-          'b1',
+          "t1",
+          "b1",
         ),
       ).rejects.toBeInstanceOf(BadRequestException);
       // Never reach the DB writes.
       expect(prisma.recipe.create).not.toHaveBeenCalled();
     });
 
-    it('mentions the offending stockItemId in the error message', async () => {
+    it("mentions the offending stockItemId in the error message", async () => {
       await expect(
         svc.create(
           {
-            productId: 'p1',
+            productId: "p1",
             ingredients: [
-              validIngredient('butter-uuid', 50),
-              validIngredient('butter-uuid', 50),
+              validIngredient("butter-uuid", 50),
+              validIngredient("butter-uuid", 50),
             ],
           } as any,
-          't1',
-          'b1',
+          "t1",
+          "b1",
         ),
       ).rejects.toThrow(/butter-uuid/);
     });
 
-    it('accepts a recipe with all distinct ingredients (happy path)', async () => {
+    it("accepts a recipe with all distinct ingredients (happy path)", async () => {
       prisma.stockItem.findMany.mockResolvedValue([
-        { id: 'flour' }, { id: 'butter' }, { id: 'sugar' },
+        { id: "flour" },
+        { id: "butter" },
+        { id: "sugar" },
       ]);
-      prisma.recipe.create.mockResolvedValue({ id: 'r1' });
+      prisma.recipe.create.mockResolvedValue({ id: "r1" });
       await svc.create(
         {
-          productId: 'p1',
+          productId: "p1",
           ingredients: [
-            validIngredient('flour', 200),
-            validIngredient('butter', 50),
-            validIngredient('sugar', 30),
+            validIngredient("flour", 200),
+            validIngredient("butter", 50),
+            validIngredient("sugar", 30),
           ],
         } as any,
-        't1',
-        'b1',
+        "t1",
+        "b1",
       );
       expect(prisma.recipe.create).toHaveBeenCalledTimes(1);
     });
@@ -107,60 +116,117 @@ describe('RecipesService (iter-93)', () => {
      * BRANCH (@@unique([productId, branchId])). The existing-recipe guard
      * keys on the compound (productId, branchId).
      */
-    it('existing-recipe guard keys on the compound (productId, branchId)', async () => {
-      prisma.stockItem.findMany.mockResolvedValue([{ id: 'flour' }]);
-      prisma.recipe.create.mockResolvedValue({ id: 'r1' });
+    it("existing-recipe guard keys on the compound (productId, branchId)", async () => {
+      prisma.stockItem.findMany.mockResolvedValue([{ id: "flour" }]);
+      prisma.recipe.create.mockResolvedValue({ id: "r1" });
 
       await svc.create(
-        { productId: 'p1', ingredients: [validIngredient('flour', 100)] } as any,
-        't1',
-        'b1',
+        {
+          productId: "p1",
+          ingredients: [validIngredient("flour", 100)],
+        } as any,
+        "t1",
+        "b1",
       );
 
       expect(prisma.recipe.findUnique).toHaveBeenCalledWith({
-        where: { productId_branchId: { productId: 'p1', branchId: 'b1' } },
+        where: { productId_branchId: { productId: "p1", branchId: "b1" } },
       });
     });
 
-    it('same product in a DIFFERENT branch is ALLOWED (per-branch recipe)', async () => {
+    it("same product in a DIFFERENT branch is ALLOWED (per-branch recipe)", async () => {
       // Branch b1 already has a recipe for p1; branch b2 has none. The
       // compound-key guard returns null for b2, so the create proceeds.
       prisma.recipe.findUnique.mockImplementation(async ({ where }: any) => {
-        return where.productId_branchId.branchId === 'b1'
-          ? { id: 'r-b1', productId: 'p1', branchId: 'b1' }
+        return where.productId_branchId.branchId === "b1"
+          ? { id: "r-b1", productId: "p1", branchId: "b1" }
           : null;
       });
-      prisma.stockItem.findMany.mockResolvedValue([{ id: 'flour' }]);
-      prisma.recipe.create.mockResolvedValue({ id: 'r-b2' });
+      prisma.stockItem.findMany.mockResolvedValue([{ id: "flour" }]);
+      prisma.recipe.create.mockResolvedValue({ id: "r-b2" });
 
       await svc.create(
-        { productId: 'p1', ingredients: [validIngredient('flour', 100)] } as any,
-        't1',
-        'b2',
+        {
+          productId: "p1",
+          ingredients: [validIngredient("flour", 100)],
+        } as any,
+        "t1",
+        "b2",
       );
 
       expect(prisma.recipe.create).toHaveBeenCalledTimes(1);
       const created = prisma.recipe.create.mock.calls[0][0].data;
-      expect(created.branchId).toBe('b2');
-      expect(created.productId).toBe('p1');
+      expect(created.branchId).toBe("b2");
+      expect(created.productId).toBe("p1");
     });
 
-    it('same product in the SAME branch is rejected', async () => {
-      const { ConflictException } = require('@nestjs/common');
-      prisma.recipe.findUnique.mockResolvedValue({ id: 'r-b1', productId: 'p1', branchId: 'b1' });
+    /**
+     * deep-review H12: the stock-item existence check on create MUST be
+     * branch-scoped. Pre-fix it filtered only on tenantId, so a recipe
+     * could reference another branch's stock item — and order deduction
+     * would then drive down the WRONG branch's stock. The findMany WHERE
+     * must carry branchId so a cross-branch ingredient is rejected.
+     */
+    it("scopes the stock-item existence check to the recipe branch (H12)", async () => {
+      prisma.stockItem.findMany.mockResolvedValue([{ id: "flour" }]);
+      prisma.recipe.create.mockResolvedValue({ id: "r1" });
+
+      await svc.create(
+        {
+          productId: "p1",
+          ingredients: [validIngredient("flour", 100)],
+        } as any,
+        "t1",
+        "b1",
+      );
+
+      expect(prisma.stockItem.findMany.mock.calls[0][0].where).toEqual({
+        id: { in: ["flour"] },
+        tenantId: "t1",
+        branchId: "b1",
+      });
+    });
+
+    it("rejects an ingredient that belongs to another branch (H12)", async () => {
+      // The cross-branch stock item is not returned by the branch-scoped
+      // findMany, so the length check fails and create is rejected.
+      prisma.stockItem.findMany.mockResolvedValue([]); // none in branch b1
+      await expect(
+        svc.create(
+          {
+            productId: "p1",
+            ingredients: [validIngredient("flour-from-b2", 100)],
+          } as any,
+          "t1",
+          "b1",
+        ),
+      ).rejects.toBeInstanceOf(BadRequestException);
+      expect(prisma.recipe.create).not.toHaveBeenCalled();
+    });
+
+    it("same product in the SAME branch is rejected", async () => {
+      const { ConflictException } = require("@nestjs/common");
+      prisma.recipe.findUnique.mockResolvedValue({
+        id: "r-b1",
+        productId: "p1",
+        branchId: "b1",
+      });
 
       await expect(
         svc.create(
-          { productId: 'p1', ingredients: [validIngredient('flour', 100)] } as any,
-          't1',
-          'b1',
+          {
+            productId: "p1",
+            ingredients: [validIngredient("flour", 100)],
+          } as any,
+          "t1",
+          "b1",
         ),
       ).rejects.toBeInstanceOf(ConflictException);
       expect(prisma.recipe.create).not.toHaveBeenCalled();
     });
   });
 
-  describe('update — duplicate-ingredient guard', () => {
+  describe("update — duplicate-ingredient guard", () => {
     let prisma: any;
     let svc: RecipesService;
 
@@ -168,7 +234,7 @@ describe('RecipesService (iter-93)', () => {
       const txMock = {
         recipe: {
           updateMany: jest.fn().mockResolvedValue({ count: 1 }),
-          findUnique: jest.fn().mockResolvedValue({ id: 'r1' }),
+          findUnique: jest.fn().mockResolvedValue({ id: "r1" }),
         },
         recipeIngredient: {
           deleteMany: jest.fn().mockResolvedValue({ count: 0 }),
@@ -179,27 +245,29 @@ describe('RecipesService (iter-93)', () => {
       prisma = {
         recipe: {
           findFirst: jest.fn().mockResolvedValue({
-            id: 'r1',
-            tenantId: 't1',
-            productId: 'p1',
-            name: 'Burger',
+            id: "r1",
+            tenantId: "t1",
+            productId: "p1",
+            name: "Burger",
             ingredients: [],
-            product: { id: 'p1', name: 'Burger' },
+            product: { id: "p1", name: "Burger" },
           }),
         },
-        $transaction: jest.fn().mockImplementation(async (fn: any) => fn(txMock)),
+        $transaction: jest
+          .fn()
+          .mockImplementation(async (fn: any) => fn(txMock)),
       };
       svc = new RecipesService(prisma);
     });
 
-    it('rejects duplicate ingredients on update', async () => {
+    it("rejects duplicate ingredients on update", async () => {
       await expect(
         svc.update(
-          'r1',
+          "r1",
           {
             ingredients: [
-              validIngredient('flour-uuid', 200),
-              validIngredient('flour-uuid', 100),
+              validIngredient("flour-uuid", 200),
+              validIngredient("flour-uuid", 100),
             ],
           } as any,
           SCOPE,
@@ -207,18 +275,18 @@ describe('RecipesService (iter-93)', () => {
       ).rejects.toBeInstanceOf(BadRequestException);
     });
 
-    it('allows omitting the ingredients array entirely (metadata-only update)', async () => {
+    it("allows omitting the ingredients array entirely (metadata-only update)", async () => {
       // Metadata-only update should still go through the txn but never
       // touch the dedup gate.
-      await svc.update('r1', { name: 'New name' } as any, SCOPE);
+      await svc.update("r1", { name: "New name" } as any, SCOPE);
       expect(prisma.$transaction).toHaveBeenCalled();
     });
 
-    it('fences both the pre-check read and the mutation on (tenantId, branchId)', async () => {
+    it("fences both the pre-check read and the mutation on (tenantId, branchId)", async () => {
       const txMock = {
         recipe: {
           updateMany: jest.fn().mockResolvedValue({ count: 1 }),
-          findUnique: jest.fn().mockResolvedValue({ id: 'r1' }),
+          findUnique: jest.fn().mockResolvedValue({ id: "r1" }),
         },
         recipeIngredient: {
           deleteMany: jest.fn(),
@@ -227,52 +295,54 @@ describe('RecipesService (iter-93)', () => {
         stockItem: { findMany: jest.fn().mockResolvedValue([]) },
       };
       const findFirst = jest.fn().mockResolvedValue({
-        id: 'r1',
-        productId: 'p1',
-        name: 'Burger',
+        id: "r1",
+        productId: "p1",
+        name: "Burger",
         ingredients: [],
-        product: { id: 'p1', name: 'Burger' },
+        product: { id: "p1", name: "Burger" },
       });
       const localPrisma: any = {
         recipe: { findFirst },
-        $transaction: jest.fn().mockImplementation(async (fn: any) => fn(txMock)),
+        $transaction: jest
+          .fn()
+          .mockImplementation(async (fn: any) => fn(txMock)),
       };
       const localSvc = new RecipesService(localPrisma);
 
-      await localSvc.update('r1', { name: 'New name' } as any, SCOPE);
+      await localSvc.update("r1", { name: "New name" } as any, SCOPE);
 
       // findOne pre-check is branch-fenced.
       expect(findFirst.mock.calls[0][0].where).toEqual({
-        id: 'r1',
-        tenantId: 't1',
-        branchId: 'b1',
+        id: "r1",
+        tenantId: "t1",
+        branchId: "b1",
       });
       // The mutation's own WHERE is branch-fenced (defence-in-depth IDOR).
       expect(txMock.recipe.updateMany.mock.calls[0][0].where).toEqual({
-        id: 'r1',
-        tenantId: 't1',
-        branchId: 'b1',
+        id: "r1",
+        tenantId: "t1",
+        branchId: "b1",
       });
     });
 
-    it('does NOT mutate a cross-branch recipe id (findOne fence → NotFound)', async () => {
+    it("does NOT mutate a cross-branch recipe id (findOne fence → NotFound)", async () => {
       const findFirst = jest.fn().mockResolvedValue(null); // wrong-branch id
       const localPrisma: any = {
         recipe: { findFirst },
         $transaction: jest.fn(),
       };
       const localSvc = new RecipesService(localPrisma);
-      const { NotFoundException } = require('@nestjs/common');
+      const { NotFoundException } = require("@nestjs/common");
 
       await expect(
-        localSvc.update('cross-branch-id', { name: 'X' } as any, SCOPE),
+        localSvc.update("cross-branch-id", { name: "X" } as any, SCOPE),
       ).rejects.toBeInstanceOf(NotFoundException);
       // The mutating transaction must never run for a cross-branch id.
       expect(localPrisma.$transaction).not.toHaveBeenCalled();
     });
   });
 
-  describe('findAll — pagination', () => {
+  describe("findAll — pagination", () => {
     let prisma: any;
     let svc: RecipesService;
 
@@ -283,35 +353,35 @@ describe('RecipesService (iter-93)', () => {
       svc = new RecipesService(prisma);
     });
 
-    it('applies a 500-row default take when no pagination passed', async () => {
+    it("applies a 500-row default take when no pagination passed", async () => {
       await svc.findAll(SCOPE);
       const call = prisma.recipe.findMany.mock.calls[0][0];
       expect(call.take).toBe(500);
       expect(call.skip).toBe(0);
     });
 
-    it('caps take at the 2000 hard max', async () => {
+    it("caps take at the 2000 hard max", async () => {
       await svc.findAll(SCOPE, { limit: 50_000 });
       const call = prisma.recipe.findMany.mock.calls[0][0];
       expect(call.take).toBe(2000);
     });
 
-    it('forwards a custom limit/offset within the cap', async () => {
+    it("forwards a custom limit/offset within the cap", async () => {
       await svc.findAll(SCOPE, { limit: 100, offset: 200 });
       const call = prisma.recipe.findMany.mock.calls[0][0];
       expect(call.take).toBe(100);
       expect(call.skip).toBe(200);
     });
 
-    it('fences the list read on (tenantId, branchId)', async () => {
+    it("fences the list read on (tenantId, branchId)", async () => {
       await svc.findAll(SCOPE);
       const where = prisma.recipe.findMany.mock.calls[0][0].where;
-      expect(where.tenantId).toBe('t1');
-      expect(where.branchId).toBe('b1');
+      expect(where.tenantId).toBe("t1");
+      expect(where.branchId).toBe("b1");
     });
   });
 
-  describe('findOne / findByProduct — branch fence', () => {
+  describe("findOne / findByProduct — branch fence", () => {
     let prisma: any;
     let svc: RecipesService;
 
@@ -320,37 +390,37 @@ describe('RecipesService (iter-93)', () => {
       svc = new RecipesService(prisma);
     });
 
-    it('findOne scopes by id + (tenantId, branchId)', async () => {
-      prisma.recipe.findFirst.mockResolvedValue({ id: 'r1', ingredients: [] });
-      await svc.findOne('r1', SCOPE);
+    it("findOne scopes by id + (tenantId, branchId)", async () => {
+      prisma.recipe.findFirst.mockResolvedValue({ id: "r1", ingredients: [] });
+      await svc.findOne("r1", SCOPE);
       expect(prisma.recipe.findFirst.mock.calls[0][0].where).toEqual({
-        id: 'r1',
-        tenantId: 't1',
-        branchId: 'b1',
+        id: "r1",
+        tenantId: "t1",
+        branchId: "b1",
       });
     });
 
-    it('findOne throws NotFound for a cross-branch id (fence returns null)', async () => {
+    it("findOne throws NotFound for a cross-branch id (fence returns null)", async () => {
       prisma.recipe.findFirst.mockResolvedValue(null);
-      const { NotFoundException } = require('@nestjs/common');
-      await expect(svc.findOne('cross-branch', SCOPE)).rejects.toBeInstanceOf(
+      const { NotFoundException } = require("@nestjs/common");
+      await expect(svc.findOne("cross-branch", SCOPE)).rejects.toBeInstanceOf(
         NotFoundException,
       );
     });
 
-    it('findByProduct scopes by productId + (tenantId, branchId)', async () => {
-      prisma.recipe.findFirst.mockResolvedValue({ id: 'r1', ingredients: [] });
-      await svc.findByProduct('p1', SCOPE);
+    it("findByProduct scopes by productId + (tenantId, branchId)", async () => {
+      prisma.recipe.findFirst.mockResolvedValue({ id: "r1", ingredients: [] });
+      await svc.findByProduct("p1", SCOPE);
       expect(prisma.recipe.findFirst.mock.calls[0][0].where).toEqual({
-        productId: 'p1',
-        tenantId: 't1',
-        branchId: 'b1',
+        productId: "p1",
+        tenantId: "t1",
+        branchId: "b1",
       });
     });
   });
 
-  describe('remove — branch fence', () => {
-    it('does NOT delete a cross-branch recipe id (findOne fence → NotFound)', async () => {
+  describe("remove — branch fence", () => {
+    it("does NOT delete a cross-branch recipe id (findOne fence → NotFound)", async () => {
       const prisma: any = {
         recipe: {
           findFirst: jest.fn().mockResolvedValue(null),
@@ -358,28 +428,28 @@ describe('RecipesService (iter-93)', () => {
         },
       };
       const svc = new RecipesService(prisma);
-      const { NotFoundException } = require('@nestjs/common');
-      await expect(svc.remove('cross-branch', SCOPE)).rejects.toBeInstanceOf(
+      const { NotFoundException } = require("@nestjs/common");
+      await expect(svc.remove("cross-branch", SCOPE)).rejects.toBeInstanceOf(
         NotFoundException,
       );
       expect(prisma.recipe.deleteMany).not.toHaveBeenCalled();
     });
 
-    it('deletes via a branch-fenced deleteMany when the recipe is in-branch', async () => {
+    it("deletes via a branch-fenced deleteMany when the recipe is in-branch", async () => {
       const prisma: any = {
         recipe: {
           findFirst: jest
             .fn()
-            .mockResolvedValue({ id: 'r1', name: 'Burger', productId: 'p1' }),
+            .mockResolvedValue({ id: "r1", name: "Burger", productId: "p1" }),
           deleteMany: jest.fn().mockResolvedValue({ count: 1 }),
         },
       };
       const svc = new RecipesService(prisma);
-      await svc.remove('r1', SCOPE);
+      await svc.remove("r1", SCOPE);
       expect(prisma.recipe.deleteMany.mock.calls[0][0].where).toEqual({
-        id: 'r1',
-        tenantId: 't1',
-        branchId: 'b1',
+        id: "r1",
+        tenantId: "t1",
+        branchId: "b1",
       });
     });
   });

--- a/backend/src/modules/stock-management/services/recipes.service.ts
+++ b/backend/src/modules/stock-management/services/recipes.service.ts
@@ -146,10 +146,16 @@ export class RecipesService {
         "A recipe already exists for this product in this branch",
       );
 
-    // Verify all stock items exist
+    // deep-review H12: scope the stock-item existence check to the
+    // recipe's branch (mirrors update() and PO create). A recipe whose
+    // ingredient referenced another branch's stock item would, on order
+    // deduction, drive down the WRONG branch's stock/batches/cost basis
+    // — silent cross-branch inventory corruption. Filtering on branchId
+    // here makes the length check below reject any ingredient not in the
+    // recipe's branch.
     const stockItemIds = dto.ingredients.map((i) => i.stockItemId);
     const stockItems = await this.prisma.stockItem.findMany({
-      where: { id: { in: stockItemIds }, tenantId },
+      where: { id: { in: stockItemIds }, tenantId, branchId },
     });
     if (stockItems.length !== stockItemIds.length) {
       throw new BadRequestException("One or more stock items not found");

--- a/backend/src/modules/subscriptions/services/subscription-metrics.spec.ts
+++ b/backend/src/modules/subscriptions/services/subscription-metrics.spec.ts
@@ -33,7 +33,9 @@ describe("SubscriptionService — subscription_billing_total counter", () => {
     metrics = { incCounter: jest.fn() };
     const notifications = {
       sendTrialStarted: jest.fn().mockResolvedValue(undefined),
-      sendSubscriptionCancelledImmediate: jest.fn().mockResolvedValue(undefined),
+      sendSubscriptionCancelledImmediate: jest
+        .fn()
+        .mockResolvedValue(undefined),
       sendSubscriptionWillCancel: jest.fn().mockResolvedValue(undefined),
       sendPlanChangeConfirmation: jest.fn().mockResolvedValue(undefined),
     } as any;
@@ -80,12 +82,16 @@ describe("SubscriptionService — subscription_billing_total counter", () => {
       role: "ADMIN",
       emailVerified: true,
     } as any);
+    // deep-review H3: createSubscription only creates TRIALING or FREE rows
+    // (paid activation goes through settlement). Use a trial-eligible PRO
+    // plan so this is a valid TRIALING creation that still records the
+    // billing-event metric.
     prisma.subscriptionPlan.findUnique.mockResolvedValue({
       id: "plan-pro",
       name: "PRO",
       displayName: "Pro",
       isActive: true,
-      trialDays: 0,
+      trialDays: 14,
       monthlyPrice: new Prisma.Decimal(100),
       yearlyPrice: new Prisma.Decimal(1000),
       currency: "TRY",

--- a/backend/src/modules/subscriptions/services/subscription.service.spec.ts
+++ b/backend/src/modules/subscriptions/services/subscription.service.spec.ts
@@ -1,9 +1,12 @@
-import { BadRequestException, NotFoundException } from '@nestjs/common';
-import { SubscriptionService } from './subscription.service';
-import { BillingService } from './billing.service';
-import { NotificationService } from './notification.service';
-import { mockPrismaClient, MockPrismaClient } from '../../../common/test/prisma-mock.service';
-import { BillingCycle } from '../../../common/constants/subscription.enum';
+import { BadRequestException, NotFoundException } from "@nestjs/common";
+import { SubscriptionService } from "./subscription.service";
+import { BillingService } from "./billing.service";
+import { NotificationService } from "./notification.service";
+import {
+  mockPrismaClient,
+  MockPrismaClient,
+} from "../../../common/test/prisma-mock.service";
+import { BillingCycle } from "../../../common/constants/subscription.enum";
 
 /**
  * Unit tests for the trial-creation paths. We mock Prisma (deep mock from
@@ -12,23 +15,23 @@ import { BillingCycle } from '../../../common/constants/subscription.enum';
  * atomicity is covered by the e2e suite; here we just verify the
  * decision-tree (eligibility, P2002 mapping, side-effects on tenant row).
  */
-describe('SubscriptionService.startTrialFromIntent', () => {
+describe("SubscriptionService.startTrialFromIntent", () => {
   let prisma: MockPrismaClient;
   let billing: jest.Mocked<BillingService>;
   let notifications: jest.Mocked<NotificationService>;
   let svc: SubscriptionService;
 
-  const PLAN_ID = 'plan-pro';
-  const TENANT_ID = 'tenant-1';
-  const USER_ID = 'user-1';
+  const PLAN_ID = "plan-pro";
+  const TENANT_ID = "tenant-1";
+  const USER_ID = "user-1";
 
   const proPlan = {
     id: PLAN_ID,
-    name: 'PRO',
-    displayName: 'Profesyonel',
-    monthlyPrice: '1299' as any,
-    yearlyPrice: '12990' as any,
-    currency: 'TRY',
+    name: "PRO",
+    displayName: "Profesyonel",
+    monthlyPrice: "1299" as any,
+    yearlyPrice: "12990" as any,
+    currency: "TRY",
     trialDays: 14,
     isActive: true,
   } as any;
@@ -43,7 +46,7 @@ describe('SubscriptionService.startTrialFromIntent', () => {
       prisma as any,
       billing,
       notifications,
-      { append: jest.fn().mockResolvedValue('outbox-id') } as any,
+      { append: jest.fn().mockResolvedValue("outbox-id") } as any,
       // v2.8.88: EntitlementService stub. Default returns an empty set
       // so existing tests (which don't care about engine routing)
       // continue to hit the plan-only fallback branch.
@@ -66,7 +69,7 @@ describe('SubscriptionService.startTrialFromIntent', () => {
     prisma.$transaction.mockImplementation(async (fn: any) => fn(prisma));
   });
 
-  it('throws NotFoundException when calling user does not exist', async () => {
+  it("throws NotFoundException when calling user does not exist", async () => {
     prisma.user.findUnique.mockResolvedValue(null);
     await expect(
       svc.startTrialFromIntent({
@@ -78,7 +81,7 @@ describe('SubscriptionService.startTrialFromIntent', () => {
     ).rejects.toBeInstanceOf(NotFoundException);
   });
 
-  it('throws BadRequestException when calling user email not verified', async () => {
+  it("throws BadRequestException when calling user email not verified", async () => {
     prisma.user.findUnique.mockResolvedValue({ emailVerified: false } as any);
     await expect(
       svc.startTrialFromIntent({
@@ -90,7 +93,7 @@ describe('SubscriptionService.startTrialFromIntent', () => {
     ).rejects.toBeInstanceOf(BadRequestException);
   });
 
-  it('throws NotFoundException when plan is missing or inactive', async () => {
+  it("throws NotFoundException when plan is missing or inactive", async () => {
     prisma.subscriptionPlan.findUnique.mockResolvedValue(null);
     await expect(
       svc.startTrialFromIntent({
@@ -102,10 +105,10 @@ describe('SubscriptionService.startTrialFromIntent', () => {
     ).rejects.toBeInstanceOf(NotFoundException);
   });
 
-  it('rejects starting a trial on the FREE plan', async () => {
+  it("rejects starting a trial on the FREE plan", async () => {
     prisma.subscriptionPlan.findUnique.mockResolvedValue({
       ...proPlan,
-      name: 'FREE',
+      name: "FREE",
     } as any);
     await expect(
       svc.startTrialFromIntent({
@@ -117,7 +120,7 @@ describe('SubscriptionService.startTrialFromIntent', () => {
     ).rejects.toBeInstanceOf(BadRequestException);
   });
 
-  it('rejects starting a trial on a plan without trialDays', async () => {
+  it("rejects starting a trial on a plan without trialDays", async () => {
     prisma.subscriptionPlan.findUnique.mockResolvedValue({
       ...proPlan,
       trialDays: 0,
@@ -132,7 +135,7 @@ describe('SubscriptionService.startTrialFromIntent', () => {
     ).rejects.toBeInstanceOf(BadRequestException);
   });
 
-  it('rejects re-trialing once the tenant has already used any trial (lifetime gate)', async () => {
+  it("rejects re-trialing once the tenant has already used any trial (lifetime gate)", async () => {
     // Trial eligibility moved from per-plan (`usedTrialPlanIds`) to a
     // lifetime per-tenant flag (`trialUsed`). The historical row is
     // still kept for audit but `trialUsed=true` is the canonical gate.
@@ -150,12 +153,12 @@ describe('SubscriptionService.startTrialFromIntent', () => {
     ).rejects.toBeInstanceOf(BadRequestException);
   });
 
-  it('rejects starting a trial when tenant has a paid (non-FREE) live sub', async () => {
+  it("rejects starting a trial when tenant has a paid (non-FREE) live sub", async () => {
     prisma.subscription.findFirst.mockResolvedValue({
-      id: 'sub-x',
-      plan: { name: 'PRO' },
+      id: "sub-x",
+      plan: { name: "PRO" },
     } as any);
-    prisma.subscription.create.mockResolvedValue({ id: 'new' } as any);
+    prisma.subscription.create.mockResolvedValue({ id: "new" } as any);
     prisma.subscription.update.mockResolvedValue({} as any);
     prisma.tenant.update.mockResolvedValue({} as any);
 
@@ -169,13 +172,16 @@ describe('SubscriptionService.startTrialFromIntent', () => {
     ).rejects.toBeInstanceOf(BadRequestException);
   });
 
-  it('cancels existing FREE sub and creates new TRIALING in one tx', async () => {
+  it("cancels existing FREE sub and creates new TRIALING in one tx", async () => {
     prisma.subscription.findFirst.mockResolvedValue({
-      id: 'free-sub',
-      plan: { name: 'FREE' },
+      id: "free-sub",
+      plan: { name: "FREE" },
     } as any);
     prisma.subscription.update.mockResolvedValue({} as any);
-    prisma.subscription.create.mockResolvedValue({ id: 'trialing-sub', plan: proPlan } as any);
+    prisma.subscription.create.mockResolvedValue({
+      id: "trialing-sub",
+      plan: proPlan,
+    } as any);
     prisma.tenant.update.mockResolvedValue({} as any);
 
     await svc.startTrialFromIntent({
@@ -188,10 +194,10 @@ describe('SubscriptionService.startTrialFromIntent', () => {
     // FREE sub cancelled with the audit reason
     expect(prisma.subscription.update).toHaveBeenCalledWith(
       expect.objectContaining({
-        where: { id: 'free-sub' },
+        where: { id: "free-sub" },
         data: expect.objectContaining({
-          status: 'CANCELLED',
-          cancellationReason: 'Replaced by paid-plan trial',
+          status: "CANCELLED",
+          cancellationReason: "Replaced by paid-plan trial",
         }),
       }),
     );
@@ -202,9 +208,9 @@ describe('SubscriptionService.startTrialFromIntent', () => {
         data: expect.objectContaining({
           tenantId: TENANT_ID,
           planId: PLAN_ID,
-          status: 'TRIALING',
+          status: "TRIALING",
           isTrialPeriod: true,
-          paymentProvider: 'PAYTR',
+          paymentProvider: "PAYTR",
         }),
       }),
     );
@@ -222,9 +228,12 @@ describe('SubscriptionService.startTrialFromIntent', () => {
     );
   });
 
-  it('creates a TRIALING sub directly when no live sub exists', async () => {
+  it("creates a TRIALING sub directly when no live sub exists", async () => {
     prisma.subscription.findFirst.mockResolvedValue(null);
-    prisma.subscription.create.mockResolvedValue({ id: 'trialing-sub', plan: proPlan } as any);
+    prisma.subscription.create.mockResolvedValue({
+      id: "trialing-sub",
+      plan: proPlan,
+    } as any);
     prisma.tenant.update.mockResolvedValue({} as any);
 
     await svc.startTrialFromIntent({
@@ -239,13 +248,16 @@ describe('SubscriptionService.startTrialFromIntent', () => {
     expect(prisma.subscription.create).toHaveBeenCalled();
   });
 
-  it('fires the trial-started email post-commit (best-effort)', async () => {
+  it("fires the trial-started email post-commit (best-effort)", async () => {
     prisma.subscription.findFirst.mockResolvedValue(null);
-    prisma.subscription.create.mockResolvedValue({ id: 'trialing-sub', plan: proPlan } as any);
+    prisma.subscription.create.mockResolvedValue({
+      id: "trialing-sub",
+      plan: proPlan,
+    } as any);
     prisma.tenant.update.mockResolvedValue({} as any);
     prisma.user.findFirst.mockResolvedValue({
-      email: 'admin@example.com',
-      tenant: { name: 'Test Restaurant' },
+      email: "admin@example.com",
+      tenant: { name: "Test Restaurant" },
     } as any);
 
     await svc.startTrialFromIntent({
@@ -259,21 +271,25 @@ describe('SubscriptionService.startTrialFromIntent', () => {
     // before asserting.
     await new Promise((r) => setImmediate(r));
     expect(notifications.sendTrialStarted).toHaveBeenCalledWith(
-      'admin@example.com',
-      'Test Restaurant',
-      'Profesyonel',
+      "admin@example.com",
+      "Test Restaurant",
+      "Profesyonel",
       14,
     );
   });
 
-  it('maps P2002 (concurrent active sub) to BadRequestException', async () => {
+  it("maps P2002 (concurrent active sub) to BadRequestException", async () => {
     prisma.subscription.findFirst.mockResolvedValue(null);
-    const p2002 = Object.assign(
-      new Error('Unique constraint failed'),
-      { code: 'P2002', clientVersion: '6.0.0', name: 'PrismaClientKnownRequestError' },
-    );
+    const p2002 = Object.assign(new Error("Unique constraint failed"), {
+      code: "P2002",
+      clientVersion: "6.0.0",
+      name: "PrismaClientKnownRequestError",
+    });
     // Make the create blow up so the catch arm fires.
-    Object.setPrototypeOf(p2002, require('@prisma/client').Prisma.PrismaClientKnownRequestError.prototype);
+    Object.setPrototypeOf(
+      p2002,
+      require("@prisma/client").Prisma.PrismaClientKnownRequestError.prototype,
+    );
     prisma.subscription.create.mockRejectedValue(p2002);
 
     await expect(
@@ -295,36 +311,38 @@ describe('SubscriptionService.startTrialFromIntent', () => {
  * No PayTR token to revoke (column dropped); cancellation is now a
  * single subscription update + best-effort notification email.
  */
-describe('SubscriptionService.cancelSubscription', () => {
+describe("SubscriptionService.cancelSubscription", () => {
   let prisma: MockPrismaClient;
   let billing: jest.Mocked<BillingService>;
   let notifications: jest.Mocked<NotificationService>;
   let svc: SubscriptionService;
 
-  const TENANT_ID = 'tenant-1';
-  const SUB_ID = 'sub-1';
+  const TENANT_ID = "tenant-1";
+  const SUB_ID = "sub-1";
 
   const activeSub: any = {
     id: SUB_ID,
     tenantId: TENANT_ID,
-    status: 'ACTIVE',
+    status: "ACTIVE",
     currentPeriodEnd: new Date(Date.now() + 24 * 60 * 60 * 1000),
-    plan: { displayName: 'Profesyonel' },
-    tenant: { name: 'Test Restoran' },
+    plan: { displayName: "Profesyonel" },
+    tenant: { name: "Test Restoran" },
   };
 
   beforeEach(() => {
     prisma = mockPrismaClient();
     billing = {} as any;
     notifications = {
-      sendSubscriptionCancelledImmediate: jest.fn().mockResolvedValue(undefined),
+      sendSubscriptionCancelledImmediate: jest
+        .fn()
+        .mockResolvedValue(undefined),
       sendSubscriptionWillCancel: jest.fn().mockResolvedValue(undefined),
     } as any;
     svc = new SubscriptionService(
       prisma as any,
       billing,
       notifications,
-      { append: jest.fn().mockResolvedValue('outbox-id') } as any,
+      { append: jest.fn().mockResolvedValue("outbox-id") } as any,
       // v2.8.88: EntitlementService stub. Default returns an empty set
       // so existing tests (which don't care about engine routing)
       // continue to hit the plan-only fallback branch.
@@ -344,17 +362,21 @@ describe('SubscriptionService.cancelSubscription', () => {
     // via findUniqueOrThrow. Mirror both in the mocks.
     prisma.subscription.updateMany.mockResolvedValue({ count: 1 } as any);
     prisma.subscription.findUniqueOrThrow.mockResolvedValue(activeSub);
-    prisma.user.findFirst.mockResolvedValue({ email: 'admin@example.com' } as any);
+    prisma.user.findFirst.mockResolvedValue({
+      email: "admin@example.com",
+    } as any);
     // v2.8.89: cancelSubscription now wraps the updateMany + tenant
     // update in $transaction. Pass-through callback so the inner
     // updateMany count flows out as the txn result.
     prisma.$transaction.mockImplementation(async (fn: any) => fn(prisma));
-    prisma.subscriptionPlan.findUnique.mockResolvedValue({ id: 'free-plan' } as any);
+    prisma.subscriptionPlan.findUnique.mockResolvedValue({
+      id: "free-plan",
+    } as any);
     prisma.tenant.update.mockResolvedValue({} as any);
   });
 
-  it('immediate=true → writes CANCELLED + cancelledAt + endedAt', async () => {
-    await svc.cancelSubscription(SUB_ID, TENANT_ID, true, 'no longer needed');
+  it("immediate=true → writes CANCELLED + cancelledAt + endedAt", async () => {
+    await svc.cancelSubscription(SUB_ID, TENANT_ID, true, "no longer needed");
 
     expect(prisma.subscription.updateMany).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -363,23 +385,28 @@ describe('SubscriptionService.cancelSubscription', () => {
           tenantId: TENANT_ID,
         }),
         data: expect.objectContaining({
-          status: 'CANCELLED',
+          status: "CANCELLED",
           cancelledAt: expect.any(Date),
           endedAt: expect.any(Date),
-          cancellationReason: 'no longer needed',
+          cancellationReason: "no longer needed",
         }),
       }),
     );
   });
 
-  it('immediate=false → writes cancelAtPeriodEnd=true (deferred)', async () => {
-    await svc.cancelSubscription(SUB_ID, TENANT_ID, false, 'will let it expire');
+  it("immediate=false → writes cancelAtPeriodEnd=true (deferred)", async () => {
+    await svc.cancelSubscription(
+      SUB_ID,
+      TENANT_ID,
+      false,
+      "will let it expire",
+    );
 
     expect(prisma.subscription.updateMany).toHaveBeenCalledWith(
       expect.objectContaining({
         data: expect.objectContaining({
           cancelAtPeriodEnd: true,
-          cancellationReason: 'will let it expire',
+          cancellationReason: "will let it expire",
         }),
       }),
     );
@@ -388,17 +415,19 @@ describe('SubscriptionService.cancelSubscription', () => {
     expect(call.data.endedAt).toBeUndefined();
   });
 
-  it('sends the immediate-cancellation email when immediate=true', async () => {
-    await svc.cancelSubscription(SUB_ID, TENANT_ID, true, 'ops cancel');
-    expect(notifications.sendSubscriptionCancelledImmediate).toHaveBeenCalledWith(
-      'admin@example.com',
-      'Test Restoran',
-      'Profesyonel',
-      'ops cancel',
+  it("sends the immediate-cancellation email when immediate=true", async () => {
+    await svc.cancelSubscription(SUB_ID, TENANT_ID, true, "ops cancel");
+    expect(
+      notifications.sendSubscriptionCancelledImmediate,
+    ).toHaveBeenCalledWith(
+      "admin@example.com",
+      "Test Restoran",
+      "Profesyonel",
+      "ops cancel",
     );
   });
 
-  it('sends the at-period-end warning email when immediate=false', async () => {
+  it("sends the at-period-end warning email when immediate=false", async () => {
     await svc.cancelSubscription(SUB_ID, TENANT_ID, false);
     expect(notifications.sendSubscriptionWillCancel).toHaveBeenCalled();
   });
@@ -416,27 +445,27 @@ describe('SubscriptionService.cancelSubscription', () => {
  *   - happy path: under all caps → downgrade is scheduled (no throw)
  * The counts come from User(status=ACTIVE)/Table/Product/Category counts.
  */
-describe('SubscriptionService — downgrade usage-limit guard (changePlan)', () => {
+describe("SubscriptionService — downgrade usage-limit guard (changePlan)", () => {
   let prisma: MockPrismaClient;
   let billing: jest.Mocked<BillingService>;
   let notifications: jest.Mocked<NotificationService>;
   let svc: SubscriptionService;
 
-  const TENANT_ID = 'tenant-1';
-  const SUB_ID = 'sub-1';
+  const TENANT_ID = "tenant-1";
+  const SUB_ID = "sub-1";
 
   // ACTIVE PRO sub priced at 100 so a 50-priced target is a downgrade.
   const proSub: any = {
     id: SUB_ID,
     tenantId: TENANT_ID,
-    status: 'ACTIVE',
-    planId: 'plan-pro',
-    amount: '100',
+    status: "ACTIVE",
+    planId: "plan-pro",
+    amount: "100",
     billingCycle: BillingCycle.MONTHLY,
     currentPeriodStart: new Date(Date.now() - 86_400_000),
     currentPeriodEnd: new Date(Date.now() + 86_400_000),
     scheduledDowngradePlanId: null,
-    plan: { id: 'plan-pro', currency: 'TRY' },
+    plan: { id: "plan-pro", currency: "TRY" },
     tenant: {},
     payments: [],
     invoices: [],
@@ -445,11 +474,11 @@ describe('SubscriptionService — downgrade usage-limit guard (changePlan)', () 
   function buildBasicPlan(overrides: Record<string, number> = {}) {
     // Generous limits by default; individual tests tighten a dimension.
     return {
-      id: 'plan-basic',
+      id: "plan-basic",
       isActive: true,
-      currency: 'TRY',
-      monthlyPrice: '50',
-      yearlyPrice: '500',
+      currency: "TRY",
+      monthlyPrice: "50",
+      yearlyPrice: "500",
       maxUsers: 10,
       maxTables: 10,
       maxProducts: 100,
@@ -468,7 +497,7 @@ describe('SubscriptionService — downgrade usage-limit guard (changePlan)', () 
       prisma as any,
       billing,
       notifications,
-      { append: jest.fn().mockResolvedValue('outbox-id') } as any,
+      { append: jest.fn().mockResolvedValue("outbox-id") } as any,
       {
         getForTenant: jest.fn().mockResolvedValue({
           features: {},
@@ -495,43 +524,46 @@ describe('SubscriptionService — downgrade usage-limit guard (changePlan)', () 
     } as any);
   });
 
-  it('counts ACTIVE users only (status=ACTIVE predicate)', async () => {
+  it("counts ACTIVE users only (status=ACTIVE predicate)", async () => {
     prisma.subscriptionPlan.findUnique.mockResolvedValue(buildBasicPlan());
-    await svc.changePlan(SUB_ID, TENANT_ID, { newPlanId: 'plan-basic' } as any);
+    await svc.changePlan(SUB_ID, TENANT_ID, { newPlanId: "plan-basic" } as any);
     expect(prisma.user.count).toHaveBeenCalledWith(
       expect.objectContaining({
-        where: expect.objectContaining({ tenantId: TENANT_ID, status: 'ACTIVE' }),
+        where: expect.objectContaining({
+          tenantId: TENANT_ID,
+          status: "ACTIVE",
+        }),
       }),
     );
   });
 
-  it('rejects the downgrade when users exceed the new plan cap', async () => {
+  it("rejects the downgrade when users exceed the new plan cap", async () => {
     prisma.user.count.mockResolvedValue(11 as any);
     prisma.subscriptionPlan.findUnique.mockResolvedValue(
       buildBasicPlan({ maxUsers: 10 }),
     );
     await expect(
-      svc.changePlan(SUB_ID, TENANT_ID, { newPlanId: 'plan-basic' } as any),
-    ).rejects.toThrow('Cannot downgrade');
+      svc.changePlan(SUB_ID, TENANT_ID, { newPlanId: "plan-basic" } as any),
+    ).rejects.toThrow("Cannot downgrade");
     // Guard fails BEFORE any scheduling write.
     expect(prisma.subscription.updateMany).not.toHaveBeenCalled();
   });
 
-  it('lists every violated dimension in order (Users, Tables, Products, Categories)', async () => {
+  it("lists every violated dimension in order (Users, Tables, Products, Categories)", async () => {
     prisma.user.count.mockResolvedValue(11 as any);
     prisma.table.count.mockResolvedValue(11 as any);
     prisma.product.count.mockResolvedValue(101 as any);
     prisma.category.count.mockResolvedValue(21 as any);
     prisma.subscriptionPlan.findUnique.mockResolvedValue(buildBasicPlan());
     await expect(
-      svc.changePlan(SUB_ID, TENANT_ID, { newPlanId: 'plan-basic' } as any),
+      svc.changePlan(SUB_ID, TENANT_ID, { newPlanId: "plan-basic" } as any),
     ).rejects.toThrow(
-      'Cannot downgrade: current usage exceeds new plan limits. Please reduce: ' +
-        'Users: 11/10, Tables: 11/10, Products: 101/100, Categories: 21/20',
+      "Cannot downgrade: current usage exceeds new plan limits. Please reduce: " +
+        "Users: 11/10, Tables: 11/10, Products: 101/100, Categories: 21/20",
     );
   });
 
-  it('treats -1 as unlimited (no violation even when usage is high)', async () => {
+  it("treats -1 as unlimited (no violation even when usage is high)", async () => {
     prisma.user.count.mockResolvedValue(9999 as any);
     prisma.table.count.mockResolvedValue(9999 as any);
     prisma.product.count.mockResolvedValue(9999 as any);
@@ -545,18 +577,18 @@ describe('SubscriptionService — downgrade usage-limit guard (changePlan)', () 
       }),
     );
     const res = await svc.changePlan(SUB_ID, TENANT_ID, {
-      newPlanId: 'plan-basic',
+      newPlanId: "plan-basic",
     } as any);
-    expect((res as any).type).toBe('downgrade');
+    expect((res as any).type).toBe("downgrade");
     expect(prisma.subscription.updateMany).toHaveBeenCalled();
   });
 
-  it('schedules the downgrade when usage is under all caps', async () => {
+  it("schedules the downgrade when usage is under all caps", async () => {
     prisma.subscriptionPlan.findUnique.mockResolvedValue(buildBasicPlan());
     const res = await svc.changePlan(SUB_ID, TENANT_ID, {
-      newPlanId: 'plan-basic',
+      newPlanId: "plan-basic",
     } as any);
-    expect((res as any).type).toBe('downgrade');
+    expect((res as any).type).toBe("downgrade");
     expect((res as any).requiresPayment).toBe(false);
     expect(prisma.subscription.updateMany).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -566,7 +598,7 @@ describe('SubscriptionService — downgrade usage-limit guard (changePlan)', () 
           scheduledDowngradePlanId: null,
         }),
         data: expect.objectContaining({
-          scheduledDowngradePlanId: 'plan-basic',
+          scheduledDowngradePlanId: "plan-basic",
         }),
       }),
     );
@@ -580,13 +612,13 @@ describe('SubscriptionService — downgrade usage-limit guard (changePlan)', () 
  * audit write is best-effort and only fires when a human actor id is
  * threaded through (scheduler/cron callers pass none).
  */
-describe('SubscriptionService — billing audit (user_activities)', () => {
+describe("SubscriptionService — billing audit (user_activities)", () => {
   let prisma: MockPrismaClient;
   let svc: SubscriptionService;
 
-  const TENANT_ID = 'tenant-1';
-  const SUB_ID = 'sub-1';
-  const ACTOR_ID = 'admin-7';
+  const TENANT_ID = "tenant-1";
+  const SUB_ID = "sub-1";
+  const ACTOR_ID = "admin-7";
 
   function build() {
     prisma = mockPrismaClient();
@@ -594,7 +626,7 @@ describe('SubscriptionService — billing audit (user_activities)', () => {
       prisma as any,
       {} as any,
       { sendTrialStarted: jest.fn().mockResolvedValue(undefined) } as any,
-      { append: jest.fn().mockResolvedValue('outbox-id') } as any,
+      { append: jest.fn().mockResolvedValue("outbox-id") } as any,
       {
         getForTenant: jest.fn().mockResolvedValue({
           features: {},
@@ -609,32 +641,35 @@ describe('SubscriptionService — billing audit (user_activities)', () => {
 
   beforeEach(build);
 
-  it('createSubscription writes SUBSCRIPTION_CREATED with actor + plan fields', async () => {
+  it("createSubscription writes SUBSCRIPTION_CREATED with actor + plan fields", async () => {
     prisma.tenant.findUnique.mockResolvedValue({
       id: TENANT_ID,
       usedTrialPlanIds: [],
       trialUsed: false,
     } as any);
     prisma.user.findFirst.mockResolvedValue({
-      id: 'u-admin',
+      id: "u-admin",
       emailVerified: true,
     } as any);
     prisma.subscriptionPlan.findUnique.mockResolvedValue({
-      id: 'plan-free',
-      name: 'FREE',
-      currency: 'TRY',
-      monthlyPrice: '0',
-      yearlyPrice: '0',
+      id: "plan-free",
+      name: "FREE",
+      currency: "TRY",
+      monthlyPrice: "0",
+      yearlyPrice: "0",
       trialDays: 0,
       isActive: true,
-      displayName: 'Ücretsiz',
+      displayName: "Ücretsiz",
     } as any);
-    prisma.subscription.create.mockResolvedValue({ id: SUB_ID, plan: {} } as any);
+    prisma.subscription.create.mockResolvedValue({
+      id: SUB_ID,
+      plan: {},
+    } as any);
     prisma.tenant.update.mockResolvedValue({} as any);
 
     await svc.createSubscription(
       TENANT_ID,
-      { planId: 'plan-free', billingCycle: BillingCycle.MONTHLY } as any,
+      { planId: "plan-free", billingCycle: BillingCycle.MONTHLY } as any,
       ACTOR_ID,
     );
 
@@ -642,69 +677,72 @@ describe('SubscriptionService — billing audit (user_activities)', () => {
       data: expect.objectContaining({
         userId: ACTOR_ID,
         tenantId: TENANT_ID,
-        action: 'SUBSCRIPTION_CREATED',
+        action: "SUBSCRIPTION_CREATED",
         metadata: expect.objectContaining({
           subscriptionId: SUB_ID,
-          planId: 'plan-free',
-          planName: 'FREE',
+          planId: "plan-free",
+          planName: "FREE",
           billingCycle: BillingCycle.MONTHLY,
         }),
       }),
     });
   });
 
-  it('createSubscription WITHOUT an actor writes no audit row', async () => {
+  it("createSubscription WITHOUT an actor writes no audit row", async () => {
     prisma.tenant.findUnique.mockResolvedValue({
       id: TENANT_ID,
       usedTrialPlanIds: [],
       trialUsed: false,
     } as any);
     prisma.user.findFirst.mockResolvedValue({
-      id: 'u-admin',
+      id: "u-admin",
       emailVerified: true,
     } as any);
     prisma.subscriptionPlan.findUnique.mockResolvedValue({
-      id: 'plan-free',
-      name: 'FREE',
-      currency: 'TRY',
-      monthlyPrice: '0',
-      yearlyPrice: '0',
+      id: "plan-free",
+      name: "FREE",
+      currency: "TRY",
+      monthlyPrice: "0",
+      yearlyPrice: "0",
       trialDays: 0,
       isActive: true,
-      displayName: 'Ücretsiz',
+      displayName: "Ücretsiz",
     } as any);
-    prisma.subscription.create.mockResolvedValue({ id: SUB_ID, plan: {} } as any);
+    prisma.subscription.create.mockResolvedValue({
+      id: SUB_ID,
+      plan: {},
+    } as any);
     prisma.tenant.update.mockResolvedValue({} as any);
 
-    await svc.createSubscription(
-      TENANT_ID,
-      { planId: 'plan-free', billingCycle: BillingCycle.MONTHLY } as any,
-    );
+    await svc.createSubscription(TENANT_ID, {
+      planId: "plan-free",
+      billingCycle: BillingCycle.MONTHLY,
+    } as any);
 
     expect(prisma.userActivity.create).not.toHaveBeenCalled();
   });
 
-  it('changePlan (downgrade) writes SUBSCRIPTION_PLAN_CHANGED with from/to', async () => {
+  it("changePlan (downgrade) writes SUBSCRIPTION_PLAN_CHANGED with from/to", async () => {
     prisma.subscription.findUnique.mockResolvedValue({
       id: SUB_ID,
       tenantId: TENANT_ID,
-      status: 'ACTIVE',
-      planId: 'plan-pro',
-      amount: '100',
+      status: "ACTIVE",
+      planId: "plan-pro",
+      amount: "100",
       billingCycle: BillingCycle.MONTHLY,
       currentPeriodStart: new Date(Date.now() - 86_400_000),
       currentPeriodEnd: new Date(Date.now() + 86_400_000),
       scheduledDowngradePlanId: null,
-      plan: { id: 'plan-pro', name: 'PRO', currency: 'TRY' },
+      plan: { id: "plan-pro", name: "PRO", currency: "TRY" },
       tenant: {},
     } as any);
     prisma.subscriptionPlan.findUnique.mockResolvedValue({
-      id: 'plan-basic',
-      name: 'BASIC',
+      id: "plan-basic",
+      name: "BASIC",
       isActive: true,
-      currency: 'TRY',
-      monthlyPrice: '50',
-      yearlyPrice: '500',
+      currency: "TRY",
+      monthlyPrice: "50",
+      yearlyPrice: "500",
       maxUsers: 10,
       maxTables: 10,
       maxProducts: 100,
@@ -724,7 +762,7 @@ describe('SubscriptionService — billing audit (user_activities)', () => {
     await svc.changePlan(
       SUB_ID,
       TENANT_ID,
-      { newPlanId: 'plan-basic' } as any,
+      { newPlanId: "plan-basic" } as any,
       ACTOR_ID,
     );
 
@@ -732,77 +770,170 @@ describe('SubscriptionService — billing audit (user_activities)', () => {
       data: expect.objectContaining({
         userId: ACTOR_ID,
         tenantId: TENANT_ID,
-        action: 'SUBSCRIPTION_PLAN_CHANGED',
+        action: "SUBSCRIPTION_PLAN_CHANGED",
         metadata: expect.objectContaining({
           subscriptionId: SUB_ID,
-          fromPlanName: 'PRO',
-          toPlanName: 'BASIC',
-          type: 'downgrade',
+          fromPlanName: "PRO",
+          toPlanName: "BASIC",
+          type: "downgrade",
         }),
       }),
     });
   });
 
-  it('cancelSubscription writes SUBSCRIPTION_CANCELLED with actor + reason', async () => {
+  it("cancelSubscription writes SUBSCRIPTION_CANCELLED with actor + reason", async () => {
     prisma.subscription.findUnique.mockResolvedValue({
       id: SUB_ID,
       tenantId: TENANT_ID,
-      status: 'ACTIVE',
-      planId: 'plan-pro',
+      status: "ACTIVE",
+      planId: "plan-pro",
       currentPeriodEnd: new Date(Date.now() + 86_400_000),
-      plan: { name: 'PRO', displayName: 'Profesyonel' },
-      tenant: { name: 'Test Restoran' },
+      plan: { name: "PRO", displayName: "Profesyonel" },
+      tenant: { name: "Test Restoran" },
     } as any);
     prisma.subscription.updateMany.mockResolvedValue({ count: 1 } as any);
     prisma.subscription.findUniqueOrThrow.mockResolvedValue({
       id: SUB_ID,
-      plan: { name: 'PRO', displayName: 'Profesyonel' },
-      tenant: { name: 'Test Restoran' },
+      plan: { name: "PRO", displayName: "Profesyonel" },
+      tenant: { name: "Test Restoran" },
     } as any);
-    prisma.subscriptionPlan.findUnique.mockResolvedValue({ id: 'free-plan' } as any);
+    prisma.subscriptionPlan.findUnique.mockResolvedValue({
+      id: "free-plan",
+    } as any);
     prisma.tenant.update.mockResolvedValue({} as any);
     prisma.user.findFirst.mockResolvedValue(null as any);
 
-    await svc.cancelSubscription(SUB_ID, TENANT_ID, true, 'churned', ACTOR_ID);
+    await svc.cancelSubscription(SUB_ID, TENANT_ID, true, "churned", ACTOR_ID);
 
     expect(prisma.userActivity.create).toHaveBeenCalledWith({
       data: expect.objectContaining({
         userId: ACTOR_ID,
         tenantId: TENANT_ID,
-        action: 'SUBSCRIPTION_CANCELLED',
+        action: "SUBSCRIPTION_CANCELLED",
         metadata: expect.objectContaining({
           subscriptionId: SUB_ID,
           immediate: true,
-          reason: 'churned',
+          reason: "churned",
         }),
       }),
     });
   });
 
-  it('is best-effort: a failing billing audit never breaks the cancel', async () => {
+  it("is best-effort: a failing billing audit never breaks the cancel", async () => {
     prisma.subscription.findUnique.mockResolvedValue({
       id: SUB_ID,
       tenantId: TENANT_ID,
-      status: 'ACTIVE',
-      planId: 'plan-pro',
+      status: "ACTIVE",
+      planId: "plan-pro",
       currentPeriodEnd: new Date(Date.now() + 86_400_000),
-      plan: { name: 'PRO', displayName: 'Profesyonel' },
-      tenant: { name: 'Test Restoran' },
+      plan: { name: "PRO", displayName: "Profesyonel" },
+      tenant: { name: "Test Restoran" },
     } as any);
     prisma.subscription.updateMany.mockResolvedValue({ count: 1 } as any);
     prisma.subscription.findUniqueOrThrow.mockResolvedValue({
       id: SUB_ID,
-      plan: { name: 'PRO', displayName: 'Profesyonel' },
-      tenant: { name: 'Test Restoran' },
+      plan: { name: "PRO", displayName: "Profesyonel" },
+      tenant: { name: "Test Restoran" },
     } as any);
-    prisma.subscriptionPlan.findUnique.mockResolvedValue({ id: 'free-plan' } as any);
+    prisma.subscriptionPlan.findUnique.mockResolvedValue({
+      id: "free-plan",
+    } as any);
     prisma.tenant.update.mockResolvedValue({} as any);
     prisma.user.findFirst.mockResolvedValue(null as any);
-    (prisma.userActivity.create as any).mockRejectedValue(new Error('audit down'));
-    jest.spyOn((svc as any).logger, 'warn').mockImplementation(() => undefined);
+    (prisma.userActivity.create as any).mockRejectedValue(
+      new Error("audit down"),
+    );
+    jest.spyOn((svc as any).logger, "warn").mockImplementation(() => undefined);
 
     await expect(
-      svc.cancelSubscription(SUB_ID, TENANT_ID, true, 'churned', ACTOR_ID),
+      svc.cancelSubscription(SUB_ID, TENANT_ID, true, "churned", ACTOR_ID),
     ).resolves.toEqual(expect.objectContaining({ id: SUB_ID }));
+  });
+});
+
+/**
+ * deep-review regressions: grant-before-pay (H3) and the trial-expiry
+ * concurrent-clobber (H2). Both protect the core billing money paths.
+ */
+describe("SubscriptionService — deep-review money-path regressions", () => {
+  let prisma: MockPrismaClient;
+  let svc: SubscriptionService;
+  const TENANT_ID = "tenant-1";
+
+  beforeEach(() => {
+    prisma = mockPrismaClient();
+    svc = new SubscriptionService(
+      prisma as any,
+      {} as any,
+      { sendTrialStarted: jest.fn().mockResolvedValue(undefined) } as any,
+      { append: jest.fn().mockResolvedValue("outbox-id") } as any,
+      {
+        getForTenant: jest.fn().mockResolvedValue({
+          features: {},
+          limits: {},
+          integrations: {},
+          computedAt: new Date(0).toISOString(),
+        }),
+      } as any,
+    );
+    prisma.$transaction.mockImplementation(async (fn: any) => fn(prisma));
+    jest.spyOn((svc as any).logger, "log").mockImplementation(() => undefined);
+  });
+
+  it("createSubscription refuses a paid, non-trial plan (H3 grant-before-pay) and writes nothing", async () => {
+    prisma.tenant.findUnique.mockResolvedValue({
+      id: TENANT_ID,
+      usedTrialPlanIds: [],
+      trialUsed: false,
+    } as any);
+    prisma.user.findFirst.mockResolvedValue({
+      id: "u-admin",
+      emailVerified: true,
+    } as any);
+    // Paid PRO plan with NO trial available (trialDays 0) → isTrialPeriod=false.
+    prisma.subscriptionPlan.findUnique.mockResolvedValue({
+      id: "plan-pro",
+      name: "PRO",
+      currency: "TRY",
+      monthlyPrice: "1299",
+      yearlyPrice: "12990",
+      trialDays: 0,
+      isActive: true,
+      displayName: "Profesyonel",
+    } as any);
+
+    await expect(
+      svc.createSubscription(TENANT_ID, {
+        planId: "plan-pro",
+        billingCycle: BillingCycle.MONTHLY,
+      } as any),
+    ).rejects.toBeInstanceOf(BadRequestException);
+    expect(prisma.subscription.create).not.toHaveBeenCalled();
+  });
+
+  it("expireTrials skips a row concurrently flipped to paid — no clobber to FREE (H2)", async () => {
+    const now = new Date();
+    prisma.subscription.findMany.mockResolvedValue([
+      {
+        id: "sub-1",
+        tenantId: TENANT_ID,
+        trialEnd: new Date(now.getTime() - 1000),
+        plan: { displayName: "Business" },
+        tenant: { name: "X" },
+      },
+    ] as any);
+    prisma.subscriptionPlan.findUnique.mockResolvedValue({
+      id: "free",
+      name: "FREE",
+      currency: "TRY",
+    } as any);
+    // The conditional claim loses (row already ACTIVE+paid via webhook).
+    prisma.subscription.updateMany.mockResolvedValue({ count: 0 } as any);
+
+    const res = await svc.expireTrials();
+
+    // Skipped, not failed; tenant pointer NOT downgraded to FREE.
+    expect(prisma.tenant.update).not.toHaveBeenCalled();
+    expect(res).toEqual({ processed: 0, failed: 0 });
   });
 });

--- a/backend/src/modules/subscriptions/services/subscription.service.ts
+++ b/backend/src/modules/subscriptions/services/subscription.service.ts
@@ -332,6 +332,23 @@ export class SubscriptionService {
       plan.name !== SubscriptionPlanType.FREE;
     const isTrialPeriod = canUseTrial;
 
+    // SECURITY (deep-review H3): this is the public ADMIN-facing creation
+    // entry point (POST /subscriptions). It must never mint a PAID,
+    // immediately-ACTIVE subscription — that is grant-before-pay. A paid
+    // plan only becomes ACTIVE after PayTR/havale settlement transitions an
+    // existing subscription (paytr-settlement / bank-transfer). The only
+    // states this path may create are a TRIALING trial or a FREE (amount 0)
+    // subscription. Without this gate a tenant whose per-plan trial slot is
+    // used and whose live subscription was cancelled/expired could POST a
+    // paid planId and self-activate paid access for free (the partial unique
+    // index only blocks while a live ACTIVE/TRIALING row already exists).
+    if (!isTrialPeriod && plan.name !== SubscriptionPlanType.FREE) {
+      throw new BadRequestException(
+        "Paid plans must be activated through checkout/payment. " +
+          "Start a trial or use the upgrade flow to pay for this plan.",
+      );
+    }
+
     // Use date-fns so DST transitions don't skew the period end by an hour.
     const now = new Date();
     const trialStart = isTrialPeriod ? now : null;
@@ -808,6 +825,22 @@ export class SubscriptionService {
         ? newPlan.monthlyPrice
         : newPlan.yearlyPrice;
 
+    // deep-review H1: roll the billing period forward as part of the same
+    // atomic claim. The downgrade cron runs at 01:00 and the period-end
+    // sweep at 02:00 on the same day; without advancing currentPeriodEnd the
+    // just-downgraded row still has a past period end, so the 02:00 sweep
+    // immediately flips it to PAST_DUE (then EXPIRED after the 7-day grace) —
+    // silently dropping a customer who scheduled a downgrade (requiresPayment
+    // = false) off the cheaper plan they meant to keep. This is a
+    // manual-renewal merchant, and the "scheduled for period end" contract
+    // already promises the cheaper plan continues, so granting the next cycle
+    // is the correct behaviour.
+    const now = new Date();
+    const newPeriodEnd =
+      billingCycle === BillingCycle.MONTHLY
+        ? addMonths(now, 1)
+        : addYears(now, 1);
+
     // v2.8.94 — wrap the claim + tenant.currentPlanId flip + lifecycle
     // event in a single $transaction. Pre-fix the subscription.planId
     // and tenant.currentPlanId could land in separate commits and the
@@ -833,6 +866,11 @@ export class SubscriptionService {
           billingCycle,
           amount: newAmount,
           currency: newPlan.currency,
+          // H1: advance the period so the period-end sweep no longer matches
+          // this row (its own currentPeriodEnd <= now guard then prevents the
+          // downgrade cron re-firing).
+          currentPeriodStart: now,
+          currentPeriodEnd: newPeriodEnd,
           scheduledDowngradePlanId: null,
           scheduledDowngradeBillingCycle: null,
         },
@@ -1417,6 +1455,9 @@ export class SubscriptionService {
     freePeriodEnd.setFullYear(freePeriodEnd.getFullYear() + 10);
 
     let failed = 0;
+    // deep-review H2: rows that were concurrently paid/cancelled between the
+    // findMany snapshot and the per-row claim are skipped, not failed.
+    let skipped = 0;
     for (const subscription of expiredTrials) {
       try {
         // Atomic transition: move the SAME subscription row from TRIALING
@@ -1425,9 +1466,21 @@ export class SubscriptionService {
         // (tenantId) WHERE status IN (ACTIVE, TRIALING) index, which
         // would fire if we tried to create a fresh FREE row alongside
         // the TRIALING one.
-        await this.prisma.$transaction(async (tx) => {
-          await tx.subscription.update({
-            where: { id: subscription.id },
+        //
+        // H2: the write is a CONDITIONAL claim (updateMany scoped to the
+        // still-TRIALING state), not an unconditional id update. If a PayTR
+        // webhook (applySuccess) flipped this row to ACTIVE+paid in the
+        // window after findMany, claim.count===0 and we MUST NOT clobber the
+        // just-paid subscription back to FREE (amount 0) — the customer was
+        // charged. The tenant.currentPlanId flip lives inside the won-claim
+        // branch so a skipped row never downgrades the tenant pointer either.
+        const transitioned = await this.prisma.$transaction(async (tx) => {
+          const claim = await tx.subscription.updateMany({
+            where: {
+              id: subscription.id,
+              status: SubscriptionStatus.TRIALING,
+              isTrialPeriod: true,
+            },
             data: {
               planId: freePlan.id,
               status: SubscriptionStatus.ACTIVE,
@@ -1438,11 +1491,22 @@ export class SubscriptionService {
               currentPeriodEnd: freePeriodEnd,
             },
           });
+          if (claim.count === 0) return false;
           await tx.tenant.update({
             where: { id: subscription.tenantId },
             data: { currentPlanId: freePlan.id },
           });
+          return true;
         });
+
+        if (!transitioned) {
+          skipped += 1;
+          this.logger.log(
+            `Trial ${subscription.id} skipped — no longer TRIALING (concurrently settled/cancelled); not downgraded to FREE`,
+          );
+          continue;
+        }
+
         this.logger.log(
           `Trial subscription ${subscription.id} expired → tenant ${subscription.tenantId} dropped to FREE`,
         );
@@ -1484,6 +1548,8 @@ export class SubscriptionService {
         );
       }
     }
-    return { processed: expiredTrials.length - failed, failed };
+    // processed = rows actually transitioned to FREE; skipped rows were
+    // concurrently paid/cancelled and are intentionally excluded from both.
+    return { processed: expiredTrials.length - failed - skipped, failed };
   }
 }

--- a/backend/src/modules/superadmin/services/superadmin-subscriptions.service.spec.ts
+++ b/backend/src/modules/superadmin/services/superadmin-subscriptions.service.spec.ts
@@ -1,36 +1,43 @@
-import { BadRequestException, NotFoundException } from '@nestjs/common';
-import { Prisma } from '@prisma/client';
-import { SuperAdminSubscriptionsService } from './superadmin-subscriptions.service';
-import { mockPrismaClient, MockPrismaClient } from '../../../common/test/prisma-mock.service';
+import {
+  BadRequestException,
+  ConflictException,
+  NotFoundException,
+} from "@nestjs/common";
+import { Prisma } from "@prisma/client";
+import { SuperAdminSubscriptionsService } from "./superadmin-subscriptions.service";
+import {
+  mockPrismaClient,
+  MockPrismaClient,
+} from "../../../common/test/prisma-mock.service";
 
 /**
  * Unit tests for the refundPayment ops endpoint. Real PayTR calls are
  * mocked at the PaytrAdapter boundary so we only assert this service's
  * eligibility checks, state transition, and audit-trail handoff.
  */
-describe('SuperAdminSubscriptionsService.refundPayment', () => {
+describe("SuperAdminSubscriptionsService.refundPayment", () => {
   let prisma: MockPrismaClient;
   let audit: any;
   let subscriptionService: any;
   let paytr: any;
   let svc: SuperAdminSubscriptionsService;
 
-  const SUB_ID = 'sub-1';
-  const PAYMENT_ID = 'pay-1';
-  const TENANT_ID = 'tenant-1';
-  const MERCHANT_OID = 'SUB-tenant-1-abc';
+  const SUB_ID = "sub-1";
+  const PAYMENT_ID = "pay-1";
+  const TENANT_ID = "tenant-1";
+  const MERCHANT_OID = "SUB-tenant-1-abc";
 
   const successfulPayment: any = {
     id: PAYMENT_ID,
     subscriptionId: SUB_ID,
-    status: 'SUCCEEDED',
-    amount: new Prisma.Decimal('799'),
+    status: "SUCCEEDED",
+    amount: new Prisma.Decimal("799"),
     paidAt: new Date(),
     paytrMerchantOid: MERCHANT_OID,
     subscription: {
       id: SUB_ID,
       tenantId: TENANT_ID,
-      tenant: { name: 'Test Restoran' },
+      tenant: { name: "Test Restoran" },
     },
   };
 
@@ -39,79 +46,108 @@ describe('SuperAdminSubscriptionsService.refundPayment', () => {
     audit = { log: jest.fn().mockResolvedValue(undefined) };
     subscriptionService = {};
     paytr = {
-      refund: jest.fn().mockResolvedValue({ status: 'success', raw: {} }),
+      refund: jest.fn().mockResolvedValue({ status: "success", raw: {} }),
     };
+    // Atomic claim (deep-review H17) runs before every PayTR call; default to
+    // "this request won the claim" so the existing eligibility/transition
+    // assertions exercise the happy path. Concurrency is asserted separately.
+    prisma.subscriptionPayment.updateMany.mockResolvedValue({
+      count: 1,
+    } as any);
     svc = new SuperAdminSubscriptionsService(
       prisma as any,
       audit,
       subscriptionService,
-      { handleSubscriptionPeriodEnd: jest.fn(), handleSubscriptionExpiryReminders: jest.fn() } as any,
+      {
+        handleSubscriptionPeriodEnd: jest.fn(),
+        handleSubscriptionExpiryReminders: jest.fn(),
+      } as any,
       paytr,
     );
   });
 
-  it('throws NotFound when the payment does not exist', async () => {
+  it("throws NotFound when the payment does not exist", async () => {
     prisma.subscriptionPayment.findUnique.mockResolvedValue(null);
     await expect(
-      svc.refundPayment(SUB_ID, { paymentId: PAYMENT_ID, reason: 'test' }, 'a1', 'a@x'),
+      svc.refundPayment(
+        SUB_ID,
+        { paymentId: PAYMENT_ID, reason: "test" },
+        "a1",
+        "a@x",
+      ),
     ).rejects.toBeInstanceOf(NotFoundException);
   });
 
-  it('throws BadRequest when the payment belongs to a different subscription', async () => {
+  it("throws BadRequest when the payment belongs to a different subscription", async () => {
     prisma.subscriptionPayment.findUnique.mockResolvedValue({
       ...successfulPayment,
-      subscriptionId: 'other-sub',
+      subscriptionId: "other-sub",
     });
     await expect(
-      svc.refundPayment(SUB_ID, { paymentId: PAYMENT_ID, reason: 'test' }, 'a1', 'a@x'),
+      svc.refundPayment(
+        SUB_ID,
+        { paymentId: PAYMENT_ID, reason: "test" },
+        "a1",
+        "a@x",
+      ),
     ).rejects.toBeInstanceOf(BadRequestException);
   });
 
-  it('throws BadRequest when the payment is not in SUCCEEDED state', async () => {
+  it("throws BadRequest when the payment is not in SUCCEEDED state", async () => {
     prisma.subscriptionPayment.findUnique.mockResolvedValue({
       ...successfulPayment,
-      status: 'PENDING',
+      status: "PENDING",
     });
     await expect(
-      svc.refundPayment(SUB_ID, { paymentId: PAYMENT_ID, reason: 'test' }, 'a1', 'a@x'),
+      svc.refundPayment(
+        SUB_ID,
+        { paymentId: PAYMENT_ID, reason: "test" },
+        "a1",
+        "a@x",
+      ),
     ).rejects.toBeInstanceOf(BadRequestException);
   });
 
-  it('throws BadRequest when the payment has no paytrMerchantOid', async () => {
+  it("throws BadRequest when the payment has no paytrMerchantOid", async () => {
     prisma.subscriptionPayment.findUnique.mockResolvedValue({
       ...successfulPayment,
       paytrMerchantOid: null,
     });
     await expect(
-      svc.refundPayment(SUB_ID, { paymentId: PAYMENT_ID, reason: 'test' }, 'a1', 'a@x'),
+      svc.refundPayment(
+        SUB_ID,
+        { paymentId: PAYMENT_ID, reason: "test" },
+        "a1",
+        "a@x",
+      ),
     ).rejects.toBeInstanceOf(BadRequestException);
   });
 
-  it('throws BadRequest when the requested amount exceeds the original', async () => {
+  it("throws BadRequest when the requested amount exceeds the original", async () => {
     prisma.subscriptionPayment.findUnique.mockResolvedValue(successfulPayment);
     await expect(
       svc.refundPayment(
         SUB_ID,
-        { paymentId: PAYMENT_ID, amount: 1000, reason: 'oversized' },
-        'a1',
-        'a@x',
+        { paymentId: PAYMENT_ID, amount: 1000, reason: "oversized" },
+        "a1",
+        "a@x",
       ),
     ).rejects.toBeInstanceOf(BadRequestException);
     expect(paytr.refund).not.toHaveBeenCalled();
   });
 
-  it('full refund: calls PayTR with payment.amount and writes REFUNDED + audit', async () => {
+  it("full refund: calls PayTR with payment.amount and writes REFUNDED + audit", async () => {
     prisma.subscriptionPayment.findUnique.mockResolvedValue(successfulPayment);
     prisma.subscriptionPayment.update.mockResolvedValue({
       ...successfulPayment,
-      status: 'REFUNDED',
+      status: "REFUNDED",
     });
 
     await svc.refundPayment(
       SUB_ID,
-      { paymentId: PAYMENT_ID, reason: 'customer requested' },
-      'actor-1',
-      'actor@example.com',
+      { paymentId: PAYMENT_ID, reason: "customer requested" },
+      "actor-1",
+      "actor@example.com",
     );
 
     expect(paytr.refund).toHaveBeenCalledWith(
@@ -125,82 +161,164 @@ describe('SuperAdminSubscriptionsService.refundPayment', () => {
       expect.objectContaining({
         where: { id: PAYMENT_ID },
         data: expect.objectContaining({
-          status: 'REFUNDED',
+          status: "REFUNDED",
           refundedAt: expect.any(Date),
         }),
       }),
     );
     expect(audit.log).toHaveBeenCalledWith(
       expect.objectContaining({
-        action: 'REFUND',
-        entityType: 'SUBSCRIPTION',
+        action: "REFUND",
+        entityType: "SUBSCRIPTION",
         entityId: SUB_ID,
-        actorId: 'actor-1',
-        actorEmail: 'actor@example.com',
+        actorId: "actor-1",
+        actorEmail: "actor@example.com",
         newData: expect.objectContaining({
-          status: 'REFUNDED',
+          status: "REFUNDED",
           refundedAmount: expect.any(String),
-          reason: 'customer requested',
+          reason: "customer requested",
         }),
       }),
     );
   });
 
-  it('partial refund: passes the smaller amount to PayTR but still REFUNDED', async () => {
+  it("partial refund: passes the smaller amount to PayTR but still REFUNDED", async () => {
     prisma.subscriptionPayment.findUnique.mockResolvedValue(successfulPayment);
     prisma.subscriptionPayment.update.mockResolvedValue(successfulPayment);
 
     await svc.refundPayment(
       SUB_ID,
-      { paymentId: PAYMENT_ID, amount: 100, reason: 'partial' },
-      'a1',
-      'a@x',
+      { paymentId: PAYMENT_ID, amount: 100, reason: "partial" },
+      "a1",
+      "a@x",
     );
 
     const refundCall = paytr.refund.mock.calls[0][0];
-    expect(new Prisma.Decimal(refundCall.amount).toString()).toBe('100');
+    expect(new Prisma.Decimal(refundCall.amount).toString()).toBe("100");
     // Audit captures the partial amount so support can later reconstruct.
     expect(audit.log).toHaveBeenCalledWith(
       expect.objectContaining({
-        newData: expect.objectContaining({ refundedAmount: '100' }),
+        newData: expect.objectContaining({ refundedAmount: "100" }),
       }),
     );
   });
 
-  it('surfaces PayTR rejections as BadRequestException with the reason', async () => {
+  it("surfaces PayTR rejections as BadRequestException with the reason", async () => {
     prisma.subscriptionPayment.findUnique.mockResolvedValue(successfulPayment);
     paytr.refund.mockResolvedValue({
-      status: 'failed',
-      reason: 'transaction_too_old',
+      status: "failed",
+      reason: "transaction_too_old",
       raw: {},
     });
 
     await expect(
-      svc.refundPayment(SUB_ID, { paymentId: PAYMENT_ID, reason: 'test' }, 'a1', 'a@x'),
-    ).rejects.toThrow('transaction_too_old');
+      svc.refundPayment(
+        SUB_ID,
+        { paymentId: PAYMENT_ID, reason: "test" },
+        "a1",
+        "a@x",
+      ),
+    ).rejects.toThrow("transaction_too_old");
     // Payment row stays SUCCEEDED on PayTR-side failures.
     expect(prisma.subscriptionPayment.update).not.toHaveBeenCalled();
   });
 
-  it('14-day cooling-off: logs warning but allows refund (soft check)', async () => {
+  it("14-day cooling-off: logs warning but allows refund (soft check)", async () => {
     const oldPaidAt = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
     prisma.subscriptionPayment.findUnique.mockResolvedValue({
       ...successfulPayment,
       paidAt: oldPaidAt,
     });
     prisma.subscriptionPayment.update.mockResolvedValue(successfulPayment);
-    const warnSpy = jest.spyOn((svc as any).logger, 'warn').mockImplementation(() => undefined);
+    const warnSpy = jest
+      .spyOn((svc as any).logger, "warn")
+      .mockImplementation(() => undefined);
 
     await svc.refundPayment(
       SUB_ID,
-      { paymentId: PAYMENT_ID, reason: 'goodwill' },
-      'a1',
-      'a@x',
+      { paymentId: PAYMENT_ID, reason: "goodwill" },
+      "a1",
+      "a@x",
     );
 
     expect(warnSpy).toHaveBeenCalled();
     expect(paytr.refund).toHaveBeenCalled(); // not blocked
     expect(prisma.subscriptionPayment.update).toHaveBeenCalled();
+  });
+
+  // deep-review H17: two ops requests (double-click / retry / two operators)
+  // both read status=SUCCEEDED and pass the eligibility guard; without an
+  // atomic claim they could both call paytr.refund() with DIFFERENT partial
+  // amounts and move real money twice. The SUCCEEDED→REFUNDING updateMany is
+  // the real de-dupe: exactly one caller wins (count===1), the loser gets 409.
+  it("concurrency: two refunds with different partial amounts call PayTR exactly once", async () => {
+    prisma.subscriptionPayment.findUnique.mockResolvedValue(successfulPayment);
+    prisma.subscriptionPayment.update.mockResolvedValue(successfulPayment);
+    // First claim wins, every subsequent claim loses (row no longer SUCCEEDED).
+    let claimed = false;
+    prisma.subscriptionPayment.updateMany.mockImplementation(async () => {
+      if (!claimed) {
+        claimed = true;
+        return { count: 1 } as any;
+      }
+      return { count: 0 } as any;
+    });
+
+    const results = await Promise.allSettled([
+      svc.refundPayment(
+        SUB_ID,
+        { paymentId: PAYMENT_ID, amount: 100, reason: "a" },
+        "op1",
+        "op1@x",
+      ),
+      svc.refundPayment(
+        SUB_ID,
+        { paymentId: PAYMENT_ID, amount: 250, reason: "b" },
+        "op2",
+        "op2@x",
+      ),
+    ]);
+
+    // PayTR is invoked exactly once — no double money movement.
+    expect(paytr.refund).toHaveBeenCalledTimes(1);
+    // Exactly one succeeded; the loser is rejected with a 409 Conflict.
+    const fulfilled = results.filter((r) => r.status === "fulfilled");
+    const rejected = results.filter((r) => r.status === "rejected");
+    expect(fulfilled).toHaveLength(1);
+    expect(rejected).toHaveLength(1);
+    expect((rejected[0] as PromiseRejectedResult).reason).toBeInstanceOf(
+      ConflictException,
+    );
+  });
+
+  it("rolls the claim back to SUCCEEDED when PayTR rejects (allows retry)", async () => {
+    prisma.subscriptionPayment.findUnique.mockResolvedValue(successfulPayment);
+    paytr.refund.mockResolvedValue({
+      status: "failed",
+      reason: "declined",
+      raw: {},
+    });
+
+    await expect(
+      svc.refundPayment(
+        SUB_ID,
+        { paymentId: PAYMENT_ID, reason: "test" },
+        "a1",
+        "a@x",
+      ),
+    ).rejects.toBeInstanceOf(BadRequestException);
+
+    // Two updateMany calls: the SUCCEEDED→REFUNDING claim, then the
+    // REFUNDING→SUCCEEDED rollback.
+    expect(prisma.subscriptionPayment.updateMany).toHaveBeenCalledTimes(2);
+    expect(prisma.subscriptionPayment.updateMany).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ status: "REFUNDING" }),
+        data: expect.objectContaining({ status: "SUCCEEDED" }),
+      }),
+    );
+    // Terminal write never happens on a PayTR rejection.
+    expect(prisma.subscriptionPayment.update).not.toHaveBeenCalled();
   });
 });
 
@@ -210,7 +328,7 @@ describe('SuperAdminSubscriptionsService.refundPayment', () => {
  * DTO validates them, but createPlan/updatePlan never mapped them into the
  * Prisma write — so a discount edit returned 200 OK and silently vanished.
  */
-describe('SuperAdminSubscriptionsService plan discount persistence', () => {
+describe("SuperAdminSubscriptionsService plan discount persistence", () => {
   let prisma: MockPrismaClient;
   let audit: any;
   let svc: SuperAdminSubscriptionsService;
@@ -230,73 +348,73 @@ describe('SuperAdminSubscriptionsService plan discount persistence', () => {
     );
   });
 
-  it('createPlan writes the discount fields (dates coerced to Date)', async () => {
-    prisma.subscriptionPlan.create.mockResolvedValue({ id: 'plan-1' });
+  it("createPlan writes the discount fields (dates coerced to Date)", async () => {
+    prisma.subscriptionPlan.create.mockResolvedValue({ id: "plan-1" });
 
     await svc.createPlan(
       {
-        name: 'pro',
-        displayName: 'Pro',
+        name: "pro",
+        displayName: "Pro",
         monthlyPrice: 100,
         yearlyPrice: 1000,
         discountPercentage: 25,
-        discountLabel: 'Launch',
-        discountStartDate: '2026-06-16',
-        discountEndDate: '2026-07-16',
+        discountLabel: "Launch",
+        discountStartDate: "2026-06-16",
+        discountEndDate: "2026-07-16",
         isDiscountActive: true,
       } as any,
-      'a1',
-      'a@x',
+      "a1",
+      "a@x",
     );
 
     expect(prisma.subscriptionPlan.create).toHaveBeenCalledWith(
       expect.objectContaining({
         data: expect.objectContaining({
           discountPercentage: 25,
-          discountLabel: 'Launch',
-          discountStartDate: new Date('2026-06-16'),
-          discountEndDate: new Date('2026-07-16'),
+          discountLabel: "Launch",
+          discountStartDate: new Date("2026-06-16"),
+          discountEndDate: new Date("2026-07-16"),
           isDiscountActive: true,
         }),
       }),
     );
   });
 
-  it('updatePlan writes the discount fields (dates coerced to Date)', async () => {
-    prisma.subscriptionPlan.findUnique.mockResolvedValue({ id: 'plan-1' });
-    prisma.subscriptionPlan.update.mockResolvedValue({ id: 'plan-1' });
+  it("updatePlan writes the discount fields (dates coerced to Date)", async () => {
+    prisma.subscriptionPlan.findUnique.mockResolvedValue({ id: "plan-1" });
+    prisma.subscriptionPlan.update.mockResolvedValue({ id: "plan-1" });
 
     await svc.updatePlan(
-      'plan-1',
+      "plan-1",
       {
         discountPercentage: 30,
-        discountLabel: 'Sale',
-        discountStartDate: '2026-06-16',
-        discountEndDate: '2026-07-16',
+        discountLabel: "Sale",
+        discountStartDate: "2026-06-16",
+        discountEndDate: "2026-07-16",
         isDiscountActive: true,
       } as any,
-      'a1',
-      'a@x',
+      "a1",
+      "a@x",
     );
 
     expect(prisma.subscriptionPlan.update).toHaveBeenCalledWith(
       expect.objectContaining({
         data: expect.objectContaining({
           discountPercentage: 30,
-          discountLabel: 'Sale',
-          discountStartDate: new Date('2026-06-16'),
-          discountEndDate: new Date('2026-07-16'),
+          discountLabel: "Sale",
+          discountStartDate: new Date("2026-06-16"),
+          discountEndDate: new Date("2026-07-16"),
           isDiscountActive: true,
         }),
       }),
     );
   });
 
-  it('updatePlan leaves discount dates untouched (undefined) when omitted', async () => {
-    prisma.subscriptionPlan.findUnique.mockResolvedValue({ id: 'plan-1' });
-    prisma.subscriptionPlan.update.mockResolvedValue({ id: 'plan-1' });
+  it("updatePlan leaves discount dates untouched (undefined) when omitted", async () => {
+    prisma.subscriptionPlan.findUnique.mockResolvedValue({ id: "plan-1" });
+    prisma.subscriptionPlan.update.mockResolvedValue({ id: "plan-1" });
 
-    await svc.updatePlan('plan-1', { monthlyPrice: 200 } as any, 'a1', 'a@x');
+    await svc.updatePlan("plan-1", { monthlyPrice: 200 } as any, "a1", "a@x");
 
     const data = prisma.subscriptionPlan.update.mock.calls[0][0].data;
     expect(data.discountStartDate).toBeUndefined();

--- a/backend/src/modules/superadmin/services/superadmin-subscriptions.service.ts
+++ b/backend/src/modules/superadmin/services/superadmin-subscriptions.service.ts
@@ -3,6 +3,7 @@ import {
   Logger,
   NotFoundException,
   BadRequestException,
+  ConflictException,
 } from "@nestjs/common";
 import { Prisma } from "@prisma/client";
 import { differenceInDays } from "date-fns";
@@ -26,6 +27,15 @@ import { captureException } from "../../../sentry.config";
 @Injectable()
 export class SuperAdminSubscriptionsService {
   private readonly logger = new Logger(SuperAdminSubscriptionsService.name);
+
+  /**
+   * Non-terminal claim state used by refundPayment to atomically reserve a
+   * payment before calling PayTR (deep-review H17). Lives as a local string
+   * literal because SubscriptionPayment.status is a free-form String column
+   * (not a Prisma enum), so no migration is needed; the shared PaymentStatus
+   * TS enum only models the terminal states.
+   */
+  private static readonly REFUNDING_STATUS = "REFUNDING";
 
   constructor(
     private prisma: PrismaService,
@@ -647,13 +657,45 @@ export class SuperAdminSubscriptionsService {
       }
     }
 
-    const result = await this.paytr.refund({
-      merchantOid: payment.paytrMerchantOid,
-      amount: refundAmount,
-      referenceNo: payment.id,
+    // Atomically claim the payment BEFORE touching PayTR (deep-review H17).
+    // The read-then-check above can be raced: two ops requests (double-click,
+    // retry, two operators) could both read status=SUCCEEDED, both pass the
+    // guard, and both call paytr.refund(). A full+full pair is caught by
+    // PayTR's duplicate rejection, but two DIFFERENT partial amounts (or a
+    // full + a partial) can BOTH succeed at PayTR — moving real money twice.
+    // updateMany with status in the WHERE is a single conditional write, so
+    // only one caller can flip SUCCEEDED→REFUNDING and proceed; the rest get
+    // a 409. No FOR UPDATE / explicit transaction needed.
+    const claim = await this.prisma.subscriptionPayment.updateMany({
+      where: { id: payment.id, status: PaymentStatus.SUCCEEDED },
+      data: { status: SuperAdminSubscriptionsService.REFUNDING_STATUS },
     });
+    if (claim.count !== 1) {
+      throw new ConflictException({
+        errorCode: "REFUND_IN_PROGRESS_OR_DONE",
+        message:
+          "A refund for this payment is already in progress or completed.",
+      });
+    }
+
+    let result: Awaited<ReturnType<PaytrAdapter["refund"]>>;
+    try {
+      result = await this.paytr.refund({
+        merchantOid: payment.paytrMerchantOid,
+        amount: refundAmount,
+        referenceNo: payment.id,
+      });
+    } catch (err) {
+      // PayTR call threw (network/timeout) — no confirmed money move. Release
+      // the claim so the payment can be retried, then rethrow.
+      await this.releaseRefundClaim(payment.id);
+      throw err;
+    }
 
     if (result.status !== "success") {
+      // PayTR rejected — no money moved. Roll the claim back REFUNDING→SUCCEEDED
+      // so the payment can be retried, then surface the rejection (H17).
+      await this.releaseRefundClaim(payment.id);
       throw new BadRequestException(
         `PayTR refund rejected: ${result.reason ?? "unknown"}`,
       );
@@ -715,6 +757,36 @@ export class SuperAdminSubscriptionsService {
         message:
           "PayTR refund succeeded but local payment state could not be updated. " +
           "Ops has been alerted — do NOT retry the refund (PayTR will reject as duplicate).",
+      });
+    }
+  }
+
+  /**
+   * Roll a refund claim back REFUNDING→SUCCEEDED when PayTR did NOT move money
+   * (threw or rejected) so the payment becomes refundable again (deep-review
+   * H17). Guarded on the REFUNDING state so it only ever touches the row this
+   * request claimed. A failure to release is logged + reported but never
+   * masks the original PayTR error — worst case the row is stuck in REFUNDING
+   * and a human un-sticks it, which is strictly safer than an unclaimed
+   * double-refund.
+   */
+  private async releaseRefundClaim(paymentId: string): Promise<void> {
+    try {
+      await this.prisma.subscriptionPayment.updateMany({
+        where: {
+          id: paymentId,
+          status: SuperAdminSubscriptionsService.REFUNDING_STATUS,
+        },
+        data: { status: PaymentStatus.SUCCEEDED },
+      });
+    } catch (releaseErr: any) {
+      this.logger.error(
+        `Failed to release refund claim for payment=${paymentId}; row may be stuck in REFUNDING: ${releaseErr?.message ?? releaseErr}`,
+      );
+      captureException(releaseErr, {
+        severity: "warning",
+        context: "refund-claim-release-failed",
+        paymentId,
       });
     }
   }

--- a/edge-device-cpp/src/camera/rtsp_client.cpp
+++ b/edge-device-cpp/src/camera/rtsp_client.cpp
@@ -4,6 +4,9 @@
 #include <gst/gst.h>
 #include <gst/app/gstappsink.h>
 
+#include <algorithm>  // deep-review NH11: std::max for fps clamp
+#include <cstddef>
+
 namespace kds {
 
 // Initialize GStreamer once
@@ -33,13 +36,15 @@ bool RTSPClient::start() {
         return true;
     }
 
-    LOG_INFO("Starting RTSP client: {}", current_url_);
+    // deep-review NH12: read a locked snapshot of the URL, never the shared member.
+    const std::string url = get_url();
+    LOG_INFO("Starting RTSP client: {}", url);
 
     // Reset statistics
     {
         std::lock_guard<std::mutex> lock(stats_mutex_);
         stats_ = CameraStats{};
-        stats_.url = current_url_;
+        stats_.url = url;
     }
 
     if (!create_pipeline()) {
@@ -121,17 +126,29 @@ bool RTSPClient::reconnect() {
 }
 
 void RTSPClient::set_url(const std::string& url) {
-    current_url_ = url;
+    // deep-review NH12: take the lock only for the write and release it before
+    // reconnect(), which calls stop()/join(). Holding url_mutex_ across the join
+    // would needlessly serialize against the capture thread (which also reads
+    // the URL via get_url()) and risk a deadlock. set_url runs on the ws/io
+    // thread, so the join itself is safe.
+    {
+        std::lock_guard<std::mutex> lock(url_mutex_);
+        current_url_ = url;
+    }
     if (running_) {
         reconnect();
     }
 }
 
 bool RTSPClient::create_pipeline() {
+    // deep-review NH12: build the pipeline from one locked snapshot of the URL
+    // so a concurrent set_url() on the ws thread can't tear the std::string read.
+    const std::string url = get_url();
+
     // Build GStreamer pipeline string
     // Use hardware decoding if available (NVDEC for Jetson)
     std::string pipeline_str =
-        "rtspsrc location=\"" + current_url_ + "\" "
+        "rtspsrc location=\"" + url + "\" "
         "latency=100 buffer-mode=auto ! "
         "rtph264depay ! "
         "h264parse ! ";
@@ -226,9 +243,14 @@ void RTSPClient::capture_loop() {
             break;
         }
 
-        // Pull sample with timeout
+        // Pull sample with timeout.
+        // deep-review NH11: clamp fps to >= 1 before dividing. A misconfigured or
+        // SIGHUP-reloaded config with fps == 0 would otherwise be integer
+        // division by zero (SIGFPE); a negative fps would wrap to a huge unsigned
+        // GstClockTime timeout and hang the capture loop.
+        const int fps = std::max(1, config_.fps);
         GstSample* sample = gst_app_sink_try_pull_sample(
-            GST_APP_SINK(appsink_), GST_SECOND / config_.fps);
+            GST_APP_SINK(appsink_), GST_SECOND / fps);
 
         if (!sample) {
             consecutive_errors++;
@@ -292,7 +314,10 @@ bool RTSPClient::process_sample(GstSample* sample) {
     gst_structure_get_int(structure, "width", &width);
     gst_structure_get_int(structure, "height", &height);
 
-    if (width == 0 || height == 0) {
+    // deep-review NM7: reject non-positive dims. The old `== 0` check let a
+    // negative-but-nonzero width/height from malicious/buggy caps through and
+    // into the cv::Mat allocation.
+    if (width <= 0 || height <= 0) {
         LOG_WARN("Invalid frame dimensions: {}x{}", width, height);
         return false;
     }
@@ -304,8 +329,24 @@ bool RTSPClient::process_sample(GstSample* sample) {
         return false;
     }
 
-    // Create OpenCV Mat from buffer data
-    cv::Mat frame(height, width, CV_8UC3, map.data);
+    // deep-review NM7: validate the mapped buffer is large enough for the
+    // negotiated frame before constructing the Mat, otherwise frame.clone()
+    // reads out-of-bounds past map.data (OOB read / crash) on a short buffer
+    // from a malformed stream or stride/padding mismatch. GStreamer BGR rows
+    // are padded up to a 4-byte boundary, so account for the real stride.
+    const std::size_t stride = GST_ROUND_UP_4(static_cast<std::size_t>(width) * 3);
+    const std::size_t expected = stride * static_cast<std::size_t>(height);
+    if (map.size < expected) {
+        LOG_WARN("Buffer too small: have {} need {} ({}x{} BGR)",
+                 map.size, expected, width, height);
+        gst_buffer_unmap(buffer, &map);  // NM7: don't leak the map on early return
+        return false;
+    }
+
+    // Create OpenCV Mat from buffer data.
+    // deep-review NM7: pass the real stride so a padded buffer isn't misread as
+    // tight-packed (which would read past the row for non-4-aligned widths).
+    cv::Mat frame(height, width, CV_8UC3, map.data, stride);
 
     // Update latest frame
     {

--- a/edge-device-cpp/src/camera/rtsp_client.hpp
+++ b/edge-device-cpp/src/camera/rtsp_client.hpp
@@ -72,7 +72,19 @@ public:
 
 private:
     CameraConfig config_;
-    std::string current_url_;
+
+    // deep-review NH12: current_url_ is read on the capture thread (pipeline
+    // build / auto-reconnect) and written on the ws/io thread (set_url from a
+    // backend config push). Guard it with a dedicated mutex; never touch the
+    // shared std::string directly — always go through get_url() for a locked
+    // snapshot.
+    mutable std::mutex url_mutex_;
+    std::string current_url_;  // guarded by url_mutex_
+
+    std::string get_url() const {
+        std::lock_guard<std::mutex> lock(url_mutex_);
+        return current_url_;
+    }
 
     // State
     std::atomic<bool> running_{false};

--- a/edge-device-cpp/src/communication/websocket_client.cpp
+++ b/edge-device-cpp/src/communication/websocket_client.cpp
@@ -1,6 +1,8 @@
 #include "websocket_client.hpp"
 #include "../utils/logger.hpp"
 
+#include <boost/asio/ssl/host_name_verification.hpp>  // deep-review NH14
+
 #include <chrono>
 #include <iomanip>
 #include <sstream>
@@ -68,15 +70,54 @@ std::shared_ptr<boost::asio::ssl::context> WebSocketClient::on_tls_init() {
         // Use system default certificates
         ctx->set_default_verify_paths();
 
-        // For development, you might want to skip verification
-        // ctx->set_verify_mode(boost::asio::ssl::verify_none);
         ctx->set_verify_mode(boost::asio::ssl::verify_peer);
+
+        // deep-review NH14: verify_peer only validates the cert chains to a
+        // trusted CA — it does NOT check the cert's hostname. Without this any
+        // CA-valid cert for the WRONG host (or a DNS-redirected MITM) would
+        // complete the handshake and capture the device's long-lived Bearer
+        // auth_token. Install RFC2818 hostname verification against the host
+        // parsed from the backend URL. (Boost.Asio does not do this under
+        // verify_peer by default.)
+        const std::string host = parse_host(config_.url);
+        if (!host.empty()) {
+            ctx->set_verify_callback(boost::asio::ssl::host_name_verification(host));
+        } else {
+            LOG_ERROR("Could not parse host from backend URL for TLS hostname "
+                      "verification: {}", config_.url);
+        }
 
     } catch (const std::exception& e) {
         LOG_ERROR("TLS init error: {}", e.what());
     }
 
     return ctx;
+}
+
+// deep-review NH14: extract the bare hostname from a ws(s)://host[:port][/path]
+// (or with a query string) URL. Returns "" if no host can be found.
+std::string WebSocketClient::parse_host(const std::string& url) {
+    std::string s = url;
+
+    // Strip scheme (ws://, wss://, http://, https://, ...).
+    const auto scheme_pos = s.find("://");
+    if (scheme_pos != std::string::npos) {
+        s = s.substr(scheme_pos + 3);
+    }
+
+    // Strip any userinfo (user:pass@host) if present.
+    const auto at_pos = s.find('@');
+    if (at_pos != std::string::npos) {
+        s = s.substr(at_pos + 1);
+    }
+
+    // Host ends at the first of '/', ':' (port) or '?' (query).
+    const auto end = s.find_first_of("/:?");
+    if (end != std::string::npos) {
+        s = s.substr(0, end);
+    }
+
+    return s;
 }
 
 bool WebSocketClient::connect() {
@@ -111,7 +152,12 @@ bool WebSocketClient::connect() {
         con->append_header("Authorization", "Bearer " + config_.auth_token);
     }
 
-    connection_ = con->get_handle();
+    {
+        // deep-review NH15: serialize the connection_ write against send_raw/
+        // disconnect reads on other threads.
+        std::lock_guard<std::mutex> lk(conn_mutex_);
+        connection_ = con->get_handle();
+    }
     client_.connect(con);
 
     return true;
@@ -124,8 +170,15 @@ void WebSocketClient::disconnect() {
 
     LOG_INFO("Disconnecting from backend");
 
+    // deep-review NH15: copy the handle under the lock before the network call.
+    ConnectionHdl hdl;
+    {
+        std::lock_guard<std::mutex> lk(conn_mutex_);
+        hdl = connection_;
+    }
+
     websocketpp::lib::error_code ec;
-    client_.close(connection_, websocketpp::close::status::normal, "Client closing", ec);
+    client_.close(hdl, websocketpp::close::status::normal, "Client closing", ec);
 
     if (ec) {
         LOG_ERROR("Close error: {}", ec.message());
@@ -175,6 +228,12 @@ void WebSocketClient::stop() {
     running_ = false;
     disconnect();
 
+    // deep-review NH13: cancel the pending registration timer before stopping
+    // the io_service so its callback can't fire against a tearing-down client.
+    if (register_timer_) {
+        register_timer_->cancel();
+    }
+
     // Stop the io_service
     client_.stop();
 
@@ -184,31 +243,60 @@ void WebSocketClient::stop() {
 
 void WebSocketClient::on_open(ConnectionHdl hdl) {
     LOG_INFO("WebSocket connection opened");
-    connection_ = hdl;
+    {
+        // deep-review NH15: serialize the connection_ write against sender-thread
+        // reads in send_raw/disconnect.
+        std::lock_guard<std::mutex> lk(conn_mutex_);
+        connection_ = hdl;
+    }
     connected_ = true;
 
     // Socket.IO open packet
     send_raw("40/analytics-edge,");
 
-    // Register device after brief delay
-    std::thread([this]() {
-        std::this_thread::sleep_for(std::chrono::milliseconds(500));
+    // deep-review NH13: schedule the delayed device registration on the
+    // io_service's own timer instead of a detached std::thread. The old detached
+    // thread captured `this` and ran 500ms later — if the client was destroyed
+    // within that window (shutdown), it dereferenced freed memory (use-after-
+    // free), and every reconnect spawned a fresh thread (thread churn on a
+    // reconnect storm). This timer is owned by, and cancelled with, the client:
+    // its callback runs on the same io thread that stop()+join() drains, so by
+    // the time the object is destroyed no callback can still be pending.
+    // Cancel any in-flight timer first so reconnects don't accumulate timers.
+    if (register_timer_) {
+        register_timer_->cancel();
+    }
+    register_timer_ = client_.set_timer(500, [this](const websocketpp::lib::error_code& ec) {
+        if (ec) {
+            return;  // cancelled (e.g. on stop) — bail
+        }
         if (connected_) {
             register_device();
         }
-    }).detach();
+    });
 }
 
 void WebSocketClient::on_close(ConnectionHdl /*hdl*/) {
     LOG_INFO("WebSocket connection closed");
     connected_ = false;
     registered_ = false;
+    // deep-review NH15: clear the stale handle so nothing is sent on a dead
+    // connection after a drop.
+    {
+        std::lock_guard<std::mutex> lk(conn_mutex_);
+        connection_ = ConnectionHdl();
+    }
 }
 
 void WebSocketClient::on_fail(ConnectionHdl /*hdl*/) {
     LOG_ERROR("WebSocket connection failed");
     connected_ = false;
     registered_ = false;
+    // deep-review NH15: clear the stale handle (see on_close).
+    {
+        std::lock_guard<std::mutex> lk(conn_mutex_);
+        connection_ = ConnectionHdl();
+    }
 }
 
 void WebSocketClient::on_message(ConnectionHdl /*hdl*/, MessagePtr msg) {
@@ -236,8 +324,16 @@ bool WebSocketClient::send_raw(const std::string& message) {
     }
 
     try {
+        // deep-review NH15: copy the handle under the lock, then send outside it
+        // so the network call isn't serialized behind conn_mutex_.
+        ConnectionHdl hdl;
+        {
+            std::lock_guard<std::mutex> lk(conn_mutex_);
+            hdl = connection_;
+        }
+
         websocketpp::lib::error_code ec;
-        client_.send(connection_, message, websocketpp::frame::opcode::text, ec);
+        client_.send(hdl, message, websocketpp::frame::opcode::text, ec);
 
         if (ec) {
             LOG_ERROR("Send error: {}", ec.message());

--- a/edge-device-cpp/src/communication/websocket_client.hpp
+++ b/edge-device-cpp/src/communication/websocket_client.hpp
@@ -96,8 +96,19 @@ private:
 
     // WebSocket client
     Client client_;
-    ConnectionHdl connection_;
+
+    // deep-review NH15: connection_ (a weak_ptr) is written on the io thread
+    // (on_open/connect) and read on the sender thread (send_raw/disconnect).
+    // weak_ptr copy is not atomic, so guard every access with this mutex.
+    mutable std::mutex conn_mutex_;
+    ConnectionHdl connection_;  // guarded by conn_mutex_
+
     std::thread io_thread_;
+
+    // deep-review NH13: delayed device-registration timer, owned by the
+    // io_service so it is cancelled when the client stops — replaces the old
+    // detached std::thread that could dereference a freed `this`.
+    Client::timer_ptr register_timer_;
 
     // State
     std::atomic<bool> running_{false};
@@ -131,6 +142,10 @@ private:
 
     // TLS context setup
     std::shared_ptr<boost::asio::ssl::context> on_tls_init();
+
+    // deep-review NH14: extract the hostname from a ws(s):// URL for RFC2818
+    // hostname verification. static so it is unit-testable in isolation.
+    static std::string parse_host(const std::string& url);
 
     // Reconnection logic
     void reconnect();

--- a/edge-device-cpp/src/detection/yolo_tensorrt.cpp
+++ b/edge-device-cpp/src/detection/yolo_tensorrt.cpp
@@ -5,6 +5,8 @@
 #include <filesystem>
 #include <fstream>
 #include <chrono>
+#include <exception>
+#include <new>
 
 #ifdef WITH_TENSORRT
 #include <NvOnnxParser.h>
@@ -206,12 +208,40 @@ bool YoloTensorRT::load_engine(const std::string& engine_path) {
         return false;
     }
 
+    // deep-review NL2: validate file size (tellg may fail -> -1, wrapping to a
+    // gigantic size_t) and detect truncation before deserializing untrusted
+    // engine bytes onto the GPU. On any failure return false; initialize()
+    // already self-heals by rebuilding from ONNX (LOG_WARN at the call site).
     file.seekg(0, std::ios::end);
-    size_t size = file.tellg();
+    const std::streamoff ssize = file.tellg();
     file.seekg(0, std::ios::beg);
+    if (!file.good() || ssize <= 0) {
+        LOG_ERROR("Engine file size invalid (tellg={}): {}",
+                  static_cast<long long>(ssize), engine_path);
+        return false;
+    }
+    constexpr std::streamoff kMaxEngineBytes = 2ll * 1024 * 1024 * 1024;  // sanity cap
+    if (ssize > kMaxEngineBytes) {
+        LOG_ERROR("Engine file too large ({} bytes): {}",
+                  static_cast<long long>(ssize), engine_path);
+        return false;
+    }
+    const size_t size = static_cast<size_t>(ssize);
 
-    std::vector<char> engine_data(size);
-    file.read(engine_data.data(), size);
+    std::vector<char> engine_data;
+    try {
+        engine_data.resize(size);
+    } catch (const std::bad_alloc&) {
+        LOG_ERROR("Failed to allocate {} bytes for engine: {}", size, engine_path);
+        return false;
+    }
+
+    file.read(engine_data.data(), static_cast<std::streamsize>(size));
+    if (static_cast<size_t>(file.gcount()) != size) {
+        LOG_ERROR("Engine file truncated: read {} of {} bytes: {}",
+                  file.gcount(), size, engine_path);
+        return false;
+    }
     file.close();
 
     // Create runtime
@@ -287,48 +317,121 @@ bool YoloTensorRT::save_engine(const std::string& engine_path) {
 
 #ifdef WITH_TENSORRT
 
+// deep-review NH9: convert a TensorRT tensor shape to an element count, rejecting
+// dynamic/unresolved (-1) and zero dims and guarding against size_t overflow.
+// A dynamic-shape engine reports d[j] == -1 here; without this guard the count
+// promotes to a gigantic size_t and resize()/cudaMalloc OOM-kills the device.
+static bool dims_to_count(const nvinfer1::Dims& dims, size_t& out) {
+    if (dims.nbDims <= 0) {
+        LOG_ERROR("Engine tensor has invalid rank {}", dims.nbDims);
+        return false;
+    }
+    size_t count = 1;
+    for (int j = 0; j < dims.nbDims; ++j) {
+        if (dims.d[j] <= 0) {  // catches -1 (dynamic/unresolved) and 0
+            LOG_ERROR("Engine tensor dim[{}]={} is non-positive/dynamic; set an "
+                      "optimization profile and context input shape before allocating",
+                      j, static_cast<long long>(dims.d[j]));
+            return false;
+        }
+        const size_t d = static_cast<size_t>(dims.d[j]);
+        // Reserve room for the later *sizeof(float) when computing byte sizes.
+        if (count > (SIZE_MAX / sizeof(float)) / d) {
+            LOG_ERROR("Engine tensor element count overflows size_t");
+            return false;
+        }
+        count *= d;
+    }
+    out = count;
+    return true;
+}
+
 bool YoloTensorRT::allocate_buffers() {
     // Get input/output tensor info
     int num_io_tensors = engine_->getNbIOTensors();
     LOG_DEBUG("Engine has {} I/O tensors", num_io_tensors);
 
-    for (int i = 0; i < num_io_tensors; ++i) {
-        const char* name = engine_->getIOTensorName(i);
-        auto mode = engine_->getTensorIOMode(name);
-        auto dims = engine_->getTensorShape(name);
+    // deep-review NM6: count inputs/outputs so we can reject multi-head/NMS-plugin
+    // engines whose IO layout this single-input/single-output path cannot serve.
+    int n_in = 0;
+    int n_out = 0;
 
-        std::string dims_str;
-        for (int j = 0; j < dims.nbDims; ++j) {
-            dims_str += std::to_string(dims.d[j]) + " ";
-        }
-        LOG_DEBUG("  Tensor '{}': mode={} dims=[{}]",
-                  name, mode == nvinfer1::TensorIOMode::kINPUT ? "INPUT" : "OUTPUT", dims_str);
+    // deep-review NH9: a std::bad_alloc / std::length_error from a bogus engine
+    // shape must surface as a clean false (-> rebuild from ONNX), not std::terminate.
+    try {
+        for (int i = 0; i < num_io_tensors; ++i) {
+            const char* name = engine_->getIOTensorName(i);
+            auto mode = engine_->getTensorIOMode(name);
+            // Read the resolved shape from the execution context, not the engine:
+            // for dynamic engines the engine shape stays -1 until the context binds
+            // a concrete input shape.
+            auto dims = context_->getTensorShape(name);
 
-        if (mode == nvinfer1::TensorIOMode::kINPUT) {
-            // Input tensor (batch, channels, height, width)
-            input_channels_ = dims.d[1];
-            input_height_ = dims.d[2];
-            input_width_ = dims.d[3];
-            input_size_ = dims.d[0] * dims.d[1] * dims.d[2] * dims.d[3];
-
-            host_input_.resize(input_size_);
-            if (cudaMalloc(&device_input_, input_size_ * sizeof(float)) != cudaSuccess) {
-                LOG_ERROR("Failed to allocate device input buffer");
-                return false;
+            std::string dims_str;
+            for (int j = 0; j < dims.nbDims; ++j) {
+                dims_str += std::to_string(dims.d[j]) + " ";
             }
-        } else {
-            // Output tensor (batch, num_classes + 4, num_detections)
-            // YOLOv8 output: (1, 84, 8400) for COCO (4 box coords + 80 classes)
-            num_classes_ = dims.d[1] - 4;
-            num_detections_ = dims.d[2];
-            output_size_ = dims.d[0] * dims.d[1] * dims.d[2];
+            LOG_DEBUG("  Tensor '{}': mode={} dims=[{}]",
+                      name, mode == nvinfer1::TensorIOMode::kINPUT ? "INPUT" : "OUTPUT", dims_str);
 
-            host_output_.resize(output_size_);
-            if (cudaMalloc(&device_output_, output_size_ * sizeof(float)) != cudaSuccess) {
-                LOG_ERROR("Failed to allocate device output buffer");
-                return false;
+            if (mode == nvinfer1::TensorIOMode::kINPUT) {
+                ++n_in;
+                input_name_ = name;  // deep-review NM6
+
+                // deep-review NH9: require a concrete NCHW shape.
+                if (dims.nbDims < 4 || dims.d[1] <= 0 || dims.d[2] <= 0 || dims.d[3] <= 0) {
+                    LOG_ERROR("Invalid input tensor shape for '{}'", name);
+                    return false;
+                }
+                input_channels_ = static_cast<int>(dims.d[1]);
+                input_height_   = static_cast<int>(dims.d[2]);
+                input_width_    = static_cast<int>(dims.d[3]);
+                if (!dims_to_count(dims, input_size_)) {
+                    return false;
+                }
+
+                host_input_.resize(input_size_);
+                if (cudaMalloc(&device_input_, input_size_ * sizeof(float)) != cudaSuccess) {
+                    LOG_ERROR("Failed to allocate device input buffer");
+                    return false;
+                }
+            } else {
+                ++n_out;
+                output_name_ = name;  // deep-review NM6
+
+                // Output tensor (batch, num_classes + 4, num_detections)
+                // YOLOv8 output: (1, 84, 8400) for COCO (4 box coords + 80 classes).
+                // deep-review NH9: d[1] must be > 4 so num_classes_ stays positive.
+                if (dims.nbDims < 3 || dims.d[1] <= 4 || dims.d[2] <= 0) {
+                    LOG_ERROR("Invalid output tensor shape for '{}'", name);
+                    return false;
+                }
+                num_classes_    = static_cast<int>(dims.d[1]) - 4;
+                num_detections_ = static_cast<int>(dims.d[2]);
+                if (!dims_to_count(dims, output_size_)) {
+                    return false;
+                }
+
+                host_output_.resize(output_size_);
+                if (cudaMalloc(&device_output_, output_size_ * sizeof(float)) != cudaSuccess) {
+                    LOG_ERROR("Failed to allocate device output buffer");
+                    return false;
+                }
             }
         }
+    } catch (const std::exception& e) {
+        LOG_ERROR("Buffer allocation failed (bad engine shape?): {}", e.what());
+        return false;
+    }
+
+    // deep-review NM6: detect() binds exactly one input + one output by name;
+    // fail fast at load time for any other layout rather than binding the wrong
+    // device buffer to the wrong tensor at inference time.
+    if (n_in != 1 || n_out != 1 || input_name_.empty() || output_name_.empty() ||
+        device_input_ == nullptr || device_output_ == nullptr) {
+        LOG_ERROR("Unsupported engine IO layout: inputs={} outputs={} (input='{}' output='{}')",
+                  n_in, n_out, input_name_, output_name_);
+        return false;
     }
 
     LOG_DEBUG("Buffers allocated: input={} output={}", input_size_, output_size_);
@@ -418,36 +521,58 @@ std::vector<Detection> YoloTensorRT::detect(const cv::Mat& frame) {
         }
     }
 
-    // Copy input to device
-    cudaMemcpyAsync(device_input_, host_input_.data(),
-                    input_size_ * sizeof(float),
-                    cudaMemcpyHostToDevice, stream_);
+    // deep-review NH10: check every CUDA call and fail closed by returning {}
+    // (the same empty-frame contract already used on enqueueV3 failure). A
+    // silently-failed copy would feed stale/uninitialized host buffers into the
+    // decoder, corrupting occupancy/tracking with no error surfaced.
 
-    // Set tensor addresses
-    const char* input_name = engine_->getIOTensorName(0);
-    const char* output_name = engine_->getIOTensorName(1);
-    context_->setTensorAddress(input_name, device_input_);
-    context_->setTensorAddress(output_name, device_output_);
+    // Copy input to device
+    cudaError_t err = cudaMemcpyAsync(device_input_, host_input_.data(),
+                                      input_size_ * sizeof(float),
+                                      cudaMemcpyHostToDevice, stream_);
+    if (err != cudaSuccess) {
+        LOG_ERROR("H2D copy failed: {}", cudaGetErrorString(err));
+        return {};
+    }
+
+    // Set tensor addresses using the names resolved by IOMode in
+    // allocate_buffers() (deep-review NM6) rather than hardcoded indices 0/1.
+    context_->setTensorAddress(input_name_.c_str(), device_input_);
+    context_->setTensorAddress(output_name_.c_str(), device_output_);
 
     // Run inference
-    bool success = context_->enqueueV3(stream_);
-    if (!success) {
-        LOG_ERROR("Inference failed");
+    if (!context_->enqueueV3(stream_)) {
+        LOG_ERROR("Inference enqueue failed");
         return {};
     }
 
     // Copy output back to host
-    cudaMemcpyAsync(host_output_.data(), device_output_,
-                    output_size_ * sizeof(float),
-                    cudaMemcpyDeviceToHost, stream_);
+    err = cudaMemcpyAsync(host_output_.data(), device_output_,
+                          output_size_ * sizeof(float),
+                          cudaMemcpyDeviceToHost, stream_);
+    if (err != cudaSuccess) {
+        LOG_ERROR("D2H copy enqueue failed: {}", cudaGetErrorString(err));
+        return {};
+    }
 
-    // Synchronize
-    cudaStreamSynchronize(stream_);
+    // Synchronize and surface any error raised during async execution.
+    err = cudaStreamSynchronize(stream_);
+    if (err != cudaSuccess) {
+        LOG_ERROR("Stream synchronize failed: {}", cudaGetErrorString(err));
+        return {};
+    }
+    // cudaStreamSynchronize already returns the first async error, but clear
+    // sticky state so a fault on this frame does not contaminate the next.
+    cudaError_t async_err = cudaGetLastError();
+    if (async_err != cudaSuccess) {
+        LOG_ERROR("CUDA async error during inference: {}", cudaGetErrorString(async_err));
+        return {};
+    }
 
     auto end = std::chrono::high_resolution_clock::now();
     inference_time_ms_ = std::chrono::duration<float, std::milli>(end - start).count();
 
-    // Postprocess
+    // Postprocess only reached when the device->host copy provably succeeded.
     return postprocess(host_output_, frame.size());
 #else
     (void)frame;

--- a/edge-device-cpp/src/detection/yolo_tensorrt.hpp
+++ b/edge-device-cpp/src/detection/yolo_tensorrt.hpp
@@ -100,6 +100,11 @@ private:
     cudaStream_t stream_ = nullptr;
     void* device_input_ = nullptr;
     void* device_output_ = nullptr;
+
+    // Resolved IO tensor names (deep-review NM6): cached by IOMode in
+    // allocate_buffers() so detect() never hardcodes getIOTensorName(0/1).
+    std::string input_name_;
+    std::string output_name_;
     std::vector<float> host_input_;
     std::vector<float> host_output_;
 

--- a/frontend/src/components/kitchen/OrderCard.tsx
+++ b/frontend/src/components/kitchen/OrderCard.tsx
@@ -2,7 +2,7 @@ import { Clock, MoreVertical, X, Check } from 'lucide-react';
 import { Order, OrderStatus } from '../../types';
 import Button from '../ui/Button';
 import { getOrderUrgency, getUrgencyStyles, cn } from '../../lib/utils';
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
 import {
@@ -37,7 +37,22 @@ const OrderCard = ({ order, onUpdateStatus, onCancelOrder, isUpdating, actionTou
   // "Emin misiniz?" row commits or aborts. Prevents one-tap mis-cancels on a
   // busy touch screen.
   const [confirmingCancel, setConfirmingCancel] = useState(false);
+  // deep-review FM5: track the active Undo toast so an unmounting card (e.g.
+  // removed by a realtime invalidation) can dismiss it before its timer fires.
+  // toast.dismiss does NOT call onAutoClose, so this safely aborts a deferred
+  // commit from a card that is no longer on the board.
+  const cancelToastIdRef = useRef<string | number | null>(null);
   const { t } = useTranslation('kitchen');
+
+  // deep-review FM5: on unmount, dismiss any pending Undo toast so a removed
+  // card cannot commit a phantom cancel after the fact.
+  useEffect(() => {
+    return () => {
+      if (cancelToastIdRef.current !== null) {
+        toast.dismiss(cancelToastIdRef.current);
+      }
+    };
+  }, []);
 
   // Update elapsed time and urgency every second
   useEffect(() => {
@@ -118,7 +133,7 @@ const OrderCard = ({ order, onUpdateStatus, onCancelOrder, isUpdating, actionTou
     if (!onCancelOrder) return;
     setConfirmingCancel(false);
     let aborted = false;
-    toast(
+    const id = toast(
       t('kitchen.cancellingToast', '#{{n}} siparişi iptal ediliyor…', { n: order.orderNumber }),
       {
         duration: 5000,
@@ -131,10 +146,13 @@ const OrderCard = ({ order, onUpdateStatus, onCancelOrder, isUpdating, actionTou
         // Only a natural timeout commits the cancel; an Undo tap or manual
         // dismiss leaves `aborted`/no-autoclose so the order is untouched.
         onAutoClose: () => {
+          cancelToastIdRef.current = null;
           if (!aborted) onCancelOrder(order.id);
         },
       }
     );
+    // deep-review FM5: remember the active toast so unmount can dismiss it.
+    cancelToastIdRef.current = id;
   };
 
   return (

--- a/frontend/src/components/pos/OrderCart.tsx
+++ b/frontend/src/components/pos/OrderCart.tsx
@@ -38,6 +38,11 @@ interface OrderCartProps {
   hasSelectedTable?: boolean;
   canProceedToPayment?: boolean;
   paymentBlockedReason?: string | null;
+  // deep-review FH2: true when the cart/discount/notes diverged from the saved
+  // order. Disables "Proceed to Payment" so the cashier is steered to "Update
+  // Order" first — otherwise two-step checkout would charge the stale server
+  // amount and drop the newly added items from the bill/kitchen.
+  cartDirty?: boolean;
 }
 
 const OrderCart = ({
@@ -63,6 +68,7 @@ const OrderCart = ({
   hasSelectedTable = false,
   canProceedToPayment = true,
   paymentBlockedReason = null,
+  cartDirty = false,
 }: OrderCartProps) => {
   const { t } = useTranslation('pos');
   const formatPrice = useFormatCurrency();
@@ -313,16 +319,25 @@ const OrderCart = ({
                     {hasActiveOrder ? t('updateOrder') : t('createOrder')}
                   </Button>
 
-                  {/* Payment button - uses canProceedToPayment for eligibility */}
+                  {/* Payment button - uses canProceedToPayment for eligibility.
+                      deep-review FH2: also blocked while the cart diverged from
+                      the saved order, so we never charge the stale amount. */}
                   <Button
                     variant="primary"
                     className="w-full"
                     size="lg"
                     onClick={onCheckout}
-                    disabled={!hasActiveOrder || !canProceedToPayment}
+                    disabled={!hasActiveOrder || !canProceedToPayment || cartDirty}
                   >
                     {t('proceedToPayment')}
                   </Button>
+
+                  {/* deep-review FH2: steer the cashier to re-sync first. */}
+                  {hasActiveOrder && canProceedToPayment && cartDirty && (
+                    <p className="text-sm text-amber-600 text-center">
+                      {t('updateOrderBeforePayment', 'Önce siparişi güncelleyin')}
+                    </p>
+                  )}
 
                   {/* Show blocked reason when payment not allowed */}
                   {hasActiveOrder && !canProceedToPayment && paymentBlockedReason && (

--- a/frontend/src/contexts/SubscriptionContext.spec.tsx
+++ b/frontend/src/contexts/SubscriptionContext.spec.tsx
@@ -90,3 +90,35 @@ describe('SubscriptionContext.hasIntegration (v2.8.88)', () => {
     expect(screen.getByTestId('ready')).toBeInTheDocument();
   });
 });
+
+/**
+ * deep-review FL2 — gates must fail CLOSED when effective-features is
+ * unavailable (still loading, or persistently errored). effective-features
+ * is the documented source of truth (it folds in per-tenant featureOverrides),
+ * so we must never fall back to the raw plan, which ignores negative overrides
+ * and would over-grant a feature an admin/abuse override has disabled.
+ */
+describe('SubscriptionContext fail-closed gating (deep-review FL2)', () => {
+  it('hasFeature returns false when effectiveFeatures is unavailable', () => {
+    const ctx = renderWith(undefined);
+    expect(ctx.hasFeature('posAccess' as any)).toBe(false);
+  });
+
+  it('checkLimit denies (limit 0) when effectiveFeatures is unavailable', () => {
+    const ctx = renderWith(undefined);
+    const result = ctx.checkLimit('maxBranches' as any, 0);
+    expect(result.allowed).toBe(false);
+    expect(result.limit).toBe(0);
+    expect(result.remaining).toBe(0);
+  });
+
+  it('hasFeature honors a negative override from effectiveFeatures', () => {
+    const ctx = renderWith({ features: { posAccess: false }, limits: {} });
+    expect(ctx.hasFeature('posAccess' as any)).toBe(false);
+  });
+
+  it('hasFeature grants when effectiveFeatures enables it', () => {
+    const ctx = renderWith({ features: { posAccess: true }, limits: {} });
+    expect(ctx.hasFeature('posAccess' as any)).toBe(true);
+  });
+});

--- a/frontend/src/contexts/SubscriptionContext.tsx
+++ b/frontend/src/contexts/SubscriptionContext.tsx
@@ -65,9 +65,18 @@ interface SubscriptionProviderProps {
 export const SubscriptionProvider = ({ children }: SubscriptionProviderProps) => {
   const { data: subscription, isLoading: subLoading } = useGetCurrentSubscription();
   const { data: plans, isLoading: plansLoading } = useGetPlans();
-  const { data: effectiveFeatures } = useGetEffectiveFeatures();
+  const {
+    data: effectiveFeatures,
+    isLoading: effLoading,
+    isError: effError,
+  } = useGetEffectiveFeatures();
 
-  const isLoading = subLoading || plansLoading;
+  // deep-review FL2 — effective-features is the documented source of truth for
+  // gates (it folds in per-tenant featureOverrides, including negative/abuse
+  // overrides). Treat its load as part of `isLoading` so FeatureGate's loading
+  // short-circuit covers the window and we never flash content gated only by
+  // the raw plan.features (which ignores overrides).
+  const isLoading = subLoading || plansLoading || effLoading;
 
   // Find the current plan from plans list
   const plan = useMemo(() => {
@@ -77,21 +86,19 @@ export const SubscriptionProvider = ({ children }: SubscriptionProviderProps) =>
 
   // Check if a feature is enabled (effective features = plan + overrides)
   const hasFeature = (feature: keyof PlanFeatures): boolean => {
-    // Use effective features if available (includes overrides)
-    if (effectiveFeatures) {
-      return effectiveFeatures.features[feature] ?? false;
-    }
-    // Fallback to plan data while effective features are loading
-    if (!plan) return false;
-    return plan.features[feature] ?? false;
+    // deep-review FL2 — fail closed when effective-features is unavailable
+    // (still loading, or persistently errored after retry). Do NOT fall back
+    // to raw plan.features: it ignores per-tenant featureOverrides and would
+    // over-grant a feature an admin/abuse override has explicitly disabled.
+    if (!effectiveFeatures) return false;
+    return effectiveFeatures.features[feature] ?? false;
   };
 
   // Check if a resource limit allows creating more items (effective limits = plan + overrides)
   const checkLimit = (resource: keyof PlanLimits, currentCount: number): LimitCheckResult => {
-    // Use effective limits if available (includes overrides)
-    const limit = effectiveFeatures
-      ? effectiveFeatures.limits[resource]
-      : plan?.limits[resource];
+    // deep-review FL2 — fail closed: only consult effective limits (plan +
+    // overrides), never the raw plan when overrides may have lowered the cap.
+    const limit = effectiveFeatures ? effectiveFeatures.limits[resource] : undefined;
 
     if (limit === undefined || limit === null) {
       return { allowed: false, current: currentCount, limit: 0, remaining: 0 };
@@ -142,7 +149,18 @@ export const SubscriptionProvider = ({ children }: SubscriptionProviderProps) =>
       isSubscriptionActive,
       isInGracePeriod,
     }),
-    [subscription, plan, isLoading, isSubscriptionActive, isInGracePeriod, effectiveFeatures]
+    // deep-review FL2 — effLoading/effError included so consumers re-render
+    // when the effective-features query settles (gate opens once it resolves).
+    [
+      subscription,
+      plan,
+      isLoading,
+      isSubscriptionActive,
+      isInGracePeriod,
+      effectiveFeatures,
+      effLoading,
+      effError,
+    ]
   );
 
   return (

--- a/frontend/src/features/auth/authApi.test.tsx
+++ b/frontend/src/features/auth/authApi.test.tsx
@@ -42,6 +42,14 @@ vi.mock('../../store/authStore', () => ({
   useAuthStore: (selector: (s: any) => unknown) => selector(storeState),
 }));
 
+// deep-review FL1 — useLogout must also clear the persisted branch scope.
+const branchScopeClearFn = vi.fn();
+vi.mock('../../store/branchScopeStore', () => ({
+  useBranchScopeStore: {
+    getState: () => ({ clear: branchScopeClearFn }),
+  },
+}));
+
 import {
   useLogin,
   useRegister,
@@ -137,6 +145,8 @@ describe('useLogout', () => {
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(logoutFn).toHaveBeenCalled();
     expect(clearSpy).toHaveBeenCalled();
+    // deep-review FL1 — branch scope is dropped on a clean logout.
+    expect(branchScopeClearFn).toHaveBeenCalled();
   });
 
   it('logs out and clears the cache EVEN when the API call fails', async () => {
@@ -149,6 +159,8 @@ describe('useLogout', () => {
     await waitFor(() => expect(result.current.isError).toBe(true));
     expect(logoutFn).toHaveBeenCalled();
     expect(clearSpy).toHaveBeenCalled();
+    // deep-review FL1 — branch scope is dropped even when the API errors.
+    expect(branchScopeClearFn).toHaveBeenCalled();
   });
 });
 

--- a/frontend/src/features/auth/authApi.ts
+++ b/frontend/src/features/auth/authApi.ts
@@ -4,6 +4,7 @@ import i18n from '../../i18n/config';
 import api from '../../lib/api';
 import { getApiErrorMessage } from '../../lib/api-error';
 import { useAuthStore } from '../../store/authStore';
+import { useBranchScopeStore } from '../../store/branchScopeStore';
 import { LoginRequest, RegisterRequest, AuthResponse, User } from '../../types';
 
 export const useLogin = () => {
@@ -94,12 +95,28 @@ export const useLogout = () => {
     },
     onSuccess: () => {
       logout();
+      // deep-review FL1: mirror the 401-interceptor cleanup (lib/api.ts)
+      // so a user-initiated logout also drops the persisted branch scope.
+      // Otherwise a same-tenant account switch on a shared device leaves
+      // the prior session's branchId/allowedBranchIds in localStorage
+      // until App's hydrateFromUser effect later re-scopes it.
+      try {
+        useBranchScopeStore.getState().clear();
+      } catch {
+        // storage/hydration race — non-fatal
+      }
       queryClient.clear();
       toast.success(i18n.t('common:notifications.logoutSuccessful'));
     },
     onError: () => {
       // Logout anyway even if API call fails
       logout();
+      // deep-review FL1: clear branch scope here too — see onSuccess.
+      try {
+        useBranchScopeStore.getState().clear();
+      } catch {
+        // non-fatal
+      }
       queryClient.clear();
     },
   });

--- a/frontend/src/features/kds/useKitchenSocket.ts
+++ b/frontend/src/features/kds/useKitchenSocket.ts
@@ -50,6 +50,12 @@ export const useKitchenSocket = () => {
     const handleConnect = () => {
       console.log('Kitchen socket connected');
       setIsConnected(true);
+      // deep-review FH4: socket.io does NOT replay events emitted while the
+      // socket was disconnected, so any order:new/updated/status-changed that
+      // fired during a drop is permanently lost and the board goes stale.
+      // Refetch the orders truth on every (re)connect so the kitchen board
+      // reconciles after a reconnect (and on first connect, harmless).
+      queryClient.invalidateQueries({ queryKey: ['orders'] });
     };
 
     const handleDisconnect = () => {

--- a/frontend/src/features/marketplace/marketplaceApi.test.tsx
+++ b/frontend/src/features/marketplace/marketplaceApi.test.tsx
@@ -3,7 +3,6 @@ import { renderHook, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import {
   useListAddOns,
-  usePurchaseAddOn,
   usePurchaseAddOnViaCheckout,
   useCancelAddOn,
   marketplaceKeys,
@@ -114,35 +113,6 @@ describe('usePurchaseAddOnViaCheckout', () => {
     result.current.mutate({ addOnCode: 'kds_extra_screen' });
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(apiPost).not.toHaveBeenCalledWith('/v1/marketplace/addons/purchase', expect.anything());
-  });
-});
-
-describe('usePurchaseAddOn', () => {
-  it('posts the input and invalidates mine + entitlements + effective-features on success', async () => {
-    apiPost.mockResolvedValue({ data: { id: 'ta1' } });
-    const client = makeClient();
-    const invalidate = vi.spyOn(client, 'invalidateQueries');
-    const { result } = renderHook(() => usePurchaseAddOn(), { wrapper: wrap(client) });
-
-    result.current.mutate({ addOnCode: 'pos-pro' });
-    await waitFor(() => expect(result.current.isSuccess).toBe(true));
-
-    expect(apiPost).toHaveBeenCalledWith('/v1/marketplace/addons/purchase', { addOnCode: 'pos-pro' });
-    const invalidatedKeys = invalidate.mock.calls.map((c) => (c[0] as any).queryKey);
-    expect(invalidatedKeys).toContainEqual(['marketplace', 'mine']);
-    expect(invalidatedKeys).toContainEqual(['entitlements', 'me']);
-    expect(invalidatedKeys).toContainEqual(['subscriptions', 'effective-features']);
-    expect(toastSuccess).toHaveBeenCalled();
-  });
-
-  it('surfaces the fallback error message via toast on failure', async () => {
-    apiPost.mockRejectedValue(new Error('nope'));
-    const client = makeClient();
-    const { result } = renderHook(() => usePurchaseAddOn(), { wrapper: wrap(client) });
-
-    result.current.mutate({ addOnCode: 'x' });
-    await waitFor(() => expect(result.current.isError).toBe(true));
-    expect(toastError).toHaveBeenCalledWith('Purchase failed');
   });
 });
 

--- a/frontend/src/features/marketplace/marketplaceApi.ts
+++ b/frontend/src/features/marketplace/marketplaceApi.ts
@@ -53,35 +53,11 @@ export const useListMyAddOns = () =>
     },
   });
 
-export const usePurchaseAddOn = () => {
-  const qc = useQueryClient();
-  return useMutation({
-    mutationFn: async (input: { addOnCode: string; quantity?: number; branchId?: string }): Promise<TenantAddOn> => {
-      const r = await api.post('/v1/marketplace/addons/purchase', input);
-      return r.data;
-    },
-    onSuccess: () => {
-      qc.invalidateQueries({ queryKey: marketplaceKeys.mine });
-      qc.invalidateQueries({ queryKey: entitlementKeys.me });
-      // v2.8.88: effective-features is the source of truth for the
-      // SubscriptionContext (hasFeature/hasIntegration). Without this
-      // invalidation a buyer waits up to 30s for the cached snapshot
-      // to expire — they'd click "purchase" and see no UI change
-      // until they hard-refresh.
-      qc.invalidateQueries({ queryKey: ['subscriptions', 'effective-features'] });
-      toast.success(
-        i18n.t('marketplace:purchase.success', { defaultValue: 'Add-on purchased.' }),
-      );
-    },
-    onError: (e) =>
-      toast.error(
-        getApiErrorMessage(
-          e,
-          i18n.t('marketplace:purchase.failed', { defaultValue: 'Purchase failed' }),
-        ),
-      ),
-  });
-};
+// SECURITY (deep-review C2): the free-grant hook `usePurchaseAddOn`
+// (POST /v1/marketplace/addons/purchase) was removed together with its
+// backend endpoint — it granted paid add-ons without collecting payment.
+// All add-on purchases now go through `usePurchaseAddOnViaCheckout` below,
+// which routes through the PayTR checkout rail.
 
 export interface AddOnCheckoutIntent {
   paymentRef: string;
@@ -97,8 +73,8 @@ export interface AddOnCheckoutIntent {
  * hosted payment page. The add-on is provisioned by the `CK-` webhook
  * (CheckoutSettlementService → confirmAndProvision → tenantMarketplace.purchase
  * with the settled paymentRef) ONLY after the money is collected. Mirrors the
- * hardware-store checkout flow. The free grant endpoint stays for superadmin
- * comps; the storefront button uses this.
+ * hardware-store checkout flow. This is the ONLY add-on purchase path; the
+ * free-grant endpoint was removed (deep-review C2).
  */
 export const usePurchaseAddOnViaCheckout = () => {
   return useMutation({

--- a/frontend/src/features/stock-management/components/PurchaseOrdersTab.test.tsx
+++ b/frontend/src/features/stock-management/components/PurchaseOrdersTab.test.tsx
@@ -5,7 +5,8 @@ import enStock from '../../../i18n/locales/en/stock.json';
 
 const orders: { data: any[]; isLoading: boolean } = { data: [], isLoading: false };
 let lastStatus: unknown = undefined;
-const noop = { mutateAsync: vi.fn(), isPending: false };
+const noop = { mutate: vi.fn(), mutateAsync: vi.fn(), isPending: false };
+const cancelMock = { mutate: vi.fn(), mutateAsync: vi.fn(), isPending: false };
 
 vi.mock('../stockManagementApi', () => ({
   usePurchaseOrders: (status: unknown) => {
@@ -15,7 +16,7 @@ vi.mock('../stockManagementApi', () => ({
   useCreatePurchaseOrder: () => noop,
   useSubmitPurchaseOrder: () => noop,
   useReceivePurchaseOrder: () => noop,
-  useCancelPurchaseOrder: () => noop,
+  useCancelPurchaseOrder: () => cancelMock,
   useSuppliers: () => ({ data: [] }),
   useStockItems: () => ({ data: [] }),
 }));
@@ -30,6 +31,7 @@ beforeEach(() => {
   orders.data = [];
   orders.isLoading = false;
   lastStatus = undefined;
+  cancelMock.mutate.mockClear();
 });
 
 describe('PurchaseOrdersTab', () => {
@@ -65,5 +67,26 @@ describe('PurchaseOrdersTab', () => {
     const select = screen.getByRole('combobox');
     fireEvent.change(select, { target: { value: 'DRAFT' } });
     expect(lastStatus).toBe('DRAFT');
+  });
+
+  // deep-review FM8: cancel must confirm before firing the destructive mutation
+  it('only cancels a purchase order after the user confirms', () => {
+    orders.data = [
+      { id: 'po1', orderNumber: 'PO-001', status: 'SUBMITTED', supplier: { name: 'Acme' }, items: [{ id: 'x' }], expectedDate: null },
+    ];
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false);
+    render(<PurchaseOrdersTab />);
+    const row = screen.getByText('PO-001').closest('tr')!;
+    const cancelBtn = within(row).getByTitle('Cancel');
+
+    fireEvent.click(cancelBtn);
+    expect(confirmSpy).toHaveBeenCalledTimes(1);
+    expect(cancelMock.mutate).not.toHaveBeenCalled();
+
+    confirmSpy.mockReturnValue(true);
+    fireEvent.click(cancelBtn);
+    expect(cancelMock.mutate).toHaveBeenCalledWith('po1');
+
+    confirmSpy.mockRestore();
   });
 });

--- a/frontend/src/features/stock-management/components/PurchaseOrdersTab.tsx
+++ b/frontend/src/features/stock-management/components/PurchaseOrdersTab.tsx
@@ -90,7 +90,13 @@ const PurchaseOrdersTab = () => {
                         <Eye className="h-4 w-4" />
                       </button>
                       {order.status === 'DRAFT' && (
-                        <button onClick={() => submitMutation.mutate(order.id)} className="p-1 text-gray-400 hover:text-blue-600" title={t('purchaseOrders.submit')}>
+                        // deep-review FM8: disable submit while a state transition is in flight to prevent double-fire
+                        <button
+                          onClick={() => submitMutation.mutate(order.id)}
+                          disabled={submitMutation.isPending || cancelMutation.isPending}
+                          className="p-1 text-gray-400 hover:text-blue-600 disabled:opacity-50 disabled:pointer-events-none"
+                          title={t('purchaseOrders.submit')}
+                        >
                           <Send className="h-4 w-4" />
                         </button>
                       )}
@@ -100,7 +106,17 @@ const PurchaseOrdersTab = () => {
                         </button>
                       )}
                       {order.status !== 'RECEIVED' && order.status !== 'CANCELLED' && (
-                        <button onClick={() => cancelMutation.mutate(order.id)} className="p-1 text-gray-400 hover:text-red-600" title={t('purchaseOrders.cancel')}>
+                        // deep-review FM8: confirm the destructive cancel (voids supplier order + reverses stock) and guard against double-fire
+                        <button
+                          onClick={() => {
+                            if (window.confirm(t('purchaseOrders.confirmCancel', { orderNumber: order.orderNumber, defaultValue: 'Cancel order {{orderNumber}}? Received stock will be reversed.' }))) {
+                              cancelMutation.mutate(order.id);
+                            }
+                          }}
+                          disabled={submitMutation.isPending || cancelMutation.isPending}
+                          className="p-1 text-gray-400 hover:text-red-600 disabled:opacity-50 disabled:pointer-events-none"
+                          title={t('purchaseOrders.cancel')}
+                        >
                           <XCircle className="h-4 w-4" />
                         </button>
                       )}

--- a/frontend/src/features/stock-management/components/StockCountsTab.test.tsx
+++ b/frontend/src/features/stock-management/components/StockCountsTab.test.tsx
@@ -5,7 +5,9 @@ import enStock from '../../../i18n/locales/en/stock.json';
 
 const counts: { data: any[]; isLoading: boolean } = { data: [], isLoading: false };
 let lastStatus: unknown = undefined;
-const noop = { mutateAsync: vi.fn(), isPending: false };
+const noop = { mutate: vi.fn(), mutateAsync: vi.fn(), isPending: false };
+const finalizeMock = { mutate: vi.fn(), mutateAsync: vi.fn(), isPending: false };
+const cancelMock = { mutate: vi.fn(), mutateAsync: vi.fn(), isPending: false };
 
 vi.mock('../stockManagementApi', () => ({
   useStockCounts: (status: unknown) => {
@@ -15,8 +17,8 @@ vi.mock('../stockManagementApi', () => ({
   useStockCount: () => ({ data: null, isLoading: false }),
   useCreateStockCount: () => noop,
   useUpdateStockCountItem: () => noop,
-  useFinalizeStockCount: () => noop,
-  useCancelStockCount: () => noop,
+  useFinalizeStockCount: () => finalizeMock,
+  useCancelStockCount: () => cancelMock,
 }));
 
 import StockCountsTab from './StockCountsTab';
@@ -29,6 +31,8 @@ beforeEach(() => {
   counts.data = [];
   counts.isLoading = false;
   lastStatus = undefined;
+  finalizeMock.mutate.mockClear();
+  cancelMock.mutate.mockClear();
 });
 
 describe('StockCountsTab', () => {
@@ -63,5 +67,26 @@ describe('StockCountsTab', () => {
     const select = screen.getByRole('combobox');
     fireEvent.change(select, { target: { value: 'COMPLETED' } });
     expect(lastStatus).toBe('COMPLETED');
+  });
+
+  // deep-review FL4: finalize/cancel must confirm before firing the inventory-mutating action
+  it('only finalizes a stock count after the user confirms', () => {
+    counts.data = [
+      { id: 'c1', name: 'June count', status: 'IN_PROGRESS', items: [{ id: 'x' }], createdAt: new Date().toISOString() },
+    ];
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false);
+    render(<StockCountsTab />);
+    const row = screen.getByText('June count').closest('tr')!;
+    const finalizeBtn = within(row).getByTitle('Finalize');
+
+    fireEvent.click(finalizeBtn);
+    expect(confirmSpy).toHaveBeenCalledTimes(1);
+    expect(finalizeMock.mutate).not.toHaveBeenCalled();
+
+    confirmSpy.mockReturnValue(true);
+    fireEvent.click(finalizeBtn);
+    expect(finalizeMock.mutate).toHaveBeenCalledWith('c1');
+
+    confirmSpy.mockRestore();
   });
 });

--- a/frontend/src/features/stock-management/components/StockCountsTab.tsx
+++ b/frontend/src/features/stock-management/components/StockCountsTab.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Plus, Eye, CheckCircle, XCircle, X } from 'lucide-react';
 import {
@@ -84,11 +84,22 @@ const StockCountsTab = () => {
                         <Eye className="h-4 w-4" />
                       </button>
                       {count.status === 'IN_PROGRESS' && (
+                        // deep-review FL4: confirm + pending-guard the inventory-mutating finalize/cancel against accidental and double clicks
                         <>
-                          <button onClick={() => finalizeMutation.mutate(count.id)} className="p-1 text-gray-400 hover:text-emerald-600" title={t('counts.finalize')}>
+                          <button
+                            onClick={() => { if (window.confirm(t('counts.confirmFinalize', { defaultValue: 'Finalize this stock count? Counted quantities will be committed as inventory adjustments and this cannot be undone.' }))) finalizeMutation.mutate(count.id); }}
+                            disabled={finalizeMutation.isPending || cancelMutation.isPending}
+                            className="p-1 text-gray-400 hover:text-emerald-600 disabled:opacity-50 disabled:pointer-events-none"
+                            title={t('counts.finalize')}
+                          >
                             <CheckCircle className="h-4 w-4" />
                           </button>
-                          <button onClick={() => cancelMutation.mutate(count.id)} className="p-1 text-gray-400 hover:text-red-600" title={t('counts.cancel')}>
+                          <button
+                            onClick={() => { if (window.confirm(t('counts.confirmCancel', { defaultValue: 'Cancel this stock count? This cannot be undone.' }))) cancelMutation.mutate(count.id); }}
+                            disabled={finalizeMutation.isPending || cancelMutation.isPending}
+                            className="p-1 text-gray-400 hover:text-red-600 disabled:opacity-50 disabled:pointer-events-none"
+                            title={t('counts.cancel')}
+                          >
                             <XCircle className="h-4 w-4" />
                           </button>
                         </>
@@ -183,8 +194,10 @@ function StockCountSession({ countId, onClose }: { countId: string; onClose: () 
           <div className="flex items-center gap-2">
             {count.status === 'IN_PROGRESS' && allCounted && (
               <button
-                onClick={() => { finalizeMutation.mutate(countId); onClose(); }}
-                className="px-3 py-1.5 text-sm bg-emerald-600 text-white rounded-lg hover:bg-emerald-700"
+                // deep-review FL4: confirm + pending-guard the session-modal finalize too
+                onClick={() => { if (window.confirm(t('counts.confirmFinalize', { defaultValue: 'Finalize this stock count? Counted quantities will be committed as inventory adjustments and this cannot be undone.' }))) { finalizeMutation.mutate(countId); onClose(); } }}
+                disabled={finalizeMutation.isPending}
+                className="px-3 py-1.5 text-sm bg-emerald-600 text-white rounded-lg hover:bg-emerald-700 disabled:opacity-50"
               >
                 {t('counts.finalize')}
               </button>
@@ -214,18 +227,9 @@ function StockCountSession({ countId, onClose }: { countId: string; onClose: () 
                     <td className="px-4 py-3 text-right text-gray-600">{Number(item.expectedQty).toFixed(2)}</td>
                     <td className="px-4 py-3 text-right">
                       {count.status === 'IN_PROGRESS' ? (
-                        <input
-                          type="number"
-                          step="0.001"
-                          value={item.countedQty ?? ''}
-                          onChange={(e) => {
-                            const val = e.target.value === '' ? null : parseFloat(e.target.value);
-                            if (val != null) {
-                              updateItemMutation.mutate({ countId, itemId: item.id, data: { countedQty: val } });
-                            }
-                          }}
-                          className="w-24 border rounded-lg px-2 py-1 text-sm text-right"
-                          placeholder="—"
+                        <CountedQtyInput
+                          committed={item.countedQty ?? null}
+                          onCommit={(v) => updateItemMutation.mutate({ countId, itemId: item.id, data: { countedQty: v } })}
                         />
                       ) : (
                         <span className="text-gray-600">{item.countedQty != null ? Number(item.countedQty).toFixed(2) : '—'}</span>
@@ -244,6 +248,43 @@ function StockCountSession({ countId, onClose }: { countId: string; onClose: () 
         </div>
       </div>
     </div>
+  );
+}
+
+// deep-review FM9: decouple the count input's display value from the committed value and
+// persist only on blur/Enter (not on every keystroke). This sends one PATCH per field edit
+// instead of one per keystroke and eliminates mid-typing out-of-order overwrites, because the
+// draft is local and only reconciles with the server value when the field is not being edited.
+// NOTE: clearing the field back to "uncounted" (null) is intentionally NOT committed here — the
+// updateStockCountItem mutation/endpoint only accepts `{ countedQty: number }`; supporting null
+// requires a backend + API-type change (out of scope for this file).
+function CountedQtyInput({ committed, onCommit }: { committed: number | null; onCommit: (v: number) => void }) {
+  const [draft, setDraft] = useState<string>(committed != null ? String(committed) : '');
+  // re-sync when the server value changes while the field isn't actively being edited
+  useEffect(() => {
+    setDraft(committed != null ? String(committed) : '');
+  }, [committed]);
+
+  const commit = () => {
+    const trimmed = draft.trim();
+    if (trimmed === '') return; // empty -> leave as-is (cannot reset to uncounted yet)
+    const next = Number.parseFloat(trimmed);
+    if (Number.isNaN(next)) return; // ignore garbage
+    if (next === committed) return; // no-op, avoids a redundant PATCH
+    onCommit(next);
+  };
+
+  return (
+    <input
+      type="number"
+      step="0.001"
+      value={draft}
+      onChange={(e) => setDraft(e.target.value)}
+      onBlur={commit}
+      onKeyDown={(e) => { if (e.key === 'Enter') (e.target as HTMLInputElement).blur(); }}
+      className="w-24 border rounded-lg px-2 py-1 text-sm text-right"
+      placeholder="—"
+    />
   );
 }
 

--- a/frontend/src/features/superadmin/api/superAdminApi.ts
+++ b/frontend/src/features/superadmin/api/superAdminApi.ts
@@ -1,5 +1,7 @@
 import axios from 'axios';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import { getApiErrorMessage } from '../../../lib/api-error';
 import { useSuperAdminAuthStore } from '../../../store/superAdminAuthStore';
 import {
   SuperAdminLoginRequest,
@@ -327,6 +329,10 @@ export const useUpdateTenantStatus = () => {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['superadmin', 'tenants'] });
     },
+    // deep-review FM10: surface failed suspend/activate/delete so the
+    // destructive lifecycle action never fails silently (mirrors the
+    // superadminBankTransferApi sonner + getApiErrorMessage convention).
+    onError: (e) => toast.error(getApiErrorMessage(e, 'Durum güncellenemedi.')),
   });
 };
 

--- a/frontend/src/lib/currency.test.ts
+++ b/frontend/src/lib/currency.test.ts
@@ -23,23 +23,26 @@ describe('getCurrencySymbol', () => {
 });
 
 describe('formatCurrency', () => {
-  it('renders symbol-prefixed two-decimal amounts', () => {
-    expect(formatCurrency(1234.5, 'USD')).toBe('$1234.50');
-    expect(formatCurrency(0, 'TRY')).toBe('₺0.00');
+  // deep-review FM12: output now uses tr-TR grouping/decimals (₺2.999,00) to
+  // match the app-wide lib/utils.formatCurrency, not the old US style.
+  it('renders symbol-prefixed amounts with Turkish grouping and decimals', () => {
+    expect(formatCurrency(2999, 'TRY')).toBe('₺2.999,00');
+    expect(formatCurrency(1234.5, 'USD')).toBe('$1.234,50');
+    expect(formatCurrency(0, 'TRY')).toBe('₺0,00');
   });
 
   it('rounds to two decimals', () => {
-    expect(formatCurrency(9.999, 'EUR')).toBe('€10.00');
-    expect(formatCurrency(9.994, 'EUR')).toBe('€9.99');
+    expect(formatCurrency(9.999, 'EUR')).toBe('€10,00');
+    expect(formatCurrency(9.994, 'EUR')).toBe('€9,99');
   });
 
   it('keeps the sign for negative amounts (refunds, write-offs)', () => {
-    expect(formatCurrency(-42.1, 'TRY')).toBe('₺-42.10');
+    expect(formatCurrency(-42.1, 'TRY')).toBe('₺-42,10');
   });
 });
 
 describe('formatCurrencyWithPeriod', () => {
   it('appends the billing period', () => {
-    expect(formatCurrencyWithPeriod(99, 'USD', 'month')).toBe('$99.00/month');
+    expect(formatCurrencyWithPeriod(99, 'USD', 'month')).toBe('$99,00/month');
   });
 });

--- a/frontend/src/lib/currency.ts
+++ b/frontend/src/lib/currency.ts
@@ -11,12 +11,22 @@ export const getCurrencySymbol = (currency: string = 'TRY'): string => {
   return CURRENCY_SYMBOLS[currency] || currency;
 };
 
+// deep-review FM12: render money with Turkish grouping/decimals (₺2.999,00) to
+// match the app-wide lib/utils.formatCurrency, instead of the divergent
+// US-style `${symbol}${toFixed(2)}` (₺2999.00) that leaked onto the
+// subscription/billing screens. The leading symbol is kept (rather than
+// Intl `style:'currency'`) so the output prefix stays consistent with the
+// rest of these screens and callers that pair it with an explicit ISO code.
 export const formatCurrency = (
   amount: number,
   currency: string = 'TRY'
 ): string => {
   const symbol = getCurrencySymbol(currency);
-  return `${symbol}${amount.toFixed(2)}`;
+  const formatted = new Intl.NumberFormat('tr-TR', {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(amount);
+  return `${symbol}${formatted}`;
 };
 
 export const formatCurrencyWithPeriod = (

--- a/frontend/src/lib/socket.test.ts
+++ b/frontend/src/lib/socket.test.ts
@@ -111,4 +111,44 @@ describe('socket switchBranch emit', () => {
 
     expect(fake.emit).toHaveBeenCalledWith('switchBranch', { branchId: 'b-2' });
   });
+
+  /**
+   * deep-review FM1/FM4 — the store subscriptions are registered ONCE at module
+   * load, so an init→disconnect→init cycle must NOT accumulate a second
+   * subscriber. A single accessToken rotation therefore reconnects the live
+   * socket exactly once, not once per cycle.
+   */
+  it('reconnects on accessToken change exactly once after an init/disconnect/init cycle', async () => {
+    const { io } = await import('socket.io-client');
+    // disconnect() must be chainable because prod calls .disconnect().connect()
+    const fake: FakeSocket = {
+      connected: true,
+      auth: {},
+      emit: vi.fn(),
+      on: vi.fn(),
+      connect: vi.fn(),
+      disconnect: vi.fn(),
+    };
+    fake.disconnect.mockReturnValue(fake);
+    (io as unknown as ReturnType<typeof vi.fn>).mockReturnValue(fake);
+
+    const socketModule = await import('./socket');
+    const { useAuthStore } = await import('../store/authStore');
+
+    socketModule.initializeSocket();
+    socketModule.disconnectSocket();
+    socketModule.initializeSocket();
+
+    // Ignore the disconnect/connect churn from the init/disconnect cycle above;
+    // only the reconnect triggered by the token rotation matters here.
+    fake.disconnect.mockClear();
+    fake.connect.mockClear();
+
+    useAuthStore.setState({ accessToken: 'rotated-token' });
+
+    // Exactly one reconnect — would be 2+ if a stale subscription leaked
+    // (one extra disconnect().connect() per init/disconnect/init cycle).
+    expect(fake.disconnect).toHaveBeenCalledTimes(1);
+    expect(fake.connect).toHaveBeenCalledTimes(1);
+  });
 });

--- a/frontend/src/lib/socket.ts
+++ b/frontend/src/lib/socket.ts
@@ -15,6 +15,44 @@ let notificationSocket: Socket | null = null;
 let socketRefCount = 0;
 let notificationRefCount = 0;
 
+// deep-review FM1/FM4 — register the store subscriptions ONCE at module load
+// instead of inside initializeSocket/initializeNotificationSocket. Previously
+// every mount/unmount or logout→login cycle re-created the sockets and added a
+// fresh, never-released pair of Zustand subscriptions. Over a long-lived
+// kiosk/KDS session that leaked memory and meant a single accessToken rotation
+// fired N stale reconnects and a branch switch emitted N duplicate
+// `switchBranch` events. The callbacks already null-check the global sockets
+// and no-op when null, so a single module-lifetime subscription pair is
+// sufficient — count stays at exactly one pair regardless of socket churn.
+useAuthStore.subscribe((state, prev) => {
+  if (state.accessToken === prev.accessToken) return;
+  if (socket) {
+    (socket.auth as any).token = state.accessToken ?? undefined;
+    if (socket.connected) {
+      socket.disconnect().connect();
+    }
+  }
+  if (notificationSocket) {
+    (notificationSocket.auth as any).token = state.accessToken ?? undefined;
+    if (notificationSocket.connected) {
+      notificationSocket.disconnect().connect();
+    }
+  }
+});
+
+// v3.0.0 — react to BranchPicker changes by emitting `switchBranch` to the live
+// socket(s). The backend moves the connection between rooms without a reconnect
+// and acks/nacks via its allow-list check.
+useBranchScopeStore.subscribe((state, prev) => {
+  if (state.branchId === prev.branchId || !state.branchId) return;
+  if (socket?.connected) {
+    socket.emit('switchBranch', { branchId: state.branchId });
+  }
+  if (notificationSocket?.connected) {
+    notificationSocket.emit('switchBranch', { branchId: state.branchId });
+  }
+});
+
 export const initializeSocket = (): Socket => {
   socketRefCount += 1;
 
@@ -38,25 +76,6 @@ export const initializeSocket = (): Socket => {
   socket = io(`${SOCKET_URL}/kds`, {
     auth: { token, branchId },
     transports: ['websocket', 'polling'],
-  });
-
-  useAuthStore.subscribe((state, prev) => {
-    if (state.accessToken !== prev.accessToken && socket) {
-      (socket.auth as any).token = state.accessToken ?? undefined;
-      if (socket.connected) {
-        socket.disconnect().connect();
-      }
-    }
-  });
-
-  // v3.0.0 — react to BranchPicker changes by emitting `switchBranch`
-  // to the live socket. The backend moves the connection between
-  // rooms without a reconnect; the SPA gets a clean ack/nack from
-  // the server's allow-list check.
-  useBranchScopeStore.subscribe((state, prev) => {
-    if (state.branchId !== prev.branchId && socket?.connected && state.branchId) {
-      socket.emit('switchBranch', { branchId: state.branchId });
-    }
   });
 
   socket.on('connect_error', (error) => {
@@ -105,28 +124,6 @@ export const initializeNotificationSocket = (
   notificationSocket = io(`${SOCKET_URL}/notifications`, {
     auth: { token, branchId },
     transports: ['websocket', 'polling'],
-  });
-
-  useAuthStore.subscribe((state, prev) => {
-    if (state.accessToken !== prev.accessToken && notificationSocket) {
-      (notificationSocket.auth as any).token = state.accessToken ?? undefined;
-      if (notificationSocket.connected) {
-        notificationSocket.disconnect().connect();
-      }
-    }
-  });
-
-  // Branch switch over the notifications socket — same shape as the
-  // KDS socket. The backend updates the tenant:${tenantId}:branch:${branchId}
-  // room membership atomically.
-  useBranchScopeStore.subscribe((state, prev) => {
-    if (
-      state.branchId !== prev.branchId &&
-      notificationSocket?.connected &&
-      state.branchId
-    ) {
-      notificationSocket.emit('switchBranch', { branchId: state.branchId });
-    }
   });
 
   notificationSocket.on('connect_error', (error) => {

--- a/frontend/src/pages/admin/MenuManagementPage.tsx
+++ b/frontend/src/pages/admin/MenuManagementPage.tsx
@@ -204,17 +204,19 @@ const MenuManagementPage = () => {
         { id: editingProduct.id, data: submitData },
         {
           onSuccess: () => {
-            if (selectedModifierGroupIds.length > 0) {
-              assignModifiersToProduct({
-                productId: editingProduct.id,
-                data: {
-                  modifierGroups: selectedModifierGroupIds.map((groupId, index) => ({
-                    groupId,
-                    displayOrder: index,
-                  })),
-                },
-              });
-            }
+            // deep-review FM7: always re-assign so an empty selection clears
+            // all groups (assign does an atomic deleteMany + createMany; an
+            // empty array correctly means "replace with none"). The previous
+            // length>0 guard silently dropped attempts to remove all groups.
+            assignModifiersToProduct({
+              productId: editingProduct.id,
+              data: {
+                modifierGroups: selectedModifierGroupIds.map((groupId, index) => ({
+                  groupId,
+                  displayOrder: index,
+                })),
+              },
+            });
             setProductModalOpen(false);
             setProductImages([]);
             setSelectedModifierGroupIds([]);

--- a/frontend/src/pages/admin/menuManagement/ModifiersTab.tsx
+++ b/frontend/src/pages/admin/menuManagement/ModifiersTab.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Plus, Settings2 } from 'lucide-react';
 import { ModifierGroupCard } from '../../../components/modifiers';
@@ -33,6 +34,14 @@ const ModifiersTab = ({
 }: ModifiersTabProps) => {
   const { t } = useTranslation(['menu', 'common']);
 
+  // deep-review FL5: copy before sorting so we never mutate the react-query
+  // cache array in place (in-place sort defeats structural-sharing / isStale
+  // referential checks). Memoized so the sort isn't recomputed every render.
+  const sortedGroups = useMemo(
+    () => (modifierGroups ? [...modifierGroups].sort((a, b) => a.displayOrder - b.displayOrder) : []),
+    [modifierGroups],
+  );
+
   return (
     <Card>
       <CardHeader className="flex flex-row items-center justify-between">
@@ -64,19 +73,17 @@ const ModifiersTab = ({
           </div>
         ) : (
           <div className="space-y-4">
-            {modifierGroups
-              .sort((a, b) => a.displayOrder - b.displayOrder)
-              .map((group) => (
-                <ModifierGroupCard
-                  key={group.id}
-                  group={group}
-                  onEditGroup={onEditGroup}
-                  onDeleteGroup={onDeleteGroup}
-                  onAddModifier={(groupId) => onAddModifier(groupId)}
-                  onEditModifier={(modifier) => onEditModifier(modifier)}
-                  onDeleteModifier={onDeleteModifier}
-                />
-              ))}
+            {sortedGroups.map((group) => (
+              <ModifierGroupCard
+                key={group.id}
+                group={group}
+                onEditGroup={onEditGroup}
+                onDeleteGroup={onDeleteGroup}
+                onAddModifier={(groupId) => onAddModifier(groupId)}
+                onEditModifier={(modifier) => onEditModifier(modifier)}
+                onDeleteModifier={onDeleteModifier}
+              />
+            ))}
           </div>
         )}
       </CardContent>

--- a/frontend/src/pages/customers/CustomerDetailPage.test.tsx
+++ b/frontend/src/pages/customers/CustomerDetailPage.test.tsx
@@ -27,6 +27,13 @@ vi.mock('../../features/customers/customersApi', () => ({
   useDeleteCustomer: () => ({ mutate: deleteCustomer }),
 }));
 
+// deep-review FM6: the page now reads the tenant currency via useCurrency
+// (react-query under the hood) — mock it so specs render without a
+// QueryClientProvider. Money fields then format as TRY (₺) instead of '$'.
+vi.mock('../../hooks/useCurrency', () => ({
+  useCurrency: () => 'TRY',
+}));
+
 let lastModalProps: any;
 vi.mock('../../components/customers/CustomerFormModal', () => ({
   default: (props: any) => {
@@ -96,6 +103,16 @@ describe('CustomerDetailPage — loaded render', () => {
     expect(screen.getByText('ORD-1')).toBeInTheDocument();
     expect(screen.getByText('vip')).toBeInTheDocument();
     expect(screen.getByText('Allergic to nuts')).toBeInTheDocument();
+  });
+
+  // deep-review FM6: money fields render in TRY with Turkish grouping (₺123,50),
+  // never the old hard-coded USD '$'.
+  it('renders money fields in TRY, not USD', () => {
+    renderPage();
+    expect(screen.getByText('₺123,50')).toBeInTheDocument(); // totalSpent
+    expect(screen.getByText('₺17,60')).toBeInTheDocument(); // averageOrder
+    expect(screen.getByText('₺50,00')).toBeInTheDocument(); // order finalAmount
+    expect(screen.queryByText(/\$\d/)).toBeNull();
   });
 
   it('shows the no-orders placeholder when the customer has no orders', () => {

--- a/frontend/src/pages/customers/CustomerDetailPage.tsx
+++ b/frontend/src/pages/customers/CustomerDetailPage.tsx
@@ -7,11 +7,15 @@ import Button from '../../components/ui/Button';
 import { Card, CardContent, CardHeader, CardTitle } from '../../components/ui/Card';
 import CustomerFormModal from '../../components/customers/CustomerFormModal';
 import { Customer } from '../../types';
+// deep-review FM6: TRY-only currency regression — money fields hard-coded '$'.
+import { useCurrency } from '../../hooks/useCurrency';
+import { formatCurrency } from '../../lib/utils';
 
 const CustomerDetailPage = () => {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
   const { t } = useTranslation('customers');
+  const currencyCode = useCurrency(); // deep-review FM6: tenant currency (TRY)
   const { data: customer, isLoading } = useCustomer(id || '');
   const { mutate: deleteCustomer } = useDeleteCustomer();
   const [isEditModalOpen, setIsEditModalOpen] = useState(false);
@@ -119,7 +123,7 @@ const CustomerDetailPage = () => {
               </div>
               <div className="text-center p-3 bg-green-50 rounded-lg">
                 <span className="text-xl font-bold text-green-600">
-                  ${parseFloat(String(typedCustomer.totalSpent || 0)).toFixed(2)}
+                  {formatCurrency(parseFloat(String(typedCustomer.totalSpent || 0)), currencyCode)}
                 </span>
                 <p className="text-xs text-slate-600">{t('customers.totalSpent')}</p>
               </div>
@@ -130,7 +134,7 @@ const CustomerDetailPage = () => {
               </div>
               <div className="text-center p-3 bg-orange-50 rounded-lg">
                 <span className="text-xl font-bold text-orange-600">
-                  ${parseFloat(String(typedCustomer.averageOrder || 0)).toFixed(2)}
+                  {formatCurrency(parseFloat(String(typedCustomer.averageOrder || 0)), currencyCode)}
                 </span>
                 <p className="text-xs text-slate-600">{t('customers.avgOrder', 'Avg Order')}</p>
               </div>
@@ -203,7 +207,7 @@ const CustomerDetailPage = () => {
                           {order.status}
                         </span>
                       </td>
-                      <td className="py-2 px-3 text-right">${parseFloat(order.finalAmount || order.totalAmount || 0).toFixed(2)}</td>
+                      <td className="py-2 px-3 text-right">{formatCurrency(parseFloat(String(order.finalAmount || order.totalAmount || 0)), currencyCode)}</td>
                     </tr>
                   ))}
                 </tbody>

--- a/frontend/src/pages/kitchen/KitchenDisplayPage.test.tsx
+++ b/frontend/src/pages/kitchen/KitchenDisplayPage.test.tsx
@@ -30,11 +30,18 @@ vi.mock('../../features/kds/useKitchenSocket', () => ({
 // OrderCard fires a sonner Undo toast after a confirmed cancel; capture it
 // so the toast doesn't reach a real (absent) Toaster.
 const toastFn = vi.fn();
+const toastWarning = vi.fn();
+const toastDismiss = vi.fn();
 vi.mock('sonner', () => ({
   toast: Object.assign((...a: unknown[]) => toastFn(...a), {
     success: vi.fn(),
     info: vi.fn(),
     error: vi.fn(),
+    // deep-review FM5: OrderCard dismisses a pending Undo toast on unmount and
+    // KitchenDisplayPage warns when a deferred cancel commits on a no-longer
+    // PENDING order — stub both so the toast never reaches a real Toaster.
+    warning: (...a: unknown[]) => toastWarning(...a),
+    dismiss: (...a: unknown[]) => toastDismiss(...a),
   }),
 }));
 
@@ -68,6 +75,9 @@ describe('KitchenDisplayPage', () => {
     updateOrderStatus.mockClear();
     cancelOrder.mockClear();
     refetch.mockClear();
+    toastFn.mockClear();
+    toastWarning.mockClear();
+    toastDismiss.mockClear();
   });
 
   it('renders order data into the stats header and the pending column card', () => {
@@ -179,6 +189,30 @@ describe('KitchenDisplayPage', () => {
     expect(cancelOrder.mock.calls[0][0]).toBe('pend-9');
     // Cancel must NOT fire a status update (no CANCELLED→PENDING flip).
     expect(updateOrderStatus).not.toHaveBeenCalled();
+  });
+
+  it('does NOT commit a deferred cancel if the order is no longer PENDING at commit time (deep-review FM5)', () => {
+    const order = makeOrder({ id: 'pend-stale', orderNumber: '6006', status: OrderStatus.PENDING });
+    ordersData.push(order);
+
+    render(<KitchenDisplayPage />);
+
+    fireEvent.click(screen.getAllByRole('button', { name: 'kitchen.moreOptions' })[0]);
+    fireEvent.click(screen.getByText('kitchen.cancelOrder'));
+    fireEvent.click(screen.getAllByText('kitchen.confirmYes')[0]);
+    expect(toastFn).toHaveBeenCalledTimes(1);
+
+    // Another station advances the order during the Undo window: the cache
+    // (same live ordersData reference returned by useOrders) flips off PENDING.
+    order.status = OrderStatus.PREPARING;
+
+    // The toast times out and tries to commit — the parent's status gate must
+    // bail (no cancel, a warning instead) so work-in-progress isn't voided.
+    const opts = toastFn.mock.calls[0][1] as { onAutoClose: () => void };
+    opts.onAutoClose();
+
+    expect(cancelOrder).not.toHaveBeenCalled();
+    expect(toastWarning).toHaveBeenCalledTimes(1);
   });
 
   it('aborts the cancel when "Geri al" (undo) is tapped before the window elapses', () => {

--- a/frontend/src/pages/kitchen/KitchenDisplayPage.tsx
+++ b/frontend/src/pages/kitchen/KitchenDisplayPage.tsx
@@ -1,5 +1,6 @@
 import { useState, useMemo, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
+import { toast } from 'sonner';
 import { AlertTriangle } from 'lucide-react';
 import { useOrders, useUpdateOrderStatus, useCancelKdsOrder } from '../../features/orders/ordersApi';
 import { useKitchenSocket } from '../../features/kds/useKitchenSocket';
@@ -73,6 +74,22 @@ const KitchenDisplayPage = () => {
   };
 
   const handleCancelOrder = (orderId: string) => {
+    // deep-review FM5: the cancel is deferred behind a 5s Undo window in
+    // OrderCard, so by the time it commits another station may have already
+    // advanced/served/cancelled this order. Re-validate against the latest
+    // cache and only proceed if it is STILL PENDING — this closes the window
+    // where a stale closure would wrongfully void work-in-progress (CANCELLED
+    // is terminal server-side and reverses stock).
+    const current = (orders || []).find((o) => o.id === orderId);
+    if (!current || current.status !== OrderStatus.PENDING) {
+      toast.warning(
+        t(
+          'kitchen.cancelStale',
+          'Sipariş artık beklemede değil; iptal edilmedi.'
+        )
+      );
+      return;
+    }
     setUpdatingOrderId(orderId);
     cancelOrder(orderId, {
       onSettled: () => {

--- a/frontend/src/pages/pos/POSPage.tsx
+++ b/frontend/src/pages/pos/POSPage.tsx
@@ -63,6 +63,12 @@ const POSPage = () => {
   const [isPaymentModalOpen, setIsPaymentModalOpen] = useState(false);
   const [currentOrderId, setCurrentOrderId] = useState<string | null>(null);
   const [currentOrderAmount, setCurrentOrderAmount] = useState<number | null>(null);
+  // deep-review FH2: tracks whether the cart/discount/notes diverged from the
+  // persisted order since it was last created/updated. While dirty, the
+  // two-step "Proceed to Payment" path must re-persist (and re-price) instead
+  // of charging the stale server amount. Set on every bill-affecting mutation
+  // (below), cleared on every successful create/update + on order clear/reset.
+  const [cartDirtySinceOrder, setCartDirtySinceOrder] = useState(false);
   const [payingOrderId, setPayingOrderId] = useState<string | null>(null);
   const [payingOrderAmount, setPayingOrderAmount] = useState<number | null>(null);
   const [isCartDrawerOpen, setIsCartDrawerOpen] = useState(false);
@@ -92,6 +98,16 @@ const POSPage = () => {
   useEffect(() => {
     if (useSideBySideLayout && isCartDrawerOpen) setIsCartDrawerOpen(false);
   }, [useSideBySideLayout, isCartDrawerOpen]);
+
+  // deep-review FH2: whenever the active order identity changes — a new order
+  // is created/loaded (e.g. selecting an OCCUPIED table) or the order is
+  // cleared — the cart is freshly synced to the server, so it is no longer
+  // dirty. This also prevents a stale `true` from a prior table carrying over
+  // when the cashier switches tables (the table-selection reset lives in
+  // useTableSelection, which has no handle on this flag).
+  useEffect(() => {
+    setCartDirtySinceOrder(false);
+  }, [currentOrderId]);
 
   // Socket.IO for real-time updates
   usePosSocket();
@@ -249,10 +265,18 @@ const POSPage = () => {
     addItemToCart(product, 1, []);
   };
 
+  // deep-review FH2: flag the cart as diverged from the persisted order. No-op
+  // when no order exists yet (the first create captures the current cart). Used
+  // to force a re-persist before the two-step payment modal opens.
+  const markCartDirty = useCallback(() => {
+    if (currentOrderId) setCartDirtySinceOrder(true);
+  }, [currentOrderId]);
+
   const addItemToCart = (product: Product, quantity: number, modifiers: SelectedModifier[]) => {
     // Dedup/merge rule (same product + same modifier set → increment) lives in
     // posCart.mergeCartItem (unit-tested).
     setCartItems((prev) => mergeCartItem(prev, product, quantity, modifiers));
+    markCartDirty();
   };
 
   const handleAddItemWithModifiers = (product: Product, quantity: number, modifiers: SelectedModifier[]) => {
@@ -268,10 +292,12 @@ const POSPage = () => {
         item.id === productId ? { ...item, quantity } : item
       )
     );
+    markCartDirty();
   };
 
   const handleRemoveItem = (productId: string) => {
     setCartItems((prev) => prev.filter((item) => item.id !== productId));
+    markCartDirty();
   };
 
   // In-cart quantity per product id (summed across lines) for the MenuPanel
@@ -293,6 +319,7 @@ const POSPage = () => {
         item.id === productId ? { ...item, quantity: item.quantity + 1 } : item,
       ),
     );
+    markCartDirty();
   };
 
   const handleMenuDecrement = (productId: string) => {
@@ -303,11 +330,25 @@ const POSPage = () => {
         return item.quantity <= 1 ? [] : [{ ...item, quantity: item.quantity - 1 }];
       }),
     );
+    markCartDirty();
+  };
+
+  // deep-review FH2: discount/notes edits also change the bill → mark dirty so
+  // the two-step payment path re-persists before charging.
+  const handleUpdateDiscount = (value: number) => {
+    setDiscount(value);
+    markCartDirty();
+  };
+
+  const handleUpdateOrderNotes = (notes: string) => {
+    setOrderNotes(notes);
+    markCartDirty();
   };
 
   const handleClearCart = () => {
     setCartItems([]);
     setDiscount(0);
+    setCartDirtySinceOrder(false);
   };
 
   // Create or update order (for two-step checkout)
@@ -323,12 +364,13 @@ const POSPage = () => {
       return;
     }
 
+    // deep-review FL3: never submit a discount larger than the live subtotal.
     const orderData = buildOrderData({
       isTablelessMode,
       selectedTable,
       customerName,
       orderNotes,
-      discount,
+      discount: Math.max(0, Math.min(discount, calculateSubtotal(cartItems))),
       cartItems,
     });
 
@@ -342,6 +384,7 @@ const POSPage = () => {
         {
           onSuccess: (order) => {
             setCurrentOrderAmount(Number(order.finalAmount));
+            setCartDirtySinceOrder(false); // deep-review FH2
             toast.success(t('orderUpdated'));
           },
         }
@@ -354,6 +397,7 @@ const POSPage = () => {
           onSuccess: (order) => {
             setCurrentOrderId(order.id);
             setCurrentOrderAmount(Number(order.finalAmount));
+            setCartDirtySinceOrder(false); // deep-review FH2
             toast.success(t('orderCreatedSuccess', { orderNumber: order.orderNumber }));
 
             // Mark table as occupied after successful order creation (if table mode)
@@ -382,18 +426,25 @@ const POSPage = () => {
       return;
     }
 
-    // If two-step checkout is enabled and order already exists, just open payment
-    if (isTwoStepCheckout && currentOrderId) {
+    // deep-review FH2: in two-step checkout, only short-circuit straight to the
+    // payment modal when the cart has NOT diverged from the saved order. If the
+    // cashier added items / changed the discount after the order was created,
+    // we must fall through to the updateOrder path below — which persists the
+    // edits and opens payment with the authoritative server finalAmount —
+    // otherwise we'd charge the stale amount and drop the new items from the
+    // bill and kitchen ticket.
+    if (isTwoStepCheckout && currentOrderId && !cartDirtySinceOrder) {
       setIsPaymentModalOpen(true);
       return;
     }
 
+    // deep-review FL3: never submit a discount larger than the live subtotal.
     const orderData = buildOrderData({
       isTablelessMode,
       selectedTable,
       customerName,
       orderNotes,
-      discount,
+      discount: Math.max(0, Math.min(discount, calculateSubtotal(cartItems))),
       cartItems,
     });
 
@@ -407,6 +458,7 @@ const POSPage = () => {
         {
           onSuccess: (order) => {
             setCurrentOrderAmount(Number(order.finalAmount));
+            setCartDirtySinceOrder(false);
             setIsPaymentModalOpen(true);
             toast.success(t('orderUpdated'));
           },
@@ -420,6 +472,7 @@ const POSPage = () => {
           onSuccess: (order) => {
             setCurrentOrderId(order.id);
             setCurrentOrderAmount(Number(order.finalAmount));
+            setCartDirtySinceOrder(false); // deep-review FH2
             setIsPaymentModalOpen(true);
 
             // Mark table as occupied after successful order creation (if table mode)
@@ -530,6 +583,7 @@ const POSPage = () => {
             setDiscount(0);
             setCustomerName('');
             setOrderNotes('');
+            setCartDirtySinceOrder(false); // deep-review FH2
           }
 
           toast.success(t('orderCompletedSuccess'));
@@ -564,6 +618,7 @@ const POSPage = () => {
           setOrderNotes('');
           setCurrentOrderId(null);
           setCurrentOrderAmount(null);
+          setCartDirtySinceOrder(false); // deep-review FH2
         },
       }
     );
@@ -608,7 +663,14 @@ const POSPage = () => {
   // posCart.ts so it shares a single tested arithmetic surface with
   // cartStore.calculateItemTotal and can never drift.
   const subtotal = calculateSubtotal(cartItems);
-  const total = subtotal - discount;
+  // deep-review FL3: re-clamp the stored discount to the LIVE subtotal at the
+  // single source of truth. The OrderCart input clamps on keystroke, but if the
+  // cashier sets a discount then removes items (shrinking the subtotal below the
+  // discount), the stored `discount` stays stale — producing a negative total in
+  // the UI and an over-discount sent to the server. Deriving the effective
+  // discount here keeps display, create, and checkout all consistent.
+  const effectiveDiscount = Math.max(0, Math.min(discount, subtotal));
+  const total = subtotal - effectiveDiscount;
   const hasCartItems = cartItems.length > 0;
 
   // Table card status styles
@@ -855,14 +917,14 @@ const POSPage = () => {
                 <div className="sticky top-0 h-full">
                   <OrderCart
                     items={cartItems}
-                    discount={discount}
+                    discount={effectiveDiscount}
                     customerName={customerName}
                     orderNotes={orderNotes}
                     onUpdateQuantity={handleUpdateQuantity}
                     onRemoveItem={handleRemoveItem}
-                    onUpdateDiscount={setDiscount}
+                    onUpdateDiscount={handleUpdateDiscount}
                     onUpdateCustomerName={setCustomerName}
-                    onUpdateOrderNotes={setOrderNotes}
+                    onUpdateOrderNotes={handleUpdateOrderNotes}
                     onClearCart={handleClearCart}
                     onCheckout={handleCheckout}
                     onCreateOrder={handleCreateOrder}
@@ -876,6 +938,7 @@ const POSPage = () => {
                     hasSelectedTable={!!selectedTable}
                     canProceedToPayment={canProceedToPayment}
                     paymentBlockedReason={paymentBlockedReason}
+                    cartDirty={cartDirtySinceOrder}
                   />
                 </div>
               </div>
@@ -927,14 +990,14 @@ const POSPage = () => {
       >
         <OrderCart
           items={cartItems}
-          discount={discount}
+          discount={effectiveDiscount}
           customerName={customerName}
           orderNotes={orderNotes}
           onUpdateQuantity={handleUpdateQuantity}
           onRemoveItem={handleRemoveItem}
-          onUpdateDiscount={setDiscount}
+          onUpdateDiscount={handleUpdateDiscount}
           onUpdateCustomerName={setCustomerName}
-          onUpdateOrderNotes={setOrderNotes}
+          onUpdateOrderNotes={handleUpdateOrderNotes}
           onClearCart={handleClearCart}
           onCheckout={() => {
             setIsCartDrawerOpen(false);
@@ -951,6 +1014,7 @@ const POSPage = () => {
           hasSelectedTable={!!selectedTable}
           canProceedToPayment={canProceedToPayment}
           paymentBlockedReason={paymentBlockedReason}
+          cartDirty={cartDirtySinceOrder}
         />
       </CartDrawer>
 

--- a/frontend/src/pages/pos/posCart.test.ts
+++ b/frontend/src/pages/pos/posCart.test.ts
@@ -14,8 +14,9 @@ import {
   type PosCartItem,
 } from './posCart';
 import type { CartItem } from './posTypes';
-import { OrderType, OrderStatus, type Order, type OrderItem, type Product } from '../../types';
+import { OrderType, OrderStatus, type Order, type OrderItem, type Product, type OrderItemModifier, type Modifier } from '../../types';
 import type { SelectedModifier } from '../../components/pos/ProductOptionsModal';
+import { buildOrderData } from './buildOrderData';
 
 const mod = (priceAdjustment: number, quantity = 1): SelectedModifier =>
   ({ modifierId: `m-${priceAdjustment}-${quantity}`, priceAdjustment, quantity } as SelectedModifier);
@@ -386,6 +387,103 @@ describe('mapOrderItemsToCart', () => {
 
   it('returns [] when there are no items', () => {
     expect(mapOrderItemsToCart({} as Pick<Order, 'orderItems' | 'items'>)).toEqual([]);
+  });
+
+  // deep-review FH3: loading an existing order must round-trip line-item
+  // modifiers, or continuing an OCCUPIED table strips paid modifiers →
+  // wrong kitchen ticket + undercharge.
+  describe('FH3: modifiers round-trip', () => {
+    const orderItemMod = (over: Partial<OrderItemModifier>): OrderItemModifier =>
+      ({
+        id: 'oim-1',
+        orderItemId: 'oi-1',
+        modifierId: 'mod-1',
+        quantity: 1,
+        priceAdjustment: 2.5,
+        modifier: { id: 'mod-1', name: 'Extra Cheese', priceAdjustment: 2.5 } as Modifier,
+        createdAt: '2026-01-01T00:00:00Z',
+        ...over,
+      } as OrderItemModifier);
+
+    it('maps each OrderItem modifier into the SelectedModifier cart shape', () => {
+      const cart = mapOrderItemsToCart({
+        orderItems: [
+          orderItem({
+            quantity: 2,
+            product: { id: 'p-1', name: 'Burger', price: 10 } as Product,
+            modifiers: [
+              orderItemMod({ modifierId: 'mod-1', quantity: 1, priceAdjustment: 2.5 }),
+              orderItemMod({
+                id: 'oim-2',
+                modifierId: 'mod-2',
+                quantity: 2,
+                priceAdjustment: 1,
+                modifier: { id: 'mod-2', name: 'Large', priceAdjustment: 1 } as Modifier,
+              }),
+            ],
+          }),
+        ],
+      } as Pick<Order, 'orderItems' | 'items'>);
+
+      expect(cart[0].modifiers).toEqual([
+        { modifierId: 'mod-1', name: 'Extra Cheese', priceAdjustment: 2.5, quantity: 1 },
+        { modifierId: 'mod-2', name: 'Large', priceAdjustment: 1, quantity: 2 },
+      ]);
+    });
+
+    it('coerces a string priceAdjustment (Decimal serialization) to a number', () => {
+      const cart = mapOrderItemsToCart({
+        orderItems: [
+          orderItem({
+            modifiers: [orderItemMod({ priceAdjustment: '3.75' as unknown as number })],
+          }),
+        ],
+      } as Pick<Order, 'orderItems' | 'items'>);
+      expect(cart[0].modifiers?.[0].priceAdjustment).toBe(3.75);
+    });
+
+    it('falls back to an empty name when the modifier relation is absent', () => {
+      const cart = mapOrderItemsToCart({
+        orderItems: [orderItem({ modifiers: [orderItemMod({ modifier: undefined })] })],
+      } as Pick<Order, 'orderItems' | 'items'>);
+      expect(cart[0].modifiers?.[0].name).toBe('');
+    });
+
+    it('round-trips modifiers through buildOrderData as {modifierId, quantity}', () => {
+      const cart = mapOrderItemsToCart({
+        orderItems: [
+          orderItem({
+            modifiers: [orderItemMod({ modifierId: 'mod-1', quantity: 3 })],
+          }),
+        ],
+      } as Pick<Order, 'orderItems' | 'items'>);
+
+      const built = buildOrderData({
+        isTablelessMode: false,
+        selectedTable: { id: 't-1' } as never,
+        customerName: '',
+        orderNotes: '',
+        discount: 0,
+        cartItems: cart,
+        generateId: () => 'fixed-id',
+      });
+
+      expect(built.items[0].modifiers).toEqual([{ modifierId: 'mod-1', quantity: 3 }]);
+    });
+
+    it('calculateSubtotal on the loaded cart includes the modifier contribution (no undercharge)', () => {
+      const cart = mapOrderItemsToCart({
+        orderItems: [
+          orderItem({
+            quantity: 2,
+            product: { id: 'p-1', name: 'Burger', price: 10 } as Product,
+            // (10 + 2.5*1) * 2 = 25  — base-only would be 20 (the silent undercharge)
+            modifiers: [orderItemMod({ priceAdjustment: 2.5, quantity: 1 })],
+          }),
+        ],
+      } as Pick<Order, 'orderItems' | 'items'>);
+      expect(calculateSubtotal(cart)).toBe(25);
+    });
   });
 });
 

--- a/frontend/src/pages/pos/posCart.ts
+++ b/frontend/src/pages/pos/posCart.ts
@@ -251,5 +251,17 @@ export function mapOrderItemsToCart(
     ...(item.product as Product),
     quantity: item.quantity,
     notes: item.notes || undefined,
+    // deep-review FH3: round-trip line-item modifiers into the SelectedModifier
+    // shape the cart + buildOrderData expect. Without this, continuing an
+    // OCCUPIED table's order stripped every paid modifier (wrong kitchen
+    // ticket + undercharge). priceAdjustment may serialize as a string from the
+    // Decimal column, hence Number(...). `name` is display-only; buildOrderData
+    // re-emits only {modifierId, quantity} and the backend re-prices server-side.
+    modifiers: item.modifiers?.map((m) => ({
+      modifierId: m.modifierId,
+      name: m.modifier?.name ?? '',
+      priceAdjustment: Number(m.priceAdjustment),
+      quantity: m.quantity,
+    })),
   }));
 }

--- a/frontend/src/pages/qr-menu/QRMenuLayout.test.tsx
+++ b/frontend/src/pages/qr-menu/QRMenuLayout.test.tsx
@@ -65,21 +65,23 @@ vi.mock('../../lib/utils', () => ({ formatCurrency: (n: number) => `$${n}` }));
 vi.mock('../../i18n/config', () => ({ RTL_LANGUAGES: ['ar', 'he'], default: {} }));
 
 const initializeSession = vi.fn();
+let mockStoreSessionId: string | null = 'sess-1';
 vi.mock('../../store/cartStore', () => ({
   useCartStore: (selector: any) => selector({
-    sessionId: 'sess-1',
+    sessionId: mockStoreSessionId,
     items: [],
     getTotal: () => 0,
     initializeSession,
   }),
 }));
 
+let mockParams: Record<string, string | null> = {};
 vi.mock('react-router-dom', async () => {
   const actual = await vi.importActual<any>('react-router-dom');
   return {
     ...actual,
     useParams: () => ({ tenantId: 't-1' }),
-    useSearchParams: () => [{ get: () => null }],
+    useSearchParams: () => [{ get: (k: string) => mockParams[k] ?? null }],
     useNavigate: () => vi.fn(),
   };
 });
@@ -104,7 +106,11 @@ const menuData = {
   categories: [],
 };
 
-beforeEach(() => vi.clearAllMocks());
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockStoreSessionId = 'sess-1';
+  mockParams = {};
+});
 
 describe('QRMenuLayout — loading', () => {
   it('shows the spinner before data resolves', () => {
@@ -132,6 +138,22 @@ describe('QRMenuLayout — successful fetch', () => {
     get.mockResolvedValue({ data: menuData });
     renderLayout({ subdomain: 'acme' });
     await waitFor(() => expect(get).toHaveBeenCalledWith(expect.stringContaining('/qr-menu/by-subdomain/acme')));
+  });
+});
+
+describe('QRMenuLayout — session is not hijackable from the URL (FH5)', () => {
+  it('ignores ?sessionId on a fresh device and never exposes it via onSessionIdChange', async () => {
+    // Attacker appends ?sessionId=<victim>; this device has no stored session.
+    mockParams = { sessionId: 'victim-session' };
+    mockStoreSessionId = null;
+    get.mockResolvedValue({ data: menuData });
+    const onSessionIdChange = vi.fn();
+    renderLayout({ onSessionIdChange });
+
+    await waitFor(() => expect(get).toHaveBeenCalled());
+    // The victim's URL session must never become this device's identity (it
+    // would otherwise drive order/loyalty PII fetches for the victim).
+    expect(onSessionIdChange).not.toHaveBeenCalledWith('victim-session');
   });
 });
 

--- a/frontend/src/pages/qr-menu/QRMenuLayout.tsx
+++ b/frontend/src/pages/qr-menu/QRMenuLayout.tsx
@@ -102,7 +102,15 @@ const QRMenuLayout: React.FC<QRMenuLayoutProps> = ({
   const urlSessionId = searchParams.get('sessionId');
 
   const storeSessionId = useCartStore(state => state.sessionId);
-  const sessionId = urlSessionId || storeSessionId;
+  // deep-review FH5: the QR session id is the only identity on the public QR
+  // menu, so it is effectively a bearer credential. It must NOT be overridable
+  // from the URL — otherwise appending `?sessionId=<victim>` to a link the
+  // customer already has open would hijack their order history / self-pay.
+  // Resolve from the persisted (per-device) store first; the URL value is only
+  // a one-time bootstrap for a device that has no session yet (e.g. a fresh
+  // same-device deep link). Combined with buildQRMenuUrl no longer emitting
+  // the id, shareable links no longer carry the credential at all.
+  const sessionId = storeSessionId || urlSessionId;
 
   const [menuData, setMenuData] = useState<MenuData | null>(null);
   const [isLoading, setIsLoading] = useState(true);

--- a/frontend/src/pages/qr-menu/QRMenuLayout.tsx
+++ b/frontend/src/pages/qr-menu/QRMenuLayout.tsx
@@ -99,18 +99,20 @@ const QRMenuLayout: React.FC<QRMenuLayoutProps> = ({
   const { tenantId: urlTenantId } = useParams<{ tenantId: string }>();
   const [searchParams] = useSearchParams();
   const tableId = searchParams.get('tableId');
-  const urlSessionId = searchParams.get('sessionId');
 
   const storeSessionId = useCartStore(state => state.sessionId);
-  // deep-review FH5: the QR session id is the only identity on the public QR
-  // menu, so it is effectively a bearer credential. It must NOT be overridable
-  // from the URL — otherwise appending `?sessionId=<victim>` to a link the
-  // customer already has open would hijack their order history / self-pay.
-  // Resolve from the persisted (per-device) store first; the URL value is only
-  // a one-time bootstrap for a device that has no session yet (e.g. a fresh
-  // same-device deep link). Combined with buildQRMenuUrl no longer emitting
-  // the id, shareable links no longer carry the credential at all.
-  const sessionId = storeSessionId || urlSessionId;
+  // deep-review FH5 (+ verification follow-up): the QR session id is the only
+  // identity on the public QR menu, so it is effectively a bearer credential.
+  // It must NEVER be sourced from the URL — appending `?sessionId=<victim>`
+  // would otherwise let an attacker drive THIS device's order-history /
+  // self-pay PII fetches as the victim. The earlier `storeSessionId ||
+  // urlSessionId` fallback still leaked on a FRESH device (null store), where
+  // the URL value won before initializeSession minted a real id. The identity
+  // is now ONLY the per-device store session (minted locally by
+  // initializeSession); a fresh device simply has no session until then.
+  // Combined with buildQRMenuUrl no longer emitting the id, shareable links
+  // carry no credential at all.
+  const sessionId = storeSessionId;
 
   const [menuData, setMenuData] = useState<MenuData | null>(null);
   const [isLoading, setIsLoading] = useState(true);

--- a/frontend/src/pages/settings/SubscriptionSettingsPage.test.tsx
+++ b/frontend/src/pages/settings/SubscriptionSettingsPage.test.tsx
@@ -60,13 +60,15 @@ vi.mock('../../components/subscriptions/ScheduledDowngradeAlert', () => ({ defau
 vi.mock('../../components/subscriptions/CancelSubscriptionModal', () => ({ default: () => null }));
 
 describe('SubscriptionSettingsPage current-plan price', () => {
-  it("renders the plan's live catalog price (₺7999.00), not the frozen amount", () => {
+  it("renders the plan's live catalog price (₺7.999,00 tr-TR), not the frozen amount", () => {
+    // deep-review FM12: money now renders in app-wide tr-TR format
+    // (₺7.999,00) instead of the US-style ₺7999.00.
     render(<SubscriptionSettingsPage />);
-    expect(screen.getByText(/₺7999\.00/)).toBeInTheDocument();
+    expect(screen.getByText(/₺7\.999,00/)).toBeInTheDocument();
   });
 
-  it('does not render the stale frozen subscription amount (₺79.99)', () => {
+  it('does not render the stale frozen subscription amount (₺79,99)', () => {
     render(<SubscriptionSettingsPage />);
-    expect(screen.queryByText(/₺79\.99/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/₺79,99/)).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/subscription/ChangePlanPage.test.tsx
+++ b/frontend/src/pages/subscription/ChangePlanPage.test.tsx
@@ -19,6 +19,7 @@ const currentSub = {
   currentPeriodEnd: '2026-12-31T00:00:00.000Z',
 };
 const plans = [
+  { id: 'plan-lite', name: 'STARTER', displayName: 'Lite', monthlyPrice: '50', yearlyPrice: '500', currency: 'TRY' },
   { id: 'plan-basic', name: 'BASIC', displayName: 'Basic', monthlyPrice: '100', yearlyPrice: '1000', currency: 'TRY' },
   { id: 'plan-pro', name: 'PRO', displayName: 'Pro', monthlyPrice: '500', yearlyPrice: '5000', currency: 'TRY' },
 ];
@@ -95,5 +96,15 @@ describe('ChangePlanPage — honors the plan picked on the plans page', () => {
     renderPage('?newPlanId=plan-basic&billingCycle=MONTHLY');
     expect(screen.queryByText('subscriptions.confirmUpgrade')).not.toBeInTheDocument();
     expect(screen.queryByText('subscriptions.confirmDowngrade')).not.toBeInTheDocument();
+  });
+
+  // deep-review FM2: a MONTHLY sub (amount=100) toggled to YEARLY and picking a
+  // CHEAPER tier (Lite, monthly 50 / yearly 500) must classify as a DOWNGRADE.
+  // The old logic compared the sub's monthly amount (100) against the toggle's
+  // yearly price (500) and wrongly framed it as an upgrade.
+  it('classifies a cheaper tier as a downgrade even when the YEARLY toggle is active', () => {
+    renderPage('?newPlanId=plan-lite&billingCycle=YEARLY');
+    expect(screen.getByText('subscriptions.confirmDowngrade')).toBeInTheDocument();
+    expect(screen.queryByText('subscriptions.confirmUpgrade')).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/subscription/ChangePlanPage.tsx
+++ b/frontend/src/pages/subscription/ChangePlanPage.tsx
@@ -94,14 +94,19 @@ const ChangePlanPage = () => {
     return [...plans].sort((a, b) => Number(a.monthlyPrice) - Number(b.monthlyPrice));
   }, [plans]);
 
-  // Determine if selected plan is upgrade or downgrade
-  const getChangeType = (newPlan: Plan): 'upgrade' | 'downgrade' => {
-    if (!currentSubscription) return 'upgrade';
-    const currentPrice = Number(currentSubscription.amount);
-    const newPrice =
-      billingCycle === BillingCycle.MONTHLY
-        ? Number(newPlan.monthlyPrice)
-        : Number(newPlan.yearlyPrice);
+  // Determine if selected plan is upgrade or downgrade.
+  // deep-review FM2: compare tier-to-tier in the SAME cycle (monthly price) so a
+  // billing-cycle toggle (e.g. MONTHLY->YEARLY) never flips a lower-tier pick into
+  // a misleading "upgrade". Comparing the sub's own-cycle amount against the
+  // toggle-selected cycle made a cheaper yearly plan (~12x monthly) read as an
+  // upgrade. This also keeps the modal consistent with the PlanCard button label.
+  const getChangeType = (
+    newPlan: Plan,
+    current: Plan | undefined
+  ): 'upgrade' | 'downgrade' => {
+    if (!currentSubscription || !current) return 'upgrade';
+    const newPrice = Number(newPlan.monthlyPrice);
+    const currentPrice = Number(current.monthlyPrice);
     return newPrice > currentPrice ? 'upgrade' : 'downgrade';
   };
 
@@ -157,7 +162,7 @@ const ChangePlanPage = () => {
   }
 
   const currentPlan = plans?.find((p) => p.id === currentSubscription.planId);
-  const changeType = selectedPlan ? getChangeType(selectedPlan) : null;
+  const changeType = selectedPlan ? getChangeType(selectedPlan, currentPlan) : null;
 
   return (
     <div className="max-w-7xl mx-auto p-6">

--- a/frontend/src/pages/subscription/PaymentResultPage.tsx
+++ b/frontend/src/pages/subscription/PaymentResultPage.tsx
@@ -39,6 +39,23 @@ const PaymentResultPage = ({ outcome }: PaymentResultPageProps) => {
   const isLive =
     subscription?.status === 'ACTIVE' || subscription?.status === 'TRIALING';
 
+  // deep-review FH1: useGetCurrentSubscription inherits the global 5-minute
+  // staleTime, so on mount this page would render the PRE-checkout cached
+  // subscription and could show a green "payment successful" for a payment
+  // that actually failed / is still pending (the cached status was already
+  // ACTIVE/TRIALING). Force a fresh read on mount so the result reflects the
+  // post-webhook truth, not stale cache. (A complete fix that correlates to
+  // THIS specific checkout needs a backend payment-status-by-merchantOid
+  // endpoint — tracked as a follow-up; this closes the stale-cache window.)
+  useEffect(() => {
+    queryClient.invalidateQueries({ queryKey: subscriptionKeys.current() });
+    queryClient.invalidateQueries({
+      queryKey: subscriptionKeys.effectiveFeatures(),
+    });
+    // mount-only: a one-shot fresh read; the poll loop below handles the rest.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   useEffect(() => {
     if (outcome !== 'success' || isLive) return;
     const start = Date.now();

--- a/frontend/src/pages/superadmin/SubscriptionsPage.test.tsx
+++ b/frontend/src/pages/superadmin/SubscriptionsPage.test.tsx
@@ -7,6 +7,10 @@ const extendMutate = vi.fn();
 const cancelMutate = vi.fn();
 let subsData: any;
 let subsArg: any;
+// deep-review FM11: mutable so a test can simulate an in-flight extend on a
+// specific row (mutate carries the id; isPending alone can't identify the row).
+let extendState: any = { isPending: false, variables: undefined };
+let cancelState: any = { isPending: false, variables: undefined };
 
 vi.mock('../../features/superadmin/api/superAdminApi', () => ({
   useSubscriptions: (filters: any) => {
@@ -14,8 +18,8 @@ vi.mock('../../features/superadmin/api/superAdminApi', () => ({
     return { data: subsData, isLoading: false };
   },
   usePlans: () => ({ data: [{ id: 'p1', displayName: 'Pro Plan' }] }),
-  useExtendSubscription: () => ({ mutate: extendMutate, isPending: false }),
-  useCancelSubscription: () => ({ mutate: cancelMutate, isPending: false }),
+  useExtendSubscription: () => ({ mutate: extendMutate, ...extendState }),
+  useCancelSubscription: () => ({ mutate: cancelMutate, ...cancelState }),
 }));
 
 vi.mock('react-i18next', () => ({
@@ -27,6 +31,10 @@ vi.mock('react-i18next', () => ({
       return key;
     },
   }),
+  // deep-review FM11: the page now surfaces errors via getApiErrorMessage,
+  // which pulls in i18n/config.ts → `.use(initReactI18next)`. Provide the
+  // plugin shape so the i18n module initialises under the mock.
+  initReactI18next: { type: '3rdParty', init: () => undefined },
 }));
 
 function sub(over: Partial<any> = {}) {
@@ -62,6 +70,8 @@ describe('SubscriptionsPage — extend-days NaN guard', () => {
   beforeEach(() => {
     extendMutate.mockReset();
     cancelMutate.mockReset();
+    extendState = { isPending: false, variables: undefined };
+    cancelState = { isPending: false, variables: undefined };
     subsData = payload([sub()]);
   });
   afterEach(() => vi.restoreAllMocks());
@@ -71,7 +81,11 @@ describe('SubscriptionsPage — extend-days NaN guard', () => {
     renderPage();
     fireEvent.click(screen.getByRole('button', { name: 'subscriptions.extend' }));
     expect(extendMutate).toHaveBeenCalledTimes(1);
-    expect(extendMutate).toHaveBeenCalledWith({ id: 'sub-1', days: 30 });
+    // deep-review FM11: mutate now passes per-call onSuccess/onError options.
+    expect(extendMutate).toHaveBeenCalledWith(
+      { id: 'sub-1', days: 30 },
+      expect.objectContaining({ onSuccess: expect.any(Function), onError: expect.any(Function) }),
+    );
   });
 
   it('does NOT extend when the prompt is cancelled (null)', () => {
@@ -100,6 +114,8 @@ describe('SubscriptionsPage — cancel-reason flow', () => {
   beforeEach(() => {
     extendMutate.mockReset();
     cancelMutate.mockReset();
+    extendState = { isPending: false, variables: undefined };
+    cancelState = { isPending: false, variables: undefined };
     subsData = payload([sub({ status: 'ACTIVE' })]);
   });
   afterEach(() => vi.restoreAllMocks());
@@ -110,7 +126,10 @@ describe('SubscriptionsPage — cancel-reason flow', () => {
     renderPage();
     fireEvent.click(screen.getByRole('button', { name: 'subscriptions.cancel' }));
     expect(window.confirm).toHaveBeenCalledWith('subscriptions.confirmCancel');
-    expect(cancelMutate).toHaveBeenCalledWith({ id: 'sub-1', reason: 'Non-payment' });
+    expect(cancelMutate).toHaveBeenCalledWith(
+      { id: 'sub-1', reason: 'Non-payment' },
+      expect.objectContaining({ onSuccess: expect.any(Function), onError: expect.any(Function) }),
+    );
   });
 
   it('cancels with reason=undefined when the reason prompt is left blank', () => {
@@ -118,7 +137,10 @@ describe('SubscriptionsPage — cancel-reason flow', () => {
     vi.spyOn(window, 'prompt').mockReturnValue('');
     renderPage();
     fireEvent.click(screen.getByRole('button', { name: 'subscriptions.cancel' }));
-    expect(cancelMutate).toHaveBeenCalledWith({ id: 'sub-1', reason: undefined });
+    expect(cancelMutate).toHaveBeenCalledWith(
+      { id: 'sub-1', reason: undefined },
+      expect.objectContaining({ onSuccess: expect.any(Function), onError: expect.any(Function) }),
+    );
   });
 
   it('does NOT prompt or cancel when the confirm is declined', () => {
@@ -141,6 +163,8 @@ describe('SubscriptionsPage — cancel-reason flow', () => {
 
 describe('SubscriptionsPage — listing & filters', () => {
   beforeEach(() => {
+    extendState = { isPending: false, variables: undefined };
+    cancelState = { isPending: false, variables: undefined };
     subsData = payload([sub()]);
   });
   afterEach(() => vi.restoreAllMocks());
@@ -157,5 +181,33 @@ describe('SubscriptionsPage — listing & filters', () => {
     const statusSelect = screen.getAllByRole('combobox')[0];
     fireEvent.change(statusSelect, { target: { value: 'TRIALING' } });
     expect(subsArg).toMatchObject({ status: 'TRIALING', page: 1 });
+  });
+});
+
+describe('SubscriptionsPage — in-flight double-submit guard (FM11)', () => {
+  beforeEach(() => {
+    extendMutate.mockReset();
+    cancelMutate.mockReset();
+    extendState = { isPending: false, variables: undefined };
+    cancelState = { isPending: false, variables: undefined };
+    subsData = payload([sub({ id: 'sub-1' })]);
+  });
+  afterEach(() => vi.restoreAllMocks());
+
+  it('disables that row Extend/Cancel while its extend is in flight', () => {
+    extendState = { isPending: true, variables: { id: 'sub-1', days: 30 } };
+    renderPage();
+    expect(screen.getByRole('button', { name: 'subscriptions.extend' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'subscriptions.cancel' })).toBeDisabled();
+  });
+
+  it('does not re-open the prompt when an extend is already in flight', () => {
+    extendState = { isPending: true, variables: { id: 'sub-1', days: 30 } };
+    const promptSpy = vi.spyOn(window, 'prompt');
+    renderPage();
+    // Button is disabled, but assert the handler short-circuit even if invoked.
+    fireEvent.click(screen.getByRole('button', { name: 'subscriptions.extend' }));
+    expect(promptSpy).not.toHaveBeenCalled();
+    expect(extendMutate).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/pages/superadmin/SubscriptionsPage.tsx
+++ b/frontend/src/pages/superadmin/SubscriptionsPage.tsx
@@ -1,7 +1,9 @@
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { toast } from 'sonner';
 import { useSubscriptions, useExtendSubscription, useCancelSubscription, usePlans } from '../../features/superadmin/api/superAdminApi';
 import { SubscriptionListItem } from '../../features/superadmin/types';
+import { getApiErrorMessage } from '../../lib/api-error';
 import { isValidExtendDays } from './subscriptions.helpers';
 
 const statusStyles: Record<string, string> = {
@@ -28,17 +30,45 @@ export default function SubscriptionsPage() {
   const extendMutation = useExtendSubscription();
   const cancelMutation = useCancelSubscription();
 
+  // deep-review FM11: mutate() carries the id, so isPending alone can't tell
+  // WHICH row is busy — track the active id to disable that row's buttons.
+  const pendingId = extendMutation.isPending
+    ? extendMutation.variables?.id
+    : cancelMutation.isPending
+      ? cancelMutation.variables?.id
+      : undefined;
+
   const handleExtend = (id: string) => {
+    // deep-review FM11: never re-open the blocking prompt while a mutation is
+    // in flight — the +N-days extend is non-idempotent, so a double-submit
+    // would drift the billing period.
+    if (extendMutation.isPending || cancelMutation.isPending) return;
     const days = prompt(t('subscriptions.promptExtendDays'));
     if (isValidExtendDays(days)) {
-      extendMutation.mutate({ id, days: Number(days) });
+      extendMutation.mutate(
+        { id, days: Number(days) },
+        {
+          // deep-review FM11: surface success/failure — previously a failed
+          // extend gave no feedback and the operator assumed it worked.
+          onSuccess: () => toast.success(t('subscriptions.extendSuccess', 'Abonelik uzatıldı.')),
+          onError: (err) => toast.error(getApiErrorMessage(err, t('subscriptions.extendFailed', 'Abonelik uzatılamadı.'))),
+        },
+      );
     }
   };
 
   const handleCancel = (id: string) => {
+    // deep-review FM11: short-circuit so a second click can't fire two cancels.
+    if (extendMutation.isPending || cancelMutation.isPending) return;
     if (window.confirm(t('subscriptions.confirmCancel'))) {
       const reason = prompt(t('subscriptions.promptCancelReason'));
-      cancelMutation.mutate({ id, reason: reason || undefined });
+      cancelMutation.mutate(
+        { id, reason: reason || undefined },
+        {
+          onSuccess: () => toast.success(t('subscriptions.cancelSuccess', 'Abonelik iptal edildi.')),
+          onError: (err) => toast.error(getApiErrorMessage(err, t('subscriptions.cancelFailed', 'Abonelik iptal edilemedi.'))),
+        },
+      );
     }
   };
 
@@ -148,14 +178,16 @@ export default function SubscriptionsPage() {
                     <div className="flex justify-end gap-2">
                       <button
                         onClick={() => handleExtend(sub.id)}
-                        className="text-xs font-medium text-zinc-600 hover:text-zinc-900 transition-colors"
+                        disabled={pendingId === sub.id}
+                        className="text-xs font-medium text-zinc-600 hover:text-zinc-900 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                       >
                         {t('subscriptions.extend')}
                       </button>
                       {sub.status === 'ACTIVE' && (
                         <button
                           onClick={() => handleCancel(sub.id)}
-                          className="text-xs font-medium text-red-600 hover:text-red-700 transition-colors"
+                          disabled={pendingId === sub.id}
+                          className="text-xs font-medium text-red-600 hover:text-red-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                         >
                           {t('subscriptions.cancel')}
                         </button>

--- a/frontend/src/store/cartStore.test.ts
+++ b/frontend/src/store/cartStore.test.ts
@@ -313,5 +313,50 @@ describe('cartStore', () => {
       expect(s.tableId).toBeNull();
       expect(s.items).toHaveLength(1);
     });
+
+    // deep-review FM3: a different table on the same shared device is a new
+    // guest — the previous guest's cart must NOT leak across.
+    it('wipes the cart and rotates the session when the table changes', () => {
+      const store = useCartStore.getState();
+      store.initializeSession('t-1', 'table-1');
+      store.addItem(makeProduct(), 1, []);
+      const firstSession = useCartStore.getState().sessionId;
+      store.initializeSession('t-1', 'table-2');
+      const s = useCartStore.getState();
+      expect(s.tableId).toBe('table-2');
+      expect(s.items).toHaveLength(0);
+      expect(s.sessionId).not.toBe(firstSession);
+    });
+
+    // deep-review FM3: an externally-issued per-guest session id that differs
+    // from the stored one forces a clean cart, even on a tenant-wide QR (no
+    // tableId) where the table check can't tell guests apart.
+    it('wipes the cart when a new url-issued sessionId is provided', () => {
+      const store = useCartStore.getState();
+      store.initializeSession('t-1', null, 'TRY', 'sess-A');
+      store.addItem(makeProduct(), 1, []);
+      expect(useCartStore.getState().sessionId).toBe('sess-A');
+      store.initializeSession('t-1', null, 'TRY', 'sess-B');
+      const s = useCartStore.getState();
+      expect(s.sessionId).toBe('sess-B');
+      expect(s.items).toHaveLength(0);
+    });
+
+    it('adopts the url-issued sessionId on first init', () => {
+      useCartStore.getState().initializeSession('t-1', 'table-1', 'TRY', 'sess-X');
+      expect(useCartStore.getState().sessionId).toBe('sess-X');
+    });
+  });
+
+  // deep-review FM3: stamp savedAt on mutating writes so the persisted cart can
+  // self-expire on rehydrate.
+  describe('cart freshness (TTL)', () => {
+    it('stamps savedAt when items are added', () => {
+      const before = Date.now();
+      useCartStore.getState().addItem(makeProduct(), 1, []);
+      const savedAt = useCartStore.getState().savedAt;
+      expect(savedAt).toBeTruthy();
+      expect(savedAt as number).toBeGreaterThanOrEqual(before);
+    });
   });
 });

--- a/frontend/src/store/cartStore.ts
+++ b/frontend/src/store/cartStore.ts
@@ -2,15 +2,28 @@ import { create } from 'zustand';
 import { persist, createJSONStorage } from 'zustand/middleware';
 import type { CartItem, Product, CartModifier } from '../types';
 
+// deep-review FM3: dine-in turnover is fast, so the persisted customer cart
+// self-expires well before the staff 12h window. A stale cart left on a shared
+// QR kiosk/tablet must never rehydrate into the next guest's session.
+const CART_TTL_MS = 4 * 60 * 60 * 1000; // 4 hours
+
 interface CartState {
   items: CartItem[];
   sessionId: string | null;
   tenantId: string | null;
   tableId: string | null;
   currency: string | null;
+  // deep-review FM3: wall-clock timestamp of the last mutating write; used to
+  // expire stale carts on rehydrate.
+  savedAt: number | null;
 
   // Actions
-  initializeSession: (tenantId: string, tableId: string | null, currency?: string) => void;
+  initializeSession: (
+    tenantId: string,
+    tableId: string | null,
+    currency?: string,
+    urlSessionId?: string | null
+  ) => void;
   setTableId: (tableId: string) => void;
   setCurrency: (currency: string) => void;
   addItem: (product: Product, quantity: number, modifiers: CartModifier[], notes?: string) => void;
@@ -44,14 +57,40 @@ const calculateItemTotal = (
 
 export const useCartStore = create<CartState>()(
   persist(
-    (set, get) => ({
+    (rawSet, get) => {
+      // deep-review FM3: every mutating write stamps savedAt so the persisted
+      // cart can self-expire on rehydrate. Wrap set instead of touching every
+      // call site.
+      const set: typeof rawSet = ((partial: unknown, replace?: boolean) => {
+        if (typeof partial === 'function') {
+          return (rawSet as (p: unknown, r?: boolean) => void)(
+            (state: CartState) => ({
+              ...(partial as (s: CartState) => Partial<CartState>)(state),
+              savedAt: Date.now(),
+            }),
+            replace as never
+          );
+        }
+        return (rawSet as (p: unknown, r?: boolean) => void)(
+          { ...(partial as Partial<CartState>), savedAt: Date.now() },
+          replace as never
+        );
+      }) as typeof rawSet;
+
+      return {
       items: [],
       sessionId: null,
       tenantId: null,
       tableId: null,
       currency: null,
+      savedAt: null,
 
-      initializeSession: (tenantId: string, tableId: string | null, currency?: string) => {
+      initializeSession: (
+        tenantId: string,
+        tableId: string | null,
+        currency?: string,
+        urlSessionId?: string | null
+      ) => {
         const currentSession = get().sessionId;
         const currentTenantId = get().tenantId;
         const currentTableId = get().tableId;
@@ -59,7 +98,7 @@ export const useCartStore = create<CartState>()(
         // If changing tenant, clear cart and create new session
         if (currentTenantId !== tenantId) {
           set({
-            sessionId: generateSessionId(),
+            sessionId: urlSessionId || generateSessionId(),
             tenantId,
             tableId,
             currency: currency || null,
@@ -68,14 +107,25 @@ export const useCartStore = create<CartState>()(
         } else if (!currentSession) {
           // First time initialization
           set({
-            sessionId: generateSessionId(),
+            sessionId: urlSessionId || generateSessionId(),
             tenantId,
             tableId,
             currency: currency || null,
           });
+        } else if (urlSessionId && urlSessionId !== currentSession) {
+          // deep-review FM3: the kiosk/server issued a fresh per-guest session
+          // id that differs from the stored one => new guest. Start a clean cart
+          // even on a tenant-wide QR where tableId can't distinguish guests.
+          set({
+            sessionId: urlSessionId,
+            tableId,
+            items: [],
+          });
         } else if (tableId && currentTableId !== tableId) {
-          // Update tableId if provided and different (but keep cart items)
-          set({ tableId });
+          // deep-review FM3: a different table on the same device is a new guest
+          // on a shared kiosk/tablet. Previously this preserved the cart, which
+          // leaked the prior guest's items. Start a clean cart + new session.
+          set({ sessionId: generateSessionId(), tableId, items: [] });
         } else if (tableId === null && currentTableId !== null) {
           // Clear tableId when using tenant-wide QR (no tableId in URL)
           // This ensures table selection modal appears for general QR codes
@@ -210,7 +260,8 @@ export const useCartStore = create<CartState>()(
         // For now, total = subtotal. Tax/service charges can be added later
         return get().getSubtotal();
       },
-    }),
+      };
+    },
     {
       name: 'customer-cart-storage', // LocalStorage key
       storage: createJSONStorage(() => localStorage),
@@ -220,7 +271,18 @@ export const useCartStore = create<CartState>()(
         tenantId: state.tenantId,
         tableId: state.tableId,
         currency: state.currency,
+        savedAt: state.savedAt,
       }),
+      // deep-review FM3: expire stale carts on rehydrate so a previous guest's
+      // items/session/table never surface to the next guest on a shared device.
+      onRehydrateStorage: () => (state) => {
+        if (!state) return;
+        if (!state.savedAt || Date.now() - state.savedAt > CART_TTL_MS) {
+          state.items = [];
+          state.sessionId = null;
+          state.tableId = null;
+        }
+      },
     }
   )
 );

--- a/frontend/src/utils/subdomain.ts
+++ b/frontend/src/utils/subdomain.ts
@@ -64,15 +64,18 @@ export function buildQRMenuUrl(
     sessionId?: string | null;
   }
 ): string {
-  const { subdomain, tenantId, tableId, sessionId } = options;
+  // deep-review FH5: `sessionId` is intentionally NOT read here anymore.
+  // It used to be emitted into shareable orders/loyalty links, turning the
+  // link into a bearer credential for the order history. The active session
+  // lives in the persisted per-device cart store, so the pages work without
+  // it. The option is kept in the type for caller compatibility.
+  const { subdomain, tenantId, tableId } = options;
 
   // Subdomain access - use root paths
   if (subdomain) {
     const params = new URLSearchParams();
     if (tableId) params.set('tableId', tableId);
-    if (sessionId && (page === 'orders' || page === 'loyalty')) {
-      params.set('sessionId', sessionId);
-    }
+    // FH5: sessionId is no longer emitted into the URL (bearer-credential leak).
     const queryString = params.toString();
 
     switch (page) {
@@ -92,9 +95,7 @@ export function buildQRMenuUrl(
     const baseUrl = `/qr-menu/${tenantId}`;
     const params = new URLSearchParams();
     if (tableId) params.set('tableId', tableId);
-    if (sessionId && (page === 'orders' || page === 'loyalty')) {
-      params.set('sessionId', sessionId);
-    }
+    // FH5: sessionId is no longer emitted into the URL (bearer-credential leak).
     const queryString = params.toString();
 
     switch (page) {


### PR DESCRIPTION
## Summary

A whole-system deep code review (multi-agent, adversarially verified) of the kds platform, with every confirmed finding fixed at the source layer and covered by tests. Scope: NestJS backend, React SPA, and the native edge/device stack (Rust local-bridge + Tauri kiosk + C++ edge).

**~90 findings reviewed → confirmed → fixed across 4 commits.** All automated gates green:
- Backend: `tsc` ✓, `eslint` ✓, jest **426 suites / 3768 tests** ✓
- Frontend: `tsc` ✓, `eslint` ✓, vitest **242 files / 1722 tests** ✓
- Native: Rust `cargo build`+`cargo test` ✓; kiosk `tsc`+vitest (41) ✓; C++ verified by inspection (built in edge CI)

## Critical (actively exploitable — recommend fast-track)
- **C1** Free self-provisioning via `POST /v1/checkout/confirm` — any tenant admin could provision hardware/add-ons/plan upgrades for free with a forged paymentRef. Now requires a settled `CheckoutIntent`.
- **C2** Free paid add-on grant via `POST /v1/marketplace/addons/purchase` — endpoint removed; `tenant.purchase()` refuses paid add-ons without a paymentRef.
- **C3** Google Sign-In account takeover — `email_verified` now enforced on both token paths (Apple hardened too).

## High / Medium highlights
- **Subscriptions:** scheduled-downgrade period roll (no false PAST_DUE), trial-expiry no longer clobbers a concurrently-paid sub, grant-before-pay closed.
- **Provisioning:** marketing-convert seeds a Main branch (no more bricked tenants) + no paid sub without payment.
- **Money/fiscal:** e-Arşiv invoice writes real columns + correct taxable base; self-pay settlement recoverable not sticky-FAILED; payByItems no longer strands orders.
- **Multi-tenancy:** device commands branch-scoped (no cross-branch terminal/drawer/printer); reservation table reassignment scoped; delivery webhooks bound to the restaurant in the URL.
- **Reliability:** outbox stuck-`dispatching` reaper; superadmin refund double-refund guard; device-command idempotency (no double-charge on requeue).
- **Frontend:** tr-TR money formatting, QR session id no longer leaked in shareable URLs, POS two-step/modifier/discount correctness, KDS realtime reconnect refetch.
- **Native:** Rust bridge crash-recovery + kind-aware requeue + durable ack (no double-charge); C++ memory-safety (engine dims/file-size validation, fps div-by-zero, stride-aware frame buffer, TLS hostname verification, URL data race).

## Deferred follow-ups (documented in code/commits)
- M23 advisory-lock pooled-connection fix (reverted — needs a design without long-held transactions).
- H7 prod backfill for already-converted (bricked) tenants.
- FH1 full per-checkout payment-status correlation (backend oid endpoint).
- Several DB-migration hardenings (unique indexes, op-key idempotency, attemptCount) + i18n key mirroring.

## Verification / rollout
Recommend deploying to **staging (`test` branch)** first to bake the behavior changes (removed marketplace endpoint, device branch-scoping, new self-pay `PARTIALLY_SETTLED` status), then tagging prod — criticals (v3.2.12) ideally ahead of the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)