### PR TITLE
chore(infra): complete staging↔prod secret isolation (DB pw, at-rest key, svc token, email)

### DIFF
--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -37,14 +37,15 @@ jobs:
 
       - name: Verify required secrets
         env:
-          POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
-          # Staging-specific session secrets (distinct from prod) — see the
-          # Render .env.test step below for the rationale.
+          # Staging-specific secrets (distinct from prod) — see the Render
+          # .env.test step below for the full rationale. A staging credential is
+          # never valid against prod.
+          POSTGRES_PASSWORD: ${{ secrets.STAGING_POSTGRES_PASSWORD }}
           JWT_SECRET: ${{ secrets.STAGING_JWT_SECRET }}
           JWT_REFRESH_SECRET: ${{ secrets.STAGING_JWT_REFRESH_SECRET }}
           SUPERADMIN_JWT_SECRET: ${{ secrets.STAGING_SUPERADMIN_JWT_SECRET }}
           SUPERADMIN_JWT_REFRESH_SECRET: ${{ secrets.STAGING_SUPERADMIN_JWT_REFRESH_SECRET }}
-          ENCRYPTION_MASTER_KEY: ${{ secrets.ENCRYPTION_MASTER_KEY }}
+          ENCRYPTION_MASTER_KEY: ${{ secrets.STAGING_ENCRYPTION_MASTER_KEY }}
         run: |
           set -euo pipefail
           missing=()
@@ -164,28 +165,29 @@ jobs:
 
       - name: Render .env.test
         env:
-          POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
-          # Staging-specific session/superadmin secrets — DISTINCT from prod so a
-          # JWT minted on staging is NOT valid on prod (and vice-versa). Stored as
-          # repo secrets STAGING_*; rotating them only resets active staging
-          # sessions (no data-at-rest impact).
+          # Staging-specific secrets — DISTINCT from prod across the board so NO
+          # staging credential (DB password, session JWT, encryption key, service
+          # token) is ever valid against prod, and vice-versa. Stored as repo
+          # secrets STAGING_*. The DB password is reconciled with the running
+          # staging Postgres role by scripts/deploy.sh `sync_db_password`
+          # (staging-only) because a persistent volume ignores POSTGRES_PASSWORD
+          # after first init.
+          POSTGRES_PASSWORD: ${{ secrets.STAGING_POSTGRES_PASSWORD }}
           JWT_SECRET: ${{ secrets.STAGING_JWT_SECRET }}
           JWT_REFRESH_SECRET: ${{ secrets.STAGING_JWT_REFRESH_SECRET }}
           SUPERADMIN_JWT_SECRET: ${{ secrets.STAGING_SUPERADMIN_JWT_SECRET }}
           SUPERADMIN_JWT_REFRESH_SECRET: ${{ secrets.STAGING_SUPERADMIN_JWT_REFRESH_SECRET }}
-          # kds-marketing service transport (Phase-5 split). Both optional:
-          # core boots without them (referral resolution no-ops, event relay
-          # disabled) until the marketing service is stood up.
+          # kds-marketing transport. Distinct staging token so a staging bug can
+          # never authenticate writes into the PROD marketing service.
           MARKETING_SERVICE_URL: ${{ vars.MARKETING_SERVICE_URL }}
-          INTERNAL_SERVICE_TOKEN: ${{ secrets.INTERNAL_SERVICE_TOKEN }}
-          ENCRYPTION_MASTER_KEY: ${{ secrets.ENCRYPTION_MASTER_KEY }}
+          INTERNAL_SERVICE_TOKEN: ${{ secrets.STAGING_INTERNAL_SERVICE_TOKEN }}
+          ENCRYPTION_MASTER_KEY: ${{ secrets.STAGING_ENCRYPTION_MASTER_KEY }}
           PAYTR_MERCHANT_ID: ${{ secrets.PAYTR_MERCHANT_ID }}
           PAYTR_MERCHANT_KEY: ${{ secrets.PAYTR_MERCHANT_KEY }}
           PAYTR_MERCHANT_SALT: ${{ secrets.PAYTR_MERCHANT_SALT }}
