### PR TITLE
feat(plans): 3-tier pricing redesign (landing-consistent)

### DIFF
--- a/frontend/src/components/subscriptions/PlanCard.tsx
+++ b/frontend/src/components/subscriptions/PlanCard.tsx
@@ -1,9 +1,10 @@
-import { Check, X, Sparkles, Clock } from 'lucide-react';
+import { Check, X, Sparkles, Clock, ArrowRight } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
-import { Plan, BillingCycle, SubscriptionPlanType } from '../../types';
-import Button from '../ui/Button';
+import { Plan, BillingCycle } from '../../types';
 import { cn } from '../../lib/utils';
 import { getCurrencySymbol } from '../../lib/currency';
+
+const display = { fontFamily: '"Fraunces", Georgia, serif' } as const;
 
 // Extended Plan type with discount info
 interface PlanWithDiscount extends Plan {
@@ -24,7 +25,7 @@ interface PlanCardProps {
   /**
    * Tenant is eligible for a free trial on this plan (per-plan model:
    * a BASIC-trialed tenant can still trial PRO). Drives a green
-   * "Sizin için 14 gün ücretsiz" badge.
+   * "Sizin için 7 gün ücretsiz" badge.
    */
   isTrialEligible?: boolean;
   onSelectPlan: (planId: string) => void;
@@ -71,7 +72,6 @@ const PlanCard = ({
     : originalPrice;
 
   const pricePerMonth = billingCycle === BillingCycle.YEARLY ? price / 12 : price;
-  const originalPricePerMonth = billingCycle === BillingCycle.YEARLY ? originalPrice / 12 : originalPrice;
 
   // Currency the plan is billed in. Non-TRY plans have no card rail
   // (PayTR is TRY-only) → bank transfer is the only path, which we badge.
@@ -90,58 +90,74 @@ const PlanCard = ({
     return date.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
   };
 
-  const planColors = {
-    [SubscriptionPlanType.TRIAL]: 'border-slate-300',
-    [SubscriptionPlanType.FREE]: 'border-slate-300',
-    [SubscriptionPlanType.BASIC]: 'border-blue-300',
-    [SubscriptionPlanType.PRO]: 'border-purple-500',
-    [SubscriptionPlanType.BUSINESS]: 'border-yellow-500',
+  // All 12 plan features mapped to localized labels so every flag renders a
+  // real, accurate label (no blank rows for the newer flags).
+  const featureLabels: Record<string, string> = {
+    advancedReports: t('subscriptions.featureAdvancedReports'),
+    multiLocation: t('subscriptions.featureMultiLocation'),
+    customBranding: t('subscriptions.featureCustomBranding'),
+    apiAccess: t('subscriptions.featureApiAccess'),
+    prioritySupport: t('subscriptions.featurePrioritySupport'),
+    inventoryTracking: t('subscriptions.featureInventoryTracking'),
+    kdsIntegration: t('subscriptions.featureKdsIntegration'),
+    posAccess: t('subscriptions.featurePosAccess'),
+    reservationSystem: t('subscriptions.featureReservationSystem'),
+    personnelManagement: t('subscriptions.featurePersonnelManagement'),
+    deliveryIntegration: t('subscriptions.featureDeliveryIntegration'),
+    externalDisplay: t('subscriptions.featureExternalDisplay'),
   };
+
+  // Disabled / dead-end CTA → keep it non-actionable, otherwise the
+  // highlighted (popular) card gets a filled orange button, the rest a
+  // neutral cream/ink button.
+  const ctaDisabled = isCurrentPlan || isLoading || !!selectDisabledHint;
 
   return (
     <div
       className={cn(
-        'relative bg-white rounded-xl border-2 shadow-lg p-6 flex flex-col transition-all duration-300',
-        isPopular ? 'border-blue-500 ring-2 ring-blue-500 ring-offset-2' : planColors[plan.name],
-        isCurrentPlan && 'bg-blue-50',
-        hasDiscount && 'ring-2 ring-red-400 ring-offset-2 border-red-400'
+        'relative flex flex-col rounded-2xl border bg-white p-7 transition-all duration-300',
+        isPopular
+          ? 'border-[#f97316] ring-1 ring-[#f97316] shadow-xl shadow-orange-500/10 lg:-translate-y-3 lg:scale-[1.02]'
+          : 'border-[#ece2d4] shadow-sm shadow-stone-900/5 hover:-translate-y-1 hover:border-[#f5c9a3] hover:shadow-xl hover:shadow-stone-900/5',
+        isCurrentPlan && 'bg-[#faf6f0]',
+        hasDiscount && 'border-[#f97316] ring-1 ring-[#f97316]'
       )}
     >
       {/* Discount Badge */}
       {hasDiscount && (
-        <div className="absolute -top-4 -right-4 z-10">
-          <div className="bg-gradient-to-r from-red-500 to-orange-500 text-white px-3 py-1.5 rounded-full text-sm font-bold shadow-lg flex items-center gap-1 animate-pulse">
-            <Sparkles className="w-4 h-4" />
+        <div className="absolute -top-3.5 -right-3.5 z-10">
+          <div className="flex items-center gap-1 rounded-full bg-[#f97316] px-3 py-1.5 text-sm font-bold text-white shadow-lg shadow-orange-500/30">
+            <Sparkles className="h-4 w-4" />
             {plan.discount!.percentage}% {t('pricing.off')}
           </div>
         </div>
       )}
 
       {isPopular && !hasDiscount && (
-        <div className="absolute -top-4 left-1/2 transform -translate-x-1/2">
-          <span className="bg-blue-500 text-white px-4 py-1 rounded-full text-sm font-semibold">
-            {t('pricing.mostPopular')}
+        <div className="absolute -top-3.5 left-1/2 -translate-x-1/2">
+          <span className="rounded-full bg-[#f97316] px-4 py-1 text-sm font-semibold text-white shadow-md shadow-orange-500/25">
+            ⭐ {t('pricing.mostPopular')}
           </span>
         </div>
       )}
 
       {isCurrentPlan && (
-        <div className="absolute -top-4 right-4">
-          <span className="bg-green-500 text-white px-4 py-1 rounded-full text-sm font-semibold">
+        <div className="absolute -top-3.5 right-4">
+          <span className="rounded-full bg-emerald-600 px-4 py-1 text-sm font-semibold text-white shadow-sm">
             {t('pricing.currentPlan')}
           </span>
         </div>
       )}
 
-      <div className="mb-6">
-        <h3 className="text-2xl font-bold text-slate-900 mb-2">{planDisplayName}</h3>
-        <p className="text-slate-600 text-sm min-h-[40px]">{planDescription}</p>
+      <div className="mb-5">
+        <h3 className="mb-2 text-2xl font-semibold text-[#1c1917]" style={display}>{planDisplayName}</h3>
+        <p className="min-h-[40px] text-sm leading-relaxed text-[#78716c]">{planDescription}</p>
         {/* Non-TRY plans can only be paid by bank transfer (no PayTR card
             rail for foreign currency), so surface that constraint up front
             with a small badge rather than letting the user discover it at
             checkout. */}
         {isNonTry && (
-          <span className="mt-2 inline-flex items-center gap-1 rounded-full bg-amber-100 px-2.5 py-0.5 text-xs font-medium text-amber-800">
+          <span className="mt-2 inline-flex items-center gap-1 rounded-full border border-[#f5c9a3] bg-[#fff3e8] px-2.5 py-0.5 text-xs font-medium text-[#b45309]">
             {t('subscriptions.havaleOnlyBadge', { defaultValue: 'Havale ile ödeme' })}
           </span>
         )}
@@ -150,30 +166,30 @@ const PlanCard = ({
       <div className="mb-6">
         {/* Original price with strikethrough if discounted */}
         {hasDiscount && originalPrice > 0 && (
-          <div className="text-lg text-slate-400 line-through mb-1">
+          <div className="mb-1 text-lg text-[#a8a29e] line-through">
             {getCurrencySymbol(planCurrency)}{originalPrice.toFixed(2)}
           </div>
         )}
 
         <div className="flex items-baseline">
-          <span className={cn(
-            'text-4xl font-bold',
-            hasDiscount ? 'text-red-600' : 'text-slate-900'
-          )}>
+          <span
+            className={cn('text-[2.75rem] font-semibold leading-none', hasDiscount ? 'text-[#ea580c]' : 'text-[#1c1917]')}
+            style={display}
+          >
             {getCurrencySymbol(planCurrency)}{price.toFixed(2)}
           </span>
           {/* Spell the ISO currency code out next to the symbol so the
               billing currency is unambiguous (₺ alone is easy to skim
               past; "TRY"/"USD" makes the rail explicit). */}
-          <span className="text-slate-500 ml-1 text-sm font-medium">{planCurrency}</span>
-          <span className="text-slate-600 ml-2">
+          <span className="ml-1.5 text-sm font-medium text-[#a8a29e]">{planCurrency}</span>
+          <span className="ml-1.5 text-[#78716c]">
             /{billingCycle === BillingCycle.MONTHLY ? t('pricing.month') : t('pricing.year')}
           </span>
         </div>
 
         {billingCycle === BillingCycle.YEARLY && price > 0 && (
-          <p className="text-sm text-green-600 mt-1">
-            {getCurrencySymbol(planCurrency)}{pricePerMonth.toFixed(2)}/{t('pricing.month')} - {t('pricing.save')}{' '}
+          <p className="mt-2 text-sm font-medium text-[#b45309]">
+            {getCurrencySymbol(planCurrency)}{pricePerMonth.toFixed(2)}/{t('pricing.month')} · {t('pricing.save')}{' '}
             {Math.round(((Number(plan.monthlyPrice) * 12 - price) / (Number(plan.monthlyPrice) * 12)) * 100)}%
           </p>
         )}
@@ -181,11 +197,11 @@ const PlanCard = ({
         {/* Discount info */}
         {hasDiscount && totalSavings > 0 && (
           <div className="mt-2 space-y-1">
-            <p className="text-sm text-red-600 font-semibold">
+            <p className="text-sm font-semibold text-[#ea580c]">
               {t('pricing.youSave')}: {getCurrencySymbol(planCurrency)}{totalSavings.toFixed(2)}
             </p>
-            <div className="flex items-center gap-1 text-xs text-orange-600">
-              <Clock className="w-3 h-3" />
+            <div className="flex items-center gap-1 text-xs text-[#b45309]">
+              <Clock className="h-3 w-3" />
               <span>
                 {plan.discount!.label} - {t('pricing.endsOn')} {formatEndDate(plan.discount!.endDate)}
               </span>
@@ -196,14 +212,13 @@ const PlanCard = ({
         {plan.trialDays > 0 && !hasDiscount && (
           isTrialEligible ? (
             // Per-tenant CTA: backend confirmed this tenant hasn't burned
-            // their per-plan trial slot yet. Green emphasis converts
-            // measurably better than the generic gray "14 günlük deneme"
-            // line below.
-            <p className="text-sm font-semibold text-emerald-700 mt-1 flex items-center gap-1">
+            // their per-plan trial slot yet. Warm emphasis converts
+            // measurably better than the generic line below.
+            <p className="mt-2 flex items-center gap-1 text-sm font-semibold text-[#b45309]">
               🎁 {t('pricing.trialPersonalised', { days: plan.trialDays, defaultValue: `Sizin için ${plan.trialDays} gün ücretsiz` })}
             </p>
           ) : (
-            <p className="text-sm text-blue-600 mt-1">
+            <p className="mt-2 text-sm text-[#78716c]">
               {plan.trialDays} {t('pricing.dayFreeTrial')}
             </p>
           )
@@ -211,84 +226,90 @@ const PlanCard = ({
       </div>
 
       <div className="mb-6 flex-grow">
-        <h4 className="font-semibold text-slate-900 mb-3">{t('subscriptions.usageLimits')}:</h4>
-        <ul className="space-y-2 mb-4">
-          <li className="flex items-center text-sm text-slate-700">
-            <Check className="h-4 w-4 text-green-500 mr-2 flex-shrink-0" />
+        <h4 className="mb-3 text-xs font-semibold uppercase tracking-wider text-[#a8a29e]">{t('subscriptions.usageLimits')}</h4>
+        <ul className="mb-5 space-y-2.5">
+          <li className="flex items-center text-sm text-[#44403c]">
+            <Check className="mr-2.5 h-4 w-4 flex-shrink-0 text-[#f97316]" />
             <span>
               {formatLimit(plan.limits.maxUsers)} {isUnlimited(plan.limits.maxUsers) || plan.limits.maxUsers > 1 ? t('subscriptions.users') : t('subscriptions.user')}
             </span>
           </li>
-          <li className="flex items-center text-sm text-slate-700">
-            <Check className="h-4 w-4 text-green-500 mr-2 flex-shrink-0" />
+          <li className="flex items-center text-sm text-[#44403c]">
+            <Check className="mr-2.5 h-4 w-4 flex-shrink-0 text-[#f97316]" />
             <span>
               {formatLimit(plan.limits.maxTables)} {isUnlimited(plan.limits.maxTables) || plan.limits.maxTables > 1 ? t('subscriptions.tables') : t('subscriptions.table')}
             </span>
           </li>
-          <li className="flex items-center text-sm text-slate-700">
-            <Check className="h-4 w-4 text-green-500 mr-2 flex-shrink-0" />
+          <li className="flex items-center text-sm text-[#44403c]">
+            <Check className="mr-2.5 h-4 w-4 flex-shrink-0 text-[#f97316]" />
             <span>
               {formatLimit(plan.limits.maxProducts)} {isUnlimited(plan.limits.maxProducts) || plan.limits.maxProducts > 1 ? t('subscriptions.products') : t('subscriptions.product')}
             </span>
           </li>
-          <li className="flex items-center text-sm text-slate-700">
-            <Check className="h-4 w-4 text-green-500 mr-2 flex-shrink-0" />
+          <li className="flex items-center text-sm text-[#44403c]">
+            <Check className="mr-2.5 h-4 w-4 flex-shrink-0 text-[#f97316]" />
             <span>
               {formatLimit(plan.limits.maxMonthlyOrders)} {isUnlimited(plan.limits.maxMonthlyOrders) || plan.limits.maxMonthlyOrders > 1 ? t('subscriptions.orders') : t('subscriptions.order')}/{t('pricing.month')}
             </span>
           </li>
         </ul>
 
-        <h4 className="font-semibold text-slate-900 mb-3">{t('subscriptions.features')}:</h4>
-        <ul className="space-y-2">
-          {Object.entries(plan.features).map(([key, value]) => {
-            const featureLabels: Record<string, string> = {
-              advancedReports: t('subscriptions.featureAdvancedReports'),
-              multiLocation: t('subscriptions.featureMultiLocation'),
-              customBranding: t('subscriptions.featureCustomBranding'),
-              apiAccess: t('subscriptions.featureApiAccess'),
-              prioritySupport: t('subscriptions.featurePrioritySupport'),
-              inventoryTracking: t('subscriptions.featureInventoryTracking'),
-              kdsIntegration: t('subscriptions.featureKdsIntegration'),
-            };
-
-            return (
-              <li key={key} className="flex items-center text-sm text-slate-700">
-                {value ? (
-                  <>
-                    <Check className="h-4 w-4 text-green-500 mr-2 flex-shrink-0" />
-                    <span>{featureLabels[key]}</span>
-                  </>
-                ) : (
-                  <>
-                    <X className="h-4 w-4 text-slate-400 mr-2 flex-shrink-0" />
-                    <span className="text-slate-400">{featureLabels[key]}</span>
-                  </>
-                )}
-              </li>
-            );
-          })}
+        <h4 className="mb-3 text-xs font-semibold uppercase tracking-wider text-[#a8a29e]">{t('subscriptions.features')}</h4>
+        <ul className="space-y-2.5">
+          {Object.entries(plan.features).map(([key, value]) => (
+            <li key={key} className="flex items-center text-sm">
+              {value ? (
+                <>
+                  <Check className="mr-2.5 h-4 w-4 flex-shrink-0 text-[#f97316]" />
+                  <span className="text-[#44403c]">{featureLabels[key]}</span>
+                </>
+              ) : (
+                <>
+                  <X className="mr-2.5 h-4 w-4 flex-shrink-0 text-[#d6ccbd]" />
+                  <span className="text-[#a8a29e]">{featureLabels[key]}</span>
+                </>
+              )}
+            </li>
+          ))}
         </ul>
       </div>
 
-      <Button
-        variant={hasDiscount ? 'danger' : (isPopular ? 'primary' : 'outline')}
-        className={cn(
-          'w-full',
-          hasDiscount && 'bg-gradient-to-r from-red-500 to-orange-500 hover:from-red-600 hover:to-orange-600 border-0'
-        )}
+      <button
+        type="button"
         onClick={() => onSelectPlan(plan.id)}
-        disabled={isCurrentPlan || isLoading || !!selectDisabledHint}
-        isLoading={isLoading}
+        disabled={ctaDisabled}
+        aria-busy={isLoading || undefined}
         title={selectDisabledHint || undefined}
+        className={cn(
+          'group inline-flex w-full items-center justify-center gap-2 rounded-xl px-5 py-3 text-base font-semibold transition disabled:cursor-not-allowed disabled:opacity-60',
+          isPopular || hasDiscount
+            ? 'bg-[#f97316] text-white shadow-lg shadow-orange-500/20 hover:bg-[#ea580c]'
+            : 'border border-[#e3d7c7] bg-white text-[#1c1917] hover:border-[#cdbfac] hover:bg-[#faf6f0]',
+          isCurrentPlan && 'bg-[#f1e8db] text-[#78716c] shadow-none hover:bg-[#f1e8db]'
+        )}
       >
-        {isCurrentPlan ? t('pricing.currentPlan') : (buttonText || t('pricing.selectPlan'))}
-      </Button>
+        {isLoading ? (
+          <>
+            <svg className="-ml-1 mr-1 h-4 w-4 animate-spin" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" aria-hidden="true">
+              <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+              <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
+            </svg>
+            {t('app.loading')}
+          </>
+        ) : isCurrentPlan ? (
+          t('pricing.currentPlan')
+        ) : (
+          <>
+            {buttonText || t('pricing.selectPlan')}
+            {(isPopular || hasDiscount) && <ArrowRight className="h-4 w-4 transition group-hover:translate-x-0.5" />}
+          </>
+        )}
+      </button>
       {/* Dead-end guard hint: a non-TRY plan with no configured payment
           path can't be checked out, so spell that out under the disabled
           CTA instead of silently bouncing the user off checkout. */}
       {selectDisabledHint && !isCurrentPlan && (
-        <p className="mt-2 text-xs text-amber-700 text-center">{selectDisabledHint}</p>
+        <p className="mt-2 text-center text-xs text-[#b45309]">{selectDisabledHint}</p>
       )}
     </div>
   );

--- a/frontend/src/components/subscriptions/PlanComparisonMatrix.tsx
+++ b/frontend/src/components/subscriptions/PlanComparisonMatrix.tsx
@@ -1,11 +1,14 @@
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Check, X, ChevronDown, ChevronUp } from 'lucide-react';
-import { Plan } from '../../types';
+import { Plan, SubscriptionPlanType } from '../../types';
+import { cn } from '../../lib/utils';
 
 interface PlanComparisonMatrixProps {
   plans: Plan[];
 }
+
+const display = { fontFamily: '"Fraunces", Georgia, serif' } as const;
 
 /**
  * Collapsible "compare plans side-by-side" table shown under the
@@ -20,14 +23,17 @@ export default function PlanComparisonMatrix({ plans }: PlanComparisonMatrixProp
   const sorted = [...plans].sort((a, b) => Number(a.monthlyPrice) - Number(b.monthlyPrice));
 
   // Feature keys mapped to readable labels. The plan object stores each
-  // flag as a top-level boolean on `plan.features`.
+  // flag as a top-level boolean on `plan.features`. All 12 features are
+  // listed so the matrix is an exhaustive, accurate side-by-side.
   const featureRows: Array<{ key: keyof Plan['features']; label: string }> = [
     { key: 'kdsIntegration', label: t('subscriptions.comparison.features.kdsIntegration') },
+    { key: 'posAccess', label: t('subscriptions.comparison.features.posAccess') },
     { key: 'inventoryTracking', label: t('subscriptions.comparison.features.inventoryTracking') },
     { key: 'advancedReports', label: t('subscriptions.comparison.features.advancedReports') },
     { key: 'reservationSystem', label: t('subscriptions.comparison.features.reservationSystem') },
     { key: 'personnelManagement', label: t('subscriptions.comparison.features.personnelManagement') },
     { key: 'deliveryIntegration', label: t('subscriptions.comparison.features.deliveryIntegration') },
+    { key: 'externalDisplay', label: t('subscriptions.comparison.features.externalDisplay') },
     { key: 'multiLocation', label: t('subscriptions.comparison.features.multiLocation') },
     { key: 'customBranding', label: t('subscriptions.comparison.features.customBranding') },
     { key: 'apiAccess', label: t('subscriptions.comparison.features.apiAccess') },
@@ -37,6 +43,7 @@ export default function PlanComparisonMatrix({ plans }: PlanComparisonMatrixProp
   const limitRows: Array<{ key: keyof Plan['limits']; label: string }> = [
     { key: 'maxUsers', label: t('subscriptions.comparison.limits.maxUsers') },
     { key: 'maxTables', label: t('subscriptions.comparison.limits.maxTables') },
+    { key: 'maxBranches', label: t('subscriptions.comparison.limits.maxBranches') },
     { key: 'maxProducts', label: t('subscriptions.comparison.limits.maxProducts') },
     { key: 'maxCategories', label: t('subscriptions.comparison.limits.maxCategories') },
     { key: 'maxMonthlyOrders', label: t('subscriptions.comparison.limits.maxMonthlyOrders') },
@@ -55,26 +62,42 @@ export default function PlanComparisonMatrix({ plans }: PlanComparisonMatrixProp
     return `${monthly.toLocaleString('tr-TR')} ${currency}`;
   };
 
+  // BUSINESS is the highlighted ("En Popüler") tier — tint its column so the
+  // matrix is visually consistent with the elevated card above.
+  const isHighlighted = (p: Plan) => p.name === SubscriptionPlanType.BUSINESS;
+
   return (
-    <div className="mt-12 border-t pt-8">
+    <div className="mt-12 border-t border-[#ece2d4] pt-8">
       <button
         onClick={() => setOpen((v) => !v)}
-        className="flex items-center gap-2 mx-auto text-slate-700 hover:text-slate-900 font-medium"
+        className="flex items-center gap-2 mx-auto rounded-xl border border-[#e3d7c7] bg-white px-5 py-2.5 text-sm font-semibold text-[#1c1917] shadow-sm transition hover:border-[#f5c9a3] hover:bg-[#fff3e8]"
       >
-        {open ? <ChevronUp className="w-5 h-5" /> : <ChevronDown className="w-5 h-5" />}
+        {open ? <ChevronUp className="w-4 h-4 text-[#f97316]" /> : <ChevronDown className="w-4 h-4 text-[#f97316]" />}
         {t('subscriptions.comparison.toggle')}
       </button>
       {open && (
-        <div className="mt-6 overflow-x-auto">
+        <div className="mt-6 overflow-x-auto rounded-2xl border border-[#ece2d4] bg-white shadow-sm shadow-stone-900/5">
           <table className="w-full text-sm border-collapse">
             <thead>
-              <tr className="border-b border-slate-200">
-                <th className="text-left py-3 pl-4 text-slate-700 font-medium">
+              <tr className="border-b border-[#ece2d4]">
+                <th className="text-left py-4 pl-5 text-[#78716c] font-medium">
                   {t('subscriptions.comparison.featureHeader')}
                 </th>
                 {sorted.map((p) => (
-                  <th key={p.id} className="text-center py-3 px-2 text-slate-900 font-semibold">
+                  <th
+                    key={p.id}
+                    className={cn(
+                      'text-center py-4 px-3 text-base font-semibold text-[#1c1917]',
+                      isHighlighted(p) && 'bg-[#fff3e8]',
+                    )}
+                    style={display}
+                  >
                     {p.displayName}
+                    {isHighlighted(p) && (
+                      <span className="mt-1 block text-[10px] font-semibold uppercase tracking-wide text-[#b45309]">
+                        ⭐ {t('subscriptions.comparison.popularBadge', 'En Popüler')}
+                      </span>
+                    )}
                   </th>
                 ))}
               </tr>
@@ -82,50 +105,68 @@ export default function PlanComparisonMatrix({ plans }: PlanComparisonMatrixProp
             <tbody>
               {/* Price row — first so the cost is the top reference point
                   when scanning columns. Shows monthly price + currency. */}
-              <tr className="border-b border-slate-100">
-                <td className="py-2.5 pl-4 text-slate-700 font-medium">
+              <tr className="border-b border-[#f1e8db]">
+                <td className="py-3 pl-5 text-[#57534e] font-medium">
                   {t('subscriptions.comparison.priceRow', 'Fiyat')}
                 </td>
                 {sorted.map((p) => (
-                  <td key={p.id} className="text-center py-2.5 px-2 text-slate-900 font-semibold">
-                    {fmtPrice(p)}
-                    <span className="block text-xs font-normal text-slate-400">
+                  <td
+                    key={p.id}
+                    className={cn(
+                      'text-center py-3 px-3 font-semibold text-[#1c1917]',
+                      isHighlighted(p) && 'bg-[#fff3e8]',
+                    )}
+                  >
+                    <span style={display}>{fmtPrice(p)}</span>
+                    <span className="block text-xs font-normal text-[#a8a29e]">
                       /{t('subscriptions.comparison.perMonth', 'ay')}
                     </span>
                   </td>
                 ))}
               </tr>
               {/* Limits group */}
-              <tr className="bg-slate-50/50">
-                <td colSpan={sorted.length + 1} className="py-2 pl-4 text-xs uppercase tracking-wider text-slate-500 font-medium">
+              <tr className="bg-[#faf6f0]">
+                <td colSpan={sorted.length + 1} className="py-2 pl-5 text-xs uppercase tracking-wider text-[#a8a29e] font-semibold">
                   {t('subscriptions.comparison.limitsGroup')}
                 </td>
               </tr>
               {limitRows.map((row) => (
-                <tr key={row.key} className="border-b border-slate-100">
-                  <td className="py-2.5 pl-4 text-slate-700">{row.label}</td>
+                <tr key={row.key} className="border-b border-[#f1e8db]">
+                  <td className="py-3 pl-5 text-[#57534e]">{row.label}</td>
                   {sorted.map((p) => (
-                    <td key={p.id} className="text-center py-2.5 px-2 text-slate-900">
+                    <td
+                      key={p.id}
+                      className={cn(
+                        'text-center py-3 px-3 text-[#1c1917]',
+                        isHighlighted(p) && 'bg-[#fff3e8] font-medium',
+                      )}
+                    >
                       {fmtLimit(Number(p.limits[row.key]))}
                     </td>
                   ))}
                 </tr>
               ))}
               {/* Features group */}
-              <tr className="bg-slate-50/50">
-                <td colSpan={sorted.length + 1} className="py-2 pl-4 text-xs uppercase tracking-wider text-slate-500 font-medium">
+              <tr className="bg-[#faf6f0]">
+                <td colSpan={sorted.length + 1} className="py-2 pl-5 text-xs uppercase tracking-wider text-[#a8a29e] font-semibold">
                   {t('subscriptions.comparison.featuresGroup')}
                 </td>
               </tr>
               {featureRows.map((row) => (
-                <tr key={row.key} className="border-b border-slate-100">
-                  <td className="py-2.5 pl-4 text-slate-700">{row.label}</td>
+                <tr key={row.key} className="border-b border-[#f1e8db] last:border-0">
+                  <td className="py-3 pl-5 text-[#57534e]">{row.label}</td>
                   {sorted.map((p) => (
-                    <td key={p.id} className="text-center py-2.5 px-2">
+                    <td
+                      key={p.id}
+                      className={cn(
+                        'text-center py-3 px-3',
+                        isHighlighted(p) && 'bg-[#fff3e8]',
+                      )}
+                    >
                       {p.features[row.key] ? (
-                        <Check className="w-4 h-4 text-emerald-600 inline-block" />
+                        <Check className="w-4 h-4 text-[#f97316] inline-block" />
                       ) : (
-                        <X className="w-4 h-4 text-slate-300 inline-block" />
+                        <X className="w-4 h-4 text-[#d6ccbd] inline-block" />
                       )}
                     </td>
                   ))}

--- a/frontend/src/i18n/locales/ar/common.json
+++ b/frontend/src/i18n/locales/ar/common.json
@@ -838,7 +838,12 @@
     "featureApiAccess": "وصول API",
     "featurePrioritySupport": "دعم ذو أولوية",
     "featureInventoryTracking": "تتبع المخزون",
-    "featureKdsIntegration": "تكامل KDS"
+    "featureKdsIntegration": "تكامل KDS",
+    "featurePosAccess": "نقطة البيع / شاشة المبيعات",
+    "featureReservationSystem": "نظام الحجز",
+    "featurePersonnelManagement": "إدارة الموظفين",
+    "featureDeliveryIntegration": "منصات التوصيل",
+    "featureExternalDisplay": "شاشة بعيدة و واجهة API للشركاء"
   },
   "landing": {
     "badge": "متاح الآن",

--- a/frontend/src/i18n/locales/ar/subscriptions.json
+++ b/frontend/src/i18n/locales/ar/subscriptions.json
@@ -265,6 +265,7 @@
       "limits": {
         "maxUsers": "المستخدمون",
         "maxTables": "الطاولات",
+        "maxBranches": "عدد الفروع",
         "maxProducts": "المنتجات",
         "maxCategories": "الفئات",
         "maxMonthlyOrders": "الطلبات الشهرية"
@@ -273,9 +274,11 @@
         "kdsIntegration": "تكامل KDS",
         "inventoryTracking": "تتبع المخزون",
         "advancedReports": "تقارير متقدمة",
+        "posAccess": "نقطة البيع / شاشة المبيعات",
         "reservationSystem": "نظام الحجز",
         "personnelManagement": "إدارة الموظفين",
         "deliveryIntegration": "منصات التوصيل",
+        "externalDisplay": "شاشة بعيدة و واجهة API للشركاء",
         "multiLocation": "تعدد الفروع",
         "customBranding": "علامة تجارية مخصصة",
         "apiAccess": "الوصول إلى API",

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -841,7 +841,12 @@
     "featureApiAccess": "API Access",
     "featurePrioritySupport": "Priority Support",
     "featureInventoryTracking": "Inventory Tracking",
-    "featureKdsIntegration": "KDS Integration"
+    "featureKdsIntegration": "KDS Integration",
+    "featurePosAccess": "POS / Sales Screen",
+    "featureReservationSystem": "Reservation System",
+    "featurePersonnelManagement": "Personnel Management",
+    "featureDeliveryIntegration": "Delivery Platforms",
+    "featureExternalDisplay": "Remote Display & Partner API"
   },
   "landing": {
     "badge": "🚀 Now Live",

--- a/frontend/src/i18n/locales/en/subscriptions.json
+++ b/frontend/src/i18n/locales/en/subscriptions.json
@@ -227,6 +227,7 @@
       "limits": {
         "maxUsers": "Users",
         "maxTables": "Tables",
+        "maxBranches": "Branches",
         "maxProducts": "Products",
         "maxCategories": "Categories",
         "maxMonthlyOrders": "Monthly orders"
@@ -235,9 +236,11 @@
         "kdsIntegration": "KDS integration",
         "inventoryTracking": "Inventory tracking",
         "advancedReports": "Advanced reports",
+        "posAccess": "POS / Sales screen",
         "reservationSystem": "Reservation system",
         "personnelManagement": "Personnel management",
         "deliveryIntegration": "Delivery platforms",
+        "externalDisplay": "Remote display & Partner API",
         "multiLocation": "Multi-location",
         "customBranding": "Custom branding",
         "apiAccess": "API access",

--- a/frontend/src/i18n/locales/ru/common.json
+++ b/frontend/src/i18n/locales/ru/common.json
@@ -828,7 +828,12 @@
     "featureApiAccess": "Доступ к API",
     "featurePrioritySupport": "Приоритетная поддержка",
     "featureInventoryTracking": "Учет инвентаря",
-    "featureKdsIntegration": "Интеграция с KDS"
+    "featureKdsIntegration": "Интеграция с KDS",
+    "featurePosAccess": "POS / Экран продаж",
+    "featureReservationSystem": "Система бронирования",
+    "featurePersonnelManagement": "Управление персоналом",
+    "featureDeliveryIntegration": "Платформы доставки",
+    "featureExternalDisplay": "Удалённый экран и Partner API"
   },
   "landing": {
     "badge": "Уже работает",

--- a/frontend/src/i18n/locales/ru/subscriptions.json
+++ b/frontend/src/i18n/locales/ru/subscriptions.json
@@ -265,6 +265,7 @@
       "limits": {
         "maxUsers": "Пользователи",
         "maxTables": "Столики",
+        "maxBranches": "Филиалы",
         "maxProducts": "Товары",
         "maxCategories": "Категории",
         "maxMonthlyOrders": "Заказы в месяц"
@@ -273,9 +274,11 @@
         "kdsIntegration": "Интеграция с KDS",
         "inventoryTracking": "Учёт склада",
         "advancedReports": "Расширенные отчёты",
+        "posAccess": "POS / Экран продаж",
         "reservationSystem": "Система бронирования",
         "personnelManagement": "Управление персоналом",
         "deliveryIntegration": "Платформы доставки",
+        "externalDisplay": "Удалённый экран и Partner API",
         "multiLocation": "Несколько локаций",
         "customBranding": "Свой брендинг",
         "apiAccess": "Доступ к API",

--- a/frontend/src/i18n/locales/tr/common.json
+++ b/frontend/src/i18n/locales/tr/common.json
@@ -841,7 +841,12 @@
     "featureApiAccess": "API Erişimi",
     "featurePrioritySupport": "Öncelikli Destek",
     "featureInventoryTracking": "Stok Takibi",
-    "featureKdsIntegration": "KDS Entegrasyonu"
+    "featureKdsIntegration": "KDS Entegrasyonu",
+    "featurePosAccess": "POS / Satış Ekranı",
+    "featureReservationSystem": "Rezervasyon Sistemi",
+    "featurePersonnelManagement": "Personel Yönetimi",
+    "featureDeliveryIntegration": "Yemek Platformu Entegrasyonu",
+    "featureExternalDisplay": "Uzak Ekran & Partner API"
   },
   "landing": {
     "badge": "🚀 Şimdi Canlı",

--- a/frontend/src/i18n/locales/tr/subscriptions.json
+++ b/frontend/src/i18n/locales/tr/subscriptions.json
@@ -227,6 +227,7 @@
       "limits": {
         "maxUsers": "Kullanıcı sayısı",
         "maxTables": "Masa sayısı",
+        "maxBranches": "Şube sayısı",
         "maxProducts": "Ürün sayısı",
         "maxCategories": "Kategori sayısı",
         "maxMonthlyOrders": "Aylık sipariş"
@@ -235,9 +236,11 @@
         "kdsIntegration": "KDS entegrasyonu",
         "inventoryTracking": "Stok takibi",
         "advancedReports": "Gelişmiş raporlar",
+        "posAccess": "POS / Satış ekranı",
         "reservationSystem": "Rezervasyon sistemi",
         "personnelManagement": "Personel yönetimi",
         "deliveryIntegration": "Yemek platformu entegrasyonu",
+        "externalDisplay": "Uzak ekran & Partner API",
         "multiLocation": "Çoklu şube",
         "customBranding": "Özel marka",
         "apiAccess": "API erişimi",

--- a/frontend/src/i18n/locales/uz/common.json
+++ b/frontend/src/i18n/locales/uz/common.json
@@ -818,7 +818,12 @@
     "featureApiAccess": "API kirish",
     "featurePrioritySupport": "Ustuvor qo'llab-quvvatlash",
     "featureInventoryTracking": "Inventar nazorati",
-    "featureKdsIntegration": "KDS integratsiyasi"
+    "featureKdsIntegration": "KDS integratsiyasi",
+    "featurePosAccess": "POS / Sotuv ekrani",
+    "featureReservationSystem": "Bronlash tizimi",
+    "featurePersonnelManagement": "Xodimlarni boshqarish",
+    "featureDeliveryIntegration": "Yetkazib berish platformalari",
+    "featureExternalDisplay": "Masofaviy ekran va Partner API"
   },
   "landing": {
     "badge": "Ishga tushirildi",

--- a/frontend/src/i18n/locales/uz/subscriptions.json
+++ b/frontend/src/i18n/locales/uz/subscriptions.json
@@ -265,6 +265,7 @@
       "limits": {
         "maxUsers": "Foydalanuvchilar",
         "maxTables": "Stollar",
+        "maxBranches": "Filiallar soni",
         "maxProducts": "Mahsulotlar",
         "maxCategories": "Kategoriyalar",
         "maxMonthlyOrders": "Oylik buyurtmalar"
@@ -273,9 +274,11 @@
         "kdsIntegration": "KDS integratsiyasi",
         "inventoryTracking": "Ombor nazorati",
         "advancedReports": "Kengaytirilgan hisobotlar",
+        "posAccess": "POS / Sotuv ekrani",
         "reservationSystem": "Bronlash tizimi",
         "personnelManagement": "Xodimlarni boshqarish",
         "deliveryIntegration": "Yetkazib berish platformalari",
+        "externalDisplay": "Masofaviy ekran va Partner API",
         "multiLocation": "Bir nechta filial",
         "customBranding": "Maxsus brending",
         "apiAccess": "API ruxsati",

--- a/frontend/src/pages/subscription/ChangePlanPage.tsx
+++ b/frontend/src/pages/subscription/ChangePlanPage.tsx
@@ -227,14 +227,14 @@ const ChangePlanPage = () => {
       </div>
 
       {/* Plans Grid */}
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">
+      <div className="grid grid-cols-1 items-start gap-6 md:grid-cols-3 lg:gap-8 lg:pt-3">
         {sortedPlans.map((plan) => (
           <PlanCard
             key={plan.id}
             plan={plan}
             billingCycle={billingCycle}
             isCurrentPlan={currentSubscription.planId === plan.id}
-            isPopular={plan.name === SubscriptionPlanType.PRO}
+            isPopular={plan.name === SubscriptionPlanType.BUSINESS}
             onSelectPlan={handleSelectPlan}
             isLoading={changePlan.isPending && selectedPlan?.id === plan.id}
             buttonText={

--- a/frontend/src/pages/subscription/SubscriptionPlansPage.tsx
+++ b/frontend/src/pages/subscription/SubscriptionPlansPage.tsx
@@ -9,7 +9,6 @@ import {
 import PlanCard from '../../components/subscriptions/PlanCard';
 import PlanCardSkeleton from '../../components/subscriptions/PlanCardSkeleton';
 import PlanComparisonMatrix from '../../components/subscriptions/PlanComparisonMatrix';
-import Button from '../../components/ui/Button';
 import { useBankTransferDetails } from '../../api/paymentsApi';
 import { BillingCycle, SubscriptionPlanType, Plan } from '../../types';
 
@@ -36,7 +35,7 @@ function YearlySavingsHint({ plans }: { plans: Plan[] }) {
   }, [plans]);
   if (!example) return null;
   return (
-    <p className="mt-3 text-sm text-emerald-700">
+    <p className="mt-3 text-sm font-medium text-[#b45309]">
       💡 {t('subscriptions.plansPage.yearlySavingsHint', {
         plan: example.planName,
         savings: example.savings.toFixed(0),
@@ -110,16 +109,16 @@ const SubscriptionPlansPage = () => {
   };
 
   if (plansLoading) {
-    // Skeleton placeholders match the eventual 4-column grid so the
+    // Skeleton placeholders match the eventual 3-column grid so the
     // layout doesn't jump when plans arrive.
     return (
-      <div className="max-w-7xl mx-auto">
-        <div className="text-center mb-12">
-          <div className="h-10 w-72 bg-slate-200 rounded mx-auto mb-4 animate-pulse" />
-          <div className="h-5 w-96 bg-slate-100 rounded mx-auto animate-pulse" />
+      <div className="mx-auto max-w-6xl">
+        <div className="mb-12 text-center">
+          <div className="mx-auto mb-4 h-10 w-72 animate-pulse rounded bg-[#ece2d4]" />
+          <div className="mx-auto h-5 w-96 animate-pulse rounded bg-[#f1e8db]" />
         </div>
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">
-          {Array.from({ length: 4 }).map((_, i) => (
+        <div className="grid grid-cols-1 gap-6 md:grid-cols-3">
+          {Array.from({ length: 3 }).map((_, i) => (
             <PlanCardSkeleton key={i} />
           ))}
         </div>
@@ -129,8 +128,8 @@ const SubscriptionPlansPage = () => {
 
   if (!plans || plans.length === 0) {
     return (
-      <div className="text-center py-12">
-        <p className="text-slate-600">{t('subscriptions.plansPage.noPlans')}</p>
+      <div className="py-12 text-center">
+        <p className="text-[#78716c]">{t('subscriptions.plansPage.noPlans')}</p>
       </div>
     );
   }
@@ -139,14 +138,15 @@ const SubscriptionPlansPage = () => {
   const sortedPlans = [...plans].sort((a, b) => a.monthlyPrice - b.monthlyPrice);
 
   const previousPlanName = currentSubscription?.plan?.displayName;
+  const display = { fontFamily: '"Fraunces", Georgia, serif' } as const;
 
   return (
-    <div className="max-w-7xl mx-auto">
+    <div className="mx-auto max-w-6xl px-1 pb-12">
       {/* Onboarding-trial lock banner: the tenant's 7-day trial ended and they
           are locked to this screen until they activate a paid plan. */}
       {currentSubscription?.status === 'TRIAL_ENDED' && (
-        <div className="mb-8 rounded-lg border border-rose-200 bg-rose-50 p-4 text-rose-900">
-          <h3 className="font-semibold mb-1">
+        <div className="mb-8 rounded-2xl border border-rose-200 bg-rose-50 p-5 text-rose-900">
+          <h3 className="mb-1 font-semibold">
             {t(
               'subscriptions.plansPage.trialEndedTitle',
               'Deneme süreniz sona erdi',
@@ -164,8 +164,8 @@ const SubscriptionPlansPage = () => {
           or EXPIRED CTA. Reminds them what plan they were on and gives
           permission to pick a different one. */}
       {isRenewFlow && (
-        <div className="mb-8 rounded-lg border border-amber-200 bg-amber-50 p-4 text-amber-900">
-          <h3 className="font-semibold mb-1">
+        <div className="mb-8 rounded-2xl border border-[#f5c9a3] bg-[#fff3e8] p-5 text-[#b45309]">
+          <h3 className="mb-1 font-semibold">
             {t('subscriptions.plansPage.renewBannerTitle', 'Aboneliğinizi yenileyin')}
           </h3>
           <p className="text-sm">
@@ -181,47 +181,61 @@ const SubscriptionPlansPage = () => {
           </p>
         </div>
       )}
-      <div className="text-center mb-12">
-        <h1 className="text-4xl font-bold text-slate-900 mb-4">{t('subscriptions.plansPage.title')}</h1>
-        <p className="text-lg text-slate-600 mb-8">
+
+      {/* Warm hero header */}
+      <div className="mb-12 text-center">
+        <span className="inline-flex items-center gap-2 rounded-full border border-[#f5c9a3] bg-[#fff3e8] px-3 py-1 text-xs font-semibold text-[#b45309]">
+          <span className="h-1.5 w-1.5 rounded-full bg-[#f97316]" /> {t('subscriptions.plansPage.heroBadge', 'Esnek planlar')}
+        </span>
+        <h1 className="mt-5 text-4xl font-semibold tracking-tight text-[#1c1917] sm:text-5xl" style={display}>
+          {t('subscriptions.plansPage.title')}
+        </h1>
+        <p className="mx-auto mt-4 max-w-xl text-lg text-[#57534e]">
           {t('subscriptions.plansPage.subtitle')}
         </p>
 
         {/* Billing Cycle Toggle */}
-        <div className="inline-flex items-center bg-slate-100 rounded-lg p-1">
+        <div className="mt-8 inline-flex items-center rounded-xl border border-[#ece2d4] bg-white p-1 shadow-sm">
           <button
             onClick={() => setBillingCycle(BillingCycle.MONTHLY)}
-            className={`px-6 py-2 rounded-md font-medium transition-colors ${billingCycle === BillingCycle.MONTHLY
-              ? 'bg-white text-blue-600 shadow-sm'
-              : 'text-slate-600 hover:text-slate-900'
-              }`}
+            className={`rounded-lg px-6 py-2 text-sm font-semibold transition ${
+              billingCycle === BillingCycle.MONTHLY
+                ? 'bg-[#1c1917] text-white shadow-sm'
+                : 'text-[#57534e] hover:text-[#1c1917]'
+            }`}
           >
             {t('subscriptions.monthly')}
           </button>
           <button
             onClick={() => setBillingCycle(BillingCycle.YEARLY)}
-            className={`px-6 py-2 rounded-md font-medium transition-colors ${billingCycle === BillingCycle.YEARLY
-              ? 'bg-white text-blue-600 shadow-sm'
-              : 'text-slate-600 hover:text-slate-900'
-              }`}
+            className={`flex items-center rounded-lg px-6 py-2 text-sm font-semibold transition ${
+              billingCycle === BillingCycle.YEARLY
+                ? 'bg-[#1c1917] text-white shadow-sm'
+                : 'text-[#57534e] hover:text-[#1c1917]'
+            }`}
           >
             {t('subscriptions.yearly')}
-            <span className="ml-2 text-xs bg-green-100 text-green-600 px-2 py-0.5 rounded-full">
+            <span
+              className={`ml-2 rounded-full px-2 py-0.5 text-xs font-semibold ${
+                billingCycle === BillingCycle.YEARLY
+                  ? 'bg-[#f97316] text-white'
+                  : 'bg-[#fff3e8] text-[#b45309]'
+              }`}
+            >
               {t('subscriptions.savePercent', { percent: maxSavingsPercent })}
             </span>
           </button>
         </div>
-        {/* Yearly savings transparency — show real numbers when yearly
-            is selected; abstract "%17 tasarruf" rarely converts on its
-            own. We pick the PRO plan as the canonical example since
-            it's the highlighted "popular" tier. */}
+        {/* Yearly savings transparency — show real numbers when yearly is
+            selected; abstract "%17 tasarruf" rarely converts on its own. */}
         {billingCycle === BillingCycle.YEARLY && (
           <YearlySavingsHint plans={sortedPlans} />
         )}
       </div>
 
-      {/* Plans Grid */}
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8 mb-12">
+      {/* Plans Grid — 3 equal columns on lg, stacked on mobile. The
+          BUSINESS card is elevated as the highlighted "En Popüler" tier. */}
+      <div className="mb-12 grid grid-cols-1 items-start gap-6 md:grid-cols-3 lg:gap-8 lg:pt-3">
         {sortedPlans.map((plan) => {
           // A non-TRY plan with bank transfer disabled has no usable
           // payment path → guard the CTA so the user doesn't dead-end at
@@ -235,7 +249,7 @@ const SubscriptionPlansPage = () => {
               plan={plan}
               billingCycle={billingCycle}
               isCurrentPlan={currentSubscription?.planId === plan.id}
-              isPopular={plan.name === SubscriptionPlanType.PRO}
+              isPopular={plan.name === SubscriptionPlanType.BUSINESS}
               isTrialEligible={trialEligibleIds.includes(plan.id)}
               onSelectPlan={handleSelectPlan}
               isLoading={processingPlanId === plan.id}
@@ -254,17 +268,20 @@ const SubscriptionPlansPage = () => {
 
       {/* Current Subscription Info */}
       {currentSubscription && (
-        <div className="bg-green-50 border border-green-200 rounded-lg p-6">
+        <div className="rounded-2xl border border-[#ece2d4] bg-white p-6 shadow-sm shadow-stone-900/5">
           <div className="text-center">
-            <h3 className="font-semibold text-slate-900 mb-2">
+            <h3 className="mb-2 font-semibold text-[#1c1917]">
               {t('subscriptions.plansPage.haveActiveSubscription')}
             </h3>
-            <p className="text-sm text-slate-600 mb-4">
+            <p className="mb-4 text-sm text-[#78716c]">
               {t('subscriptions.plansPage.toChangePlan')}
             </p>
-            <Button variant="primary" onClick={() => navigate('/admin/settings/subscription')}>
+            <button
+              onClick={() => navigate('/admin/settings/subscription')}
+              className="inline-flex items-center gap-2 rounded-xl bg-[#f97316] px-5 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:bg-[#ea580c]"
+            >
               {t('subscriptions.plansPage.manageSubscription')}
-            </Button>
+            </button>
           </div>
         </div>
       )}
@@ -274,35 +291,24 @@ const SubscriptionPlansPage = () => {
       <PlanComparisonMatrix plans={sortedPlans} />
 
       {/* FAQ Section */}
-      <div className="mt-16 border-t pt-12">
-        <h2 className="text-2xl font-bold text-slate-900 mb-6 text-center">
+      <div className="mt-16 border-t border-[#ece2d4] pt-12">
+        <h2 className="mb-8 text-center text-2xl font-semibold tracking-tight text-[#1c1917] sm:text-3xl" style={display}>
           {t('subscriptions.plansPage.faqTitle')}
         </h2>
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-8 max-w-4xl mx-auto">
-          <div>
-            <h3 className="font-semibold text-slate-900 mb-2">{t('subscriptions.plansPage.faqChangePlans')}</h3>
-            <p className="text-slate-600 text-sm">
-              {t('subscriptions.plansPage.faqChangePlansAnswer')}
-            </p>
-          </div>
-          <div>
-            <h3 className="font-semibold text-slate-900 mb-2">{t('subscriptions.plansPage.faqPaymentMethods')}</h3>
-            <p className="text-slate-600 text-sm">
-              {t('subscriptions.plansPage.faqPaymentMethodsAnswer')}
-            </p>
-          </div>
-          <div>
-            <h3 className="font-semibold text-slate-900 mb-2">{t('subscriptions.plansPage.faqCancelAnytime')}</h3>
-            <p className="text-slate-600 text-sm">
-              {t('subscriptions.plansPage.faqCancelAnytimeAnswer')}
-            </p>
-          </div>
-          <div>
-            <h3 className="font-semibold text-slate-900 mb-2">{t('subscriptions.plansPage.faqFreeTrial')}</h3>
-            <p className="text-slate-600 text-sm">
-              {t('subscriptions.plansPage.faqFreeTrialAnswer')}
-            </p>
-          </div>
+        <div className="mx-auto grid max-w-4xl grid-cols-1 gap-5 md:grid-cols-2">
+          {[
+            { q: 'faqChangePlans', a: 'faqChangePlansAnswer' },
+            { q: 'faqPaymentMethods', a: 'faqPaymentMethodsAnswer' },
+            { q: 'faqCancelAnytime', a: 'faqCancelAnytimeAnswer' },
+            { q: 'faqFreeTrial', a: 'faqFreeTrialAnswer' },
+          ].map((item) => (
+            <div key={item.q} className="rounded-2xl border border-[#ece2d4] bg-white p-6 shadow-sm shadow-stone-900/5">
+              <h3 className="mb-2 font-semibold text-[#1c1917]">{t(`subscriptions.plansPage.${item.q}`)}</h3>
+              <p className="text-sm leading-relaxed text-[#78716c]">
+                {t(`subscriptions.plansPage.${item.a}`)}
+              </p>
+            </div>
+          ))}
         </div>
       </div>
     </div>


### PR DESCRIPTION
Warm landing-consistent 3-tier pricing page (BASIC/PRO/BUSINESS), BUSINESS 'En Popüler'. Comparison matrix accuracy fix (adds posAccess, externalDisplay, maxBranches → all 12 features + 6 limits) + i18n parity (5 locales). FREE UI remnants removed (enum tombstone kept). Staging verified green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)