### PR TITLE
chore(infra): isolate staging Google OAuth + prep PayTR (finish isolation surface)

### DIFF
--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -125,7 +125,10 @@ jobs:
             VITE_API_BASE_URL=https://staging.hummytummy.com
             VITE_SOCKET_URL=https://staging.hummytummy.com
             VITE_WS_URL=wss://staging.hummytummy.com
-            VITE_GOOGLE_CLIENT_ID=${{ secrets.VITE_GOOGLE_CLIENT_ID }}
+            # Google sign-in is OFF on staging until it has its OWN OAuth client
+            # (never the prod client). Empty here → SocialLoginButtons renders
+            # nothing. Set STAGING_GOOGLE_CLIENT_ID to enable an isolated client.
+            VITE_GOOGLE_CLIENT_ID=${{ secrets.STAGING_GOOGLE_CLIENT_ID }}
             VITE_APP_VERSION=${{ steps.commit.outputs.sha }}
             VITE_BUILD_TIME=${{ github.event.head_commit.timestamp }}
             VITE_COMMIT_SHA=${{ github.sha }}
@@ -182,14 +185,21 @@ jobs:
           MARKETING_SERVICE_URL: ${{ vars.MARKETING_SERVICE_URL }}
           INTERNAL_SERVICE_TOKEN: ${{ secrets.STAGING_INTERNAL_SERVICE_TOKEN }}
           ENCRYPTION_MASTER_KEY: ${{ secrets.STAGING_ENCRYPTION_MASTER_KEY }}
-          PAYTR_MERCHANT_ID: ${{ secrets.PAYTR_MERCHANT_ID }}
-          PAYTR_MERCHANT_KEY: ${{ secrets.PAYTR_MERCHANT_KEY }}
-          PAYTR_MERCHANT_SALT: ${{ secrets.PAYTR_MERCHANT_SALT }}
+          # PayTR: prefer a dedicated staging TEST merchant when set, else fall
+          # back to the shared merchant. Staging is always PAYTR_TEST_MODE=1 (no
+          # real charges); a separate test merchant additionally isolates the
+          # webhook (its own panel notify URL). Until then the shared merchant is
+          # used (test mode → no money risk).
+          PAYTR_MERCHANT_ID: ${{ secrets.STAGING_PAYTR_MERCHANT_ID || secrets.PAYTR_MERCHANT_ID }}
+          PAYTR_MERCHANT_KEY: ${{ secrets.STAGING_PAYTR_MERCHANT_KEY || secrets.PAYTR_MERCHANT_KEY }}
+          PAYTR_MERCHANT_SALT: ${{ secrets.STAGING_PAYTR_MERCHANT_SALT || secrets.PAYTR_MERCHANT_SALT }}
           # NOTE: EMAIL_HOST/USER/PASSWORD deliberately NOT rendered on staging →
           # EmailService runs in mock mode (logs, never sends) so staging testing
           # can't deliver real mail to real recipients via prod SMTP.
-          GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
-          GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET }}
+          # Google: staging uses its OWN client only (never prod's). Empty unless
+          # STAGING_GOOGLE_* is set → backend rejects Google sign-in on staging.
+          GOOGLE_CLIENT_ID: ${{ secrets.STAGING_GOOGLE_CLIENT_ID }}
+          GOOGLE_CLIENT_SECRET: ${{ secrets.STAGING_GOOGLE_CLIENT_SECRET }}
           DESKTOP_RELEASE_API_KEY: ${{ secrets.DESKTOP_RELEASE_API_KEY }}
         run: |
           set -euo pipefail

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -46,11 +46,17 @@ the prod (un-prefixed) secret.
 | User sessions | `JWT_SECRET`, `JWT_REFRESH_SECRET` | `STAGING_JWT_SECRET`, `STAGING_JWT_REFRESH_SECRET` |
 | Superadmin sessions | `SUPERADMIN_JWT_SECRET`, `SUPERADMIN_JWT_REFRESH_SECRET` | `STAGING_SUPERADMIN_JWT_SECRET`, `STAGING_SUPERADMIN_JWT_REFRESH_SECRET` |
 
