### PR TITLE
Onboarding TRIAL plan + TRIAL_ENDED lock (decouple trial from BUSINESS/FREE)

### DIFF
--- a/backend/prisma/migrations/20260619140000_onboarding_trial_plan/migration.sql
+++ b/backend/prisma/migrations/20260619140000_onboarding_trial_plan/migration.sql
@@ -1,0 +1,59 @@
+-- Onboarding-trial redesign — set up the plan catalog.
+--
+-- New tenants start on a dedicated, non-purchasable TRIAL plan (7-day full
+-- premium). At expiry the subscription goes to TRIAL_ENDED (locked) and the
+-- tenant must activate a paid plan. This decouples the trial from BUSINESS
+-- (the old design ran the trial on BUSINESS, coupling signup to
+-- BUSINESS.trialDays) and retires FREE (no post-trial free landing).
+--
+-- The system is not yet in production use, so there is no live tenant/trial/
+-- FREE data to migrate; this brings the plan catalog in line with the new
+-- model. Idempotent (ADD COLUMN IF NOT EXISTS + upsert-by-unique-name).
+
+-- 1) Self-serve / purchasable flag on plans.
+ALTER TABLE "subscription_plans"
+  ADD COLUMN IF NOT EXISTS "isPublic" BOOLEAN NOT NULL DEFAULT true;
+
+-- 2) Paid tiers are purchasable; per-plan trials are removed (single
+--    onboarding trial only), so their trialDays go to 0.
+UPDATE "subscription_plans"
+   SET "isPublic" = true, "trialDays" = 0
+ WHERE "name" IN ('BASIC', 'PRO', 'BUSINESS');
+
+-- 3) Retire FREE — no post-trial free landing, nothing lands on it. Keep the
+--    row (avoid FK churn) but deactivate + hide it.
+UPDATE "subscription_plans"
+   SET "isActive" = false, "isPublic" = false
+ WHERE "name" = 'FREE';
+
+-- 4) Create (or refresh) the TRIAL onboarding plan: full premium, 7-day
+--    trial, not purchasable, hidden from pricing. Mirrors BUSINESS's
+--    unlimited limits + all features open.
+INSERT INTO "subscription_plans" (
+  "id", "name", "displayName", "description",
+  "monthlyPrice", "yearlyPrice", "currency", "trialDays",
+  "maxUsers", "maxTables", "maxBranches", "maxProducts", "maxCategories", "maxMonthlyOrders",
+  "advancedReports", "multiLocation", "customBranding", "apiAccess", "prioritySupport",
+  "inventoryTracking", "kdsIntegration", "reservationSystem", "personnelManagement",
+  "deliveryIntegration", "posAccess",
+  "commissionRate", "isActive", "isPublic", "createdAt", "updatedAt"
+) VALUES (
+  gen_random_uuid(), 'TRIAL', 'Deneme', '7 günlük tam özellikli onboarding denemesi',
+  0, 0, 'TRY', 7,
+  -1, -1, -1, -1, -1, -1,
+  true, true, true, true, true,
+  true, true, true, true,
+  true, true,
+  0.10, true, false, NOW(), NOW()
+)
+ON CONFLICT ("name") DO UPDATE SET
+  "displayName" = EXCLUDED."displayName",
+  "description" = EXCLUDED."description",
+  "monthlyPrice" = 0, "yearlyPrice" = 0, "currency" = 'TRY', "trialDays" = 7,
+  "maxUsers" = -1, "maxTables" = -1, "maxBranches" = -1, "maxProducts" = -1,
+  "maxCategories" = -1, "maxMonthlyOrders" = -1,
+  "advancedReports" = true, "multiLocation" = true, "customBranding" = true,
+  "apiAccess" = true, "prioritySupport" = true, "inventoryTracking" = true,
+  "kdsIntegration" = true, "reservationSystem" = true, "personnelManagement" = true,
+  "deliveryIntegration" = true, "posAccess" = true,
+  "isActive" = true, "isPublic" = false, "updatedAt" = NOW();

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -996,6 +996,11 @@ model SubscriptionPlan {
 
   isActive Boolean @default(true)
 
+  // Onboarding-trial redesign: purchasable on the self-serve choose-plan
+  // screen / public pricing grid. The TRIAL onboarding plan is isPublic=false
+  // (granted automatically at signup, never bought); paid tiers are true.
+  isPublic Boolean @default(true)
+
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 

--- a/backend/prisma/seed.ts
+++ b/backend/prisma/seed.ts
@@ -1,85 +1,84 @@
-import { PrismaClient } from '@prisma/client';
-import * as bcrypt from 'bcryptjs';
-import { UserRole } from '../src/common/constants/roles.enum';
+import { PrismaClient } from "@prisma/client";
+import * as bcrypt from "bcryptjs";
+import { UserRole } from "../src/common/constants/roles.enum";
 
 const prisma = new PrismaClient();
 
 async function main() {
-  console.log('🌱 Seeding database...');
+  console.log("🌱 Seeding database...");
 
   // Create subscription plans. The `update` branch mirrors every field
   // that can drift after the first seed (prices/currency/displayName);
-  // otherwise re-running `prisma:seed` keeps stale USD numbers when the
-  // codebase has migrated to TRY.
-  // FREE plan is the post-trial fallback, not a self-serve choice.
-  // Registration grants an automatic 14-day BUSINESS trial; when that
-  // trial expires without a paid subscription the tenant falls through
-  // to FREE (PlanFeatureGuard treats FREE as live without requiring an
-  // active Subscription row).
+  // otherwise re-running `prisma:seed` keeps stale numbers.
   //
-  // The plan stays `isActive: true` so /subscriptions/plans and
-  // /superadmin/plans still surface it for internal consumers (the
-  // PlanFeatureGuard, the post-trial scheduler, e2e tests). The
-  // landing page deliberately omits it from the public pricing grid
-  // — see landing/src/components/sections/Pricing.tsx.
-  const freePlan = await prisma.subscriptionPlan.upsert({
-    where: { name: 'FREE' },
+  // Onboarding-trial redesign: every new tenant starts on the dedicated,
+  // non-purchasable TRIAL plan (7-day full premium). At expiry the
+  // subscription goes to TRIAL_ENDED (locked) and the tenant must activate a
+  // paid plan. FREE is retired (no post-trial free landing) — it is simply
+  // not seeded. Paid tiers (BASIC/PRO/BUSINESS) are isPublic=true with no
+  // per-plan trial (trialDays=0); the single onboarding trial replaces them.
+  const trialPlan = await prisma.subscriptionPlan.upsert({
+    where: { name: "TRIAL" },
     update: {
-      displayName: 'Ücretsiz',
-      description: 'Deneme sürümü sona erdiğinde kullanılan kısıtlı plan',
+      displayName: "Deneme",
+      description: "7 günlük tam özellikli onboarding denemesi",
       monthlyPrice: 0,
       yearlyPrice: 0,
-      currency: 'TRY',
-      maxBranches: 1,
-      advancedReports: false,
-      multiLocation: false,
-      customBranding: false,
-      apiAccess: false,
-      prioritySupport: false,
-      inventoryTracking: false,
+      currency: "TRY",
+      trialDays: 7,
+      isPublic: false,
+      maxBranches: -1,
+      advancedReports: true,
+      multiLocation: true,
+      customBranding: true,
+      apiAccess: true,
+      prioritySupport: true,
+      inventoryTracking: true,
       kdsIntegration: true,
-      reservationSystem: false,
-      personnelManagement: false,
-      deliveryIntegration: false,
-      posAccess: false,
+      reservationSystem: true,
+      personnelManagement: true,
+      deliveryIntegration: true,
+      posAccess: true,
     },
     create: {
-      name: 'FREE',
-      displayName: 'Ücretsiz',
-      description: 'Deneme sürümü sona erdiğinde kullanılan kısıtlı plan',
+      name: "TRIAL",
+      displayName: "Deneme",
+      description: "7 günlük tam özellikli onboarding denemesi",
       monthlyPrice: 0,
       yearlyPrice: 0,
-      currency: 'TRY',
-      trialDays: 0,
-      maxUsers: 2,
-      maxTables: 5,
-      maxBranches: 1,
-      maxProducts: 25,
-      maxCategories: 5,
-      maxMonthlyOrders: 50,
-      advancedReports: false,
-      multiLocation: false,
-      customBranding: false,
-      apiAccess: false,
-      prioritySupport: false,
-      inventoryTracking: false,
+      currency: "TRY",
+      trialDays: 7,
+      isPublic: false,
+      maxUsers: -1,
+      maxTables: -1,
+      maxBranches: -1,
+      maxProducts: -1,
+      maxCategories: -1,
+      maxMonthlyOrders: -1,
+      advancedReports: true,
+      multiLocation: true,
+      customBranding: true,
+      apiAccess: true,
+      prioritySupport: true,
+      inventoryTracking: true,
       kdsIntegration: true,
-      reservationSystem: false,
-      personnelManagement: false,
-      deliveryIntegration: false,
-      posAccess: false,
+      reservationSystem: true,
+      personnelManagement: true,
+      deliveryIntegration: true,
+      posAccess: true,
       isActive: true,
     },
   });
 
   const basicPlan = await prisma.subscriptionPlan.upsert({
-    where: { name: 'BASIC' },
+    where: { name: "BASIC" },
     update: {
-      displayName: 'Başlangıç',
-      description: 'Kafe ve küçük restoranlar için temel POS + stok takibi',
+      isPublic: true,
+      displayName: "Başlangıç",
+      description: "Kafe ve küçük restoranlar için temel POS + stok takibi",
       monthlyPrice: 499,
       yearlyPrice: 4490, // 2 ay bedava (10 ay × 499 = 4990 → 4490 promosyon)
-      currency: 'TRY',
+      currency: "TRY",
       maxBranches: 1,
       advancedReports: false,
       multiLocation: false,
@@ -94,13 +93,16 @@ async function main() {
       posAccess: true,
     },
     create: {
-      name: 'BASIC',
-      displayName: 'Başlangıç',
-      description: 'Kafe ve küçük restoranlar için temel POS + stok takibi',
+      name: "BASIC",
+      displayName: "Başlangıç",
+      description: "Kafe ve küçük restoranlar için temel POS + stok takibi",
       monthlyPrice: 499,
       yearlyPrice: 4490,
-      currency: 'TRY',
-      trialDays: 14,
+      currency: "TRY",
+      // Onboarding-trial redesign: no per-plan trial; the single TRIAL plan
+      // is the only trial. Paid tiers are purchasable (isPublic) with trialDays 0.
+      trialDays: 0,
+      isPublic: true,
       maxUsers: 5,
       maxTables: 20,
       maxBranches: 1,
@@ -123,13 +125,15 @@ async function main() {
   });
 
   const proPlan = await prisma.subscriptionPlan.upsert({
-    where: { name: 'PRO' },
+    where: { name: "PRO" },
     update: {
-      displayName: 'Profesyonel',
-      description: 'Şehir merkezi restoranlar için rezervasyon + delivery + personel takibi',
+      isPublic: true,
+      displayName: "Profesyonel",
+      description:
+        "Şehir merkezi restoranlar için rezervasyon + delivery + personel takibi",
       monthlyPrice: 1299,
       yearlyPrice: 12990, // 2 ay bedava (10 ay × 1299 = 12990 düz)
-      currency: 'TRY',
+      currency: "TRY",
       maxBranches: 3,
       advancedReports: true,
       multiLocation: true,
@@ -144,13 +148,17 @@ async function main() {
       posAccess: true,
     },
     create: {
-      name: 'PRO',
-      displayName: 'Profesyonel',
-      description: 'Şehir merkezi restoranlar için rezervasyon + delivery + personel takibi',
+      name: "PRO",
+      displayName: "Profesyonel",
+      description:
+        "Şehir merkezi restoranlar için rezervasyon + delivery + personel takibi",
       monthlyPrice: 1299,
       yearlyPrice: 12990,
-      currency: 'TRY',
-      trialDays: 14,
+      currency: "TRY",
+      // Onboarding-trial redesign: no per-plan trial; the single TRIAL plan
+      // is the only trial. Paid tiers are purchasable (isPublic) with trialDays 0.
+      trialDays: 0,
+      isPublic: true,
       maxUsers: 15,
       maxTables: 50,
       maxBranches: 3,
@@ -173,13 +181,15 @@ async function main() {
   });
 
   const businessPlan = await prisma.subscriptionPlan.upsert({
-    where: { name: 'BUSINESS' },
+    where: { name: "BUSINESS" },
     update: {
-      displayName: 'Kurumsal',
-      description: 'Çok şubeli zincirler için sınırsız + API erişimi + öncelikli destek',
+      isPublic: true,
+      displayName: "Kurumsal",
+      description:
+        "Çok şubeli zincirler için sınırsız + API erişimi + öncelikli destek",
       monthlyPrice: 2999,
       yearlyPrice: 29990, // 2 ay bedava (10 ay × 2999 = 29990 düz)
-      currency: 'TRY',
+      currency: "TRY",
       maxBranches: -1,
       advancedReports: true,
       multiLocation: true,
@@ -194,13 +204,17 @@ async function main() {
       posAccess: true,
     },
     create: {
-      name: 'BUSINESS',
-      displayName: 'Kurumsal',
-      description: 'Çok şubeli zincirler için sınırsız + API erişimi + öncelikli destek',
+      name: "BUSINESS",
+      displayName: "Kurumsal",
+      description:
+        "Çok şubeli zincirler için sınırsız + API erişimi + öncelikli destek",
       monthlyPrice: 2999,
       yearlyPrice: 29990,
-      currency: 'TRY',
-      trialDays: 14,
+      currency: "TRY",
+      // Onboarding-trial redesign: no per-plan trial; the single TRIAL plan
+      // is the only trial. Paid tiers are purchasable (isPublic) with trialDays 0.
+      trialDays: 0,
+      isPublic: true,
       maxUsers: -1,
       maxTables: -1,
       maxBranches: -1,
@@ -222,70 +236,101 @@ async function main() {
     },
   });
 
-  console.log('✅ Subscription plans created');
+  console.log("✅ Subscription plans created");
 
   // Upsert tenant and users so re-running the seed against an existing
   // DB no longer hits @@unique constraints. The previous `create` calls
   // worked exactly once per database — every subsequent run blew up on
   // `subdomain` or `email` collision and required a manual reset.
   const tenant = await prisma.tenant.upsert({
-    where: { subdomain: 'demo' },
+    where: { subdomain: "demo" },
     update: {},
     create: {
-      name: 'Demo Restaurant',
-      subdomain: 'demo',
-      status: 'ACTIVE',
-      currentPlanId: freePlan.id,
+      name: "Demo Restaurant",
+      subdomain: "demo",
+      status: "ACTIVE",
+      // Onboarding-trial redesign: FREE is retired, so the demo tenant runs on
+      // a real ACTIVE BUSINESS subscription (created below) instead of the old
+      // always-live FREE plan.
+      currentPlanId: businessPlan.id,
     },
   });
 
-  console.log('✅ Tenant created:', tenant.name);
+  console.log("✅ Tenant created:", tenant.name);
+
+  // Demo tenant needs a live ACTIVE subscription (the new PlanFeatureGuard no
+  // longer treats any plan as live without one — FREE is gone). Idempotent:
+  // only create if the tenant has no subscription yet.
+  const existingDemoSub = await prisma.subscription.findFirst({
+    where: { tenantId: tenant.id },
+  });
+  if (!existingDemoSub) {
+    const periodEnd = new Date();
+    periodEnd.setMonth(periodEnd.getMonth() + 1);
+    await prisma.subscription.create({
+      data: {
+        tenantId: tenant.id,
+        planId: businessPlan.id,
+        status: "ACTIVE",
+        billingCycle: "MONTHLY",
+        paymentProvider: "PAYTR",
+        startDate: new Date(),
+        currentPeriodStart: new Date(),
+        currentPeriodEnd: periodEnd,
+        isTrialPeriod: false,
+        amount: businessPlan.monthlyPrice,
+        currency: businessPlan.currency,
+        cancelAtPeriodEnd: false,
+      },
+    });
+    console.log("✅ Demo BUSINESS subscription created");
+  }
 
   // v3.0.0 — every tenant needs at least one branch. The strict
   // branch-scope schema requires Table.branchId, Order.branchId, etc.,
   // so seed must mint a default "Main" branch before any branch-scoped
   // row is created. Upsert keeps the seed idempotent against re-runs.
   const mainBranch = await prisma.branch.upsert({
-    where: { tenantId_code: { tenantId: tenant.id, code: 'MAIN' } },
+    where: { tenantId_code: { tenantId: tenant.id, code: "MAIN" } },
     update: {},
     create: {
       tenantId: tenant.id,
-      name: 'Main',
-      code: 'MAIN',
-      timezone: 'Europe/Istanbul',
-      status: 'active',
+      name: "Main",
+      code: "MAIN",
+      timezone: "Europe/Istanbul",
+      status: "active",
     },
   });
 
-  console.log('✅ Default branch created:', mainBranch.name);
+  console.log("✅ Default branch created:", mainBranch.name);
 
   // Create users
-  const hashedPassword = await bcrypt.hash('password123', 10);
+  const hashedPassword = await bcrypt.hash("password123", 10);
 
   const admin = await prisma.user.upsert({
-    where: { email: 'admin@restaurant.com' },
+    where: { email: "admin@restaurant.com" },
     update: {},
     create: {
-      email: 'admin@restaurant.com',
+      email: "admin@restaurant.com",
       password: hashedPassword,
-      firstName: 'John',
-      lastName: 'Admin',
+      firstName: "John",
+      lastName: "Admin",
       role: UserRole.ADMIN,
-      status: 'ACTIVE',
+      status: "ACTIVE",
       tenantId: tenant.id,
     },
   });
 
   const waiter = await prisma.user.upsert({
-    where: { email: 'waiter@restaurant.com' },
+    where: { email: "waiter@restaurant.com" },
     update: {},
     create: {
-      email: 'waiter@restaurant.com',
+      email: "waiter@restaurant.com",
       password: hashedPassword,
-      firstName: 'Jane',
-      lastName: 'Waiter',
+      firstName: "Jane",
+      lastName: "Waiter",
       role: UserRole.WAITER,
-      status: 'ACTIVE',
+      status: "ACTIVE",
       tenantId: tenant.id,
       // v3.0.0 — DB CHECK constraint requires hard-restricted roles
       // (WAITER/KITCHEN/COURIER) to carry a primaryBranchId.
@@ -294,27 +339,27 @@ async function main() {
   });
 
   const kitchen = await prisma.user.upsert({
-    where: { email: 'kitchen@restaurant.com' },
+    where: { email: "kitchen@restaurant.com" },
     update: {},
     create: {
-      email: 'kitchen@restaurant.com',
+      email: "kitchen@restaurant.com",
       password: hashedPassword,
-      firstName: 'Mike',
-      lastName: 'Chef',
+      firstName: "Mike",
+      lastName: "Chef",
       role: UserRole.KITCHEN,
-      status: 'ACTIVE',
+      status: "ACTIVE",
       tenantId: tenant.id,
       primaryBranchId: mainBranch.id,
     },
   });
 
-  console.log('✅ Users created');
+  console.log("✅ Users created");
 
   // Create categories
   const appetizers = await prisma.category.create({
     data: {
-      name: 'Appetizers',
-      description: 'Start your meal with our delicious starters',
+      name: "Appetizers",
+      description: "Start your meal with our delicious starters",
       displayOrder: 1,
       isActive: true,
       tenantId: tenant.id,
@@ -323,8 +368,8 @@ async function main() {
 
   const mains = await prisma.category.create({
     data: {
-      name: 'Main Courses',
-      description: 'Our signature main dishes',
+      name: "Main Courses",
+      description: "Our signature main dishes",
       displayOrder: 2,
       isActive: true,
       tenantId: tenant.id,
@@ -333,8 +378,8 @@ async function main() {
 
   const desserts = await prisma.category.create({
     data: {
-      name: 'Desserts',
-      description: 'Sweet endings to your meal',
+      name: "Desserts",
+      description: "Sweet endings to your meal",
       displayOrder: 3,
       isActive: true,
       tenantId: tenant.id,
@@ -343,23 +388,23 @@ async function main() {
 
   const beverages = await prisma.category.create({
     data: {
-      name: 'Beverages',
-      description: 'Refreshing drinks',
+      name: "Beverages",
+      description: "Refreshing drinks",
       displayOrder: 4,
       isActive: true,
       tenantId: tenant.id,
     },
   });
 
-  console.log('✅ Categories created');
+  console.log("✅ Categories created");
 
   // Create products
   const products = await prisma.product.createMany({
     data: [
       // Appetizers
       {
-        name: 'Caesar Salad',
-        description: 'Fresh romaine lettuce with Caesar dressing and croutons',
+        name: "Caesar Salad",
+        description: "Fresh romaine lettuce with Caesar dressing and croutons",
         price: 8.99,
         isAvailable: true,
         stockTracked: true,
@@ -368,8 +413,8 @@ async function main() {
         tenantId: tenant.id,
       },
       {
-        name: 'Garlic Bread',
-        description: 'Toasted bread with garlic butter',
+        name: "Garlic Bread",
+        description: "Toasted bread with garlic butter",
         price: 5.99,
         isAvailable: true,
         stockTracked: true,
@@ -378,8 +423,8 @@ async function main() {
         tenantId: tenant.id,
       },
       {
-        name: 'Buffalo Wings',
-        description: 'Spicy chicken wings with ranch dressing',
+        name: "Buffalo Wings",
+        description: "Spicy chicken wings with ranch dressing",
         price: 12.99,
         isAvailable: true,
         stockTracked: true,
@@ -389,8 +434,8 @@ async function main() {
       },
       // Main Courses
       {
-        name: 'Grilled Salmon',
-        description: 'Fresh Atlantic salmon with vegetables',
+        name: "Grilled Salmon",
+        description: "Fresh Atlantic salmon with vegetables",
         price: 24.99,
         isAvailable: true,
         stockTracked: true,
@@ -399,8 +444,8 @@ async function main() {
         tenantId: tenant.id,
       },
       {
-        name: 'Beef Burger',
-        description: 'Premium beef patty with cheese and fries',
+        name: "Beef Burger",
+        description: "Premium beef patty with cheese and fries",
         price: 15.99,
         isAvailable: true,
         stockTracked: true,
@@ -409,8 +454,8 @@ async function main() {
         tenantId: tenant.id,
       },
       {
-        name: 'Pasta Carbonara',
-        description: 'Classic Italian pasta with creamy sauce',
+        name: "Pasta Carbonara",
+        description: "Classic Italian pasta with creamy sauce",
         price: 16.99,
         isAvailable: true,
         stockTracked: true,
@@ -419,8 +464,8 @@ async function main() {
         tenantId: tenant.id,
       },
       {
-        name: 'Chicken Tikka Masala',
-        description: 'Marinated chicken in spicy tomato sauce',
+        name: "Chicken Tikka Masala",
+        description: "Marinated chicken in spicy tomato sauce",
         price: 18.99,
         isAvailable: true,
         stockTracked: true,
@@ -430,8 +475,8 @@ async function main() {
       },
       // Desserts
       {
-        name: 'Chocolate Lava Cake',
-        description: 'Warm chocolate cake with molten center',
+        name: "Chocolate Lava Cake",
+        description: "Warm chocolate cake with molten center",
         price: 7.99,
         isAvailable: true,
         stockTracked: true,
@@ -440,8 +485,8 @@ async function main() {
         tenantId: tenant.id,
       },
       {
-        name: 'Tiramisu',
-        description: 'Classic Italian coffee-flavored dessert',
+        name: "Tiramisu",
+        description: "Classic Italian coffee-flavored dessert",
         price: 8.99,
         isAvailable: true,
         stockTracked: true,
@@ -450,8 +495,8 @@ async function main() {
         tenantId: tenant.id,
       },
       {
-        name: 'Ice Cream Sundae',
-        description: 'Three scoops with toppings',
+        name: "Ice Cream Sundae",
+        description: "Three scoops with toppings",
         price: 6.99,
         isAvailable: true,
         stockTracked: true,
@@ -461,8 +506,8 @@ async function main() {
       },
       // Beverages
       {
-        name: 'Coca Cola',
-        description: 'Refreshing soft drink',
+        name: "Coca Cola",
+        description: "Refreshing soft drink",
         price: 2.99,
         isAvailable: true,
         stockTracked: true,
@@ -471,8 +516,8 @@ async function main() {
         tenantId: tenant.id,
       },
       {
-        name: 'Fresh Orange Juice',
-        description: 'Freshly squeezed orange juice',
+        name: "Fresh Orange Juice",
+        description: "Freshly squeezed orange juice",
         price: 4.99,
         isAvailable: true,
         stockTracked: true,
@@ -481,8 +526,8 @@ async function main() {
         tenantId: tenant.id,
       },
       {
-        name: 'Coffee',
-        description: 'Freshly brewed coffee',
+        name: "Coffee",
+        description: "Freshly brewed coffee",
         price: 3.99,
         isAvailable: true,
         stockTracked: false,
@@ -493,71 +538,71 @@ async function main() {
     ],
   });
 
-  console.log('✅ Products created');
+  console.log("✅ Products created");
 
   // Create tables
   await prisma.table.createMany({
     data: [
       {
-        number: '1',
+        number: "1",
         capacity: 2,
-        section: 'Main Hall',
-        status: 'AVAILABLE',
+        section: "Main Hall",
+        status: "AVAILABLE",
         tenantId: tenant.id,
         branchId: mainBranch.id,
       },
       {
-        number: '2',
+        number: "2",
         capacity: 4,
-        section: 'Main Hall',
-        status: 'AVAILABLE',
+        section: "Main Hall",
+        status: "AVAILABLE",
         tenantId: tenant.id,
         branchId: mainBranch.id,
       },
       {
-        number: '3',
+        number: "3",
         capacity: 4,
-        section: 'Main Hall',
-        status: 'AVAILABLE',
+        section: "Main Hall",
+        status: "AVAILABLE",
         tenantId: tenant.id,
         branchId: mainBranch.id,
       },
       {
-        number: '4',
+        number: "4",
         capacity: 6,
-        section: 'Main Hall',
-        status: 'AVAILABLE',
+        section: "Main Hall",
+        status: "AVAILABLE",
         tenantId: tenant.id,
         branchId: mainBranch.id,
       },
       {
-        number: '5',
+        number: "5",
         capacity: 2,
-        section: 'Terrace',
-        status: 'AVAILABLE',
+        section: "Terrace",
+        status: "AVAILABLE",
         tenantId: tenant.id,
         branchId: mainBranch.id,
       },
       {
-        number: '6',
+        number: "6",
         capacity: 4,
-        section: 'Terrace',
-        status: 'AVAILABLE',
+        section: "Terrace",
+        status: "AVAILABLE",
         tenantId: tenant.id,
         branchId: mainBranch.id,
       },
       {
-        number: '7',
+        number: "7",
         capacity: 8,
-        section: 'Private Room',
-        status: 'AVAILABLE',
+        section: "Private Room",
+        status: "AVAILABLE",
         tenantId: tenant.id,
         branchId: mainBranch.id,
       },
     ],
   });
 
-  console.log('✅ Tables created');
+  console.log("✅ Tables created");
 
   // Default credentials are intentionally NOT echoed: this script runs in
   // CI pipelines whose logs are often retained for weeks, and leaking
@@ -575,7 +620,7 @@ async function main() {
 
 main()
   .catch((e) => {
-    console.error('❌ Error seeding database:', e);
+    console.error("❌ Error seeding database:", e);
     process.exit(1);
   })
   .finally(async () => {

--- a/backend/src/common/constants/subscription-plans.const.ts
+++ b/backend/src/common/constants/subscription-plans.const.ts
@@ -32,6 +32,39 @@ export interface PlanConfig {
 }
 
 export const SUBSCRIPTION_PLANS: Record<SubscriptionPlanType, PlanConfig> = {
+  // Onboarding-trial redesign: the dedicated non-purchasable onboarding plan
+  // every new tenant starts on (7-day full premium). FREE below is a retired
+  // tombstone (kept only because the enum value still exists).
+  [SubscriptionPlanType.TRIAL]: {
+    name: SubscriptionPlanType.TRIAL,
+    displayName: "Deneme",
+    description: "7 günlük tam özellikli onboarding denemesi",
+    monthlyPrice: 0,
+    yearlyPrice: 0,
+    currency: "TRY",
+    trialDays: 7,
+    limits: {
+      maxUsers: -1,
+      maxTables: -1,
+      maxBranches: -1,
+      maxProducts: -1,
+      maxCategories: -1,
+      maxMonthlyOrders: -1,
+    },
+    features: {
+      advancedReports: true,
+      multiLocation: true,
+      customBranding: true,
+      apiAccess: true,
+      prioritySupport: true,
+      inventoryTracking: true,
+      kdsIntegration: true,
+      reservationSystem: true,
+      personnelManagement: true,
+      deliveryIntegration: true,
+      posAccess: true,
+    },
+  },
   [SubscriptionPlanType.FREE]: {
     name: SubscriptionPlanType.FREE,
     displayName: "Ücretsiz",

--- a/backend/src/common/constants/subscription.enum.ts
+++ b/backend/src/common/constants/subscription.enum.ts
@@ -1,8 +1,17 @@
 export enum SubscriptionPlanType {
-  FREE = "FREE",
+  // TRIAL is the dedicated, non-purchasable onboarding plan every new tenant
+  // starts on (7-day full-premium trial). It decouples the trial from any paid
+  // tier — the old design ran the trial ON the BUSINESS plan, which coupled
+  // signup to BUSINESS.trialDays and caused silent TRIALING(BUSINESS)→FREE
+  // transitions.
+  TRIAL = "TRIAL",
   BASIC = "BASIC",
   PRO = "PRO",
   BUSINESS = "BUSINESS",
+  // FREE retired (onboarding-trial redesign) — kept as a tombstone so legacy
+  // references still compile, but no FREE plan row is seeded/active and nothing
+  // lands on it. New tenants start on TRIAL and must pick a paid plan at expiry.
+  FREE = "FREE",
 }
 
 export enum SubscriptionStatus {
@@ -11,6 +20,11 @@ export enum SubscriptionStatus {
   EXPIRED = "EXPIRED",
   PAST_DUE = "PAST_DUE",
   TRIALING = "TRIALING",
+  // Onboarding trial ended without a paid subscription. The tenant is LOCKED:
+  // PlanFeatureGuard + the global SubscriptionStatusGuard treat this as
+  // not-live, so the app is gated to the plan-selection + checkout flow until a
+  // paid plan is activated. Replaces the old silent trial→FREE downgrade.
+  TRIAL_ENDED = "TRIAL_ENDED",
   // Pre-activation state used between PayTR intent creation and webhook
   // confirmation. PENDING subscriptions don't grant feature access and
   // don't appear in the partial-unique (tenantId) WHERE status IN

--- a/backend/src/modules/auth/auth.module.ts
+++ b/backend/src/modules/auth/auth.module.ts
@@ -15,6 +15,7 @@ import { JwtAuthGuard } from "./guards/jwt-auth.guard";
 import { RolesGuard } from "./guards/roles.guard";
 import { TenantGuard } from "./guards/tenant.guard";
 import { BranchGuard } from "./guards/branch.guard";
+import { SubscriptionStatusGuard } from "../subscriptions/guards/subscription-status.guard";
 import { NotificationsModule } from "../notifications/notifications.module";
 
 @Module({
@@ -62,6 +63,13 @@ import { NotificationsModule } from "../notifications/notifications.module";
     {
       provide: APP_GUARD,
       useClass: BranchGuard,
+    },
+    // Onboarding-trial lock — runs LAST (after Jwt/Tenant/Branch set
+    // req.user.tenantId). A tenant with no live subscription (TRIAL_ENDED /
+    // EXPIRED) is gated to the plan-selection + checkout flow.
+    {
+      provide: APP_GUARD,
+      useClass: SubscriptionStatusGuard,
     },
   ],
   exports: [AuthService],

--- a/backend/src/modules/auth/auth.service.ts
+++ b/backend/src/modules/auth/auth.service.ts
@@ -243,26 +243,23 @@ export class AuthService {
 
       const finalSubdomain = await this.allocateSubdomain(baseSubdomain);
 
-      // Every new tenant gets a 14-day BUSINESS trial — the top-tier
-      // plan with every premium feature open — at zero charge. Trial is
-      // a one-time per-tenant benefit; the SchedulerService.expireTrials
-      // job downgrades the tenant to FREE at trialEnd. We need the
-      // BUSINESS plan here, not FREE, so the new tenant boots into a
-      // fully-featured workspace from the first dashboard load.
-      const businessPlan = await this.provisioning.loadBusinessPlanOrThrow();
+      // Every new tenant starts on the dedicated 7-day onboarding TRIAL plan —
+      // full premium, zero charge. At trialEnd SchedulerService.expireTrials
+      // flips the subscription to TRIAL_ENDED (locked) and the tenant must
+      // activate a paid plan to continue (no FREE landing). Using a dedicated
+      // TRIAL plan decouples signup from any paid tier.
+      const trialPlan = await this.provisioning.loadTrialPlanOrThrow();
 
-      // Tenant + TRIALING BUSINESS subscription must be created
-      // atomically so other modules never observe a tenant without a
-      // matching subscription.
+      // Tenant + TRIALING TRIAL subscription must be created atomically so
+      // other modules never observe a tenant without a matching subscription.
       const now = new Date();
-      const trialEnd = addDays(now, businessPlan.trialDays);
+      const trialEnd = addDays(now, trialPlan.trialDays);
 
-      // Seed `featureOverrides` with the BUSINESS plan's flag set so
-      // PlanFeatureGuard's fallback path resolves correctly during the
-      // first ~30 seconds while the entitlement engine projector is
-      // still warming up.
+      // Seed `featureOverrides` with the plan's flag set so PlanFeatureGuard's
+      // fallback path resolves correctly during the first ~30 seconds while the
+      // entitlement engine projector is still warming up.
       const planFeatureOverrides =
-        this.provisioning.buildPlanFeatureOverrides(businessPlan);
+        this.provisioning.buildPlanFeatureOverrides(trialPlan);
 
       try {
         const txResult = await this.prisma.$transaction(async (tx) =>
@@ -273,7 +270,7 @@ export class AuthService {
           this.provisioning.provisionNewTenantWithAdmin(tx, {
             restaurantName: registerDto.restaurantName,
             finalSubdomain,
-            businessPlan,
+            trialPlan,
             planFeatureOverrides,
             now,
             trialEnd,

--- a/backend/src/modules/auth/services/auth-provisioning.service.spec.ts
+++ b/backend/src/modules/auth/services/auth-provisioning.service.spec.ts
@@ -1,5 +1,5 @@
-import { AuthProvisioningService } from './auth-provisioning.service';
-import { ResourceNotFoundException } from '../../../common/exceptions';
+import { AuthProvisioningService } from "./auth-provisioning.service";
+import { ResourceNotFoundException } from "../../../common/exceptions";
 
 /**
  * Spec for the standalone (non-transactional) AuthProvisioningService helpers:
@@ -16,65 +16,81 @@ function makePrisma() {
   };
 }
 
-describe('AuthProvisioningService.allocateSubdomain', () => {
-  it('returns the preferred slug when it is free', async () => {
+describe("AuthProvisioningService.allocateSubdomain", () => {
+  it("returns the preferred slug when it is free", async () => {
     const prisma = makePrisma();
     const svc = new AuthProvisioningService(prisma as any);
-    await expect(svc.allocateSubdomain('acme')).resolves.toBe('acme');
+    await expect(svc.allocateSubdomain("acme")).resolves.toBe("acme");
   });
 
   it('defaults a blank base to "restaurant"', async () => {
     const prisma = makePrisma();
     const svc = new AuthProvisioningService(prisma as any);
-    await expect(svc.allocateSubdomain('')).resolves.toBe('restaurant');
+    await expect(svc.allocateSubdomain("")).resolves.toBe("restaurant");
   });
 
-  it('appends a random suffix when the preferred slug is already taken', async () => {
+  it("appends a random suffix when the preferred slug is already taken", async () => {
     const prisma = makePrisma();
     // preferred lookup returns a row (taken); suffixed candidates are free
     prisma.tenant.findUnique
-      .mockResolvedValueOnce({ id: 'existing' }) // preferred taken
+      .mockResolvedValueOnce({ id: "existing" }) // preferred taken
       .mockResolvedValue(null); // candidates free
     const svc = new AuthProvisioningService(prisma as any);
-    const result = await svc.allocateSubdomain('acme');
+    const result = await svc.allocateSubdomain("acme");
     expect(result).toMatch(/^acme-[0-9a-f]{6}$/);
   });
 
-  it('throws after exhausting suffix attempts', async () => {
+  it("throws after exhausting suffix attempts", async () => {
     const prisma = makePrisma();
-    prisma.tenant.findUnique.mockResolvedValue({ id: 'always-taken' });
+    prisma.tenant.findUnique.mockResolvedValue({ id: "always-taken" });
     const svc = new AuthProvisioningService(prisma as any);
-    await expect(svc.allocateSubdomain('acme')).rejects.toThrow(/Could not allocate/);
+    await expect(svc.allocateSubdomain("acme")).rejects.toThrow(
+      /Could not allocate/,
+    );
   });
 });
 
-describe('AuthProvisioningService.loadBusinessPlanOrThrow', () => {
-  it('returns the plan when seeded with a positive trial', async () => {
+describe("AuthProvisioningService.loadTrialPlanOrThrow", () => {
+  // Onboarding-trial redesign: new tenants start on the dedicated TRIAL plan,
+  // not BUSINESS. The guard now loads/validates the TRIAL plan.
+  it("returns the TRIAL plan when seeded with a positive trial", async () => {
     const prisma = makePrisma();
-    prisma.subscriptionPlan.findUnique.mockResolvedValue({ name: 'BUSINESS', trialDays: 14 });
+    prisma.subscriptionPlan.findUnique.mockResolvedValue({
+      name: "TRIAL",
+      trialDays: 7,
+    });
     const svc = new AuthProvisioningService(prisma as any);
-    await expect(svc.loadBusinessPlanOrThrow()).resolves.toMatchObject({ trialDays: 14 });
+    await expect(svc.loadTrialPlanOrThrow()).resolves.toMatchObject({
+      trialDays: 7,
+    });
   });
 
-  it('throws when the BUSINESS plan is missing (seed misconfig)', async () => {
+  it("throws when the TRIAL plan is missing (seed/migration misconfig)", async () => {
     const prisma = makePrisma();
     prisma.subscriptionPlan.findUnique.mockResolvedValue(null);
     const svc = new AuthProvisioningService(prisma as any);
-    await expect(svc.loadBusinessPlanOrThrow()).rejects.toBeInstanceOf(ResourceNotFoundException);
+    await expect(svc.loadTrialPlanOrThrow()).rejects.toBeInstanceOf(
+      ResourceNotFoundException,
+    );
   });
 
-  it('throws when the plan has no trialDays', async () => {
+  it("throws when the TRIAL plan has no trialDays", async () => {
     const prisma = makePrisma();
-    prisma.subscriptionPlan.findUnique.mockResolvedValue({ name: 'BUSINESS', trialDays: 0 });
+    prisma.subscriptionPlan.findUnique.mockResolvedValue({
+      name: "TRIAL",
+      trialDays: 0,
+    });
     const svc = new AuthProvisioningService(prisma as any);
-    await expect(svc.loadBusinessPlanOrThrow()).rejects.toBeInstanceOf(ResourceNotFoundException);
+    await expect(svc.loadTrialPlanOrThrow()).rejects.toBeInstanceOf(
+      ResourceNotFoundException,
+    );
   });
 });
 
-describe('AuthProvisioningService.buildPlanFeatureOverrides', () => {
+describe("AuthProvisioningService.buildPlanFeatureOverrides", () => {
   const svc = new AuthProvisioningService(makePrisma() as any);
 
-  it('coerces truthy flags to true and null/undefined to false', () => {
+  it("coerces truthy flags to true and null/undefined to false", () => {
     const overrides = svc.buildPlanFeatureOverrides({
       advancedReports: true,
       multiLocation: false,
@@ -89,15 +105,15 @@ describe('AuthProvisioningService.buildPlanFeatureOverrides', () => {
     expect(overrides.inventoryTracking).toBe(true);
   });
 
-  it('always returns the full set of eleven feature flags as booleans (incl. posAccess)', () => {
+  it("always returns the full set of eleven feature flags as booleans (incl. posAccess)", () => {
     const overrides = svc.buildPlanFeatureOverrides({});
     const keys = Object.keys(overrides);
     // posAccess was historically omitted (v3.0.7 bug); it MUST be present so a
     // fresh BUSINESS tenant's override fallback never hides POS during warm-up.
-    expect(keys).toContain('posAccess');
+    expect(keys).toContain("posAccess");
     expect(keys).toHaveLength(11);
     for (const v of Object.values(overrides)) {
-      expect(typeof v).toBe('boolean');
+      expect(typeof v).toBe("boolean");
     }
   });
 });

--- a/backend/src/modules/auth/services/auth-provisioning.service.ts
+++ b/backend/src/modules/auth/services/auth-provisioning.service.ts
@@ -79,26 +79,26 @@ export class AuthProvisioningService {
   }
 
   /**
-   * Load the BUSINESS plan and assert it is seeded with a positive trial.
-   * Throws (rather than silently landing the tenant on FREE) when the seed
-   * is misconfigured — identical to the original register() guard.
+   * Load the dedicated onboarding TRIAL plan and assert it is seeded with a
+   * positive trial length. Every new tenant starts on this plan (full-premium
+   * 7-day trial) instead of the old "trial on the BUSINESS plan" coupling —
+   * which made signup depend on BUSINESS.trialDays and caused silent
+   * trial→FREE transitions. Throws (refusing to register) if the seed/migration
+   * for the TRIAL plan is missing or misconfigured.
    */
-  async loadBusinessPlanOrThrow() {
-    const businessPlan = await this.prisma.subscriptionPlan.findUnique({
-      where: { name: "BUSINESS" },
+  async loadTrialPlanOrThrow() {
+    const trialPlan = await this.prisma.subscriptionPlan.findUnique({
+      where: { name: "TRIAL" },
     });
-    if (!businessPlan) {
-      // Seed misconfigured — refuse to register rather than silently
-      // landing the tenant on FREE without a trial. The user will get
-      // a clear error and ops can re-seed.
-      throw new ResourceNotFoundException("BUSINESS subscription plan");
+    if (!trialPlan) {
+      throw new ResourceNotFoundException("TRIAL subscription plan");
     }
-    if (businessPlan.trialDays <= 0) {
+    if (trialPlan.trialDays <= 0) {
       throw new ResourceNotFoundException(
-        "BUSINESS plan has no trialDays configured — re-seed plans",
+        "TRIAL plan has no trialDays configured — re-seed/migrate plans",
       );
     }
-    return businessPlan;
+    return trialPlan;
   }
 
   /**
@@ -202,7 +202,7 @@ export class AuthProvisioningService {
     args: {
       restaurantName: string;
       finalSubdomain: string;
-      businessPlan: any;
+      trialPlan: any;
       planFeatureOverrides: Record<string, boolean>;
       now: Date;
       trialEnd: Date;
@@ -212,7 +212,7 @@ export class AuthProvisioningService {
     const {
       restaurantName,
       finalSubdomain,
-      businessPlan,
+      trialPlan,
       planFeatureOverrides,
       now,
       trialEnd,
@@ -223,23 +223,19 @@ export class AuthProvisioningService {
       data: {
         name: restaurantName,
         subdomain: finalSubdomain,
-        currentPlanId: businessPlan.id,
-        // Per-tenant trial bookkeeping. `trialUsed=true` is the
-        // canonical lifetime-trial gate read by
-        // PaymentsService.createIntent + SubscriptionService;
-        // once stamped, no further trials regardless of plan.
-        // `usedTrialPlanIds` is kept for audit/reporting.
+        currentPlanId: trialPlan.id,
+        // Onboarding trial bookkeeping (the single trial; per-plan
+        // usedTrialPlanIds is retired). trialEndsAt drives the lock countdown.
         trialUsed: true,
         trialStartedAt: now,
         trialEndsAt: trialEnd,
-        usedTrialPlanIds: [businessPlan.id],
         featureOverrides: planFeatureOverrides,
       },
     });
     await tx.subscription.create({
       data: {
         tenantId: created.id,
-        planId: businessPlan.id,
+        planId: trialPlan.id,
         status: "TRIALING",
         billingCycle: "MONTHLY",
         // PayTR is the only configured provider; this row is the
@@ -247,15 +243,15 @@ export class AuthProvisioningService {
         paymentProvider: PaymentProvider.PAYTR,
         startDate: now,
         currentPeriodStart: now,
-        // During trial, currentPeriodEnd == trialEnd. After
-        // expireTrials downgrades to FREE, the FREE write path
-        // resets these fields.
+        // During trial, currentPeriodEnd == trialEnd. At expiry expireTrials
+        // flips the status to TRIAL_ENDED (locked) — the plan does NOT change
+        // (no FREE landing); the tenant must activate a paid plan to continue.
         currentPeriodEnd: trialEnd,
         isTrialPeriod: true,
         trialStart: now,
         trialEnd,
-        amount: businessPlan.monthlyPrice,
-        currency: businessPlan.currency,
+        amount: trialPlan.monthlyPrice,
+        currency: trialPlan.currency,
         cancelAtPeriodEnd: false,
       },
     });
@@ -320,21 +316,17 @@ export class AuthProvisioningService {
       .replace(/^-|-$/g, "");
     const subdomain = await this.allocateSubdomain(baseSubdomain);
 
-    // Social signups get the SAME provisioning as email registration: a
-    // 14-day BUSINESS trial + an auto-created Main branch + seeded
-    // featureOverrides. Diverging here (the old FREE-plan, no-branch path)
-    // shipped the "trial never started / 'Bu özellik aboneliğinizde yok' when
-    // creating the first branch" bug for Google/Apple signups — a fresh tenant
-    // landed with no branch and a plan that gates MULTI_LOCATION. Keep this in
-    // lockstep with register()'s ADMIN scenario.
-    const businessPlan = await this.loadBusinessPlanOrThrow();
+    // Social signups get the SAME provisioning as email registration: the
+    // 7-day onboarding TRIAL plan + an auto-created Main branch + seeded
+    // featureOverrides. Keep this in lockstep with register()'s ADMIN scenario.
+    const trialPlan = await this.loadTrialPlanOrThrow();
 
     const now = new Date();
-    const trialEnd = addDays(now, businessPlan.trialDays);
+    const trialEnd = addDays(now, trialPlan.trialDays);
 
     // Seed the plan's flag set so PlanFeatureGuard's fallback resolves while
     // the entitlement projector warms up — see register() for the full story.
-    const planFeatureOverrides = this.buildPlanFeatureOverrides(businessPlan);
+    const planFeatureOverrides = this.buildPlanFeatureOverrides(trialPlan);
 
     // Tenant + subscription + Main branch + user in one transaction so a
     // failure midway does not leave orphaned rows.
@@ -345,18 +337,17 @@ export class AuthProvisioningService {
           data: {
             name: restaurantName,
             subdomain,
-            currentPlanId: businessPlan.id,
+            currentPlanId: trialPlan.id,
             trialUsed: true,
             trialStartedAt: now,
             trialEndsAt: trialEnd,
-            usedTrialPlanIds: [businessPlan.id],
             featureOverrides: planFeatureOverrides,
           },
         });
         await tx.subscription.create({
           data: {
             tenantId: tenant.id,
-            planId: businessPlan.id,
+            planId: trialPlan.id,
             status: "TRIALING",
             billingCycle: "MONTHLY",
             paymentProvider: PaymentProvider.PAYTR,
@@ -366,8 +357,8 @@ export class AuthProvisioningService {
             isTrialPeriod: true,
             trialStart: now,
             trialEnd,
-            amount: businessPlan.monthlyPrice,
-            currency: businessPlan.currency,
+            amount: trialPlan.monthlyPrice,
+            currency: trialPlan.currency,
             cancelAtPeriodEnd: false,
           },
         });

--- a/backend/src/modules/payments/payments.service.ts
+++ b/backend/src/modules/payments/payments.service.ts
@@ -112,10 +112,15 @@ export class PaymentsService {
         where: { id: tenantId },
         include: {
           subscriptions: {
-            where: { status: { in: ["ACTIVE", "TRIALING", "PAST_DUE"] } },
-            // Plan included so trial-eligibility can distinguish a real
-            // paid subscription from the auto-created FREE sub that
-            // every tenant gets on registration.
+            // Include TRIAL_ENDED (onboarding-trial redesign): when a locked
+            // tenant picks a paid plan from the choose-plan screen, createIntent
+            // must find their existing (TRIAL_ENDED) subscription so the payment
+            // + PendingPlanChange reuse that row — settlement then flips the SAME
+            // row to ACTIVE on the chosen plan and releases the lock (instead of
+            // leaving a stale TRIAL_ENDED row beside a new ACTIVE one).
+            where: {
+              status: { in: ["ACTIVE", "TRIALING", "PAST_DUE", "TRIAL_ENDED"] },
+            },
             include: { plan: true },
             take: 1,
           },

--- a/backend/src/modules/subscriptions/guards/plan-feature.guard.ts
+++ b/backend/src/modules/subscriptions/guards/plan-feature.guard.ts
@@ -115,7 +115,11 @@ export class PlanFeatureGuard implements CanActivate {
       },
     });
 
-    if (!activeSubscription && currentPlan.name !== "FREE") {
+    // Onboarding-trial redesign: FREE is retired, so there is no "always-live"
+    // plan — a tenant with no live (ACTIVE/TRIALING/PAST_DUE) subscription is
+    // gated. (The global SubscriptionStatusGuard already locks TRIAL_ENDED /
+    // EXPIRED tenants to the plan-selection flow; this is defence in depth.)
+    if (!activeSubscription) {
       throw new ForbiddenException(
         "Your subscription has expired or been cancelled. Please renew to access this feature.",
       );

--- a/backend/src/modules/subscriptions/guards/subscription-status.guard.spec.ts
+++ b/backend/src/modules/subscriptions/guards/subscription-status.guard.spec.ts
@@ -1,0 +1,85 @@
+import { ForbiddenException } from "@nestjs/common";
+import { SubscriptionStatusGuard } from "./subscription-status.guard";
+
+/**
+ * Onboarding-trial lock: a tenant with no live subscription (TRIAL_ENDED /
+ * EXPIRED) is 403'd on non-allowlisted routes; the allowlist (auth, plans,
+ * payments, profile, legal) lets them recover.
+ */
+describe("SubscriptionStatusGuard", () => {
+  let prisma: { subscription: { findFirst: jest.Mock } };
+  let reflector: { getAllAndOverride: jest.Mock };
+  let guard: SubscriptionStatusGuard;
+
+  beforeEach(() => {
+    prisma = { subscription: { findFirst: jest.fn() } };
+    reflector = { getAllAndOverride: jest.fn().mockReturnValue(false) };
+    guard = new SubscriptionStatusGuard(reflector as any, prisma as any);
+  });
+
+  function ctx(path: string, user: any) {
+    return {
+      getHandler: () => ({}),
+      getClass: () => ({}),
+      switchToHttp: () => ({ getRequest: () => ({ path, user }) }),
+    } as any;
+  }
+
+  it("allows @Public routes without touching the DB", async () => {
+    reflector.getAllAndOverride.mockReturnValue(true);
+    await expect(guard.canActivate(ctx("/api/orders", { tenantId: "t1" }))).resolves.toBe(true);
+    expect(prisma.subscription.findFirst).not.toHaveBeenCalled();
+  });
+
+  it("allows requests with no tenant principal (superadmin / unauthenticated)", async () => {
+    await expect(guard.canActivate(ctx("/api/orders", undefined))).resolves.toBe(true);
+    expect(prisma.subscription.findFirst).not.toHaveBeenCalled();
+  });
+
+  it("allows allowlisted recovery routes even when locked (no DB query)", async () => {
+    for (const p of [
+      "/api/subscriptions/plans",
+      "/api/subscriptions/current",
+      "/api/payments/create-intent",
+      "/api/checkout/intent",
+      "/api/legal/documents",
+      "/api/users/me",
+      "/api/auth/refresh",
+    ]) {
+      await expect(guard.canActivate(ctx(p, { tenantId: "t1" }))).resolves.toBe(true);
+    }
+    expect(prisma.subscription.findFirst).not.toHaveBeenCalled();
+  });
+
+  it("allows a gated route when the tenant has a live subscription", async () => {
+    prisma.subscription.findFirst.mockResolvedValue({ id: "sub-1" });
+    await expect(guard.canActivate(ctx("/api/orders", { tenantId: "t1" }))).resolves.toBe(true);
+    expect(prisma.subscription.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          tenantId: "t1",
+          status: { in: ["ACTIVE", "TRIALING", "PAST_DUE"] },
+        }),
+      }),
+    );
+  });
+
+  it("LOCKS a gated route when the tenant has no live subscription (TRIAL_ENDED)", async () => {
+    prisma.subscription.findFirst.mockResolvedValue(null);
+    await expect(
+      guard.canActivate(ctx("/api/orders", { tenantId: "t1" })),
+    ).rejects.toBeInstanceOf(ForbiddenException);
+    try {
+      await guard.canActivate(ctx("/api/orders", { tenantId: "t1" }));
+    } catch (e: any) {
+      expect(e.getResponse().errorCode).toBe("PLAN_SELECTION_REQUIRED");
+    }
+  });
+
+  it("is segment-aware: '/api/menu' does NOT match the '/me' allowlist (locked → blocked)", async () => {
+    prisma.subscription.findFirst.mockResolvedValue(null);
+    await expect(
+      guard.canActivate(ctx("/api/menu/categories", { tenantId: "t1" })),
+    ).rejects.toBeInstanceOf(ForbiddenException);
+  });
+});

--- a/backend/src/modules/subscriptions/guards/subscription-status.guard.ts
+++ b/backend/src/modules/subscriptions/guards/subscription-status.guard.ts
@@ -1,0 +1,104 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  ForbiddenException,
+  Injectable,
+} from "@nestjs/common";
+import { Reflector } from "@nestjs/core";
+import { IS_PUBLIC_KEY } from "../../auth/decorators/public.decorator";
+import { PrismaService } from "../../../prisma/prisma.service";
+
+/**
+ * Global lock for the onboarding-trial redesign.
+ *
+ * A tenant whose onboarding trial has ended without a paid subscription is in
+ * status TRIAL_ENDED (and EXPIRED/CANCELLED tenants are likewise not live).
+ * Such a tenant is LOCKED: every tenant-scoped route is 403'd EXCEPT an
+ * allowlist needed to recover (see plans, pay, refresh tokens, read profile).
+ * This is the default-deny backend half of the lock; the SPA's SubscriptionGate
+ * redirects to /choose-plan on the PLAN_SELECTION_REQUIRED code.
+ *
+ * Registered as the LAST APP_GUARD (after Jwt/Tenant/Branch) so req.user.tenantId
+ * is set. Superadmin requests carry no req.user.tenantId, so they fly through.
+ *
+ * NOTE: this adds one indexed subscription lookup per non-allowlisted tenant
+ * request. A short-TTL per-tenant cache (invalidated on settlement/expiry) is a
+ * follow-up optimization if request volume warrants it.
+ */
+@Injectable()
+export class SubscriptionStatusGuard implements CanActivate {
+  constructor(
+    private readonly reflector: Reflector,
+    private readonly prisma: PrismaService,
+  ) {}
+
+  // Path prefixes (after the /api global prefix) a LOCKED tenant may still
+  // reach: auth/session, own profile, the plan catalog + current subscription,
+  // the payment + checkout rails, legal consent docs, entitlement self-read,
+  // public webhooks, and health. Everything else is gated.
+  private static readonly UNLOCKED_PREFIXES = [
+    "/auth",
+    "/me",
+    "/users/me",
+    "/profile",
+    "/subscriptions",
+    "/payments",
+    "/checkout",
+    "/legal",
+    "/entitlements",
+    "/webhooks",
+    "/health",
+  ];
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const isPublic = this.reflector.getAllAndOverride<boolean>(IS_PUBLIC_KEY, [
+      context.getHandler(),
+      context.getClass(),
+    ]);
+    if (isPublic) return true;
+
+    const request = context.switchToHttp().getRequest();
+    const tenantId = request.user?.tenantId;
+    // No tenant principal (unauthenticated handled by JwtAuthGuard, or the
+    // superadmin realm) — nothing to lock here.
+    if (!tenantId) return true;
+
+    const path: string = String(request.path ?? request.url ?? "").split(
+      "?",
+    )[0];
+    if (this.isUnlocked(path)) return true;
+
+    // A live subscription is ACTIVE / TRIALING / PAST_DUE (PAST_DUE keeps its
+    // 7-day grace, matching PlanFeatureGuard). TRIAL_ENDED / EXPIRED / none →
+    // locked.
+    const live = await this.prisma.subscription.findFirst({
+      where: {
+        tenantId,
+        status: { in: ["ACTIVE", "TRIALING", "PAST_DUE"] },
+      },
+      select: { id: true },
+    });
+    if (live) return true;
+
+    throw new ForbiddenException({
+      statusCode: 403,
+      error: "Plan Selection Required",
+      errorCode: "PLAN_SELECTION_REQUIRED",
+      message: "Deneme süreniz sona erdi. Devam etmek için bir plan seçin.",
+    });
+  }
+
+  /**
+   * Segment-aware prefix match against the request path (which carries the
+   * /api global prefix). "/me" matches "/api/users/me" and "/api/me" but NOT
+   * "/api/menu" — the same boundary rule the SPA's isTenantWidePath uses.
+   */
+  private isUnlocked(path: string): boolean {
+    return SubscriptionStatusGuard.UNLOCKED_PREFIXES.some((prefix) => {
+      const idx = path.indexOf(prefix);
+      if (idx === -1) return false;
+      const after = path.charAt(idx + prefix.length);
+      return after === "" || after === "/";
+    });
+  }
+}

--- a/backend/src/modules/subscriptions/services/subscription.service.spec.ts
+++ b/backend/src/modules/subscriptions/services/subscription.service.spec.ts
@@ -932,8 +932,45 @@ describe("SubscriptionService — deep-review money-path regressions", () => {
 
     const res = await svc.expireTrials();
 
-    // Skipped, not failed; tenant pointer NOT downgraded to FREE.
+    // Skipped, not failed; tenant is NOT locked (the just-paid sub is untouched).
     expect(prisma.tenant.update).not.toHaveBeenCalled();
     expect(res).toEqual({ processed: 0, failed: 0 });
+  });
+
+  it("expireTrials LOCKS an expired trial → TRIAL_ENDED (onboarding redesign)", async () => {
+    const now = new Date();
+    prisma.subscription.findMany.mockResolvedValue([
+      {
+        id: "sub-1",
+        tenantId: TENANT_ID,
+        trialEnd: new Date(now.getTime() - 1000),
+        currentPeriodStart: new Date(now.getTime() - 7 * 86_400_000),
+        currentPeriodEnd: new Date(now.getTime() - 1000),
+        plan: { name: "TRIAL", displayName: "Deneme" },
+        tenant: { name: "X" },
+      },
+    ] as any);
+    // Conditional claim wins → row flips to TRIAL_ENDED.
+    prisma.subscription.updateMany.mockResolvedValue({ count: 1 } as any);
+    prisma.user.findFirst.mockResolvedValue(null as any); // no admin email → skip email
+
+    const res = await svc.expireTrials();
+
+    // The claim sets status TRIAL_ENDED (no plan change, no FREE landing).
+    expect(prisma.subscription.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          status: "TRIALING",
+          isTrialPeriod: true,
+        }),
+        data: expect.objectContaining({
+          status: "TRIAL_ENDED",
+          isTrialPeriod: false,
+        }),
+      }),
+    );
+    // No FREE plan lookup, no tenant.currentPlanId rewrite.
+    expect(prisma.tenant.update).not.toHaveBeenCalled();
+    expect(res).toEqual({ processed: 1, failed: 0 });
   });
 });

--- a/backend/src/modules/subscriptions/services/subscription.service.ts
+++ b/backend/src/modules/subscriptions/services/subscription.service.ts
@@ -1413,10 +1413,12 @@ export class SubscriptionService {
   }
 
   /**
-   * Trial expiry cron. Trials don't auto-charge at expiry — we move them
-   * to PAST_DUE (so the tenant keeps read-only access) and notify the
-   * admin to re-checkout. Each row is wrapped in try/catch so one bad
-   * tenant does not skip everyone else's expiry.
+   * Trial expiry cron. Trials don't auto-charge at expiry — the onboarding
+   * trial LOCKS: each expired TRIALING row flips to TRIAL_ENDED (no plan
+   * change, no FREE landing), which the status guards treat as not-live so the
+   * app is gated to plan-selection + checkout. The admin is emailed to pick a
+   * plan. Each row is wrapped in try/catch so one bad tenant does not skip
+   * everyone else's expiry.
    */
   async expireTrials(): Promise<{ processed: number; failed: number }> {
     const now = new Date();
@@ -1433,93 +1435,55 @@ export class SubscriptionService {
       return { processed: 0, failed: 0 };
     }
 
-    // Look up FREE once for the whole batch. If the seed is missing
-    // FREE the entire batch fails loudly; no per-row fallback because
-    // there's no sensible alternative target.
-    const freePlan = await this.prisma.subscriptionPlan.findUnique({
-      where: { name: "FREE" },
-    });
-    if (!freePlan) {
-      this.logger.error(
-        "FREE plan missing from catalog — cannot expire trials",
-      );
-      return { processed: 0, failed: expiredTrials.length };
-    }
-
-    // FREE has no real period boundary, but currentPeriodEnd is a
-    // non-null column. Project ~10 years out, matching the placeholder
-    // AuthService.register used to write for the FREE subscription it
-    // created at signup. Same intent: the column exists for plan-tier
-    // bookkeeping, not for a real billing cycle.
-    const freePeriodEnd = new Date(now);
-    freePeriodEnd.setFullYear(freePeriodEnd.getFullYear() + 10);
-
     let failed = 0;
     // deep-review H2: rows that were concurrently paid/cancelled between the
     // findMany snapshot and the per-row claim are skipped, not failed.
     let skipped = 0;
     for (const subscription of expiredTrials) {
       try {
-        // Atomic transition: move the SAME subscription row from TRIALING
-        // BUSINESS → ACTIVE FREE and update Tenant.currentPlanId in lock
-        // step. Reusing the row avoids tripping the partial-unique
-        // (tenantId) WHERE status IN (ACTIVE, TRIALING) index, which
-        // would fire if we tried to create a fresh FREE row alongside
-        // the TRIALING one.
+        // Onboarding-trial redesign: at expiry the trial does NOT downgrade to
+        // a plan — it LOCKS. Flip TRIALING → TRIAL_ENDED (status only; the plan
+        // pointer stays TRIAL, no FREE landing). The global
+        // SubscriptionStatusGuard + PlanFeatureGuard then gate the app to the
+        // plan-selection + checkout flow until a paid plan is activated.
         //
-        // H2: the write is a CONDITIONAL claim (updateMany scoped to the
-        // still-TRIALING state), not an unconditional id update. If a PayTR
-        // webhook (applySuccess) flipped this row to ACTIVE+paid in the
-        // window after findMany, claim.count===0 and we MUST NOT clobber the
-        // just-paid subscription back to FREE (amount 0) — the customer was
-        // charged. The tenant.currentPlanId flip lives inside the won-claim
-        // branch so a skipped row never downgrades the tenant pointer either.
-        const transitioned = await this.prisma.$transaction(async (tx) => {
-          const claim = await tx.subscription.updateMany({
-            where: {
-              id: subscription.id,
-              status: SubscriptionStatus.TRIALING,
-              isTrialPeriod: true,
-            },
-            data: {
-              planId: freePlan.id,
-              status: SubscriptionStatus.ACTIVE,
-              isTrialPeriod: false,
-              amount: 0,
-              currency: freePlan.currency,
-              currentPeriodStart: now,
-              currentPeriodEnd: freePeriodEnd,
-            },
-          });
-          if (claim.count === 0) return false;
-          await tx.tenant.update({
-            where: { id: subscription.tenantId },
-            data: { currentPlanId: freePlan.id },
-          });
-          return true;
+        // H2 atomic CONDITIONAL claim: only a row STILL TRIALING transitions.
+        // If a PayTR webhook flipped it to ACTIVE+paid after the findMany
+        // snapshot, claim.count===0 and we leave the just-paid subscription
+        // untouched (never lock a tenant that already paid).
+        const claim = await this.prisma.subscription.updateMany({
+          where: {
+            id: subscription.id,
+            status: SubscriptionStatus.TRIALING,
+            isTrialPeriod: true,
+          },
+          data: {
+            status: SubscriptionStatus.TRIAL_ENDED,
+            isTrialPeriod: false,
+          },
         });
 
-        if (!transitioned) {
+        if (claim.count === 0) {
           skipped += 1;
           this.logger.log(
-            `Trial ${subscription.id} skipped — no longer TRIALING (concurrently settled/cancelled); not downgraded to FREE`,
+            `Trial ${subscription.id} skipped — no longer TRIALING (concurrently settled/cancelled)`,
           );
           continue;
         }
 
         this.logger.log(
-          `Trial subscription ${subscription.id} expired → tenant ${subscription.tenantId} dropped to FREE`,
+          `Trial subscription ${subscription.id} expired → tenant ${subscription.tenantId} LOCKED (TRIAL_ENDED); must activate a paid plan`,
         );
 
-        // Plan tier changed → entitlement set needs rebuilding. Treated as a
-        // downgrade so consumers can distinguish trial-expiry from a paid
-        // upgrade if they ever need to (the projector itself doesn't care).
+        // The subscription is no longer live, so re-project entitlements to
+        // revoke the trial grants. (The status guard is the hard lock; this
+        // keeps the entitlement set consistent with the locked state.)
         await this.emitLifecycle(EventTypes.SubscriptionDowngraded, {
           id: subscription.id,
           tenantId: subscription.tenantId,
-          plan: { name: "FREE" },
-          currentPeriodStart: now,
-          currentPeriodEnd: freePeriodEnd,
+          plan: { name: subscription.plan.name },
+          currentPeriodStart: subscription.currentPeriodStart,
+          currentPeriodEnd: subscription.currentPeriodEnd,
         });
 
         // Best-effort trial-expired email; failure here mustn't block the

--- a/backend/src/modules/subscriptions/services/subscription.service.ts
+++ b/backend/src/modules/subscriptions/services/subscription.service.ts
@@ -1214,8 +1214,12 @@ export class SubscriptionService {
   }
 
   async getAvailablePlans() {
+    // Onboarding-trial redesign: only PUBLIC plans are self-serve purchasable.
+    // This excludes the TRIAL onboarding plan (isPublic=false, granted at
+    // signup) and the retired FREE plan (isActive=false), so the choose-plan
+    // screen lists only BASIC/PRO/BUSINESS.
     const plans = await this.prisma.subscriptionPlan.findMany({
-      where: { isActive: true },
+      where: { isActive: true, isPublic: true },
       orderBy: { monthlyPrice: "asc" },
     });
 

--- a/docs/superpowers/specs/2026-06-19-onboarding-trial-plan-design.md
+++ b/docs/superpowers/specs/2026-06-19-onboarding-trial-plan-design.md
@@ -1,0 +1,134 @@
+# Onboarding Trial Plan — Design
+
+**Date:** 2026-06-19
+**Status:** Approved (brainstorming)
+**Author:** deep-review follow-up (Claude)
+
+## Problem
+
+Today registration grants a 14-day **BUSINESS** trial: the trial experience is
+coupled to a real paid tier. Two classes of logic error fall out of that:
+
+1. The trial's existence depends on `BUSINESS.trialDays > 0`. A BUSINESS row
+   created with the schema default (`trialDays = 0`) hard-blocks **all**
+   signups (`loadBusinessPlanOrThrow` throws "BUSINESS plan has no trialDays
+   configured"). This actually happened.
+2. At expiry the system **silently** transitions `TRIALING(BUSINESS) → ACTIVE(FREE)`.
+   That implicit transition is the source of edge-case bugs (e.g. the
+   concurrent-clobber where a just-paid subscription is overwritten back to
+   FREE), plus per-plan trial bookkeeping (`usedTrialPlanIds`) that adds more
+   state to get wrong.
+
+The system is **not yet in production use** — there is no live tenant/trial/FREE
+data to migrate. We can redesign cleanly.
+
+## Goal
+
+Decouple the trial from any paid tier by introducing a dedicated, non-purchasable
+**onboarding trial plan**. New tenants start on it; it expires; the tenant is then
+**forced to pick a paid plan** before continuing. No silent transitions, no
+trial↔paid-tier coupling.
+
+## Decisions (from brainstorming)
+
+- **Trial length:** 7 days.
+- **At expiry:** lock the tenant to a plan-selection screen — they cannot use
+  the app until they activate a paid plan. No silent auto-downgrade.
+- **Post-trial choices:** paid only — BASIC / PRO / BUSINESS. No FREE landing.
+- **Trial feature grant:** full premium (BUSINESS-equivalent feature set).
+- **Per-plan trials removed:** one trial concept only. Drop `usedTrialPlanIds`,
+  per-plan `trialDays` trial flows, and `startTrialFromIntent`.
+- **FREE plan:** retired entirely (no FREE landing, no existing FREE users).
+- **Lock screen:** read-only summary + plan selection (not a full blackout) to
+  maximize conversion; only ADMIN can pick/pay, other roles see "ask your admin".
+
+## Plan model
+
+| Plan      | Purchasable | Role |
+|-----------|-------------|------|
+| `TRIAL`   | No (`isPublic=false`, `isActive=true`) | 7-day onboarding; full premium grant via the existing entitlement projection |
+| `BASIC`   | Yes | paid |
+| `PRO`     | Yes | paid |
+| `BUSINESS`| Yes | paid |
+| `FREE`    | **Removed** | — |
+
+`TRIAL` grants the same feature/limit set as BUSINESS (everything open) so the
+tenant experiences the full product. It is never shown on the public pricing grid
+and cannot be selected/purchased.
+
+## Subscription state machine
+
+```
+register ──> TRIALING (plan=TRIAL, trialEnd = now + 7d)
+                 │
+                 │ expireTrials cron, trialEnd <= now
+                 ▼
+            TRIAL_ENDED  ── (locked: app gated to /choose-plan) ──┐
+                 │                                                 │
+                 │ ADMIN picks BASIC/PRO/BUSINESS                  │
+                 ▼                                                 │
+            PayTR checkout ── webhook settlement ──> ACTIVE (paid) ┘ (unlocked)
+```
+
+- New status value **`TRIAL_ENDED`** added to the subscription-status enum.
+- `expireTrials` uses an atomic conditional claim (`updateMany WHERE status=TRIALING`)
+  so a concurrently-activated subscription is never clobbered. It only flips the
+  status to `TRIAL_ENDED`; **the plan does not change** (no FREE).
+
+## Enforcement
+
+**Backend** — `PlanFeatureGuard` treats `TRIAL_ENDED` as **not live**. While in
+`TRIAL_ENDED`, all tenant routes return 403 **except** an allowlist needed to
+recover:
+- `/auth/*`, `/me`
+- `/subscriptions` (plan list + `current`)
+- `/checkout/intent` (+ the PayTR webhook, which is `@Public`)
+- read-only summary endpoints the lock screen needs (tenant/branch counts) —
+  scoped to the minimum.
+
+**Frontend** — a global `SubscriptionGate` reads the current subscription; when
+status is `TRIAL_ENDED` it redirects to `/choose-plan` and blocks all other
+in-app routes. The choose-plan screen shows a read-only summary (e.g. "you have
+N branches / M products — pick a plan to continue") + the paid plans. Only ADMIN
+sees the purchase actions; other roles see "ask your admin to choose a plan".
+
+## Activation (unlock)
+
+`/choose-plan` → select BASIC/PRO/BUSINESS → existing PayTR checkout rail
+(`POST /v1/checkout/intent` → `CK-` webhook → `CheckoutSettlementService` /
+subscription settlement). The settlement transition is extended to activate from
+**`TRIAL_ENDED`** (today it activates from `TRIALING`/`PENDING`). On success the
+subscription becomes `ACTIVE` on the chosen paid plan and the gate releases.
+
+## Removed (legacy / logic-error sources)
+
+- `FREE` plan: removed from seed; all `→ FREE` fallbacks replaced by the
+  `TRIAL_ENDED` lock. Enum value may remain as a tombstone but is unused.
+- `usedTrialPlanIds` per-plan trial registry + per-plan `trialDays` trial logic.
+- `startTrialFromIntent` (card-free paid-plan trial) and the "ücretsiz dene"
+  per-plan CTAs in the SPA.
+- `loadBusinessPlanOrThrow` → `loadTrialPlanOrThrow` (loads the TRIAL plan;
+  no BUSINESS coupling).
+- `createSubscription` public ADMIN endpoint no longer needed for trials
+  (register auto-creates the TRIAL sub; paid activation goes through settlement).
+  Keep only if another caller needs it; otherwise restrict/remove.
+
+## Testing
+
+- Seed: `TRIAL` plan exists (full premium, isPublic=false), no `FREE`.
+- `register()` → subscription `{ plan: TRIAL, status: TRIALING, trialEnd ≈ +7d }`,
+  Main branch + admin primaryBranchId seeded (provisioning parity preserved).
+- `expireTrials`: `TRIALING` past `trialEnd` → `TRIAL_ENDED`; a concurrently
+  ACTIVE-paid row is skipped (not clobbered).
+- `PlanFeatureGuard`: `TRIAL_ENDED` → 403 on a gated route, 200 on the allowlist.
+- Settlement: `TRIAL_ENDED` + paid checkout → `ACTIVE` on the chosen plan.
+- Frontend: `SubscriptionGate` redirects `TRIAL_ENDED` to `/choose-plan`; ADMIN
+  sees purchase actions, non-admin sees the ask-admin message.
+
+## Out of scope / notes
+
+- No data migration (system not in use). A seed change + `prisma migrate deploy`
+  schema migration for the new enum value is sufficient.
+- The pending `hotfix/business-trialdays-signup` (BUSINESS.trialDays backfill)
+  is **superseded** by this redesign and will be abandoned.
+- Dunning / proration for paid renewals is unchanged and out of scope here.

--- a/frontend/src/components/layout/Layout.tsx
+++ b/frontend/src/components/layout/Layout.tsx
@@ -8,6 +8,7 @@ import { SubscriptionProvider } from '../../contexts/SubscriptionContext';
 import { OnboardingProvider } from '../../features/onboarding';
 import { RTL_LANGUAGES } from '../../i18n/config';
 import SubscriptionStatusBanner from '../subscriptions/SubscriptionStatusBanner';
+import SubscriptionGate from '../subscriptions/SubscriptionGate';
 
 const Layout = () => {
   const { i18n } = useTranslation();
@@ -43,7 +44,11 @@ const Layout = () => {
               null when there's nothing to surface, so layout doesn't shift. */}
           <SubscriptionStatusBanner />
           <main className="flex-1 overflow-y-auto bg-slate-50/50 p-4 md:p-6 lg:p-8 relative">
-            <Outlet />
+            {/* Onboarding-trial lock: redirects locked (TRIAL_ENDED) tenants to
+                plan selection, keeping recovery routes reachable. */}
+            <SubscriptionGate>
+              <Outlet />
+            </SubscriptionGate>
             {import.meta.env.VITE_APP_VERSION && (
               <div
                 className="fixed bottom-4 right-4 text-xs bg-white/90 backdrop-blur-sm px-3 py-1.5 rounded-lg shadow-sm border border-slate-200/60 z-10 cursor-help hover:shadow-md transition-all duration-200"

--- a/frontend/src/components/subscriptions/SubscriptionGate.test.tsx
+++ b/frontend/src/components/subscriptions/SubscriptionGate.test.tsx
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import SubscriptionGate from './SubscriptionGate';
+
+// Mock the subscription context — the gate only reads { subscription, isLoading }.
+let mockSub: any = { status: 'ACTIVE' };
+let mockLoading = false;
+vi.mock('../../contexts/SubscriptionContext', () => ({
+  useSubscription: () => ({ subscription: mockSub, isLoading: mockLoading }),
+}));
+
+function renderAt(path: string) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route
+          path="*"
+          element={
+            <SubscriptionGate>
+              <div>APP CONTENT</div>
+            </SubscriptionGate>
+          }
+        />
+        <Route path="/subscription/plans" element={<div>PLANS SCREEN</div>} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe('SubscriptionGate (onboarding-trial lock)', () => {
+  it('renders the app for a live (ACTIVE) tenant', () => {
+    mockSub = { status: 'ACTIVE' };
+    mockLoading = false;
+    renderAt('/dashboard');
+    expect(screen.getByText('APP CONTENT')).toBeInTheDocument();
+  });
+
+  it('renders the app for a TRIALING tenant', () => {
+    mockSub = { status: 'TRIALING' };
+    renderAt('/dashboard');
+    expect(screen.getByText('APP CONTENT')).toBeInTheDocument();
+  });
+
+  it('LOCKS a TRIAL_ENDED tenant on a normal route → redirects to plans', () => {
+    mockSub = { status: 'TRIAL_ENDED' };
+    renderAt('/dashboard');
+    expect(screen.getByText('PLANS SCREEN')).toBeInTheDocument();
+    expect(screen.queryByText('APP CONTENT')).not.toBeInTheDocument();
+  });
+
+  it('does NOT redirect a locked tenant already on a recovery path', () => {
+    mockSub = { status: 'TRIAL_ENDED' };
+    renderAt('/subscription/checkout');
+    expect(screen.getByText('APP CONTENT')).toBeInTheDocument();
+  });
+
+  it('allows /admin/plan for a locked tenant (recovery path)', () => {
+    mockSub = { status: 'TRIAL_ENDED' };
+    renderAt('/admin/plan');
+    expect(screen.getByText('APP CONTENT')).toBeInTheDocument();
+  });
+
+  it('does not redirect while the subscription is still loading', () => {
+    mockSub = undefined;
+    mockLoading = true;
+    renderAt('/dashboard');
+    expect(screen.getByText('APP CONTENT')).toBeInTheDocument();
+    mockLoading = false;
+  });
+});

--- a/frontend/src/components/subscriptions/SubscriptionGate.tsx
+++ b/frontend/src/components/subscriptions/SubscriptionGate.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { Navigate, useLocation } from 'react-router-dom';
+import { useSubscription } from '../../contexts/SubscriptionContext';
+
+/**
+ * Onboarding-trial lock (frontend half).
+ *
+ * When a tenant's onboarding trial has ended without a paid subscription the
+ * backend marks it TRIAL_ENDED (and EXPIRED/CANCELLED are likewise not live).
+ * Such a tenant is LOCKED: this gate redirects every in-app route to the
+ * plan-selection screen until they activate a paid plan. The backend's global
+ * SubscriptionStatusGuard is the real enforcement (403 PLAN_SELECTION_REQUIRED);
+ * this gate is the UX so the user lands on /subscription/plans instead of
+ * hitting a wall of 403s.
+ *
+ * Recovery paths (plan selection, checkout, profile, legal, help) stay
+ * reachable so the user can actually pick + pay + read the consent docs.
+ */
+const RECOVERY_PREFIXES = [
+  '/subscription',
+  '/admin/plan',
+  '/profile',
+  '/legal',
+  '/help',
+];
+
+const SubscriptionGate = ({ children }: { children: React.ReactNode }) => {
+  const { subscription, isLoading } = useSubscription();
+  const location = useLocation();
+
+  // Don't redirect while the subscription query is still resolving — avoids a
+  // flash-redirect before the real status arrives.
+  if (isLoading) return <>{children}</>;
+
+  const status = subscription?.status;
+  const isLive =
+    status === 'ACTIVE' || status === 'TRIALING' || status === 'PAST_DUE';
+  // Lock only on an explicit not-live status (TRIAL_ENDED / EXPIRED /
+  // CANCELLED). A null subscription (no data / query error) is left to the API
+  // interceptor + backend guard rather than risking a false lock here.
+  const isLocked = !!subscription && !isLive;
+
+  const onRecoveryPath = RECOVERY_PREFIXES.some(
+    (p) =>
+      location.pathname === p || location.pathname.startsWith(`${p}/`),
+  );
+
+  if (isLocked && !onRecoveryPath) {
+    return <Navigate to="/subscription/plans" replace state={{ locked: true }} />;
+  }
+
+  return <>{children}</>;
+};
+
+export default SubscriptionGate;

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -162,6 +162,31 @@ api.interceptors.response.use(
   async (error) => {
     const originalRequest = error.config;
 
+    // Onboarding-trial lock backstop: the backend SubscriptionStatusGuard 403s a
+    // locked (TRIAL_ENDED / EXPIRED) tenant with errorCode
+    // PLAN_SELECTION_REQUIRED. The in-app SubscriptionGate already redirects on
+    // the cached status, but if the cache is stale (still ACTIVE/TRIALING) an
+    // API call surfaces the lock first — force the user to the plan-selection
+    // screen. Guard against a redirect loop while already on /subscription/*.
+    if (
+      error.response?.status === 403 &&
+      error.response?.data?.errorCode === 'PLAN_SELECTION_REQUIRED'
+    ) {
+      try {
+        if (
+          typeof window !== 'undefined' &&
+          window.location &&
+          !window.location.pathname.startsWith('/subscription')
+        ) {
+          window.location.href =
+            import.meta.env.BASE_URL + 'subscription/plans';
+        }
+      } catch {
+        // location unavailable (SSR / sandbox) — non-fatal; just reject below.
+      }
+      return Promise.reject(error);
+    }
+
     if (error.response?.status === 401 && !originalRequest._retry) {
       originalRequest._retry = true;
 

--- a/frontend/src/pages/subscription/SubscriptionPlansPage.tsx
+++ b/frontend/src/pages/subscription/SubscriptionPlansPage.tsx
@@ -142,6 +142,24 @@ const SubscriptionPlansPage = () => {
 
   return (
     <div className="max-w-7xl mx-auto">
+      {/* Onboarding-trial lock banner: the tenant's 7-day trial ended and they
+          are locked to this screen until they activate a paid plan. */}
+      {currentSubscription?.status === 'TRIAL_ENDED' && (
+        <div className="mb-8 rounded-lg border border-rose-200 bg-rose-50 p-4 text-rose-900">
+          <h3 className="font-semibold mb-1">
+            {t(
+              'subscriptions.plansPage.trialEndedTitle',
+              'Deneme süreniz sona erdi',
+            )}
+          </h3>
+          <p className="text-sm">
+            {t(
+              'subscriptions.plansPage.trialEndedBody',
+              'Kullanmaya devam etmek için aşağıdaki paketlerden birini seçin. Verileriniz güvende; bir plan etkinleştirdiğinizde kaldığınız yerden devam edersiniz.',
+            )}
+          </p>
+        </div>
+      )}
       {/* Renewal banner: surfaces when the user arrives from a PAST_DUE
           or EXPIRED CTA. Reminds them what plan they were on and gives
           permission to pick a different one. */}


### PR DESCRIPTION
## Summary

Redesigns the signup/trial model so the trial is a **dedicated plan**, not the BUSINESS tier. Every new tenant starts on a non-purchasable **TRIAL** plan (7-day full premium); at expiry the subscription **LOCKS** (`TRIAL_ENDED`) and the tenant must activate a **paid** plan (BASIC/PRO/BUSINESS) to continue. No silent trial→FREE downgrade; **FREE is retired**.

This removes the two logic-error classes from the old model: signup depending on `BUSINESS.trialDays` (a `0` value bricked all registrations — the bug you hit), and the silent `TRIALING(BUSINESS)→ACTIVE(FREE)` transition (H2-style edge cases). The system isn't in production use yet, so there's **no live-data migration**.

Design doc: `docs/superpowers/specs/2026-06-19-onboarding-trial-plan-design.md`. Supersedes `hotfix/business-trialdays-signup` (abandon it).

## What changed
**Foundation** — `SubscriptionStatus += TRIAL_ENDED`, `SubscriptionPlanType += TRIAL`; `SubscriptionPlan += isPublic`. Migration `20260619140000_onboarding_trial_plan` (validated on a throwaway Postgres, idempotent): creates the TRIAL plan, retires FREE, sets paid tiers `isPublic=true`/`trialDays=0`. seed.ts mirrors it.

**Register / expiry** — `loadTrialPlanOrThrow` (no BUSINESS coupling); register + social signup create a TRIALING subscription on TRIAL. `expireTrials` flips TRIALING→TRIAL_ENDED (atomic claim kept; a concurrently-paid row is never locked).

**Lock enforcement** — new global `SubscriptionStatusGuard` (last APP_GUARD): a tenant with no live subscription is 403'd `PLAN_SELECTION_REQUIRED` on every route except a recovery allowlist. `PlanFeatureGuard` drops the FREE-as-live fallback.

**Activation** — `createIntent` recognizes TRIAL_ENDED, so picking a paid plan reuses that subscription row and settlement flips it to ACTIVE (unlock). `getAvailablePlans` lists only `isPublic` plans.

**Frontend** — `SubscriptionGate` redirects locked tenants to `/subscription/plans`; api interceptor 403 backstop; "trial ended — pick a plan" banner; per-plan trial CTAs auto-hide.

## Verification
- Backend: tsc ✓, eslint ✓, jest **427 suites / 3801 tests** ✓
- Frontend: tsc ✓, eslint ✓, i18n gates ✓, vitest **243 files / 1729 tests** ✓
- Migration idempotency asserted on a throwaway Postgres.

## Follow-ups
Landing-site pricing copy (separate `landing/` app) may still mention a 14-day BUSINESS trial / show FREE; per-tenant cache for the new guard; marketing-convert path left on its own model (works with the lock, doesn't use the TRIAL plan).

🤖 Generated with [Claude Code](https://claude.com/claude-code)