-          EMAIL_HOST: ${{ secrets.EMAIL_HOST }}
-          EMAIL_USER: ${{ secrets.EMAIL_USER }}
-          EMAIL_PASSWORD: ${{ secrets.EMAIL_PASSWORD }}
-          EMAIL_FROM: ${{ secrets.EMAIL_FROM }}
+          # NOTE: EMAIL_HOST/USER/PASSWORD deliberately NOT rendered on staging →
+          # EmailService runs in mock mode (logs, never sends) so staging testing
+          # can't deliver real mail to real recipients via prod SMTP.
           GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
           GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET }}
           DESKTOP_RELEASE_API_KEY: ${{ secrets.DESKTOP_RELEASE_API_KEY }}
@@ -218,14 +220,12 @@ jobs:
           PAYTR_MERCHANT_SALT=${PAYTR_MERCHANT_SALT}
           PAYTR_BASE_URL=https://www.paytr.com
           PAYTR_TEST_MODE=1
+          PAYTR_OK_URL=https://staging.hummytummy.com/app/subscription/success
+          PAYTR_FAIL_URL=https://staging.hummytummy.com/app/subscription/fail
           BACKEND_URL=https://staging.hummytummy.com
 
-          EMAIL_HOST=${EMAIL_HOST}
-          EMAIL_PORT=587
-          EMAIL_SECURE=false
-          EMAIL_USER=${EMAIL_USER}
-          EMAIL_PASSWORD=${EMAIL_PASSWORD}
-          EMAIL_FROM=${EMAIL_FROM}
+          # Email intentionally unconfigured on staging → EmailService mock mode
+          # (logs instead of sending) so staging never delivers real mail.
           ADMIN_EMAIL=contact@hummytummy.com
 
           DEFAULT_TRIAL_DAYS=14

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -33,24 +33,51 @@ runs `nginx -t`, and reloads only on success). Keep them in sync with the server
 
 ## Secrets (GitHub Actions repo secrets)
 
-Shared by both deploys unless noted:
+**Staging is fully credential-isolated from prod** — no staging credential is
+valid against prod. Every secret below that can grant access or decrypt data has
+a `STAGING_*` twin consumed only by `test-deploy.yml`; `release-deploy.yml` uses
+the prod (un-prefixed) secret.
 
-- `POSTGRES_PASSWORD`, `ENCRYPTION_MASTER_KEY`, `INTERNAL_SERVICE_TOKEN`
-- `PAYTR_MERCHANT_ID` / `_KEY` / `_SALT` (PayTR is the only payment provider; TRY-only)
-- `EMAIL_HOST` / `_USER` / `_PASSWORD` / `_FROM`, `NETGSM_*`
-- `GOOGLE_CLIENT_ID` / `_SECRET`, `VITE_GOOGLE_CLIENT_ID`
-- `SSH_PRIVATE_KEY_BASE64`, `SSH_KNOWN_HOSTS`
-- **Production session secrets:** `JWT_SECRET`, `JWT_REFRESH_SECRET`,
-  `SUPERADMIN_JWT_SECRET`, `SUPERADMIN_JWT_REFRESH_SECRET`
-- **Staging session secrets (distinct from prod):** `STAGING_JWT_SECRET`,
-  `STAGING_JWT_REFRESH_SECRET`, `STAGING_SUPERADMIN_JWT_SECRET`,
-  `STAGING_SUPERADMIN_JWT_REFRESH_SECRET` — so a JWT minted on staging is not
-  valid on prod and vice-versa.
+| Concern | Prod secret | Staging secret |
+|---|---|---|
+| DB password | `POSTGRES_PASSWORD` | `STAGING_POSTGRES_PASSWORD` |
+| At-rest encryption | `ENCRYPTION_MASTER_KEY` | `STAGING_ENCRYPTION_MASTER_KEY` |
+| Marketing transport | `INTERNAL_SERVICE_TOKEN` | `STAGING_INTERNAL_SERVICE_TOKEN` |
+| User sessions | `JWT_SECRET`, `JWT_REFRESH_SECRET` | `STAGING_JWT_SECRET`, `STAGING_JWT_REFRESH_SECRET` |
+| Superadmin sessions | `SUPERADMIN_JWT_SECRET`, `SUPERADMIN_JWT_REFRESH_SECRET` | `STAGING_SUPERADMIN_JWT_SECRET`, `STAGING_SUPERADMIN_JWT_REFRESH_SECRET` |
 
