### PR TITLE
chore(deploy): auto-reproject entitlements post-migration

### DIFF
--- a/backend/src/modules/entitlements/entitlements.module.ts
+++ b/backend/src/modules/entitlements/entitlements.module.ts
@@ -15,6 +15,7 @@ import {
   AddOnLifecyclePayload,
 } from "../outbox/event-types";
 import { EntitlementsController } from "./entitlements.controller";
+import { InternalEntitlementsController } from "./internal-entitlements.controller";
 import { EntitlementService } from "./entitlement.service";
 import { EntitlementGuard } from "./entitlement.guard";
 import { PlanProjectorService } from "./plan-projector.service";
@@ -45,7 +46,7 @@ import { EntitlementInvalidationBus } from "./entitlement-invalidation.bus";
 @Global()
 @Module({
   imports: [PrismaModule],
-  controllers: [EntitlementsController],
+  controllers: [EntitlementsController, InternalEntitlementsController],
   providers: [
     EntitlementService,
     EntitlementGuard,

--- a/backend/src/modules/entitlements/internal-entitlements.controller.spec.ts
+++ b/backend/src/modules/entitlements/internal-entitlements.controller.spec.ts
@@ -1,0 +1,67 @@
+import { GUARDS_METADATA } from "@nestjs/common/constants";
+import { InternalEntitlementsController } from "./internal-entitlements.controller";
+import { InternalServiceTokenGuard } from "../../common/guards/internal-service-token.guard";
+import { IS_PUBLIC_KEY } from "../auth/decorators/public.decorator";
+
+/**
+ * Spec for the deploy-triggered entitlement reprojection endpoint.
+ *
+ * Load-bearing contracts:
+ *   - the handler delegates to PlanProjectorService.reconcileNightly() (the
+ *     advisory-locked, idempotent "reproject EVERY tenant" sweep — NOT the
+ *     boot backfill, which skips tenants that already have rows and would miss
+ *     a newly-added plan feature column) and returns the { ok: true } envelope
+ *     the deploy gates on;
+ *   - the controller is locked behind InternalServiceTokenGuard and opted out
+ *     of the global tenant-JWT pipeline via @Public — i.e. it is reachable ONLY
+ *     with the internal service token, exactly like InternalProvisioningController.
+ */
+describe("InternalEntitlementsController", () => {
+  let planProjector: { reconcileNightly: jest.Mock };
+  let controller: InternalEntitlementsController;
+
+  beforeEach(() => {
+    planProjector = {
+      reconcileNightly: jest.fn().mockResolvedValue(undefined),
+    };
+    controller = new InternalEntitlementsController(planProjector as never);
+  });
+
+  describe("reprojectAll", () => {
+    it("calls the projector's reconcileNightly() sweep and returns { ok: true }", async () => {
+      await expect(controller.reprojectAll()).resolves.toEqual({ ok: true });
+      expect(planProjector.reconcileNightly).toHaveBeenCalledTimes(1);
+    });
+
+    it("propagates a sweep failure (so the deploy can surface it)", async () => {
+      planProjector.reconcileNightly.mockRejectedValue(new Error("boom"));
+      await expect(controller.reprojectAll()).rejects.toThrow("boom");
+    });
+  });
+
+  describe("guarding", () => {
+    it("is guarded by InternalServiceTokenGuard at the class level", () => {
+      const guards = Reflect.getMetadata(
+        GUARDS_METADATA,
+        InternalEntitlementsController,
+      );
+      expect(guards).toContain(InternalServiceTokenGuard);
+    });
+
+    it("opts out of the global tenant-JWT pipeline via @Public()", () => {
+      const isPublic = Reflect.getMetadata(
+        IS_PUBLIC_KEY,
+        InternalEntitlementsController,
+      );
+      expect(isPublic).toBe(true);
+    });
+
+    it("skips the throttler (machine traffic, not a browser)", () => {
+      const skip = Reflect.getMetadata(
+        "THROTTLER:SKIPdefault",
+        InternalEntitlementsController,
+      );
+      expect(skip).toBe(true);
+    });
+  });
+});

--- a/backend/src/modules/entitlements/internal-entitlements.controller.ts
+++ b/backend/src/modules/entitlements/internal-entitlements.controller.ts
@@ -1,0 +1,57 @@
+import { Controller, HttpCode, Post, UseGuards, Logger } from "@nestjs/common";
+import { SkipThrottle } from "@nestjs/throttler";
+import { ApiExcludeController } from "@nestjs/swagger";
+import { Public } from "../auth/decorators/public.decorator";
+import { InternalServiceTokenGuard } from "../../common/guards/internal-service-token.guard";
+import { PlanProjectorService } from "./plan-projector.service";
+
+/**
+ * Internal maintenance surface for the entitlement engine — service-to-service
+ * only, NOT for browsers or the marketing peer's normal traffic.
+ *
+ * The single endpoint, POST /api/internal/entitlements/reproject-all, exists so
+ * the deploy pipeline can re-run the "reproject every tenant" sweep right after
+ * `prisma migrate deploy` lands a schema change. When a migration adds a new
+ * Boolean feature column to SubscriptionPlan, existing tenants already have
+ * FeatureEntitlement rows, so the on-boot backfill (which skips tenants that
+ * already have ANY row) does NOT pick the new flag up — only a full reprojection
+ * does. That gap is exactly what hid the externalDisplay "Partner API Keys" page
+ * for existing tenants in v3.2.32; scripts/deploy.sh now calls this endpoint so
+ * a feature migration surfaces immediately instead of waiting up to ~24h for the
+ * 03:15 UTC nightly reconcile.
+ *
+ * Auth mirrors InternalProvisioningController EXACTLY:
+ *   - @Public() opts out of the global tenant-JWT pipeline (which would 401
+ *     before the service-token check could run);
+ *   - @SkipThrottle() because this is machine traffic, not a browser;
+ *   - @UseGuards(InternalServiceTokenGuard) requires the shared
+ *     INTERNAL_SERVICE_TOKEN in the `x-internal-token` header (503 when the
+ *     secret is unset so the caller can tell "not configured" from "wrong
+ *     token", 401 on a missing/mismatched token);
+ *   - @ApiExcludeController() keeps it out of the public Swagger doc.
+ */
+@ApiExcludeController()
+@Controller("internal/entitlements")
+@Public()
+@SkipThrottle()
+@UseGuards(InternalServiceTokenGuard)
+export class InternalEntitlementsController {
+  private readonly logger = new Logger(InternalEntitlementsController.name);
+
+  constructor(private readonly planProjector: PlanProjectorService) {}
+
+  /**
+   * Reproject EVERY tenant's entitlements (advisory-locked + idempotent via
+   * PlanProjectorService.reconcileNightly — the same sweep the nightly cron
+   * runs). Returns `{ ok: true }` once the sweep completes so the deploy can
+   * gate on a 2xx + body.
+   */
+  @Post("reproject-all")
+  @HttpCode(200)
+  async reprojectAll(): Promise<{ ok: true }> {
+    this.logger.log("Reprojecting all tenants (deploy-triggered)");
+    await this.planProjector.reconcileNightly();
+    this.logger.log("Reproject-all complete");
+    return { ok: true };
+  }
+}

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -485,9 +485,11 @@ verify_and_promote() {
 # We hit the internal maintenance endpoint from INSIDE the backend container so
 # the call is loopback-local and carries the container's INTERNAL_SERVICE_TOKEN
 # env (the prod image has no curl guaranteed, so we use node's global fetch).
-# The backend always listens on :3000 inside the container in BOTH envs (only
-# the host port mapping differs: 3000 prod / 3002 staging), so localhost:3000 is
-# correct here regardless of ENV.
+# The in-container listen port is NOT the same across envs: prod sets PORT=3000,
+# staging sets PORT=3002 (compose `environment:` overrides). main.ts binds to
+# `process.env.PORT || 3000`, so the node one-liner reads the SAME env var the
+# app bound to — never a hardcoded port. (The host-side port mapping is a
+# separate concern and irrelevant here since we exec inside the container.)
 #
 # NON-FATAL by design: a reproject failure must NOT abort/rollback the deploy —
 # the 03:15 UTC nightly reconcile (plan-projector.service.ts#reconcileNightly)
@@ -502,7 +504,7 @@ reproject_entitlements() {
   fi
 
   log "▶ Reproject all tenants' entitlements (post-migration data op)"
-  if docker exec "$BACKEND_CONTAINER" node -e "fetch('http://localhost:3000/api/internal/entitlements/reproject-all',{method:'POST',headers:{'x-internal-token':process.env.INTERNAL_SERVICE_TOKEN}}).then(r=>{console.log('reproject',r.status);process.exit(r.ok?0:1)}).catch(e=>{console.error(e);process.exit(1)})"; then
+  if docker exec "$BACKEND_CONTAINER" node -e "const p=process.env.PORT||3000;fetch('http://127.0.0.1:'+p+'/api/internal/entitlements/reproject-all',{method:'POST',headers:{'x-internal-token':process.env.INTERNAL_SERVICE_TOKEN}}).then(r=>{console.log('reproject',r.status);process.exit(r.ok?0:1)}).catch(e=>{console.error(e);process.exit(1)})"; then
     ok "✓ Entitlement reprojection triggered"
   else
     warn "Entitlement reprojection FAILED — a newly-added plan feature may not surface"

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -474,6 +474,43 @@ verify_and_promote() {
   ok "All :current tags point at $VERSION"
 }
 
+# Post-migration DATA reconciliation. A `prisma migrate deploy` only changes
+# the SCHEMA — when a migration adds a new Boolean feature column to
+# SubscriptionPlan, existing tenants keep their old FeatureEntitlement rows and
+# the on-boot backfill (which skips any tenant that already has rows) never
+# surfaces the new flag. Only a full reprojection does. That gap is exactly what
+# hid the externalDisplay "Partner API Keys" page for existing tenants in
+# v3.2.32, forcing a hand-run reprojection. We now trigger it automatically here.
+#
+# We hit the internal maintenance endpoint from INSIDE the backend container so
+# the call is loopback-local and carries the container's INTERNAL_SERVICE_TOKEN
+# env (the prod image has no curl guaranteed, so we use node's global fetch).
+# The backend always listens on :3000 inside the container in BOTH envs (only
+# the host port mapping differs: 3000 prod / 3002 staging), so localhost:3000 is
+# correct here regardless of ENV.
+#
+# NON-FATAL by design: a reproject failure must NOT abort/rollback the deploy —
+# the 03:15 UTC nightly reconcile (plan-projector.service.ts#reconcileNightly)
+# is the backstop and self-heals within ~24h. So this runs OUTSIDE the `step`
+# helper and always returns 0; we surface failures LOUDLY with warn().
+reproject_entitlements() {
+  # If the token isn't configured for this env, the endpoint's guard would 503
+  # anyway — skip with a clear warning rather than emit a confusing failure.
+  if ! grep -qE '^INTERNAL_SERVICE_TOKEN=.+' "$ENV_FILE"; then
+    warn "INTERNAL_SERVICE_TOKEN unset in $ENV_FILE — skipping entitlement reprojection (nightly reconcile is the backstop)"
+    return 0
+  fi
+
+  log "▶ Reproject all tenants' entitlements (post-migration data op)"
+  if docker exec "$BACKEND_CONTAINER" node -e "fetch('http://localhost:3000/api/internal/entitlements/reproject-all',{method:'POST',headers:{'x-internal-token':process.env.INTERNAL_SERVICE_TOKEN}}).then(r=>{console.log('reproject',r.status);process.exit(r.ok?0:1)}).catch(e=>{console.error(e);process.exit(1)})"; then
+    ok "✓ Entitlement reprojection triggered"
+  else
+    warn "Entitlement reprojection FAILED — a newly-added plan feature may not surface"
+    warn "for existing tenants until the 03:15 UTC nightly reconcile. Deploy NOT aborted."
+  fi
+  return 0
+}
+
 restore_image_ids() {
   if [ ! -f "$STATE_FILE" ]; then
     err "No snapshot at $STATE_FILE — cannot auto-rollback"
@@ -546,6 +583,11 @@ run_deploy() {
   step "8/10 Swap backend"               swap_backend
   step "9/10 Swap frontend + landing"    swap_app_containers
   step "10/10 Verify + promote :current" verify_and_promote
+  # Post-deploy DATA reconciliation. Runs AFTER the new backend is verified
+  # healthy + promoted (so the endpoint is live) and is deliberately NOT wrapped
+  # in `step` — it's non-fatal (returns 0 even on failure) so a reproject hiccup
+  # can never trip the ERR trap and roll back an otherwise-good deploy.
+  reproject_entitlements
   ok "=== Deploy SUCCESS: $ENV @ $VERSION ==="
 }
 


### PR DESCRIPTION
After `prisma migrate deploy`, deploy.sh triggers a full entitlement reprojection via a new internal-token-guarded endpoint, so a newly-added plan feature column surfaces immediately for existing tenants (the v3.2.32 externalDisplay gap). Non-fatal + idempotent; nightly 03:15 reconcile remains the backstop. Staging green (reproject 200).

🤖 Generated with [Claude Code](https://claude.com/claude-code)