-Genuinely shared (no isolation concern): `PAYTR_MERCHANT_*` (staging runs
-`PAYTR_TEST_MODE=1` → no real charges), `GOOGLE_CLIENT_*`, `SSH_*`, `NETGSM_*`
-(never rendered to staging → SMS mock). **Email:** staging does **not** render
-`EMAIL_HOST/USER/PASSWORD`, so `EmailService` runs in mock mode (logs, never
-sends) — staging testing can't deliver real mail.
+Other external integrations:
+- **Email** — staging renders no `EMAIL_HOST/USER/PASSWORD` → `EmailService` mock
+  mode (logs, never sends). Real mail can't leak from staging.
+- **SMS / NETGSM** — never rendered to staging → `SmsService` mock mode.
+- **Google OAuth** — staging uses its OWN client only (`STAGING_GOOGLE_CLIENT_ID`/
+  `_SECRET` + `STAGING_GOOGLE_CLIENT_ID` as the FE build arg). With none set,
+  Google sign-in is **OFF on staging** (the button is hidden; the backend rejects
+  Google tokens) — staging never touches the prod client.
+- **PayTR** — `STAGING_PAYTR_MERCHANT_*` if set, else falls back to the shared
+  merchant. Staging is always `PAYTR_TEST_MODE=1` (no real charges).
+- `SSH_*` are genuinely shared (deploy transport only).
 
 > `STAGING_POSTGRES_PASSWORD` note: a persistent staging volume ignores
 > `POSTGRES_PASSWORD` after first init, so `scripts/deploy.sh` runs a
@@ -66,16 +72,27 @@ sends) — staging testing can't deliver real mail.
 > If you hit that on stale staging data, reset the staging DB for a clean slate:
 > `docker compose -p kds-staging --env-file .env.test -f docker-compose.staging.yml down && docker volume rm kds-staging_postgres_data_staging` then re-deploy (push `test`).
 