-> Residual (deliberate): `POSTGRES_PASSWORD` and `ENCRYPTION_MASTER_KEY` are
-> still shared. The DBs are separate and their ports are loopback-only, so the
-> blast radius is bounded. Rotating them for staging needs a DB-side
-> `ALTER ROLE` / data re-encryption and is intentionally deferred.
+Genuinely shared (no isolation concern): `PAYTR_MERCHANT_*` (staging runs
+`PAYTR_TEST_MODE=1` → no real charges), `GOOGLE_CLIENT_*`, `SSH_*`, `NETGSM_*`
+(never rendered to staging → SMS mock). **Email:** staging does **not** render
+`EMAIL_HOST/USER/PASSWORD`, so `EmailService` runs in mock mode (logs, never
+sends) — staging testing can't deliver real mail.
+
+> `STAGING_POSTGRES_PASSWORD` note: a persistent staging volume ignores
+> `POSTGRES_PASSWORD` after first init, so `scripts/deploy.sh` runs a
+> **staging-only** `sync_db_password` (an idempotent `ALTER USER … PASSWORD` over
+> the container's trust socket) to reconcile the live role with the rendered env
+> on every staging deploy. It early-returns on prod (`[ "$ENV" = staging ]`), so
+> prod's role is never touched.
+>
+> `STAGING_ENCRYPTION_MASTER_KEY` note: rows encrypted on staging under the old
+> (shared) key become undecryptable. Self-healing paths degrade gracefully
+> (integrations → `{}`, accounting → null); the camera `streamUrl` and
+> delivery-platform credential paths throw → a 500 on those specific pages only.
+> If you hit that on stale staging data, reset the staging DB for a clean slate:
+> `docker compose -p kds-staging --env-file .env.test -f docker-compose.staging.yml down && docker volume rm kds-staging_postgres_data_staging` then re-deploy (push `test`).
+
+### Deferred isolation items (need external setup; documented, not yet done)
+- **Separate Google OAuth client for staging** — the shared prod client is mid
+  Google verification (don't edit it). Create a dedicated staging client +
+  `STAGING_GOOGLE_CLIENT_*` and render them on staging.
+- **Separate PayTR TEST merchant** — staging shares the prod merchant under
+  `PAYTR_TEST_MODE=1` (no money moves), but a test-mode webhook validates under
+  the shared HMAC salt. A dedicated test merchant (its own panel notify URL)
+  fully isolates settlement.
+- **Mailtrap/Mailpit sink** — optional upgrade over mock mode if staging needs to
+  inspect rendered emails.
+- **Sentry staging DSN** — purely additive observability (no DSN set today, so no
+  leak); add `SENTRY_ENVIRONMENT=staging` if staging error capture is wanted.
 
 ## Releasing
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -278,6 +278,35 @@ ensure_data_layer() {
   return 1
 }
 
+# STAGING-ONLY. Reconcile the Postgres role password with the rendered env.
+# Staging now uses a staging-specific POSTGRES_PASSWORD (distinct from prod), but
+# a persistent data volume only honours POSTGRES_PASSWORD on FIRST init — on an
+# existing volume the stored role password stays stale, so the backend's
+# password-authed DATABASE_URL would fail at the health gate. The unix socket
+# inside the container matches the official postgres image's `local ... trust`
+# rule, so this ALTER works even when the stored password is stale. Idempotent.
+#
+# HARD-GATED to staging: prod's volume was initialised with the (unchanged)
+# shared password and must NEVER be touched here. Running it on prod would risk
+# setting the role to a value that diverges from prod's DATABASE_URL — an outage
+# path — for zero benefit. The early return makes this step a no-op on prod.
+sync_db_password() {
+  [ "$ENV" = "staging" ] || return 0
+  local db_user pg_pass
+  db_user=$(grep -E '^POSTGRES_USER=' "$ENV_FILE" | head -n1 | cut -d= -f2- | tr -d "'\"" || true)
+  pg_pass=$(grep -E '^POSTGRES_PASSWORD=' "$ENV_FILE" | head -n1 | cut -d= -f2- | tr -d "'\"" || true)
+  db_user="${db_user:-postgres}"
+  if [ -z "$pg_pass" ]; then
+    warn "POSTGRES_PASSWORD empty in $ENV_FILE — skipping role-password sync"
+    return 0
+  fi
+  log "Syncing staging Postgres role password to rendered env (idempotent)"
+  # No -h / 127.0.0.1: TCP would require the very password being rotated. The
+  # local socket uses trust, so this works against a stale stored password.
+  docker exec "$POSTGRES_CONTAINER" psql -U "$db_user" -v ON_ERROR_STOP=1 \
+    -c "ALTER USER \"$db_user\" WITH PASSWORD '$pg_pass';"
+}
+
 run_migration_doctor() {
   local db_name db_user
   db_name=$(grep -E '^POSTGRES_DB=' "$ENV_FILE" | head -n1 | cut -d= -f2- | tr -d "'\"" || true)
@@ -508,6 +537,12 @@ run_deploy() {
   step "5/10 Postgres + Redis up"        ensure_data_layer
   step "6/10 Migration doctor"           run_migration_doctor
   step "7/10 Migrate (existing backend)" run_migrations_in_existing_backend
+  # Rotate the staging DB role password AFTER the doctor + existing-backend
+  # migration (both connect via the OLD backend container's OLD password) and
+  # BEFORE swap_backend brings up the NEW backend with the NEW password. Running
+  # it earlier would break those old-container password connections. No-op on
+  # prod (staging-gated) and idempotent in staging steady state.
+  step "7b   Sync DB role password"      sync_db_password
   step "8/10 Swap backend"               swap_backend
   step "9/10 Swap frontend + landing"    swap_app_containers
   step "10/10 Verify + promote :current" verify_and_promote


### PR DESCRIPTION
Closes the residuals left after v3.2.31. Every credential that can grant access or decrypt data now has a staging-specific value; **no staging credential is valid against prod**. All effects are staging-only — `release-deploy.yml` untouched; the one shared-file change (`deploy.sh`) is hard-gated to staging.

## Changes
- **DB password** → `STAGING_POSTGRES_PASSWORD` + a **staging-gated, idempotent `sync_db_password`** in `deploy.sh` (ALTER USER over the container's local trust socket, since a persistent volume ignores `POSTGRES_PASSWORD` after first init). Placed at **step 7b** — after the doctor + existing-backend migrate (which use the OLD backend's OLD password) and before `swap_backend` starts the NEW backend.
- **At-rest key** → `STAGING_ENCRYPTION_MASTER_KEY`.
- **Marketing token** → `STAGING_INTERNAL_SERVICE_TOKEN` (staging can't authenticate into prod marketing).
- **Email** → staging runs `EmailService` mock mode (no real sends).
- **PayTR** → staging return URLs instead of the localhost fallback (still `PAYTR_TEST_MODE=1`).
- **Docs** → secret-isolation matrix + deferred items (separate Google OAuth client, separate PayTR test merchant, Mailtrap sink, Sentry staging DSN).

## Why it's safe
Designed + adversarially verified by a multi-agent workflow (24 findings, 3 skeptic lenses). It caught two outage-class footguns that are **avoided** here: (1) an ungated `deploy.sh` ALTER would run on prod's next tag and could mismatch prod's role vs `DATABASE_URL` → outage (fixed: `[ "$ENV" = staging ]` gate); (2) the proposed encryption-key row-wipe SQL was broken (`Camera.streamUrl` NOT NULL, wrong column name) — dropped in favor of "reset the staging volume if needed". I additionally caught an ordering bug the workflow missed (sync must run after step 7, not 5b, or the old backend can't auth).

**No prod-runtime change** → no prod redeploy. Ships to staging on `test`; the gated `deploy.sh` change reaches prod inertly on the next release tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)