### PR TITLE
fix(demo): reserve a non-colliding subdomain + idempotent seed

### DIFF
--- a/backend/src/modules/demo/demo.service.spec.ts
+++ b/backend/src/modules/demo/demo.service.spec.ts
@@ -43,20 +43,21 @@ describe('DemoService', () => {
 
     expect(admin.id).toBe('demo-admin');
     // No seeding happened.
-    expect(prisma.tenant.create).not.toHaveBeenCalled();
+    expect(prisma.tenant.upsert).not.toHaveBeenCalled();
     expect(prisma.subscriptionPlan.upsert).not.toHaveBeenCalled();
   });
 
   it('seeds the full demo on a cold start (plan, tenant, branch, sub, admin, content)', async () => {
     (prisma.user.findFirst as jest.Mock).mockResolvedValue(null);
     (prisma.subscriptionPlan.upsert as jest.Mock).mockResolvedValue({ id: 'plan-demo' });
-    (prisma.tenant.create as jest.Mock).mockResolvedValue({
+    (prisma.tenant.upsert as jest.Mock).mockResolvedValue({
       id: 'tenant-demo',
-      subdomain: 'demo',
+      subdomain: 'demo-explore',
     });
-    (prisma.branch.create as jest.Mock).mockResolvedValue({ id: 'branch-demo' });
+    (prisma.branch.upsert as jest.Mock).mockResolvedValue({ id: 'branch-demo' });
+    (prisma.subscription.findFirst as jest.Mock).mockResolvedValue(null);
     (prisma.subscription.create as jest.Mock).mockResolvedValue({ id: 'sub-demo' });
-    (prisma.user.create as jest.Mock).mockResolvedValue({
+    (prisma.user.upsert as jest.Mock).mockResolvedValue({
       id: 'admin-demo',
       email: DemoService.ADMIN_EMAIL,
       firstName: 'Demo',
@@ -66,6 +67,7 @@ describe('DemoService', () => {
       phone: '+905550000000',
       locale: null,
     });
+    (prisma.category.count as jest.Mock).mockResolvedValue(0);
     let cat = 0;
     (prisma.category.create as jest.Mock).mockImplementation(() =>
       Promise.resolve({ id: `cat-${cat++}` }),
@@ -87,14 +89,52 @@ describe('DemoService', () => {
     const planArgs = (prisma.subscriptionPlan.upsert as jest.Mock).mock.calls[0][0];
     expect(planArgs.create.isActive).toBe(false);
     expect(planArgs.create.isPublic).toBe(false);
-    expect(prisma.tenant.create).toHaveBeenCalledTimes(1);
-    expect(prisma.branch.create).toHaveBeenCalledTimes(1);
+    // Idempotent: tenant/branch/admin go through upsert on their unique keys so
+    // a pre-existing/partial demo never collides on the subdomain.
+    const tenantArgs = (prisma.tenant.upsert as jest.Mock).mock.calls[0][0];
+    expect(tenantArgs.where.subdomain).toBe('demo-explore');
+    expect(prisma.tenant.upsert).toHaveBeenCalledTimes(1);
+    expect(prisma.branch.upsert).toHaveBeenCalledTimes(1);
+    expect(prisma.user.upsert).toHaveBeenCalledTimes(1);
     expect(prisma.subscription.create).toHaveBeenCalledTimes(1);
     // Showcase content seeded.
     expect((prisma.category.create as jest.Mock).mock.calls.length).toBeGreaterThan(0);
     expect((prisma.product.create as jest.Mock).mock.calls.length).toBeGreaterThan(0);
     expect((prisma.table.create as jest.Mock).mock.calls.length).toBe(8);
     expect((prisma.order.create as jest.Mock).mock.calls.length).toBe(6);
+  });
+
+  it('self-heals a partial prior seed without re-creating the tenant or content', async () => {
+    // No admin yet (e.g. a prior run created the tenant then threw), but the
+    // tenant + a subscription + menu already exist.
+    (prisma.user.findFirst as jest.Mock).mockResolvedValue(null);
+    (prisma.subscriptionPlan.upsert as jest.Mock).mockResolvedValue({ id: 'plan-demo' });
+    (prisma.tenant.upsert as jest.Mock).mockResolvedValue({
+      id: 'tenant-demo',
+      subdomain: 'demo-explore',
+    });
+    (prisma.branch.upsert as jest.Mock).mockResolvedValue({ id: 'branch-demo' });
+    (prisma.subscription.findFirst as jest.Mock).mockResolvedValue({ id: 'sub-existing' });
+    (prisma.user.upsert as jest.Mock).mockResolvedValue({
+      id: 'admin-demo',
+      email: DemoService.ADMIN_EMAIL,
+      firstName: 'Demo',
+      lastName: 'Yönetici',
+      role: 'ADMIN',
+      tenantId: 'tenant-demo',
+      phone: '+905550000000',
+      locale: null,
+    });
+    (prisma.category.count as jest.Mock).mockResolvedValue(5);
+
+    const admin = await service.ensureDemoTenant();
+
+    expect(admin.id).toBe('admin-demo');
+    // Tenant upsert is a no-op (existing) — no second subscription, no dup menu.
+    expect(prisma.subscription.create).not.toHaveBeenCalled();
+    expect(prisma.category.create).not.toHaveBeenCalled();
+    expect(prisma.table.create).not.toHaveBeenCalled();
+    expect(prisma.order.create).not.toHaveBeenCalled();
   });
 
   it('resetDemoData is a no-op before the demo tenant exists', async () => {

--- a/backend/src/modules/demo/demo.service.ts
+++ b/backend/src/modules/demo/demo.service.ts
@@ -27,9 +27,14 @@ import {
 export class DemoService {
   private readonly logger = new Logger(DemoService.name);
 
-  static readonly SUBDOMAIN = "demo";
+  // Reserved subdomain for the explore-demo tenant. Deliberately NOT "demo" —
+  // prisma/seed.ts already owns "demo" ("Demo Restaurant"), so creating another
+  // would hit the subdomain unique constraint ("A record with this subdomain
+  // already exists"). This one is ours alone.
+  static readonly SUBDOMAIN = "demo-explore";
   static readonly ADMIN_EMAIL = "demo-admin@demo.hummytummy.local";
   private static readonly PLAN_NAME = "DEMO";
+  private static readonly BRANCH_CODE = "MAIN";
 
   // All plan features ON so every screen is reachable in the demo. Mirrors the
   // tenant featureOverrides contract (PlanFeatureGuard fallback reads these).
@@ -95,8 +100,14 @@ export class DemoService {
       },
     });
 
-    const tenant = await this.prisma.tenant.create({
-      data: {
+    // Every step is find-or-create so the seed is idempotent AND self-healing:
+    // a re-run, a partial prior seed (tenant created but a later step threw), or
+    // two simultaneous first-clicks all converge instead of colliding. Upserts
+    // key on the unique columns (subdomain, (tenantId,code), email).
+    const tenant = await this.prisma.tenant.upsert({
+      where: { subdomain: DemoService.SUBDOMAIN },
+      update: {},
+      create: {
         name: "HummyTummy Demo Restoran",
         subdomain: DemoService.SUBDOMAIN,
         status: "ACTIVE",
@@ -105,26 +116,46 @@ export class DemoService {
       },
     });
 
-    const branch = await this.prisma.branch.create({
-      data: { tenantId: tenant.id, name: "Merkez" },
-    });
-
-    const now = new Date();
-    await this.prisma.subscription.create({
-      data: {
+    const branch = await this.prisma.branch.upsert({
+      where: {
+        tenantId_code: {
+          tenantId: tenant.id,
+          code: DemoService.BRANCH_CODE,
+        },
+      },
+      update: {},
+      create: {
         tenantId: tenant.id,
-        planId: plan.id,
-        status: "ACTIVE",
-        billingCycle: "MONTHLY",
-        paymentProvider: "EMAIL",
-        currentPeriodStart: now,
-        currentPeriodEnd: new Date(now.getTime() + 365 * 24 * 3600 * 1000),
-        amount: "0.00",
+        name: "Merkez",
+        code: DemoService.BRANCH_CODE,
+        status: "active",
       },
     });
 
-    const admin = await this.prisma.user.create({
-      data: {
+    const existingSub = await this.prisma.subscription.findFirst({
+      where: { tenantId: tenant.id },
+      select: { id: true },
+    });
+    if (!existingSub) {
+      const now = new Date();
+      await this.prisma.subscription.create({
+        data: {
+          tenantId: tenant.id,
+          planId: plan.id,
+          status: "ACTIVE",
+          billingCycle: "MONTHLY",
+          paymentProvider: "EMAIL",
+          currentPeriodStart: now,
+          currentPeriodEnd: new Date(now.getTime() + 365 * 24 * 3600 * 1000),
+          amount: "0.00",
+        },
+      });
+    }
+
+    const admin = await this.prisma.user.upsert({
+      where: { email: DemoService.ADMIN_EMAIL },
+      update: {},
+      create: {
         email: DemoService.ADMIN_EMAIL,
         // Login is never used for the demo (the session is minted directly);
         // a random hash keeps the credential unusable.
@@ -150,8 +181,15 @@ export class DemoService {
       },
     });
 
-    await this.seedContent(tenant.id, branch.id, admin.id);
-    this.logger.log(`Seeded demo tenant ${tenant.id} (${tenant.subdomain})`);
+    // Showcase content once — only when the menu is still empty so re-runs
+    // don't pile up duplicate categories/products/tables.
+    const categoryCount = await this.prisma.category.count({
+      where: { tenantId: tenant.id },
+    });
+    if (categoryCount === 0) {
+      await this.seedContent(tenant.id, branch.id, admin.id);
+    }
+    this.logger.log(`Ensured demo tenant ${tenant.id} (${tenant.subdomain})`);
     return admin;
   }
 


### PR DESCRIPTION
## Bug
"Demo'yu keşfet" returned **"A record with this subdomain already exists"**. `prisma/seed.ts` already creates a tenant with subdomain `demo` ("Demo Restaurant"), so `DemoService`'s `tenant.create({ subdomain: "demo" })` hit the unique constraint. Because the seed chain wasn't idempotent, a partial prior run could also strand a tenant and re-error on every retry.

## Fix
- Reserved subdomain `demo` → **`demo-explore`** (ours alone; never collides with seed.ts or a real customer).
- `seed()` is now **find-or-create at every step** — tenant upsert by subdomain, branch upsert by `(tenantId, code=MAIN)`, subscription guarded by `findFirst`, admin upsert by email, showcase content only when the menu is empty. Re-runs, partial prior seeds, and two simultaneous first-clicks all converge instead of colliding.

## Validation
Ran the real `DemoService` against a throwaway Postgres with a pre-existing `demo` tenant present (the exact collision condition): `ensureDemoTenant` created `demo-explore` cleanly and was idempotent on re-run — same admin, **5 categories / 14 products / 8 tables / 6 orders / 1 subscription / 1 branch, no duplication**.

Gates: backend tsc + eslint clean; demo + auth specs (26 suites / 184) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)