-### Deferred isolation items (need external setup; documented, not yet done)
-- **Separate Google OAuth client for staging** — the shared prod client is mid
-  Google verification (don't edit it). Create a dedicated staging client +
-  `STAGING_GOOGLE_CLIENT_*` and render them on staging.
-- **Separate PayTR TEST merchant** — staging shares the prod merchant under
-  `PAYTR_TEST_MODE=1` (no money moves), but a test-mode webhook validates under
-  the shared HMAC salt. A dedicated test merchant (its own panel notify URL)
-  fully isolates settlement.
+### Items that need an external account to ENABLE (wiring is already in place)
+These are **isolated by default** (Google off; PayTR shared in test-mode). The
+wiring consumes `STAGING_*` secrets the moment you create the external resource —
+no further code change, just `gh secret set` + a `test` deploy.
+
+- **Google OAuth — enable an isolated staging login (optional).** Google is OFF on
+  staging today (fully isolated). To turn it on with its OWN client (never prod's):
+  1. Google Cloud Console → APIs & Services → Credentials → Create OAuth client
+     (Web). Authorized JS origin `https://staging.hummytummy.com`; redirect URIs to
+     match. **Do NOT edit the prod client** (it's mid-verification).
+  2. `gh secret set STAGING_GOOGLE_CLIENT_ID --body <id>` and
+     `gh secret set STAGING_GOOGLE_CLIENT_SECRET --body <secret>`.
+  3. Push `test` → staging rebuilds with the staging client.
+- **PayTR — fully isolate the test merchant (optional).** Staging works now via the
+  shared merchant in test mode (no money). To isolate the webhook too:
+  1. PayTR panel → create/obtain a TEST merchant; set its notification URL to
+     `https://staging.hummytummy.com/api/...` (the PayTR webhook route).
+  2. `gh secret set STAGING_PAYTR_MERCHANT_ID|_KEY|_SALT`.
+  3. Push `test`.
 - **Mailtrap/Mailpit sink** — optional upgrade over mock mode if staging needs to
-  inspect rendered emails.
+  inspect rendered emails (email is already isolated via mock).
 - **Sentry staging DSN** — purely additive observability (no DSN set today, so no
   leak); add `SENTRY_ENVIRONMENT=staging` if staging error capture is wanted.
 

--- a/frontend/src/components/ui/SocialLoginButtons.test.tsx
+++ b/frontend/src/components/ui/SocialLoginButtons.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Stub the Google Identity Services button: render a plain button that hands
 // back a fake ID token via onSuccess on click, so we can assert the wiring
@@ -20,6 +20,23 @@ vi.mock('@react-oauth/google', () => ({
 import { SocialLoginButtons } from './SocialLoginButtons';
 
 describe('SocialLoginButtons', () => {
+  // The component renders nothing unless a Google client ID is configured for
+  // the build (staging ships without one → Google off). Stub it for the
+  // happy-path tests; the guard itself is covered separately below.
+  beforeEach(() => {
+    vi.stubEnv('VITE_GOOGLE_CLIENT_ID', 'test-google-client-id');
+  });
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('renders nothing when no Google client ID is configured (staging)', () => {
+    vi.stubEnv('VITE_GOOGLE_CLIENT_ID', '');
+    const { container } = render(<SocialLoginButtons onGoogleSuccess={() => {}} />);
+    expect(container).toBeEmptyDOMElement();
+    expect(screen.queryByTestId('gis-button')).toBeNull();
+  });
+
   it('renders the Google sign-in button and the login divider text', () => {
     render(<SocialLoginButtons onGoogleSuccess={() => {}} />);
     expect(screen.getByTestId('gis-button')).toBeInTheDocument();

--- a/frontend/src/components/ui/SocialLoginButtons.tsx
+++ b/frontend/src/components/ui/SocialLoginButtons.tsx
@@ -24,6 +24,15 @@ const SocialLoginButtons: React.FC<SocialLoginButtonsProps> = ({
 }) => {
   const { t } = useTranslation(['auth']);
 
+  // Only show Google sign-in when a client ID is baked into this build. Staging
+  // builds carry no STAGING_GOOGLE_CLIENT_ID → Google is intentionally OFF on
+  // staging (it must not use the prod OAuth client) until it has its own client.
+  // This also avoids rendering a broken GIS button when clientId is empty.
+  const googleClientId = import.meta.env.VITE_GOOGLE_CLIENT_ID as
+    | string
+    | undefined;
+  if (!googleClientId) return null;
+
   const dividerText =
     variant === 'login'
       ? t('auth:login.orContinueWith', 'or continue with')


### PR DESCRIPTION
Last leg of staging↔prod isolation — as far as possible without creating resources in the user's Google/PayTR consoles.

- **Google OAuth → isolated.** Staging uses its OWN client only (`STAGING_GOOGLE_*`); with none set, Google sign-in is **off on staging** (button hidden via a new `SocialLoginButtons` guard; backend gets empty `GOOGLE_CLIENT_ID` so it can't validate against the prod client). Prod-neutral (prod bakes its client → renders as before). +test.
- **PayTR → prepped, still functional.** `STAGING_PAYTR_MERCHANT_* || shared` fallback; staging stays `PAYTR_TEST_MODE=1` (no money). Set `STAGING_PAYTR_*` after creating a TEST merchant to fully isolate the webhook.
- **Docs** → per-integration isolation status + exact "enable with your own account" steps.

Email stays mock (already isolated). Mailpit intentionally skipped (new container in shared deploy.sh for an optional gain).

Staging-only + prod-neutral: `release-deploy.yml` untouched; the FE guard rides the next prod release harmlessly. Full frontend suite green (245 files / 1744).

🤖 Generated with [Claude Code](https://claude.com/claude-code)