### PR TITLE
feat(dev-portal): developer.hummytummy.com bilingual docs portal

### DIFF
--- a/.github/workflows/release-deploy.yml
+++ b/.github/workflows/release-deploy.yml
@@ -271,6 +271,21 @@ jobs:
           cache-from: type=registry,ref=${{ env.GHCR_BASE }}/landing:buildcache
           cache-to:   type=registry,ref=${{ env.GHCR_BASE }}/landing:buildcache,mode=max
 
+      # Developer docs portal (Nextra). Standalone Next build; takes no
+      # NEXT_PUBLIC_* / Sentry build-args (the Dockerfile declares none),
+      # so this mirrors the landing step minus the args block. Served at
+      # developer.hummytummy.com (host 3200 → container 3000).
+      - name: Build & push developer
+        uses: docker/build-push-action@v5
+        with:
+          context: ./developer
+          file: ./developer/Dockerfile
+          push: true
+          tags: |
+            ${{ env.GHCR_BASE }}/developer:${{ steps.version.outputs.VERSION }}
+          cache-from: type=registry,ref=${{ env.GHCR_BASE }}/developer:buildcache
+          cache-to:   type=registry,ref=${{ env.GHCR_BASE }}/developer:buildcache,mode=max
+
 
   # -------------------------------------------------------------------
   # Render .env.production from secrets, ship it + the repo HEAD to the

--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -146,6 +146,19 @@ jobs:
           cache-from: type=registry,ref=${{ env.GHCR_BASE }}/landing-staging:buildcache
           cache-to:   type=registry,ref=${{ env.GHCR_BASE }}/landing-staging:buildcache,mode=max
 
+      # Developer docs portal (Nextra) — staging image. Standalone Next build
+      # with no NEXT_PUBLIC_* / Sentry build-args (the Dockerfile declares
+      # none), so this mirrors the landing-staging step minus the args block.
+      - name: Build & push developer
+        uses: docker/build-push-action@v5
+        with:
+          context: ./developer
+          file: ./developer/Dockerfile
+          push: true
+          tags: ${{ env.GHCR_BASE }}/developer-staging:${{ steps.commit.outputs.sha }}
+          cache-from: type=registry,ref=${{ env.GHCR_BASE }}/developer-staging:buildcache
+          cache-to:   type=registry,ref=${{ env.GHCR_BASE }}/developer-staging:buildcache,mode=max
+
 
   deploy:
     name: Deploy staging

--- a/developer/.dockerignore
+++ b/developer/.dockerignore
@@ -1,0 +1,8 @@
+node_modules
+.next
+out
+dist
+.git
+.env*.local
+*.log
+.DS_Store

--- a/developer/.gitignore
+++ b/developer/.gitignore
@@ -1,0 +1,7 @@
+node_modules
+.next
+out
+dist
+.env*.local
+next-env.d.ts
+.DS_Store

--- a/developer/Dockerfile
+++ b/developer/Dockerfile
@@ -1,0 +1,18 @@
+# HummyTummy documentation portal (Nextra) — standalone Next build.
+FROM node:20-alpine AS builder
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+COPY . .
+RUN npm run build
+
+FROM node:20-alpine AS runner
+WORKDIR /app
+ENV NODE_ENV=production
+# Next standalone server (listens on PORT || 3000). Mapped to host 3200 in
+# compose, mirroring the landing service's 3100:3000 shape.
+COPY --from=builder /app/public ./public
+COPY --from=builder /app/.next/standalone ./
+COPY --from=builder /app/.next/static ./.next/static
+EXPOSE 3000
+CMD ["node", "server.js"]

--- a/developer/middleware.ts
+++ b/developer/middleware.ts
@@ -1,0 +1,7 @@
+export { middleware } from 'nextra/locales'
+
+export const config = {
+  // Run on every path except API, Next internals, pagefind and files with an
+  // extension — so the locale prefix is applied to doc routes only.
+  matcher: ['/((?!api|_next/static|_next/image|_pagefind|favicon.ico|.*\\..*).*)'],
+}

--- a/developer/next.config.mjs
+++ b/developer/next.config.mjs
@@ -1,0 +1,20 @@
+import nextra from 'nextra'
+
+const withNextra = nextra({
+  theme: 'nextra-theme-docs',
+  themeConfig: './theme.config.tsx',
+  defaultShowCopyCode: true,
+})
+
+export default withNextra({
+  // Standalone build for a small Docker image (mirrors the other apps).
+  output: 'standalone',
+  reactStrictMode: true,
+  // Bilingual: Turkish default, English secondary. Locale-suffixed page
+  // files (*.tr.mdx / *.en.mdx) + _meta.{tr,en}.json + nextra/locales
+  // middleware drive the routing.
+  i18n: {
+    locales: ['tr', 'en'],
+    defaultLocale: 'tr',
+  },
+})

--- a/developer/package-lock.json
+++ b/developer/package-lock.json
@@ -1,0 +1,5729 @@
+{
+  "name": "hummytummy-developer-docs",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "hummytummy-developer-docs",
+      "version": "1.0.0",
+      "dependencies": {
+        "next": "^14.2.15",
+        "nextra": "^3.3.1",
+        "nextra-theme-docs": "^3.3.1",
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1"
+      },
+      "devDependencies": {
+        "@types/node": "^20.14.0",
+        "@types/react": "^18.3.3",
+        "typescript": "^5.5.4"
+      }
+    },
+    "node_modules/@antfu/install-pkg": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@antfu/install-pkg/-/install-pkg-1.1.0.tgz",
+      "integrity": "sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "package-manager-detector": "^1.3.0",
+        "tinyexec": "^1.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@braintree/sanitize-url": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-7.1.2.tgz",
+      "integrity": "sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==",
+      "license": "MIT"
+    },
+    "node_modules/@chevrotain/types": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-11.1.2.tgz",
+      "integrity": "sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@floating-ui/core": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
+      "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
+      "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.7.5",
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/react": {
+      "version": "0.26.28",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.26.28.tgz",
+      "integrity": "sha512-yORQuuAtVpiRjpMhdc0wJj06b9JFjrYF4qp96j++v2NBpbi6SEGF7donUJ3TMieerQ6qVkAv1tgr7L4r5roTqw==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.1.2",
+        "@floating-ui/utils": "^0.2.8",
+        "tabbable": "^6.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.8.tgz",
+      "integrity": "sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.7.6"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
+      "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
+      "license": "MIT"
+    },
+    "node_modules/@formatjs/intl-localematcher": {
+      "version": "0.5.10",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.5.10.tgz",
+      "integrity": "sha512-af3qATX+m4Rnd9+wHcjJ4w2ijq+rAVP3CCinJQvFv1kgSu1W6jypUmvleJxcewdxmutM8dmIRZFxO/IQBZmP2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@headlessui/react": {
+      "version": "2.2.10",
+      "resolved": "https://registry.npmjs.org/@headlessui/react/-/react-2.2.10.tgz",
+      "integrity": "sha512-5pVLNK9wlpxTUTy9GpgbX/SdcRh+HBnPktjM2wbiLTH4p+2EPHBO1aoSryUCuKUIItdDWO9ITlhUL8UnUN/oIA==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react": "^0.26.16",
+        "@react-aria/focus": "^3.20.2",
+        "@react-aria/interactions": "^3.25.0",
+        "@tanstack/react-virtual": "^3.13.9",
+        "use-sync-external-store": "^1.5.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^18 || ^19 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/@iconify/types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@iconify/types/-/types-2.0.0.tgz",
+      "integrity": "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==",
+      "license": "MIT"
+    },
+    "node_modules/@iconify/utils": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@iconify/utils/-/utils-3.1.3.tgz",
+      "integrity": "sha512-LPKOXPn/zV+zis1oOfGWogaXVpqUybF3ZS6SCZIsz8vg0ivVp9+fVqyYB7xq0aiST/VhUQYGO1qo6uoYSiEJqw==",
+      "license": "MIT",
+      "dependencies": {
+        "@antfu/install-pkg": "^1.1.0",
+        "@iconify/types": "^2.0.0",
+        "import-meta-resolve": "^4.2.0"
+      }
+    },
+    "node_modules/@internationalized/date": {
+      "version": "3.12.2",
+      "resolved": "https://registry.npmjs.org/@internationalized/date/-/date-3.12.2.tgz",
+      "integrity": "sha512-FY1Y+H64NDs+HAF6omlnWxm3mEpfgaCSWtL5l551ZZfImA+kGjPFgrnJrGjH6lfmLL0g8Z/mBu1R3kufeCp6Jw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      }
+    },
+    "node_modules/@internationalized/number": {
+      "version": "3.6.7",
+      "resolved": "https://registry.npmjs.org/@internationalized/number/-/number-3.6.7.tgz",
+      "integrity": "sha512-3ji1fcrT+FPAK86UqEhB/psHixYo6niWPJtt7+qRaYFynt/BaJG8GhAPimtWUpEiVSTq8ZM8L5psMxGquiB/Vg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      }
+    },
+    "node_modules/@internationalized/string": {
+      "version": "3.2.9",
+      "resolved": "https://registry.npmjs.org/@internationalized/string/-/string-3.2.9.tgz",
+      "integrity": "sha512-kzP/M/mbQxODlmOt4bIQZ2SBVUWUSqMLXooXixnX7noche8WHaQcA+nwFN1K2KCF/cp+LDUhcJsCicwkvhD1pg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      }
+    },
+    "node_modules/@mdx-js/mdx": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@mdx-js/mdx/-/mdx-3.1.1.tgz",
+      "integrity": "sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdx": "^2.0.0",
+        "acorn": "^8.0.0",
+        "collapse-white-space": "^2.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "estree-util-scope": "^1.0.0",
+        "estree-walker": "^3.0.0",
+        "hast-util-to-jsx-runtime": "^2.0.0",
+        "markdown-extensions": "^2.0.0",
+        "recma-build-jsx": "^1.0.0",
+        "recma-jsx": "^1.0.0",
+        "recma-stringify": "^1.0.0",
+        "rehype-recma": "^1.0.0",
+        "remark-mdx": "^3.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-rehype": "^11.0.0",
+        "source-map": "^0.7.0",
+        "unified": "^11.0.0",
+        "unist-util-position-from-estree": "^2.0.0",
+        "unist-util-stringify-position": "^4.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/@mdx-js/react": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-3.1.1.tgz",
+      "integrity": "sha512-f++rKLQgUVYDAtECQ6fn/is15GkEH9+nZPM3MS0RcxVqoTfawHvDlSCH7JbMhAM6uJ32v3eXLvLmLvjGu7PTQw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdx": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16",
+        "react": ">=16"
+      }
+    },
+    "node_modules/@mermaid-js/parser": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-1.1.1.tgz",
+      "integrity": "sha512-VuHdsYMK1bT6X2JbcAaWAhugTRvRBRyuZgd+c22swUeI9g/ntaxF7CY7dYarhZovofCbUNO0G7JesfmNtjYOCw==",
+      "license": "MIT",
+      "dependencies": {
+        "@chevrotain/types": "~11.1.1"
+      }
+    },
+    "node_modules/@napi-rs/simple-git": {
+      "version": "0.1.22",
+      "resolved": "https://registry.npmjs.org/@napi-rs/simple-git/-/simple-git-0.1.22.tgz",
+      "integrity": "sha512-bMVoAKhpjTOPHkW/lprDPwv5aD4R4C3Irt8vn+SKA9wudLe9COLxOhurrKRsxmZccUbWXRF7vukNeGUAj5P8kA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@napi-rs/simple-git-android-arm-eabi": "0.1.22",
+        "@napi-rs/simple-git-android-arm64": "0.1.22",
+        "@napi-rs/simple-git-darwin-arm64": "0.1.22",
+        "@napi-rs/simple-git-darwin-x64": "0.1.22",
+        "@napi-rs/simple-git-freebsd-x64": "0.1.22",
+        "@napi-rs/simple-git-linux-arm-gnueabihf": "0.1.22",
+        "@napi-rs/simple-git-linux-arm64-gnu": "0.1.22",
+        "@napi-rs/simple-git-linux-arm64-musl": "0.1.22",
+        "@napi-rs/simple-git-linux-ppc64-gnu": "0.1.22",
+        "@napi-rs/simple-git-linux-s390x-gnu": "0.1.22",
+        "@napi-rs/simple-git-linux-x64-gnu": "0.1.22",
+        "@napi-rs/simple-git-linux-x64-musl": "0.1.22",
+        "@napi-rs/simple-git-win32-arm64-msvc": "0.1.22",
+        "@napi-rs/simple-git-win32-ia32-msvc": "0.1.22",
+        "@napi-rs/simple-git-win32-x64-msvc": "0.1.22"
+      }
+    },
+    "node_modules/@napi-rs/simple-git-android-arm-eabi": {
+      "version": "0.1.22",
+      "resolved": "https://registry.npmjs.org/@napi-rs/simple-git-android-arm-eabi/-/simple-git-android-arm-eabi-0.1.22.tgz",
+      "integrity": "sha512-JQZdnDNm8o43A5GOzwN/0Tz3CDBQtBUNqzVwEopm32uayjdjxev1Csp1JeaqF3v9djLDIvsSE39ecsN2LhCKKQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/simple-git-android-arm64": {
+      "version": "0.1.22",
+      "resolved": "https://registry.npmjs.org/@napi-rs/simple-git-android-arm64/-/simple-git-android-arm64-0.1.22.tgz",
+      "integrity": "sha512-46OZ0SkhnvM+fapWjzg/eqbJvClxynUpWYyYBn4jAj7GQs1/Yyc8431spzDmkA8mL0M7Xo8SmbkzTDE7WwYAfg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/simple-git-darwin-arm64": {
+      "version": "0.1.22",
+      "resolved": "https://registry.npmjs.org/@napi-rs/simple-git-darwin-arm64/-/simple-git-darwin-arm64-0.1.22.tgz",
+      "integrity": "sha512-zH3h0C8Mkn9//MajPI6kHnttywjsBmZ37fhLX/Fiw5XKu84eHA6dRyVtMzoZxj6s+bjNTgaMgMUucxPn9ktxTQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/simple-git-darwin-x64": {
+      "version": "0.1.22",
+      "resolved": "https://registry.npmjs.org/@napi-rs/simple-git-darwin-x64/-/simple-git-darwin-x64-0.1.22.tgz",
+      "integrity": "sha512-GZN7lRAkGKB6PJxWsoyeYJhh85oOOjVNyl+/uipNX8bR+mFDCqRsCE3rRCFGV9WrZUHXkcuRL2laIRn7lLi3ag==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/simple-git-freebsd-x64": {
+      "version": "0.1.22",
+      "resolved": "https://registry.npmjs.org/@napi-rs/simple-git-freebsd-x64/-/simple-git-freebsd-x64-0.1.22.tgz",
+      "integrity": "sha512-xyqX1C5I0WBrUgZONxHjZH5a4LqQ9oki3SKFAVpercVYAcx3pq6BkZy1YUOP4qx78WxU1CCNfHBN7V+XO7D99A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/simple-git-linux-arm-gnueabihf": {
+      "version": "0.1.22",
+      "resolved": "https://registry.npmjs.org/@napi-rs/simple-git-linux-arm-gnueabihf/-/simple-git-linux-arm-gnueabihf-0.1.22.tgz",
+      "integrity": "sha512-4LOtbp9ll93B9fxRvXiUJd1/RM3uafMJE7dGBZGKWBMGM76+BAcCEUv2BY85EfsU/IgopXI6n09TycRfPWOjxA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/simple-git-linux-arm64-gnu": {
+      "version": "0.1.22",
+      "resolved": "https://registry.npmjs.org/@napi-rs/simple-git-linux-arm64-gnu/-/simple-git-linux-arm64-gnu-0.1.22.tgz",
+      "integrity": "sha512-GVOjP/JjCzbQ0kSqao7ctC/1sodVtv5VF57rW9BFpo2y6tEYPCqHnkQkTpieuwMNe+TVOhBUC1+wH0d9/knIHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/simple-git-linux-arm64-musl": {
+      "version": "0.1.22",
+      "resolved": "https://registry.npmjs.org/@napi-rs/simple-git-linux-arm64-musl/-/simple-git-linux-arm64-musl-0.1.22.tgz",
+      "integrity": "sha512-MOs7fPyJiU/wqOpKzAOmOpxJ/TZfP4JwmvPad/cXTOWYwwyppMlXFRms3i98EU3HOazI/wMU2Ksfda3+TBluWA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/simple-git-linux-ppc64-gnu": {
+      "version": "0.1.22",
+      "resolved": "https://registry.npmjs.org/@napi-rs/simple-git-linux-ppc64-gnu/-/simple-git-linux-ppc64-gnu-0.1.22.tgz",
+      "integrity": "sha512-L59dR30VBShRUIZ5/cQHU25upNgKS0AMQ7537J6LCIUEFwwXrKORZKJ8ceR+s3Sr/4jempWVvMdjEpFDE4HYww==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/simple-git-linux-s390x-gnu": {
+      "version": "0.1.22",
+      "resolved": "https://registry.npmjs.org/@napi-rs/simple-git-linux-s390x-gnu/-/simple-git-linux-s390x-gnu-0.1.22.tgz",
+      "integrity": "sha512-4FHkPlCSIZUGC6HiADffbe6NVoTBMd65pIwcd40IDbtFKOgFMBA+pWRqKiQ21FERGH16Zed7XHJJoY3jpOqtmQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/simple-git-linux-x64-gnu": {
+      "version": "0.1.22",
+      "resolved": "https://registry.npmjs.org/@napi-rs/simple-git-linux-x64-gnu/-/simple-git-linux-x64-gnu-0.1.22.tgz",
+      "integrity": "sha512-Ei1tM5Ho/dwknF3pOzqkNW9Iv8oFzRxE8uOhrITcdlpxRxVrBVptUF6/0WPdvd7R9747D/q61QG/AVyWsWLFKw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/simple-git-linux-x64-musl": {
+      "version": "0.1.22",
+      "resolved": "https://registry.npmjs.org/@napi-rs/simple-git-linux-x64-musl/-/simple-git-linux-x64-musl-0.1.22.tgz",
+      "integrity": "sha512-zRYxg7it0p3rLyEJYoCoL2PQJNgArVLyNavHW03TFUAYkYi5bxQ/UFNVpgxMaXohr5yu7qCBqeo9j4DWeysalg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/simple-git-win32-arm64-msvc": {
+      "version": "0.1.22",
+      "resolved": "https://registry.npmjs.org/@napi-rs/simple-git-win32-arm64-msvc/-/simple-git-win32-arm64-msvc-0.1.22.tgz",
+      "integrity": "sha512-XGFR1fj+Y9cWACcovV2Ey/R2xQOZKs8t+7KHPerYdJ4PtjVzGznI4c2EBHXtdOIYvkw7tL5rZ7FN1HJKdD5Quw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/simple-git-win32-ia32-msvc": {
+      "version": "0.1.22",
+      "resolved": "https://registry.npmjs.org/@napi-rs/simple-git-win32-ia32-msvc/-/simple-git-win32-ia32-msvc-0.1.22.tgz",
+      "integrity": "sha512-Gqr9Y0gs6hcNBA1IXBpoqTFnnIoHuZGhrYqaZzEvGMLrTrpbXrXVEtX3DAAD2RLc1b87CPcJ49a7sre3PU3Rfw==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/simple-git-win32-x64-msvc": {
+      "version": "0.1.22",
+      "resolved": "https://registry.npmjs.org/@napi-rs/simple-git-win32-x64-msvc/-/simple-git-win32-x64-msvc-0.1.22.tgz",
+      "integrity": "sha512-hQjcreHmUcpw4UrtkOron1/TQObfe484lxiXFLLUj7aWnnnOVs1mnXq5/Bo9+3NYZldFpFRJPdPBeHCisXkKJg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/env": {
+      "version": "14.2.35",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.35.tgz",
+      "integrity": "sha512-DuhvCtj4t9Gwrx80dmz2F4t/zKQ4ktN8WrMwOuVzkJfBilwAwGr6v16M5eI8yCuZ63H9TTuEU09Iu2HqkzFPVQ==",
+      "license": "MIT"
+    },
+    "node_modules/@next/swc-darwin-arm64": {
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.33.tgz",
+      "integrity": "sha512-HqYnb6pxlsshoSTubdXKu15g3iivcbsMXg4bYpjL2iS/V6aQot+iyF4BUc2qA/J/n55YtvE4PHMKWBKGCF/+wA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.33.tgz",
+      "integrity": "sha512-8HGBeAE5rX3jzKvF593XTTFg3gxeU4f+UWnswa6JPhzaR6+zblO5+fjltJWIZc4aUalqTclvN2QtTC37LxvZAA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.33.tgz",
+      "integrity": "sha512-JXMBka6lNNmqbkvcTtaX8Gu5by9547bukHQvPoLe9VRBx1gHwzf5tdt4AaezW85HAB3pikcvyqBToRTDA4DeLw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.33.tgz",
+      "integrity": "sha512-Bm+QulsAItD/x6Ih8wGIMfRJy4G73tu1HJsrccPW6AfqdZd0Sfm5Imhgkgq2+kly065rYMnCOxTBvmvFY1BKfg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-gnu": {
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.33.tgz",
+      "integrity": "sha512-FnFn+ZBgsVMbGDsTqo8zsnRzydvsGV8vfiWwUo1LD8FTmPTdV+otGSWKc4LJec0oSexFnCYVO4hX8P8qQKaSlg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-musl": {
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.33.tgz",
+      "integrity": "sha512-345tsIWMzoXaQndUTDv1qypDRiebFxGYx9pYkhwY4hBRaOLt8UGfiWKr9FSSHs25dFIf8ZqIFaPdy5MljdoawA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.33.tgz",
+      "integrity": "sha512-nscpt0G6UCTkrT2ppnJnFsYbPDQwmum4GNXYTeoTIdsmMydSKFz9Iny2jpaRupTb+Wl298+Rh82WKzt9LCcqSQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-ia32-msvc": {
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.33.tgz",
+      "integrity": "sha512-pc9LpGNKhJ0dXQhZ5QMmYxtARwwmWLpeocFmVG5Z0DzWq5Uf0izcI8tLc+qOpqxO1PWqZ5A7J1blrUIKrIFc7Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-x64-msvc": {
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.33.tgz",
+      "integrity": "sha512-nOjfZMy8B94MdisuzZo9/57xuFVLHJaDj5e/xrduJp9CV2/HrfxTRH2fbyLe+K9QT41WBLUd4iXX3R7jBp0EUg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@react-aria/focus": {
+      "version": "3.22.1",
+      "resolved": "https://registry.npmjs.org/@react-aria/focus/-/focus-3.22.1.tgz",
+      "integrity": "sha512-CPxtkyrBi/HYY5P3lE/57sQ6qfa0lN8E55TOm89H0kNGv0lKt+/0zP7lWERzBjRr5IxBVrQX4gFEowBN52LPaA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0",
+        "react-aria": "^3.48.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/interactions": {
+      "version": "3.28.1",
+      "resolved": "https://registry.npmjs.org/@react-aria/interactions/-/interactions-3.28.1.tgz",
+      "integrity": "sha512-Bqb+HrD5I5MHS2SKBhISYqo2SW8Y2dfzgF/Y1lIJq7xqLxheo9vzxPGEHhz+XzkgGfoqEJx8A6a3C7uiqS3HWA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.34.0",
+        "@swc/helpers": "^0.5.0",
+        "react-aria": "^3.48.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/shared": {
+      "version": "3.36.0",
+      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.36.0.tgz",
+      "integrity": "sha512-DkP/H0C2YjjS7gZWKNqOmU8a16qHPjQNdzMwmTq9SzplM6Iw0kVMTZ0OIoe6FOgGqa+FwMsE2QbPjh/n3g/jXQ==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@shikijs/core": {
+      "version": "1.29.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-1.29.2.tgz",
+      "integrity": "sha512-vju0lY9r27jJfOY4Z7+Rt/nIOjzJpZ3y+nYpqtUZInVoXQ/TJZcfGnNOGnKjFdVZb8qexiCuSlZRKcGfhhTTZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/engine-javascript": "1.29.2",
+        "@shikijs/engine-oniguruma": "1.29.2",
+        "@shikijs/types": "1.29.2",
+        "@shikijs/vscode-textmate": "^10.0.1",
+        "@types/hast": "^3.0.4",
+        "hast-util-to-html": "^9.0.4"
+      }
+    },
+    "node_modules/@shikijs/engine-javascript": {
+      "version": "1.29.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-1.29.2.tgz",
+      "integrity": "sha512-iNEZv4IrLYPv64Q6k7EPpOCE/nuvGiKl7zxdq0WFuRPF5PAE9PRo2JGq/d8crLusM59BRemJ4eOqrFrC4wiQ+A==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "1.29.2",
+        "@shikijs/vscode-textmate": "^10.0.1",
+        "oniguruma-to-es": "^2.2.0"
+      }
+    },
+    "node_modules/@shikijs/engine-oniguruma": {
+      "version": "1.29.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-1.29.2.tgz",
+      "integrity": "sha512-7iiOx3SG8+g1MnlzZVDYiaeHe7Ez2Kf2HrJzdmGwkRisT7r4rak0e655AcM/tF9JG/kg5fMNYlLLKglbN7gBqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "1.29.2",
+        "@shikijs/vscode-textmate": "^10.0.1"
+      }
+    },
+    "node_modules/@shikijs/langs": {
+      "version": "1.29.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-1.29.2.tgz",
+      "integrity": "sha512-FIBA7N3LZ+223U7cJDUYd5shmciFQlYkFXlkKVaHsCPgfVLiO+e12FmQE6Tf9vuyEsFe3dIl8qGWKXgEHL9wmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "1.29.2"
+      }
+    },
+    "node_modules/@shikijs/themes": {
+      "version": "1.29.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-1.29.2.tgz",
+      "integrity": "sha512-i9TNZlsq4uoyqSbluIcZkmPL9Bfi3djVxRnofUHwvx/h6SRW3cwgBC5SML7vsDcWyukY0eCzVN980rqP6qNl9g==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "1.29.2"
+      }
+    },
+    "node_modules/@shikijs/twoslash": {
+      "version": "1.29.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/twoslash/-/twoslash-1.29.2.tgz",
+      "integrity": "sha512-2S04ppAEa477tiaLfGEn1QJWbZUmbk8UoPbAEw4PifsrxkBXtAtOflIZJNtuCwz8ptc/TPxy7CO7gW4Uoi6o/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/core": "1.29.2",
+        "@shikijs/types": "1.29.2",
+        "twoslash": "^0.2.12"
+      }
+    },
+    "node_modules/@shikijs/types": {
+      "version": "1.29.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-1.29.2.tgz",
+      "integrity": "sha512-VJjK0eIijTZf0QSTODEXCqinjBn0joAHQ+aPSBzrv4O2d/QSbsMw+ZeSRx03kV34Hy7NzUvV/7NqfYGRLrASmw==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/vscode-textmate": "^10.0.1",
+        "@types/hast": "^3.0.4"
+      }
+    },
+    "node_modules/@shikijs/vscode-textmate": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
+      "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
+      "license": "MIT"
+    },
+    "node_modules/@swc/counter": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
+      "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.5.tgz",
+      "integrity": "sha512-KGYxvIOXcceOAbEk4bi/dVLEK9z8sZ0uBB3Il5b1rhfClSpcX0yfRO0KmTkqR2cnQDymwLB+25ZyMzICg/cm/A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/counter": "^0.1.3",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tanstack/react-virtual": {
+      "version": "3.14.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.14.3.tgz",
+      "integrity": "sha512-k/cnHPVaOfn46hSbiY6n4Dzf4QjCGWSF40zR5QIIYUqPAjpA6TN7InfYmcMiDVQGP2iUn9xsRbAl8u1v3UmeVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.17.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.17.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.17.1.tgz",
+      "integrity": "sha512-VZyW2Uiml5tmBZwPGrSD3Sz73OxzljQMCmzYHsUTPEuTsERf5xwa+uWb01xEzkz3ZSYTjj8NEb/mKHvgKxyZdA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@theguild/remark-mermaid": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@theguild/remark-mermaid/-/remark-mermaid-0.1.3.tgz",
+      "integrity": "sha512-2FjVlaaKXK7Zj7UJAgOVTyaahn/3/EAfqYhyXg0BfDBVUl+lXcoIWRaxzqfnDr2rv8ax6GsC5mNh6hAaT86PDw==",
+      "license": "MIT",
+      "dependencies": {
+        "mermaid": "^11.0.0",
+        "unist-util-visit": "^5.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.2.0"
+      }
+    },
+    "node_modules/@theguild/remark-npm2yarn": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@theguild/remark-npm2yarn/-/remark-npm2yarn-0.3.3.tgz",
+      "integrity": "sha512-ma6DvR03gdbvwqfKx1omqhg9May/VYGdMHvTzB4VuxkyS7KzfZ/lzrj43hmcsggpMje0x7SADA/pcMph0ejRnA==",
+      "license": "MIT",
+      "dependencies": {
+        "npm-to-yarn": "^3.0.0",
+        "unist-util-visit": "^5.0.0"
+      }
+    },
+    "node_modules/@types/d3": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@types/d3/-/d3-7.4.3.tgz",
+      "integrity": "sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-array": "*",
+        "@types/d3-axis": "*",
+        "@types/d3-brush": "*",
+        "@types/d3-chord": "*",
+        "@types/d3-color": "*",
+        "@types/d3-contour": "*",
+        "@types/d3-delaunay": "*",
+        "@types/d3-dispatch": "*",
+        "@types/d3-drag": "*",
+        "@types/d3-dsv": "*",
+        "@types/d3-ease": "*",
+        "@types/d3-fetch": "*",
+        "@types/d3-force": "*",
+        "@types/d3-format": "*",
+        "@types/d3-geo": "*",
+        "@types/d3-hierarchy": "*",
+        "@types/d3-interpolate": "*",
+        "@types/d3-path": "*",
+        "@types/d3-polygon": "*",
+        "@types/d3-quadtree": "*",
+        "@types/d3-random": "*",
+        "@types/d3-scale": "*",
+        "@types/d3-scale-chromatic": "*",
+        "@types/d3-selection": "*",
+        "@types/d3-shape": "*",
+        "@types/d3-time": "*",
+        "@types/d3-time-format": "*",
+        "@types/d3-timer": "*",
+        "@types/d3-transition": "*",
+        "@types/d3-zoom": "*"
+      }
+    },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-axis": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-axis/-/d3-axis-3.0.6.tgz",
+      "integrity": "sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-brush": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-brush/-/d3-brush-3.0.6.tgz",
+      "integrity": "sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-chord": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-chord/-/d3-chord-3.0.6.tgz",
+      "integrity": "sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-contour": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-contour/-/d3-contour-3.0.6.tgz",
+      "integrity": "sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-array": "*",
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-dispatch": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-dispatch/-/d3-dispatch-3.0.7.tgz",
+      "integrity": "sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-drag": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.7.tgz",
+      "integrity": "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-dsv": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-dsv/-/d3-dsv-3.0.7.tgz",
+      "integrity": "sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-fetch": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-fetch/-/d3-fetch-3.0.7.tgz",
+      "integrity": "sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-dsv": "*"
+      }
+    },
+    "node_modules/@types/d3-force": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@types/d3-force/-/d3-force-3.0.10.tgz",
+      "integrity": "sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-format": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-3.0.4.tgz",
+      "integrity": "sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-geo": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-geo/-/d3-geo-3.1.0.tgz",
+      "integrity": "sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/d3-hierarchy": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-hierarchy/-/d3-hierarchy-3.1.7.tgz",
+      "integrity": "sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-polygon": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-polygon/-/d3-polygon-3.0.2.tgz",
+      "integrity": "sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-quadtree": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-quadtree/-/d3-quadtree-3.0.6.tgz",
+      "integrity": "sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-random": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-random/-/d3-random-3.0.3.tgz",
+      "integrity": "sha512-Imagg1vJ3y76Y2ea0871wpabqp613+8/r0mCLEBfdtqC7xMSfj9idOnmBYyMoULfHePJyxMAw3nWhJxzc+LFwQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-selection": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
+      "integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-time-format": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-4.0.3.tgz",
+      "integrity": "sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-transition": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.9.tgz",
+      "integrity": "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-zoom": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.8.tgz",
+      "integrity": "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-interpolate": "*",
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/debug": {
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+      "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/estree-jsx": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-1.0.5.tgz",
+      "integrity": "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*"
+      }
+    },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/hast": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/katex": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@types/katex/-/katex-0.16.8.tgz",
+      "integrity": "sha512-trgaNyfU+Xh2Tc+ABIb44a5AYUpicB3uwirOioeOkNPPbmgRNtcWyDeeFRzjPZENO9Vq8gvVqfhaaXWLlevVwg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/mdx": {
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/@types/mdx/-/mdx-2.0.14.tgz",
+      "integrity": "sha512-T48PeuJtvLosNTPVhfnIp3i/n3a4g4Bad7YCq5k64D4u7NwDrAotikQ+5+sjtUvBmxCMlbo3dVL+C2dP0rWHzg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/nlcst": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/nlcst/-/nlcst-2.0.3.tgz",
+      "integrity": "sha512-vSYNSDe6Ix3q+6Z7ri9lyWqgGhJTmzRjZRqyq15N0Z/1/UnVsno9G/N40NBijoYx2seFDIl0+B2mgAb9mezUCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "18.3.31",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.31.tgz",
+      "integrity": "sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
+    },
+    "node_modules/@typescript/vfs": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/@typescript/vfs/-/vfs-1.6.4.tgz",
+      "integrity": "sha512-PJFXFS4ZJKiJ9Qiuix6Dz/OwEIqHD7Dme1UwZhTK11vR+5dqW2ACbdndWQexBzCx+CPuMe5WBYQWCsFyGlQLlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3"
+      },
+      "peerDependencies": {
+        "typescript": "*"
+      }
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.1.tgz",
+      "integrity": "sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==",
+      "license": "ISC"
+    },
+    "node_modules/@upsetjs/venn.js": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@upsetjs/venn.js/-/venn.js-2.0.0.tgz",
+      "integrity": "sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "d3-selection": "^3.0.0",
+        "d3-transition": "^3.0.1"
+      }
+    },
+    "node_modules/@xmldom/xmldom": {
+      "version": "0.9.10",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.10.tgz",
+      "integrity": "sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.6"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/arg": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
+      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+      "license": "MIT"
+    },
+    "node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/aria-hidden": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
+      "integrity": "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/array-iterate": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/array-iterate/-/array-iterate-2.0.1.tgz",
+      "integrity": "sha512-I1jXZMjAgCMmxT4qxXfPXa6SthSoE8h6gkSI9BGGNv8mP8G/v0blc+qFnZu6K42vTOiuME596QaLO0TP3Lk0xg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/astring": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/astring/-/astring-1.9.0.tgz",
+      "integrity": "sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==",
+      "license": "MIT",
+      "bin": {
+        "astring": "bin/astring"
+      }
+    },
+    "node_modules/bail": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+      "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/better-react-mathjax": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/better-react-mathjax/-/better-react-mathjax-2.3.0.tgz",
+      "integrity": "sha512-K0ceQC+jQmB+NLDogO5HCpqmYf18AU2FxDbLdduYgkHYWZApFggkHE4dIaXCV1NqeoscESYXXo1GSkY6fA295w==",
+      "license": "MIT",
+      "dependencies": {
+        "mathjax-full": "^3.2.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001799",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
+      "integrity": "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/character-entities": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-reference-invalid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
+      "integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/client-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
+      "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
+      "license": "MIT"
+    },
+    "node_modules/clipboardy": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/clipboardy/-/clipboardy-4.0.0.tgz",
+      "integrity": "sha512-5mOlNS0mhX0707P2I0aZ2V/cmHUEO/fL7VFLqszkhUsxt7RwnmrInf/eEQKlf5GzvYeHIjT+Ov1HRfNmymlG0w==",
+      "license": "MIT",
+      "dependencies": {
+        "execa": "^8.0.1",
+        "is-wsl": "^3.1.0",
+        "is64bit": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/collapse-white-space": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/collapse-white-space/-/collapse-white-space-2.1.0.tgz",
+      "integrity": "sha512-loKTxY1zCOuG4j9f6EPnuyyYkf58RnhhWTvRoZEokgB+WbdXehfjFviyOVYkqzEWz1Q5kRiZdBYS5SwxbQYwzw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/commander": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/compute-scroll-into-view": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-3.1.1.tgz",
+      "integrity": "sha512-VRhuHOLoKYOy4UbilLbUzbYg93XLjv2PncJC50EuTWPA3gaja1UjBsUP/D/9/juV3vQFr6XBEzn9KCAHdUvOHw==",
+      "license": "MIT"
+    },
+    "node_modules/cose-base": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/cose-base/-/cose-base-1.0.3.tgz",
+      "integrity": "sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg==",
+      "license": "MIT",
+      "dependencies": {
+        "layout-base": "^1.0.0"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "license": "MIT"
+    },
+    "node_modules/cytoscape": {
+      "version": "3.34.0",
+      "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.34.0.tgz",
+      "integrity": "sha512-62rNSrioXw93uliKFBwjukeQyeWwH2PqDrTac31r2P6464u3AUvTk0xS4LVvT251g7IgkFunrI48ZEZGjywSOg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/cytoscape-cose-bilkent": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cytoscape-cose-bilkent/-/cytoscape-cose-bilkent-4.1.0.tgz",
+      "integrity": "sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cose-base": "^1.0.0"
+      },
+      "peerDependencies": {
+        "cytoscape": "^3.2.0"
+      }
+    },
+    "node_modules/cytoscape-fcose": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cytoscape-fcose/-/cytoscape-fcose-2.2.0.tgz",
+      "integrity": "sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cose-base": "^2.2.0"
+      },
+      "peerDependencies": {
+        "cytoscape": "^3.2.0"
+      }
+    },
+    "node_modules/cytoscape-fcose/node_modules/cose-base": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cose-base/-/cose-base-2.2.0.tgz",
+      "integrity": "sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==",
+      "license": "MIT",
+      "dependencies": {
+        "layout-base": "^2.0.0"
+      }
+    },
+    "node_modules/cytoscape-fcose/node_modules/layout-base": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/layout-base/-/layout-base-2.0.1.tgz",
+      "integrity": "sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg==",
+      "license": "MIT"
+    },
+    "node_modules/d3": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/d3/-/d3-7.9.0.tgz",
+      "integrity": "sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "3",
+        "d3-axis": "3",
+        "d3-brush": "3",
+        "d3-chord": "3",
+        "d3-color": "3",
+        "d3-contour": "4",
+        "d3-delaunay": "6",
+        "d3-dispatch": "3",
+        "d3-drag": "3",
+        "d3-dsv": "3",
+        "d3-ease": "3",
+        "d3-fetch": "3",
+        "d3-force": "3",
+        "d3-format": "3",
+        "d3-geo": "3",
+        "d3-hierarchy": "3",
+        "d3-interpolate": "3",
+        "d3-path": "3",
+        "d3-polygon": "3",
+        "d3-quadtree": "3",
+        "d3-random": "3",
+        "d3-scale": "4",
+        "d3-scale-chromatic": "3",
+        "d3-selection": "3",
+        "d3-shape": "3",
+        "d3-time": "3",
+        "d3-time-format": "4",
+        "d3-timer": "3",
+        "d3-transition": "3",
+        "d3-zoom": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-axis": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-3.0.0.tgz",
+      "integrity": "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-brush": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-3.0.0.tgz",
+      "integrity": "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "3",
+        "d3-transition": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-chord": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-3.0.1.tgz",
+      "integrity": "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-contour": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-4.0.2.tgz",
+      "integrity": "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==",
+      "license": "ISC",
+      "dependencies": {
+        "delaunator": "5"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dsv": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-3.0.1.tgz",
+      "integrity": "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==",
+      "license": "ISC",
+      "dependencies": {
+        "commander": "7",
+        "iconv-lite": "0.6",
+        "rw": "1"
+      },
+      "bin": {
+        "csv2json": "bin/dsv2json.js",
+        "csv2tsv": "bin/dsv2dsv.js",
+        "dsv2dsv": "bin/dsv2dsv.js",
+        "dsv2json": "bin/dsv2json.js",
+        "json2csv": "bin/json2dsv.js",
+        "json2dsv": "bin/json2dsv.js",
+        "json2tsv": "bin/json2dsv.js",
+        "tsv2csv": "bin/dsv2dsv.js",
+        "tsv2json": "bin/dsv2json.js"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dsv/node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-fetch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-fetch/-/d3-fetch-3.0.1.tgz",
+      "integrity": "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dsv": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-force": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
+      "integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-quadtree": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-geo": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.1.tgz",
+      "integrity": "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.5.0 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-hierarchy": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
+      "integrity": "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-polygon": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-3.0.1.tgz",
+      "integrity": "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-quadtree": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
+      "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-random": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-random/-/d3-random-3.0.1.tgz",
+      "integrity": "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-sankey": {
+      "version": "0.12.3",
+      "resolved": "https://registry.npmjs.org/d3-sankey/-/d3-sankey-0.12.3.tgz",
+      "integrity": "sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-array": "1 - 2",
+        "d3-shape": "^1.2.0"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/d3-array": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
+      "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "internmap": "^1.0.0"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/d3-path": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
+      "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-sankey/node_modules/d3-shape": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
+      "integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-path": "1"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/internmap": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
+      "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==",
+      "license": "ISC"
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-interpolate": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/dagre-d3-es": {
+      "version": "7.0.14",
+      "resolved": "https://registry.npmjs.org/dagre-d3-es/-/dagre-d3-es-7.0.14.tgz",
+      "integrity": "sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg==",
+      "license": "MIT",
+      "dependencies": {
+        "d3": "^7.9.0",
+        "lodash-es": "^4.17.21"
+      }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.21",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.21.tgz",
+      "integrity": "sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==",
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decode-named-character-reference": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+      "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/delaunator": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.1.0.tgz",
+      "integrity": "sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==",
+      "license": "ISC",
+      "dependencies": {
+        "robust-predicates": "^3.0.2"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.11",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
+      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
+    },
+    "node_modules/emoji-regex-xs": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex-xs/-/emoji-regex-xs-1.0.0.tgz",
+      "integrity": "sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg==",
+      "license": "MIT"
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.48.1",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.48.1.tgz",
+      "integrity": "sha512-wfnXlwd5I75eXRtdD2vuEs50xHHESECDsGD7yiQnfFVNoa5522NwXEbmgo98LfiukSQHs+mBM7/YG3qKJB9/mQ==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
+    },
+    "node_modules/esast-util-from-estree": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/esast-util-from-estree/-/esast-util-from-estree-2.0.0.tgz",
+      "integrity": "sha512-4CyanoAudUSBAn5K13H4JhsMH6L9ZP7XbLVe/dKybkxMO7eDyLsT8UHl9TRNrU2Gr9nz+FovfSIjuXWJ81uVwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-visit": "^2.0.0",
+        "unist-util-position-from-estree": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/esast-util-from-js": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/esast-util-from-js/-/esast-util-from-js-2.0.1.tgz",
+      "integrity": "sha512-8Ja+rNJ0Lt56Pcf3TAmpBZjmx8ZcK5Ts4cAzIOjsjevg9oSXJnl6SUQ2EevU8tv3h6ZLWmoKL5H4fgWvdvfETw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "acorn": "^8.0.0",
+        "esast-util-from-estree": "^2.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/esm": {
+      "version": "3.2.25",
+      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
+      "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/estree-util-attach-comments": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-attach-comments/-/estree-util-attach-comments-3.0.0.tgz",
+      "integrity": "sha512-cKUwm/HUcTDsYh/9FgnuFqpfquUbwIqwKM26BVCGDPVgvaCl/nDCCjUfiLlx6lsEZ3Z4RFxNbOQ60pkaEwFxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/estree-util-build-jsx": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/estree-util-build-jsx/-/estree-util-build-jsx-3.0.1.tgz",
+      "integrity": "sha512-8U5eiL6BTrPxp/CHbs2yMgP8ftMhR5ww1eIKoWRMlqvltHF8fZn5LRDvTKuxD3DUn+shRbLGqXemcP51oFCsGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "estree-walker": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/estree-util-is-identifier-name": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-is-identifier-name/-/estree-util-is-identifier-name-3.0.0.tgz",
+      "integrity": "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/estree-util-scope": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-scope/-/estree-util-scope-1.0.0.tgz",
+      "integrity": "sha512-2CAASclonf+JFWBNJPndcOpA8EMJwa0Q8LUFJEKqXLW6+qBvbFZuF5gItbQOs/umBUkjviCSDCbBwU2cXbmrhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "devlop": "^1.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/estree-util-to-js": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-to-js/-/estree-util-to-js-2.0.0.tgz",
+      "integrity": "sha512-WDF+xj5rRWmD5tj6bIqRi6CkLIXbbNQUcxQHzGysQzvHmdYG2G7p/Tf0J0gpxGgkeMZNTIjT/AoSvC9Xehcgdg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "astring": "^1.8.0",
+        "source-map": "^0.7.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/estree-util-value-to-estree": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/estree-util-value-to-estree/-/estree-util-value-to-estree-3.5.0.tgz",
+      "integrity": "sha512-aMV56R27Gv3QmfmF1MY12GWkGzzeAezAX+UplqHVASfjc9wNzI/X6hC0S9oxq61WT4aQesLGslWP9tKk6ghRZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/remcohaszing"
+      }
+    },
+    "node_modules/estree-util-visit": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-visit/-/estree-util-visit-2.0.0.tgz",
+      "integrity": "sha512-m5KgiH85xAhhW8Wta0vShLcUvOsh3LLPI2YVwcbio1l7E09NTLL1EyMZFM1OyWowoH0skScNbhOPl4kcBgzTww==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/execa": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
+      "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^8.0.1",
+        "human-signals": "^5.0.0",
+        "is-stream": "^3.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^5.1.0",
+        "onetime": "^6.0.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.17"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
+    },
+    "node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
+      "license": "MIT",
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/fault": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fault/-/fault-2.0.1.tgz",
+      "integrity": "sha512-WtySTkS4OKev5JtpHXnib4Gxiurzh5NCGvWrFaZ34m6JehfTUhKZvn9njTfw48t6JumVQOmrKqpmGcdwxnhqBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "format": "^0.2.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/flexsearch": {
+      "version": "0.7.43",
+      "resolved": "https://registry.npmjs.org/flexsearch/-/flexsearch-0.7.43.tgz",
+      "integrity": "sha512-c5o/+Um8aqCSOXGcZoqZOm+NqtVwNsvVpWv6lfmSclU954O3wvQKxxK8zj74fPaSJbXpSLTs4PRhh+wnoCXnKg==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/format": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/format/-/format-0.2.2.tgz",
+      "integrity": "sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==",
+      "engines": {
+        "node": ">=0.4.x"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
+      "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/github-slugger": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-2.0.0.tgz",
+      "integrity": "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==",
+      "license": "ISC"
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC"
+    },
+    "node_modules/gray-matter": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-4.0.3.tgz",
+      "integrity": "sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-yaml": "^3.13.1",
+        "kind-of": "^6.0.2",
+        "section-matter": "^1.0.0",
+        "strip-bom-string": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
+    "node_modules/hachure-fill": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/hachure-fill/-/hachure-fill-0.5.2.tgz",
+      "integrity": "sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==",
+      "license": "MIT"
+    },
+    "node_modules/hast-util-from-dom": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-from-dom/-/hast-util-from-dom-5.0.1.tgz",
+      "integrity": "sha512-N+LqofjR2zuzTjCPzyDUdSshy4Ma6li7p/c3pA78uTwzFgENbgbUrm2ugwsOdcjI1muO+o6Dgzp9p8WHtn/39Q==",
+      "license": "ISC",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hastscript": "^9.0.0",
+        "web-namespaces": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-from-html": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hast-util-from-html/-/hast-util-from-html-2.0.3.tgz",
+      "integrity": "sha512-CUSRHXyKjzHov8yKsQjGOElXy/3EKpyX56ELnkHH34vDVw1N1XSQ1ZcAvTyAPtGqLTuKP/uxM+aLkSPqF/EtMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "devlop": "^1.1.0",
+        "hast-util-from-parse5": "^8.0.0",
+        "parse5": "^7.0.0",
+        "vfile": "^6.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-from-html-isomorphic": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-from-html-isomorphic/-/hast-util-from-html-isomorphic-2.0.0.tgz",
+      "integrity": "sha512-zJfpXq44yff2hmE0XmwEOzdWin5xwH+QIhMLOScpX91e/NSGPsAzNCvLQDIEPyO2TXi+lBmU6hjLIhV8MwP2kw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-from-dom": "^5.0.0",
+        "hast-util-from-html": "^2.0.0",
+        "unist-util-remove-position": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-from-parse5": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-8.0.3.tgz",
+      "integrity": "sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "devlop": "^1.0.0",
+        "hastscript": "^9.0.0",
+        "property-information": "^7.0.0",
+        "vfile": "^6.0.0",
+        "vfile-location": "^5.0.0",
+        "web-namespaces": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-is-element": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-3.0.0.tgz",
+      "integrity": "sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-parse-selector": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz",
+      "integrity": "sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-raw": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/hast-util-raw/-/hast-util-raw-9.1.0.tgz",
+      "integrity": "sha512-Y8/SBAHkZGoNkpzqqfCldijcuUKh7/su31kEBp67cFY09Wy0mTRgtsLYsiIxMJxlu0f6AA5SUTbDR8K0rxnbUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "hast-util-from-parse5": "^8.0.0",
+        "hast-util-to-parse5": "^8.0.0",
+        "html-void-elements": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "parse5": "^7.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0",
+        "web-namespaces": "^2.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-estree": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/hast-util-to-estree/-/hast-util-to-estree-3.1.3.tgz",
+      "integrity": "sha512-48+B/rJWAp0jamNbAAf9M7Uf//UVqAoMmgXhBdxTDJLGKY+LRnZ99qcG+Qjl5HfMpYNzS5v4EAwVEF34LeAj7w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-attach-comments": "^3.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "mdast-util-mdx-expression": "^2.0.0",
+        "mdast-util-mdx-jsx": "^3.0.0",
+        "mdast-util-mdxjs-esm": "^2.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "style-to-js": "^1.0.0",
+        "unist-util-position": "^5.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-html": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
+      "integrity": "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "html-void-elements": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "stringify-entities": "^4.0.0",
+        "zwitch": "^2.0.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-jsx-runtime": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
+      "integrity": "sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "mdast-util-mdx-expression": "^2.0.0",
+        "mdast-util-mdx-jsx": "^3.0.0",
+        "mdast-util-mdxjs-esm": "^2.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "style-to-js": "^1.0.0",
+        "unist-util-position": "^5.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-to-parse5/-/hast-util-to-parse5-8.0.1.tgz",
+      "integrity": "sha512-MlWT6Pjt4CG9lFCjiz4BH7l9wmrMkfkJYCxFwKQic8+RTZgWPuWxwAfjJElsXkex7DJjfSJsQIt931ilUgmwdA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "devlop": "^1.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "web-namespaces": "^2.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-string": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-to-string/-/hast-util-to-string-3.0.1.tgz",
+      "integrity": "sha512-XelQVTDWvqcl3axRfI0xSeoVKzyIFPwsAGSLIsKdJKQMXDYJS4WYrBNF/8J7RdhIcFI2BOHgAifggsvsxp/3+A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-text": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/hast-util-to-text/-/hast-util-to-text-4.0.2.tgz",
+      "integrity": "sha512-KK6y/BN8lbaq654j7JgBydev7wuNMcID54lkRav1P0CaE1e47P72AWWPiGKXTJU271ooYzcvTAn/Zt0REnvc7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "hast-util-is-element": "^3.0.0",
+        "unist-util-find-after": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hastscript": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-9.0.1.tgz",
+      "integrity": "sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-parse-selector": "^4.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/html-void-elements": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
+      "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/human-signals": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
+      "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=16.17.0"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/import-meta-resolve": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
+      "integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/inline-style-parser": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
+      "integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
+      "license": "MIT"
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/is-alphabetical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
+      "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-alphanumerical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
+      "integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-alphabetical": "^2.0.0",
+        "is-decimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-decimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
+      "integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-docker": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-hexadecimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
+      "integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-inside-container": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^3.0.0"
+      },
+      "bin": {
+        "is-inside-container": "cli.js"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-wsl": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
+      "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-inside-container": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is64bit": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is64bit/-/is64bit-2.0.0.tgz",
+      "integrity": "sha512-jv+8jaWCl0g2lSBkNSVXdzfBA0npK1HGC2KtWM9FumFRoGS94g3NbCCLVnCYHLjp4GrW2KZeeSTMo5ddtznmGw==",
+      "license": "MIT",
+      "dependencies": {
+        "system-architecture": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/katex": {
+      "version": "0.16.47",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.47.tgz",
+      "integrity": "sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==",
+      "funding": [
+        "https://opencollective.com/katex",
+        "https://github.com/sponsors/katex"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^8.3.0"
+      },
+      "bin": {
+        "katex": "cli.js"
+      }
+    },
+    "node_modules/khroma": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/khroma/-/khroma-2.1.0.tgz",
+      "integrity": "sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw=="
+    },
+    "node_modules/kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/layout-base": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/layout-base/-/layout-base-1.0.2.tgz",
+      "integrity": "sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash-es": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
+      "license": "MIT"
+    },
+    "node_modules/longest-streak": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+      "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/markdown-extensions": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-extensions/-/markdown-extensions-2.0.0.tgz",
+      "integrity": "sha512-o5vL7aDWatOTX8LzaS1WMoaoxIiLRQJuIKKe2wAw6IeULDHaqbiqiggmx+pKvZDb1Sj+pE46Sn1T7lCqfFtg1Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/markdown-table": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
+      "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/marked": {
+      "version": "16.4.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-16.4.2.tgz",
+      "integrity": "sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/mathjax-full": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/mathjax-full/-/mathjax-full-3.2.2.tgz",
+      "integrity": "sha512-+LfG9Fik+OuI8SLwsiR02IVdjcnRCy5MufYLi0C3TdMT56L/pjB0alMVGgoWJF8pN9Rc7FESycZB9BMNWIid5w==",
+      "deprecated": "Version 4 replaces this package with the scoped package @mathjax/src",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "esm": "^3.2.25",
+        "mhchemparser": "^4.1.0",
+        "mj-context-menu": "^0.6.1",
+        "speech-rule-engine": "^4.0.6"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
+      "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "escape-string-regexp": "^5.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-from-markdown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
+      "integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark": "^4.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-frontmatter": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-frontmatter/-/mdast-util-frontmatter-2.0.1.tgz",
+      "integrity": "sha512-LRqI9+wdgC25P0URIJY9vwocIzCcksduHQ9OF2joxQoyTNVduwLAFUzjoopuRJbJAReaKrNQKAZKL3uCMugWJA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "escape-string-regexp": "^5.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "micromark-extension-frontmatter": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
+      "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-gfm-autolink-literal": "^2.0.0",
+        "mdast-util-gfm-footnote": "^2.0.0",
+        "mdast-util-gfm-strikethrough": "^2.0.0",
+        "mdast-util-gfm-table": "^2.0.0",
+        "mdast-util-gfm-task-list-item": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-autolink-literal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
+      "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-find-and-replace": "^3.0.0",
+        "micromark-util-character": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-strikethrough": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
+      "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-table": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
+      "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "markdown-table": "^3.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-task-list-item": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
+      "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-math": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-math/-/mdast-util-math-3.0.0.tgz",
+      "integrity": "sha512-Tl9GBNeG/AhJnQM221bJR2HPvLOSnLE/T9cJI9tlc6zwQk2nPk/4f0cHkOdEixQPC/j8UtKDdITswvLAy1OZ1w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.1.0",
+        "unist-util-remove-position": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx/-/mdast-util-mdx-3.0.0.tgz",
+      "integrity": "sha512-JfbYLAW7XnYTTbUsmpu0kdBUVe+yKVJZBItEjwyYJiDJuZ9w4eeaqks4HQO+R7objWgS2ymV60GYpI14Ug554w==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-mdx-expression": "^2.0.0",
+        "mdast-util-mdx-jsx": "^3.0.0",
+        "mdast-util-mdxjs-esm": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-expression": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-expression/-/mdast-util-mdx-expression-2.0.1.tgz",
+      "integrity": "sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-jsx": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-3.2.0.tgz",
+      "integrity": "sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "parse-entities": "^4.0.0",
+        "stringify-entities": "^4.0.0",
+        "unist-util-stringify-position": "^4.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdxjs-esm": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdxjs-esm/-/mdast-util-mdxjs-esm-2.0.1.tgz",
+      "integrity": "sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-phrasing": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+      "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-hast": {
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-markdown": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+      "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "unist-util-visit": "^5.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+      "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "license": "MIT"
+    },
+    "node_modules/mermaid": {
+      "version": "11.15.0",
+      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.15.0.tgz",
+      "integrity": "sha512-pTMbcf3rWdtLiYGpmoTjHEpeY8seiy6sR+9nD7LOs8KfUbHE4lOUAprTRqRAcWSQ6MQpdX+YEsxShtGsINtPtw==",
+      "license": "MIT",
+      "dependencies": {
+        "@braintree/sanitize-url": "^7.1.1",
+        "@iconify/utils": "^3.0.2",
+        "@mermaid-js/parser": "^1.1.1",
+        "@types/d3": "^7.4.3",
+        "@upsetjs/venn.js": "^2.0.0",
+        "cytoscape": "^3.33.1",
+        "cytoscape-cose-bilkent": "^4.1.0",
+        "cytoscape-fcose": "^2.2.0",
+        "d3": "^7.9.0",
+        "d3-sankey": "^0.12.3",
+        "dagre-d3-es": "7.0.14",
+        "dayjs": "^1.11.19",
+        "dompurify": "^3.3.1",
+        "es-toolkit": "^1.45.1",
+        "katex": "^0.16.25",
+        "khroma": "^2.1.0",
+        "marked": "^16.3.0",
+        "roughjs": "^4.6.6",
+        "stylis": "^4.3.6",
+        "ts-dedent": "^2.2.0",
+        "uuid": "^11.1.0 || ^12 || ^13 || ^14.0.0"
+      }
+    },
+    "node_modules/mhchemparser": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/mhchemparser/-/mhchemparser-4.2.1.tgz",
+      "integrity": "sha512-kYmyrCirqJf3zZ9t/0wGgRZ4/ZJw//VwaRVGA75C4nhE60vtnIzhl9J9ndkX/h6hxSN7pjg/cE0VxbnNM+bnDQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/micromark": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+      "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-core-commonmark": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+      "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-destination": "^2.0.0",
+        "micromark-factory-label": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-title": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-html-tag-name": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-frontmatter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-frontmatter/-/micromark-extension-frontmatter-2.0.0.tgz",
+      "integrity": "sha512-C4AkuM3dA58cgZha7zVnuVxBhDsbttIMiytjgsM2XbHAB2faRVaHRle40558FBN+DJcrLNCoqG5mlrpdU4cRtg==",
+      "license": "MIT",
+      "dependencies": {
+        "fault": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
+      "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-extension-gfm-autolink-literal": "^2.0.0",
+        "micromark-extension-gfm-footnote": "^2.0.0",
+        "micromark-extension-gfm-strikethrough": "^2.0.0",
+        "micromark-extension-gfm-table": "^2.0.0",
+        "micromark-extension-gfm-tagfilter": "^2.0.0",
+        "micromark-extension-gfm-task-list-item": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-autolink-literal": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
+      "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-strikethrough": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
+      "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-table": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
+      "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-tagfilter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
+      "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-task-list-item": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
+      "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-math": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-math/-/micromark-extension-math-3.1.0.tgz",
+      "integrity": "sha512-lvEqd+fHjATVs+2v/8kg9i5Q0AP2k85H0WUOwpIVvUML8BapsMvh1XAogmQjOCsLpoKRCVQqEkQBB3NhVBcsOg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/katex": "^0.16.0",
+        "devlop": "^1.0.0",
+        "katex": "^0.16.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-mdx-expression": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-mdx-expression/-/micromark-extension-mdx-expression-3.0.1.tgz",
+      "integrity": "sha512-dD/ADLJ1AeMvSAKBwO22zG22N4ybhe7kFIZ3LsDI0GlsNr2A3KYxb0LdC1u5rj4Nw+CHKY0RVdnHX8vj8ejm4Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-mdx-expression": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-events-to-acorn": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-mdx-jsx": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-extension-mdx-jsx/-/micromark-extension-mdx-jsx-3.0.2.tgz",
+      "integrity": "sha512-e5+q1DjMh62LZAJOnDraSSbDMvGJ8x3cbjygy2qFEi7HCeUT4BDKCvMozPozcD6WmOt6sVvYDNBKhFSz3kjOVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "micromark-factory-mdx-expression": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-events-to-acorn": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-mdx-md": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-mdx-md/-/micromark-extension-mdx-md-2.0.0.tgz",
+      "integrity": "sha512-EpAiszsB3blw4Rpba7xTOUptcFeBFi+6PY8VnJ2hhimH+vCQDirWgsMpz7w1XcZE7LVrSAUGb9VJpG9ghlYvYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-mdxjs": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-mdxjs/-/micromark-extension-mdxjs-3.0.0.tgz",
+      "integrity": "sha512-A873fJfhnJ2siZyUrJ31l34Uqwy4xIFmvPY1oj+Ean5PHcPBYzEsvqvWGaWcfEIr11O5Dlw3p2y0tZWpKHDejQ==",
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.0.0",
+        "acorn-jsx": "^5.0.0",
+        "micromark-extension-mdx-expression": "^3.0.0",
+        "micromark-extension-mdx-jsx": "^3.0.0",
+        "micromark-extension-mdx-md": "^2.0.0",
+        "micromark-extension-mdxjs-esm": "^3.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-mdxjs-esm": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-mdxjs-esm/-/micromark-extension-mdxjs-esm-3.0.0.tgz",
+      "integrity": "sha512-DJFl4ZqkErRpq/dAPyeWp15tGrcrrJho1hKK5uBS70BCtfrIFg81sqcTVu3Ta+KD1Tk5vAtBNElWxtAa+m8K9A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-events-to-acorn": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-position-from-estree": "^2.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-factory-destination": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+      "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-label": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+      "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-mdx-expression": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-factory-mdx-expression/-/micromark-factory-mdx-expression-2.0.3.tgz",
+      "integrity": "sha512-kQnEtA3vzucU2BkrIa8/VaSAsP+EJ3CKOvhMuJgOEGg9KDC6OAY6nSnNDVRiVNRqj7Y4SlSzcStaH/5jge8JdQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-events-to-acorn": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-position-from-estree": "^2.0.0",
+        "vfile-message": "^4.0.0"
+      }
+    },
+    "node_modules/micromark-factory-space": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+      "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-title": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+      "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-whitespace": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+      "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-chunked": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+      "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-classify-character": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+      "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-combine-extensions": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+      "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-numeric-character-reference": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+      "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
+      "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-events-to-acorn": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-util-events-to-acorn/-/micromark-util-events-to-acorn-2.0.3.tgz",
+      "integrity": "sha512-jmsiEIiZ1n7X1Rr5k8wVExBQCg5jy4UXVADItHmNk1zkwEVhBuIUKRu3fqv+hs4nxLISi2DQGlqIOGiFxgbfHg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/unist": "^3.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-visit": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "vfile-message": "^4.0.0"
+      }
+    },
+    "node_modules/micromark-util-html-tag-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+      "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-normalize-identifier": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+      "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-resolve-all": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+      "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-subtokenize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+      "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/mimic-fn": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+      "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mj-context-menu": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/mj-context-menu/-/mj-context-menu-0.6.1.tgz",
+      "integrity": "sha512-7NO5s6n10TIV96d4g2uDpG7ZDpIhMh0QNfGdJw/W47JswFcosz457wqz/b5sAKvl12sxINGFCn80NZHKwxQEXA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.15",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
+      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/next": {
+      "version": "14.2.35",
+      "resolved": "https://registry.npmjs.org/next/-/next-14.2.35.tgz",
+      "integrity": "sha512-KhYd2Hjt/O1/1aZVX3dCwGXM1QmOV4eNM2UTacK5gipDdPN/oHHK/4oVGy7X8GMfPMsUTUEmGlsy0EY1YGAkig==",
+      "license": "MIT",
+      "dependencies": {
+        "@next/env": "14.2.35",
+        "@swc/helpers": "0.5.5",
+        "busboy": "1.6.0",
+        "caniuse-lite": "^1.0.30001579",
+        "graceful-fs": "^4.2.11",
+        "postcss": "8.4.31",
+        "styled-jsx": "5.1.1"
+      },
+      "bin": {
+        "next": "dist/bin/next"
+      },
+      "engines": {
+        "node": ">=18.17.0"
+      },
+      "optionalDependencies": {
+        "@next/swc-darwin-arm64": "14.2.33",
+        "@next/swc-darwin-x64": "14.2.33",
+        "@next/swc-linux-arm64-gnu": "14.2.33",
+        "@next/swc-linux-arm64-musl": "14.2.33",
+        "@next/swc-linux-x64-gnu": "14.2.33",
+        "@next/swc-linux-x64-musl": "14.2.33",
+        "@next/swc-win32-arm64-msvc": "14.2.33",
+        "@next/swc-win32-ia32-msvc": "14.2.33",
+        "@next/swc-win32-x64-msvc": "14.2.33"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.1.0",
+        "@playwright/test": "^1.41.2",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0",
+        "sass": "^1.3.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@playwright/test": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/next-themes": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.4.6.tgz",
+      "integrity": "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/nextra": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/nextra/-/nextra-3.3.1.tgz",
+      "integrity": "sha512-jiwj+LfUPHHeAxJAEqFuglxnbjFgzAOnDWFsjv7iv3BWiX8OksDwd3I2Sv3j2zba00iIBDEPdNeylfzTtTLZVg==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/intl-localematcher": "^0.5.4",
+        "@headlessui/react": "^2.1.2",
+        "@mdx-js/mdx": "^3.0.0",
+        "@mdx-js/react": "^3.0.0",
+        "@napi-rs/simple-git": "^0.1.9",
+        "@shikijs/twoslash": "^1.0.0",
+        "@theguild/remark-mermaid": "^0.1.3",
+        "@theguild/remark-npm2yarn": "^0.3.2",
+        "better-react-mathjax": "^2.0.3",
+        "clsx": "^2.0.0",
+        "estree-util-to-js": "^2.0.0",
+        "estree-util-value-to-estree": "^3.0.1",
+        "github-slugger": "^2.0.0",
+        "graceful-fs": "^4.2.11",
+        "gray-matter": "^4.0.3",
+        "hast-util-to-estree": "^3.1.0",
+        "katex": "^0.16.9",
+        "mdast-util-from-markdown": "^2.0.1",
+        "mdast-util-gfm": "^3.0.0",
+        "mdast-util-to-hast": "^13.2.0",
+        "negotiator": "^1.0.0",
+        "p-limit": "^6.0.0",
+        "react-medium-image-zoom": "^5.2.12",
+        "rehype-katex": "^7.0.0",
+        "rehype-pretty-code": "0.14.0",
+        "rehype-raw": "^7.0.0",
+        "remark-frontmatter": "^5.0.0",
+        "remark-gfm": "^4.0.0",
+        "remark-math": "^6.0.0",
+        "remark-reading-time": "^2.0.1",
+        "remark-smartypants": "^3.0.0",
+        "shiki": "^1.0.0",
+        "slash": "^5.1.0",
+        "title": "^4.0.0",
+        "unist-util-remove": "^4.0.0",
+        "unist-util-visit": "^5.0.0",
+        "yaml": "^2.3.2",
+        "zod": "^3.22.3",
+        "zod-validation-error": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "next": ">=13",
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
+    "node_modules/nextra-theme-docs": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/nextra-theme-docs/-/nextra-theme-docs-3.3.1.tgz",
+      "integrity": "sha512-P305m2UcW2IDyQhjrcAu0qpdPArikofinABslUCAyixYShsmcdDRUhIMd4QBHYru4gQuVjGWX9PhWZZCbNvzDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@headlessui/react": "^2.1.2",
+        "clsx": "^2.0.0",
+        "escape-string-regexp": "^5.0.0",
+        "flexsearch": "^0.7.43",
+        "next-themes": "^0.4.0",
+        "scroll-into-view-if-needed": "^3.1.0",
+        "zod": "^3.22.3"
+      },
+      "peerDependencies": {
+        "next": ">=13",
+        "nextra": "3.3.1",
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
+    "node_modules/nlcst-to-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/nlcst-to-string/-/nlcst-to-string-4.0.0.tgz",
+      "integrity": "sha512-YKLBCcUYKAg0FNlOBT6aI91qFmSiFKiluk655WzPF+DDMA02qIyy8uiRqI8QXtcFpEvll12LpL5MXqEmAZ+dcA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/nlcst": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/npm-run-path": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
+      "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npm-run-path/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npm-to-yarn": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/npm-to-yarn/-/npm-to-yarn-3.0.1.tgz",
+      "integrity": "sha512-tt6PvKu4WyzPwWUzy/hvPFqn+uwXO0K1ZHka8az3NnrhWJDmSqI8ncWq0fkL0k/lmmi5tAC11FXwXuh0rFbt1A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/nebrelbug/npm-to-yarn?sponsor=1"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+      "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/oniguruma-to-es": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-2.3.0.tgz",
+      "integrity": "sha512-bwALDxriqfKGfUufKGGepCzu9x7nJQuoRoAFp4AnwehhC2crqrDIAP/uN2qdlsAvSMpeRC3+Yzhqc7hLmle5+g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex-xs": "^1.0.0",
+        "regex": "^5.1.1",
+        "regex-recursion": "^5.1.1"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-6.2.0.tgz",
+      "integrity": "sha512-kuUqqHNUqoIWp/c467RI4X6mmyuojY5jGutNU0wVTmEOOfcuwLqyMVoAi9MKi2Ak+5i9+nhmrK4ufZE8069kHA==",
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/package-manager-detector": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.6.0.tgz",
+      "integrity": "sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==",
+      "license": "MIT"
+    },
+    "node_modules/parse-entities": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
+      "integrity": "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "character-entities-legacy": "^3.0.0",
+        "character-reference-invalid": "^2.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "is-alphanumerical": "^2.0.0",
+        "is-decimal": "^2.0.0",
+        "is-hexadecimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/parse-entities/node_modules/@types/unist": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+      "license": "MIT"
+    },
+    "node_modules/parse-latin": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/parse-latin/-/parse-latin-7.0.0.tgz",
+      "integrity": "sha512-mhHgobPPua5kZ98EF4HWiH167JWBfl4pvAIXXdbaVohtK7a6YBOy56kvhCqduqyo/f3yrHFWmqmiMg/BkBkYYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/nlcst": "^2.0.0",
+        "@types/unist": "^3.0.0",
+        "nlcst-to-string": "^4.0.0",
+        "unist-util-modify-children": "^4.0.0",
+        "unist-util-visit-children": "^3.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/parse-numeric-range": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/parse-numeric-range/-/parse-numeric-range-1.3.0.tgz",
+      "integrity": "sha512-twN+njEipszzlMJd4ONUYgSfZPDxgHhT9Ahed5uTigpQn90FggW4SA/AIPq/6a149fTbE9qBEcSwE3FAEp6wQQ==",
+      "license": "ISC"
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/path-data-parser": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/path-data-parser/-/path-data-parser-0.1.0.tgz",
+      "integrity": "sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==",
+      "license": "MIT"
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/points-on-curve": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/points-on-curve/-/points-on-curve-0.2.0.tgz",
+      "integrity": "sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A==",
+      "license": "MIT"
+    },
+    "node_modules/points-on-path": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/points-on-path/-/points-on-path-0.2.1.tgz",
+      "integrity": "sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==",
+      "license": "MIT",
+      "dependencies": {
+        "path-data-parser": "0.1.0",
+        "points-on-curve": "0.2.0"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.4.31",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
+      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.6",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.0.2"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/property-information": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.2.0.tgz",
+      "integrity": "sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-aria": {
+      "version": "3.50.0",
+      "resolved": "https://registry.npmjs.org/react-aria/-/react-aria-3.50.0.tgz",
+      "integrity": "sha512-S0Os6QZk33fzUAKu1QLT9afoUaCBt1ZNdoiq0n2YMVgKIdNIQS8zxiZ8O9hYE6QyDkHKjD6q39LQZ+qaSAIgjw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@internationalized/date": "^3.12.2",
+        "@internationalized/number": "^3.6.7",
+        "@internationalized/string": "^3.2.9",
+        "@react-types/shared": "^3.36.0",
+        "@swc/helpers": "^0.5.0",
+        "aria-hidden": "^1.2.3",
+        "clsx": "^2.0.0",
+        "react-stately": "3.48.0",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-medium-image-zoom": {
+      "version": "5.4.8",
+      "resolved": "https://registry.npmjs.org/react-medium-image-zoom/-/react-medium-image-zoom-5.4.8.tgz",
+      "integrity": "sha512-72CIldEUaPejjcaDOYIeDsGlWzNKpmxyKgiPi1LBCkWCIGHDLlA2KTeo2uNtmN/m72Y3k/2uWDfon9SDiPbHaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/rpearce"
+        }
+      ],
+      "license": "BSD-3-Clause",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/react-stately": {
+      "version": "3.48.0",
+      "resolved": "https://registry.npmjs.org/react-stately/-/react-stately-3.48.0.tgz",
+      "integrity": "sha512-ImicSAG+lTotAe5izcs1fz49Zk48w7pDusqYg04WaPhCoej8BJ24soMu3iLXIrsi273s4P1gZrYGrqReMfgEEA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@internationalized/date": "^3.12.2",
+        "@internationalized/number": "^3.6.7",
+        "@internationalized/string": "^3.2.9",
+        "@react-types/shared": "^3.36.0",
+        "@swc/helpers": "^0.5.0",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/reading-time": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/reading-time/-/reading-time-1.5.0.tgz",
+      "integrity": "sha512-onYyVhBNr4CmAxFsKS7bz+uTLRakypIe4R+5A824vBSkQy/hB3fZepoVEf8OVAxzLvK+H/jm9TzpI3ETSm64Kg==",
+      "license": "MIT"
+    },
+    "node_modules/recma-build-jsx": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/recma-build-jsx/-/recma-build-jsx-1.0.0.tgz",
+      "integrity": "sha512-8GtdyqaBcDfva+GUKDr3nev3VpKAhup1+RvkMvUxURHpW7QyIvk9F5wz7Vzo06CEMSilw6uArgRqhpiUcWp8ew==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "estree-util-build-jsx": "^3.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/recma-jsx": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/recma-jsx/-/recma-jsx-1.0.1.tgz",
+      "integrity": "sha512-huSIy7VU2Z5OLv6oFLosQGGDqPqdO1iq6bWNAdhzMxSJP7RAso4fCZ1cKu8j9YHCZf3TPrq4dw3okhrylgcd7w==",
+      "license": "MIT",
+      "dependencies": {
+        "acorn-jsx": "^5.0.0",
+        "estree-util-to-js": "^2.0.0",
+        "recma-parse": "^1.0.0",
+        "recma-stringify": "^1.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      },
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/recma-parse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/recma-parse/-/recma-parse-1.0.0.tgz",
+      "integrity": "sha512-OYLsIGBB5Y5wjnSnQW6t3Xg7q3fQ7FWbw/vcXtORTnyaSFscOtABg+7Pnz6YZ6c27fG1/aN8CjfwoUEUIdwqWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "esast-util-from-js": "^2.0.0",
+        "unified": "^11.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/recma-stringify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/recma-stringify/-/recma-stringify-1.0.0.tgz",
+      "integrity": "sha512-cjwII1MdIIVloKvC9ErQ+OgAtwHBmcZ0Bg4ciz78FtbT8In39aAYbaA7zvxQ61xVMSPE8WxhLwLbhif4Js2C+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "estree-util-to-js": "^2.0.0",
+        "unified": "^11.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/regex": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/regex/-/regex-5.1.1.tgz",
+      "integrity": "sha512-dN5I359AVGPnwzJm2jN1k0W9LPZ+ePvoOeVMMfqIMFz53sSwXkxaJoxr50ptnsC771lK95BnTrVSZxq0b9yCGw==",
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-recursion": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/regex-recursion/-/regex-recursion-5.1.1.tgz",
+      "integrity": "sha512-ae7SBCbzVNrIjgSbh7wMznPcQel1DNlDtzensnFxpiNpXt1U2ju/bHugH422r+4LAVS1FpW1YCwilmnNsjum9w==",
+      "license": "MIT",
+      "dependencies": {
+        "regex": "^5.1.1",
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-utilities": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/regex-utilities/-/regex-utilities-2.3.0.tgz",
+      "integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
+      "license": "MIT"
+    },
+    "node_modules/rehype-katex": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/rehype-katex/-/rehype-katex-7.0.1.tgz",
+      "integrity": "sha512-OiM2wrZ/wuhKkigASodFoo8wimG3H12LWQaH8qSPVJn9apWKFSH3YOCtbKpBorTVw/eI7cuT21XBbvwEswbIOA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/katex": "^0.16.0",
+        "hast-util-from-html-isomorphic": "^2.0.0",
+        "hast-util-to-text": "^4.0.0",
+        "katex": "^0.16.0",
+        "unist-util-visit-parents": "^6.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-parse": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/rehype-parse/-/rehype-parse-9.0.1.tgz",
+      "integrity": "sha512-ksCzCD0Fgfh7trPDxr2rSylbwq9iYDkSn8TCDmEJ49ljEUBxDVCzCHv7QNzZOfODanX4+bWQ4WZqLCRWYLfhag==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-from-html": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-pretty-code": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/rehype-pretty-code/-/rehype-pretty-code-0.14.0.tgz",
+      "integrity": "sha512-hBeKF/Wkkf3zyUS8lal9RCUuhypDWLQc+h9UrP9Pav25FUm/AQAVh4m5gdvJxh4Oz+U+xKvdsV01p1LdvsZTiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.4",
+        "hast-util-to-string": "^3.0.0",
+        "parse-numeric-range": "^1.3.0",
+        "rehype-parse": "^9.0.0",
+        "unified": "^11.0.5",
+        "unist-util-visit": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "shiki": "^1.3.0"
+      }
+    },
+    "node_modules/rehype-raw": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/rehype-raw/-/rehype-raw-7.0.0.tgz",
+      "integrity": "sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-raw": "^9.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-recma": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/rehype-recma/-/rehype-recma-1.0.0.tgz",
+      "integrity": "sha512-lqA4rGUf1JmacCNWWZx0Wv1dHqMwxzsDWYMTowuplHF3xH0N/MmrZ/G3BDZnzAkRmxDadujCjaKM2hqYdCBOGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "hast-util-to-estree": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-frontmatter": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/remark-frontmatter/-/remark-frontmatter-5.0.0.tgz",
+      "integrity": "sha512-XTFYvNASMe5iPN0719nPrdItC9aU0ssC4v14mH1BCi1u0n1gAocqcujWUrByftZTbLhRtiKRyjYTSIOcr69UVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-frontmatter": "^2.0.0",
+        "micromark-extension-frontmatter": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-gfm": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
+      "integrity": "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-gfm": "^3.0.0",
+        "micromark-extension-gfm": "^3.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-stringify": "^11.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-math": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/remark-math/-/remark-math-6.0.0.tgz",
+      "integrity": "sha512-MMqgnP74Igy+S3WwnhQ7kqGlEerTETXMvJhrUzDikVZ2/uogJCb+WHUg97hK9/jcfc0dkD73s3LN8zU49cTEtA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-math": "^3.0.0",
+        "micromark-extension-math": "^3.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-mdx": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/remark-mdx/-/remark-mdx-3.1.1.tgz",
+      "integrity": "sha512-Pjj2IYlUY3+D8x00UJsIOg5BEvfMyeI+2uLPn9VO9Wg4MEtN/VTIq2NEJQfde9PnX15KgtHyl9S0BcTnWrIuWg==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-mdx": "^3.0.0",
+        "micromark-extension-mdxjs": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-parse": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
+      "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-reading-time": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/remark-reading-time/-/remark-reading-time-2.1.0.tgz",
+      "integrity": "sha512-gBsJbQv87TUq4dRMSOgIX6P60Tk9ke8c29KsL7bccmsv2m9AycDfVu3ghRtrNpHLZU3TE5P/vImGOMSPzYU8rA==",
+      "license": "ISC",
+      "dependencies": {
+        "estree-util-is-identifier-name": "^3.0.0",
+        "estree-util-value-to-estree": "^3.3.3",
+        "reading-time": "^1.3.0",
+        "unist-util-visit": "^5.0.0"
+      }
+    },
+    "node_modules/remark-rehype": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.2.tgz",
+      "integrity": "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "unified": "^11.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-smartypants": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/remark-smartypants/-/remark-smartypants-3.0.2.tgz",
+      "integrity": "sha512-ILTWeOriIluwEvPjv67v7Blgrcx+LZOkAUVtKI3putuhlZm84FnqDORNXPPm+HY3NdZOMhyDwZ1E+eZB/Df5dA==",
+      "license": "MIT",
+      "dependencies": {
+        "retext": "^9.0.0",
+        "retext-smartypants": "^6.0.0",
+        "unified": "^11.0.4",
+        "unist-util-visit": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/remark-stringify": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
+      "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/retext": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/retext/-/retext-9.0.0.tgz",
+      "integrity": "sha512-sbMDcpHCNjvlheSgMfEcVrZko3cDzdbe1x/e7G66dFp0Ff7Mldvi2uv6JkJQzdRcvLYE8CA8Oe8siQx8ZOgTcA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/nlcst": "^2.0.0",
+        "retext-latin": "^4.0.0",
+        "retext-stringify": "^4.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/retext-latin": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/retext-latin/-/retext-latin-4.0.0.tgz",
+      "integrity": "sha512-hv9woG7Fy0M9IlRQloq/N6atV82NxLGveq+3H2WOi79dtIYWN8OaxogDm77f8YnVXJL2VD3bbqowu5E3EMhBYA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/nlcst": "^2.0.0",
+        "parse-latin": "^7.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/retext-smartypants": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/retext-smartypants/-/retext-smartypants-6.2.0.tgz",
+      "integrity": "sha512-kk0jOU7+zGv//kfjXEBjdIryL1Acl4i9XNkHxtM7Tm5lFiCog576fjNC9hjoR7LTKQ0DsPWy09JummSsH1uqfQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/nlcst": "^2.0.0",
+        "nlcst-to-string": "^4.0.0",
+        "unist-util-visit": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/retext-stringify": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/retext-stringify/-/retext-stringify-4.0.0.tgz",
+      "integrity": "sha512-rtfN/0o8kL1e+78+uxPTqu1Klt0yPzKuQ2BfWwwfgIUSayyzxpM1PJzkKt4V8803uB9qSy32MvI7Xep9khTpiA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/nlcst": "^2.0.0",
+        "nlcst-to-string": "^4.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/robust-predicates": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.3.tgz",
+      "integrity": "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==",
+      "license": "Unlicense"
+    },
+    "node_modules/roughjs": {
+      "version": "4.6.6",
+      "resolved": "https://registry.npmjs.org/roughjs/-/roughjs-4.6.6.tgz",
+      "integrity": "sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "hachure-fill": "^0.5.2",
+        "path-data-parser": "^0.1.0",
+        "points-on-curve": "^0.2.0",
+        "points-on-path": "^0.2.1"
+      }
+    },
+    "node_modules/rw": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
+      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/scroll-into-view-if-needed": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/scroll-into-view-if-needed/-/scroll-into-view-if-needed-3.1.0.tgz",
+      "integrity": "sha512-49oNpRjWRvnU8NyGVmUaYG4jtTkNonFZI86MmGRDqBphEK2EXT9gdEUoQPZhuBM8yWHxCWbobltqYO5M4XrUvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "compute-scroll-into-view": "^3.0.2"
+      }
+    },
+    "node_modules/section-matter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/section-matter/-/section-matter-1.0.0.tgz",
+      "integrity": "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==",
+      "license": "MIT",
+      "dependencies": {
+        "extend-shallow": "^2.0.1",
+        "kind-of": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shiki": {
+      "version": "1.29.2",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-1.29.2.tgz",
+      "integrity": "sha512-njXuliz/cP+67jU2hukkxCNuH1yUi4QfdZZY+sMr5PPrIyXSu5iTb/qYC4BiWWB0vZ+7TbdvYUCeL23zpwCfbg==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/core": "1.29.2",
+        "@shikijs/engine-javascript": "1.29.2",
+        "@shikijs/engine-oniguruma": "1.29.2",
+        "@shikijs/langs": "1.29.2",
+        "@shikijs/themes": "1.29.2",
+        "@shikijs/types": "1.29.2",
+        "@shikijs/vscode-textmate": "^10.0.1",
+        "@types/hast": "^3.0.4"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/slash": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
+      "integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
+      "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/speech-rule-engine": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/speech-rule-engine/-/speech-rule-engine-4.1.4.tgz",
+      "integrity": "sha512-i/VCLG1fvRc95pMHRqG4aQNscv+9aIsqA2oI7ZQS51sTdUcDHYX6cpT8/tqZ+enjs1tKVwbRBWgxut9SWn+f9g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@xmldom/xmldom": "0.9.10",
+        "commander": "13.1.0",
+        "wicked-good-xpath": "1.3.0"
+      },
+      "bin": {
+        "sre": "bin/sre"
+      }
+    },
+    "node_modules/speech-rule-engine/node_modules/commander": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
+      "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/strip-bom-string": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
+      "integrity": "sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/strip-final-newline": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+      "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/style-to-js": {
+      "version": "1.1.21",
+      "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
+      "integrity": "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "style-to-object": "1.0.14"
+      }
+    },
+    "node_modules/style-to-object": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.14.tgz",
+      "integrity": "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==",
+      "license": "MIT",
+      "dependencies": {
+        "inline-style-parser": "0.2.7"
+      }
+    },
+    "node_modules/styled-jsx": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.1.tgz",
+      "integrity": "sha512-pW7uC1l4mBZ8ugbiZrcIsiIvVx1UmTfw7UkC3Um2tmfUq9Bhk8IiyEIPl6F8agHgjzku6j0xQEZbfA5uSgSaCw==",
+      "license": "MIT",
+      "dependencies": {
+        "client-only": "0.0.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8.0 || 17.x.x || ^18.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "babel-plugin-macros": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/stylis": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.4.0.tgz",
+      "integrity": "sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA==",
+      "license": "MIT"
+    },
+    "node_modules/system-architecture": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/system-architecture/-/system-architecture-0.1.0.tgz",
+      "integrity": "sha512-ulAk51I9UVUyJgxlv9M6lFot2WP3e7t8Kz9+IS6D4rVba1tR9kON+Ey69f+1R4Q8cd45Lod6a4IcJIxnzGc/zA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/tabbable": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.5.0.tgz",
+      "integrity": "sha512-wieBHXygIm7OyQOu5hQlkk62/WyCFYGlWg7L6/ZCUZwx0o398Zkn4pVmMyfYhfMG8kGrj/Krt8eIk6UKC6VzwA==",
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/title": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/title/-/title-4.0.1.tgz",
+      "integrity": "sha512-xRnPkJx9nvE5MF6LkB5e8QJjE2FW8269wTu/LQdf7zZqBgPly0QJPf/CWAo7srj5so4yXfoLEdCFgurlpi47zg==",
+      "license": "MIT",
+      "dependencies": {
+        "arg": "^5.0.0",
+        "chalk": "^5.0.0",
+        "clipboardy": "^4.0.0"
+      },
+      "bin": {
+        "title": "dist/esm/bin.js"
+      }
+    },
+    "node_modules/trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/trough": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+      "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/ts-dedent": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-2.3.0.tgz",
+      "integrity": "sha512-JfJeIHke7y2egdGGgRAvpCwYFUsHlM2gPcrVOxFkznt/4uzQ7HFmvE63iFHVLBJNDuyDOQgijDK/tXH/f6Msjg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.10"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/twoslash": {
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/twoslash/-/twoslash-0.2.12.tgz",
+      "integrity": "sha512-tEHPASMqi7kqwfJbkk7hc/4EhlrKCSLcur+TcvYki3vhIfaRMXnXjaYFgXpoZRbT6GdprD4tGuVBEmTpUgLBsw==",
+      "license": "MIT",
+      "dependencies": {
+        "@typescript/vfs": "^1.6.0",
+        "twoslash-protocol": "0.2.12"
+      },
+      "peerDependencies": {
+        "typescript": "*"
+      }
+    },
+    "node_modules/twoslash-protocol": {
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/twoslash-protocol/-/twoslash-protocol-0.2.12.tgz",
+      "integrity": "sha512-5qZLXVYfZ9ABdjqbvPc4RWMr7PrpPaaDSeaYY55vl/w1j6H6kzsWK/urAEIXlzYlyrFmyz1UbwIt+AA0ck+wbg==",
+      "license": "MIT"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unified": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+      "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "bail": "^2.0.0",
+        "devlop": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-find-after": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-find-after/-/unist-util-find-after-5.0.0.tgz",
+      "integrity": "sha512-amQa0Ep2m6hE2g72AugUItjbuM8X8cGQnFoHk0pGfrFeT9GZhzN5SW8nRsiGKK7Aif4CrACPENkA6P/Lw6fHGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-modify-children": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-modify-children/-/unist-util-modify-children-4.0.0.tgz",
+      "integrity": "sha512-+tdN5fGNddvsQdIzUF3Xx82CU9sMM+fA0dLgR9vOmT0oPT2jH+P1nd5lSqfCfXAw+93NhcXNY2qqvTUtE4cQkw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "array-iterate": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position-from-estree": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position-from-estree/-/unist-util-position-from-estree-2.0.0.tgz",
+      "integrity": "sha512-KaFVRjoqLyF6YXCbVLNad/eS4+OfPQQn2yOd7zF/h5T/CSL2v8NpN6a5TPvtbXthAGw5nG+PuTtq+DdIZr+cRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-remove": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-remove/-/unist-util-remove-4.0.0.tgz",
+      "integrity": "sha512-b4gokeGId57UVRX/eVKej5gXqGlc9+trkORhFJpu9raqZkZhU0zm8Doi05+HaiBsMEIJowL+2WtQ5ItjsngPXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-remove-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-5.0.0.tgz",
+      "integrity": "sha512-Hp5Kh3wLxv0PHj9m2yZhhLt58KzPtEYKQQ4yxfYFEO7EvHwzyDYnduhHnY1mDxoqr7VUwVuHXk9RXKIiYS1N8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-visit": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-children": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-children/-/unist-util-visit-children-3.0.0.tgz",
+      "integrity": "sha512-RgmdTfSBOg04sdPcpTSD1jzoNBjt9a80/ZCzp5cI9n1qPzLZWF9YdvWGN2zmTumP1HWhXKdUWexjy/Wy/lJ7tA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz",
+      "integrity": "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
+      }
+    },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-location": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-5.0.3.tgz",
+      "integrity": "sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/web-namespaces": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
+      "integrity": "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wicked-good-xpath": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/wicked-good-xpath/-/wicked-good-xpath-1.3.0.tgz",
+      "integrity": "sha512-Gd9+TUn5nXdwj/hFsPVx5cuHHiF5Bwuc30jZ4+ronF1qHK5O7HD0sgmXWSEgwKquT3ClLoKPVbO6qGwVwLzvAw==",
+      "license": "MIT"
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.2.tgz",
+      "integrity": "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-validation-error": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/zod-validation-error/-/zod-validation-error-3.5.4.tgz",
+      "integrity": "sha512-+hEiRIiPobgyuFlEojnqjJnhFvg4r/i3cqgcm67eehZf/WBaK3g6cD02YU9mtdVxZjv8CzCA9n/Rhrs3yAAvAw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "zod": "^3.24.4"
+      }
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    }
+  }
+}

--- a/developer/package.json
+++ b/developer/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "hummytummy-developer-docs",
+  "private": true,
+  "version": "1.0.0",
+  "description": "HummyTummy documentation portal (developer.hummytummy.com)",
+  "scripts": {
+    "dev": "next dev -p 3200",
+    "build": "next build",
+    "start": "next start -p 3200"
+  },
+  "dependencies": {
+    "next": "^14.2.15",
+    "nextra": "^3.3.1",
+    "nextra-theme-docs": "^3.3.1",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "@types/node": "^20.14.0",
+    "@types/react": "^18.3.3",
+    "typescript": "^5.5.4"
+  }
+}

--- a/developer/pages/_app.tsx
+++ b/developer/pages/_app.tsx
@@ -1,0 +1,7 @@
+import type { AppProps } from 'next/app'
+import 'nextra-theme-docs/style.css'
+import '../styles/globals.css'
+
+export default function App({ Component, pageProps }: AppProps) {
+  return <Component {...pageProps} />
+}

--- a/developer/pages/en/_meta.ts
+++ b/developer/pages/en/_meta.ts
@@ -1,0 +1,10 @@
+export default {
+  "index": "Home",
+  "getting-started": "Getting Started",
+  "admin-guide": "Admin Guide",
+  "plans": "Plans",
+  "marketplace": "Marketplace",
+  "developer": "Developer / Integration",
+  "desktop": "Desktop App",
+  "reference": "Reference"
+}

--- a/developer/pages/en/admin-guide/_meta.ts
+++ b/developer/pages/en/admin-guide/_meta.ts
@@ -1,0 +1,3 @@
+export default {
+  "index": "Overview"
+}

--- a/developer/pages/en/admin-guide/_meta.ts
+++ b/developer/pages/en/admin-guide/_meta.ts
@@ -1,3 +1,15 @@
 export default {
-  "index": "Overview"
-}
+  "index": "Overview",
+  "pos": "POS (Sales Screen)",
+  "qr-menu": "QR Menu",
+  "kitchen": "Kitchen Display (KDS)",
+  "tables": "Tables & Floor Plan",
+  "orders": "Orders",
+  "stock": "Stock & Inventory",
+  "reports": "Reports & Analytics",
+  "reservations": "Reservations",
+  "personnel": "Personnel",
+  "customers": "Customers",
+  "branches": "Branches",
+  "settings": "Settings",
+};

--- a/developer/pages/en/admin-guide/branches.mdx
+++ b/developer/pages/en/admin-guide/branches.mdx
@@ -1,0 +1,58 @@
+---
+title: Branches
+description: HummyTummy multi-branch management — adding branches, usage/limit tracking, branch scope and the bridge/device/health screens. Purpose, usage and tips.
+---
+
+import { Callout } from 'nextra/components'
+
+# Branches
+
+**Menu path:** Multi-Branch → Branches &nbsp;•&nbsp; **URL:** `/admin/branches`
+**Access:** ADMIN, MANAGER
+**Plan:** `multiLocation` — **Professional (PRO)** and above (or the `extra_branch` add-on)
+
+## Purpose
+
+The Branches screen manages **all the branches in your restaurant chain** from one panel. Each branch has its own tables, menu, orders and reports; the manager switches between branches and sees the consolidated picture.
+
+<Callout type="info">
+  Multi-branch is unlocked on **Professional (PRO)** and higher plans. PRO gives **3
+  branches**, Enterprise (BUSINESS) gives **unlimited**. To add an extra branch without
+  moving up to PRO, you can buy the **`extra_branch`** marketplace add-on (each one raises
+  the branch limit). Full limits: **[Plans](/en/plans)**.
+</Callout>
+
+## What's on the screen
+
+- **Usage badge:** "X / Y branches" — how many branches you use and your limit. Unlimited shows as **∞**.
+- **Branch list:** each branch's name, code, timezone and **status** (active / suspended / archived).
+- **Add branch:** create a new branch with a name, code and timezone (default `Europe/Istanbul`). At the limit, adding is **locked** and an add-on prompt appears.
+
+## Branch scope
+
+HummyTummy filters every branch-scoped request by the active branch. Use the **branch picker (BranchPicker)** in the top bar to change the branch you're working on; screens like POS, tables, orders and stock then show that branch's data. Switching branches clears the cache — the previous branch's data can't bleed through.
+
+<Callout type="warning">
+  Some screens are **tenant-wide** (not tied to a branch): profile, subscription/plan,
+  billing, and so on. These screens are unaffected by the branch selection.
+</Callout>
+
+## Related screens in the same section
+
+The "Multi-Branch" menu also contains:
+
+- **Devices** (`/admin/devices`) — branch-bound POS/printer/screen devices. (Accessible on all plans.)
+- **Bridges** (`/admin/bridges`) — local hardware bridges. (Shown/hidden by `multiLocation`.)
+- **Health** (`/admin/health`) — system/branch health status. (On all plans.)
+
+## Tips
+
+- **Pick the timezone correctly:** reports and end-of-day (Z-report) closings are computed in the branch timezone — a wrong timezone shifts the end of day.
+- **Archive unused branches:** instead of deleting a closed/paused branch, change its status; historical data is preserved.
+- **Branch-level reporting:** use the branch filter on the Reports screen to compare branches; see which branch is strong on which product.
+
+## Related screens
+
+- **[Reports & Analytics](/en/admin-guide/reports)** — comparison via the branch filter.
+- **[Plans](/en/plans)** — branch limits and the `extra_branch` add-on.
+- **[Marketplace](/en/marketplace)** — extra branches and other add-ons.

--- a/developer/pages/en/admin-guide/customers.mdx
+++ b/developer/pages/en/admin-guide/customers.mdx
@@ -1,0 +1,41 @@
+---
+title: Customers
+description: HummyTummy customer management — add/edit customers, spend/order/loyalty-point summaries and the customer detail page. Purpose, usage and tips.
+---
+
+import { Callout } from 'nextra/components'
+
+# Customers
+
+**Menu path:** Business → Customers &nbsp;•&nbsp; **URL:** `/customers`
+**Access:** ADMIN, MANAGER, WAITER
+**Plan:** Available on all plans
+
+## Purpose
+
+The Customers screen holds your restaurant's **customer records** (CRM): name, email, phone, along with each customer's **total spend**, **total orders** and **loyalty points**. You recognize repeat guests and base your loyalty program on this data.
+
+## What's on the screen
+
+- **Summary stats:** total customers, total spend, total orders, total loyalty points.
+- **Search:** filter by name, email or phone.
+- **Customer list:** each row shows basic info + spend/orders/points; clicking a row takes you to the **customer detail page** (`/customers/:id`).
+- **Add / Edit / Delete:** a new-customer form, editing, and delete with a confirmation dialog.
+
+<Callout type="info">
+  Customer management is available on **all plans**. If a customer name/phone is entered
+  while taking an order in POS, it can be linked to the records; customers who self-pay
+  from the QR menu can also be matched by their phone number.
+</Callout>
+
+## Tips
+
+- **Enter the phone correctly:** loyalty points and matching to past orders usually run through the phone number — make entering the customer's phone in POS a habit.
+- **Find your most valuable customers:** sort the list by spend/orders to identify regulars, and target campaigns at them.
+- **Combine with analytics:** the **Customers** tab on the Reports screen gives per-period customer analytics; this screen shows the individual record, that tab shows aggregated behavior.
+
+## Related screens
+
+- **[POS](/en/admin-guide/pos)** — customer name/phone is entered on the order.
+- **[Reports & Analytics](/en/admin-guide/reports)** — Customer analytics tab.
+- **[QR Menu](/en/admin-guide/qr-menu)** — loyalty page (`/qr-menu/:tenantId/loyalty`).

--- a/developer/pages/en/admin-guide/index.mdx
+++ b/developer/pages/en/admin-guide/index.mdx
@@ -1,7 +1,71 @@
 ---
-title: Admin Guide
+title: Admin Guide — Overview
+description: Every screen in the HummyTummy admin panel — POS, QR menu, kitchen, tables, stock, reports and more. What each screen is for, how to use it, and which plan unlocks it.
 ---
+
+import { Callout, Cards } from 'nextra/components'
 
 # Admin Guide
 
-This section is being prepared.
+This section walks through the HummyTummy **admin panel** (the app you see after signing in), screen by screen. For each page it covers its **purpose**, **what you do there**, and day-to-day **tips**.
+
+Audience: the restaurant **owner (ADMIN)** and **manager (MANAGER)**. Some screens are also open to the waiter (WAITER) and kitchen (KITCHEN) roles; the top of each page states which roles can access it.
+
+<Callout type="info">
+  The currency is **Turkish Lira (TRY)**. The left sidebar groups screens into six
+  sections: **Business**, **Menu & Tables**, **Operations**, **Multi-Branch**,
+  **Marketplace** and **Settings & Access**. If a screen isn't included in your plan
+  it simply **doesn't appear** in the menu (you never get a 403) — it shows up
+  automatically once you upgrade.
+</Callout>
+
+## Screens
+
+<Cards>
+  <Cards.Card title="POS (Sales Screen)" href="/en/admin-guide/pos" arrow />
+  <Cards.Card title="QR Menu" href="/en/admin-guide/qr-menu" arrow />
+  <Cards.Card title="Kitchen Display (KDS)" href="/en/admin-guide/kitchen" arrow />
+  <Cards.Card title="Tables & Floor Plan" href="/en/admin-guide/tables" arrow />
+  <Cards.Card title="Orders" href="/en/admin-guide/orders" arrow />
+  <Cards.Card title="Stock & Inventory" href="/en/admin-guide/stock" arrow />
+  <Cards.Card title="Reports & Analytics" href="/en/admin-guide/reports" arrow />
+  <Cards.Card title="Reservations" href="/en/admin-guide/reservations" arrow />
+  <Cards.Card title="Personnel" href="/en/admin-guide/personnel" arrow />
+  <Cards.Card title="Customers" href="/en/admin-guide/customers" arrow />
+  <Cards.Card title="Branches" href="/en/admin-guide/branches" arrow />
+  <Cards.Card title="Settings" href="/en/admin-guide/settings" arrow />
+</Cards>
+
+## Which screen needs which plan?
+
+Each advanced screen is tied to a **plan feature flag**. The table below shows the lowest plan that unlocks it, and the alternative **marketplace add-on** that can unlock it on a lower plan.
+
+| Screen | Feature flag | Minimum plan | Add-on alternative |
+| --- | --- | --- | --- |
+| POS (Sales Screen) | `posAccess` | **Starter (BASIC)** | — |
+| Kitchen Display (KDS) | `kdsIntegration` | **All plans** | — |
+| QR Menu | — | **All plans** | — |
+| Tables & Floor Plan | — | **All plans** (limit varies by plan) | — |
+| Customers | — | **All plans** | — |
+| Stock & Inventory | `inventoryTracking` | **Starter (BASIC)** | — |
+| Reports | `advancedReports` | **Professional (PRO)** | `advanced_reports` |
+| Analytics | `advancedReports` | **Professional (PRO)** | `advanced_reports` |
+| Reservations | `reservationSystem` | **Professional (PRO)** | — |
+| Personnel | `personnelManagement` | **Professional (PRO)** | — |
+| Branches / Bridges | `multiLocation` | **Professional (PRO)** | `extra_branch` |
+| Custom Branding | `customBranding` | **Professional (PRO)** | — |
+| Integrations / Webhooks | `apiAccess` | **Enterprise (BUSINESS)** | `api_access` |
+| Partner Display API keys | `externalDisplay` | **Enterprise (BUSINESS)** | — |
+
+<Callout type="info">
+  For the full plan comparison, pricing and usage limits see **[Plans](/en/plans)**.
+  Integrations such as delivery (Yemeksepeti/Getir), SMS, e-Invoice and Caller ID are
+  unlocked via separate add-ons — see **[Marketplace](/en/marketplace)**.
+</Callout>
+
+<Callout type="warning">
+  The plan gate (FeatureGate) is a **presentation-only** guard — the real authorization
+  check always lives on the server. Even if you unhide a screen with a browser trick,
+  the backend (PlanFeatureGuard) rejects the unauthorized request. So "forcing open" a
+  module that isn't in your plan won't work; the right path is to upgrade the plan.
+</Callout>

--- a/developer/pages/en/admin-guide/index.mdx
+++ b/developer/pages/en/admin-guide/index.mdx
@@ -1,0 +1,7 @@
+---
+title: Admin Guide
+---
+
+# Admin Guide
+
+This section is being prepared.

--- a/developer/pages/en/admin-guide/kitchen.mdx
+++ b/developer/pages/en/admin-guide/kitchen.mdx
@@ -1,0 +1,70 @@
+---
+title: Kitchen Display (KDS)
+description: The HummyTummy kitchen display — orders arriving in real time, the three-column queue (pending / preparing / ready), kiosk mode and safe cancellation. Purpose, usage and tips.
+---
+
+import { Callout } from 'nextra/components'
+
+# Kitchen Display (KDS)
+
+**Menu path:** Business → Kitchen &nbsp;•&nbsp; **URL:** `/kitchen`
+**Access:** ADMIN, MANAGER, KITCHEN
+**Plan:** `kdsIntegration` — available on **all plans**
+
+## Purpose
+
+The KDS (Kitchen Display System) is where orders from the till or the QR menu **land in the kitchen in real time**. It replaces the paper ticket: the cook sees the order, starts preparing it, and marks it "ready" when done. All updates stream instantly over WebSocket — the moment the till writes an order, the kitchen sees it.
+
+<Callout type="info">
+  KDS is available on **all plans** (including the lowest, Starter). Unlike POS, it has
+  no separate plan gate.
+</Callout>
+
+## Screen layout
+
+The kitchen screen splits orders into columns by **three statuses**:
+
+| Column | Status | Meaning |
+| --- | --- | --- |
+| **Pending** | `PENDING` | Just arrived, prep not started |
+| **Preparing** | `PREPARING` | The cook has started |
+| **Ready** | `READY` | Done, waiting to be served/handed off |
+
+- **Desktop (≥1024px):** the three columns appear side by side.
+- **Tablet/phone:** they appear as three tabs, each showing that status's count.
+
+The **stats header** at the top shows the live state (connection status, order counts) and a **refresh** button. Each order card ages by **how long it has been waiting**; urgent (long-waiting) orders are highlighted with a **red alert dot** and surfaced on the tab badge.
+
+## Usage
+
+The cook advances an order to the next status with a single tap on the card:
+
+1. **Pending → Preparing** (start work)
+2. **Preparing → Ready** (ready to serve)
+
+Ready orders appear in the "awaiting payment" list on the till side and close out after they're served/paid.
+
+<Callout type="warning">
+  **Safe cancellation:** only an order in **Pending** can be cancelled, and the cancel
+  commits after a 5-second **undo** window. In that gap another station may have advanced
+  the order — when the system commits the cancel, it re-verifies the order is still
+  "Pending". If it isn't, it won't cancel (you get an "order is no longer pending"
+  warning). A cancellation **restores stock** server-side (line items return to inventory).
+</Callout>
+
+## Kiosk mode
+
+The kiosk toggle at the top turns the screen into a **full-screen, dark-themed** kitchen board — readable from a distance, with distracting UI hidden. If you've mounted a fixed screen/tablet in the kitchen, leave it in kiosk mode.
+
+## Connection drops and resilience
+
+- If the live connection (WebSocket) drops, the screen **auto-polls** roughly every 10 seconds to stay current; polling stops once the connection returns.
+- The last known orders stay on screen (the board **never blanks out** during a transient error).
+- If a fetch fails, a red **warning banner** appears showing the time of the last successful sync; one click refreshes.
+- On first open, before data has arrived, a **skeleton** is shown instead of empty columns — so "still loading" is never confused with "kitchen is empty".
+
+## Tips
+
+- Put a **dedicated screen/tablet** in the kitchen and turn on kiosk mode; define a user with the KITCHEN role (their access is limited to the kitchen screen + board).
+- The "urgent" red dot flags a long-waiting order — use it to prioritize during the rush.
+- If an order came in wrong (the customer changed their mind), cancel it **only while Pending**; once prep has started, manage it from the till.

--- a/developer/pages/en/admin-guide/orders.mdx
+++ b/developer/pages/en/admin-guide/orders.mdx
@@ -1,0 +1,76 @@
+---
+title: Orders
+description: The HummyTummy order lifecycle — statuses, order types, the QR-menu approval queue, waiter and bill requests. Where orders are managed and tips.
+---
+
+import { Callout } from 'nextra/components'
+
+# Orders
+
+**Where it's managed:** **[POS](/en/admin-guide/pos)** (`/pos`) and the **[Kitchen Display](/en/admin-guide/kitchen)** (`/kitchen`)
+**Access:** ADMIN, MANAGER, WAITER, KITCHEN (by role)
+**Plan:** Taking orders needs POS (`posAccess`, BASIC+); the kitchen flow is on all plans
+
+## Purpose
+
+HummyTummy has **no separate "Orders" page** — orders are managed where they're created and processed: inside **POS** and the **Kitchen Display (KDS)**. This page brings the order **lifecycle** and where orders surface in the app together in one place.
+
+## Order lifecycle (statuses)
+
+An order moves through these statuses:
+
+| Status | Meaning | Where it shows |
+| --- | --- | --- |
+| `PENDING_APPROVAL` | A QR-menu order **awaiting approval** | POS notification bar → "Pending orders" |
+| `PENDING` | Approved, **waiting** in the kitchen | Kitchen "Pending" column |
+| `PREPARING` | The cook is **preparing** it | Kitchen "Preparing" column |
+| `READY` | **Ready**, waiting to be served/paid | Kitchen "Ready" + POS "awaiting payment" |
+| `SERVED` | **Served**, awaiting payment | POS "awaiting payment" |
+| `PAID` | **Paid**, closed | Reports/Z-Report |
+| `CANCELLED` | **Cancelled** (stock is restored) | — |
+
+<Callout type="info">
+  The kitchen screen shows only the active queue (`PENDING`, `PREPARING`, `READY`).
+  `SERVED` and `PAID` orders are tracked at the till/in reports. A cancellation
+  (`CANCELLED`) is terminal and restores stock on the server.
+</Callout>
+
+## Order types
+
+| Type | Meaning |
+| --- | --- |
+| `DINE_IN` | Served at the table (dine-in) |
+| `TAKEAWAY` | Takeaway |
+| `DELIVERY` | Delivery to an address (delivery integration) |
+| `COUNTER` | Tableless self-pay / counter order (bucketed separately in the Z-report) |
+
+## QR-menu approval queue and requests
+
+The **live notification bar** at the top of the POS screen shows three queues in real time:
+
+- **Pending orders** — orders from the QR menu in `PENDING_APPROVAL`. Approving them from the panel sends them to the kitchen.
+- **Waiter calls** — "call the waiter" requests from tables.
+- **Bill requests** — "bring the bill" requests from tables.
+
+Each opens its own panel, where you act on them one by one. All of this streams instantly over WebSocket.
+
+## POS operations on orders
+
+- **Transfer table** — move an open order to another table.
+- **Merge tables** — combine multiple tables' orders onto one bill.
+- **Split bill** — split a bill by amount or by guest.
+- **Progressive (Dutch) payment** — collect each table's order in a merged group in turn.
+
+Details: **[POS](/en/admin-guide/pos)**.
+
+## Tips
+
+- **Don't forget to approve QR orders:** the counter on the "Pending orders" panel shows customer orders awaiting approval — watch the notification bar so none slips through during the rush.
+- **Cancellation is only safe while "Pending":** if the kitchen has started preparing, manage the order from the till; because cancellation restores stock, a wrong cancel corrupts both the bill and inventory.
+- **Sales history lives in reports:** for summaries of closed (`PAID`) orders, payment-method breakdown and daily/hourly distribution, see **[Reports](/en/admin-guide/reports)**.
+
+## Related screens
+
+- **[POS](/en/admin-guide/pos)** — taking orders, the approval queue, payment, table operations.
+- **[Kitchen Display (KDS)](/en/admin-guide/kitchen)** — order status flow.
+- **[Reports & Analytics](/en/admin-guide/reports)** — sales and order reports.

--- a/developer/pages/en/admin-guide/personnel.mdx
+++ b/developer/pages/en/admin-guide/personnel.mdx
@@ -1,0 +1,53 @@
+---
+title: Personnel
+description: HummyTummy personnel management — attendance, shift templates, scheduling and performance. How it differs from user management, its purpose and tips.
+---
+
+import { Callout } from 'nextra/components'
+
+# Personnel
+
+**Menu path:** Operations → Personnel &nbsp;•&nbsp; **URL:** `/admin/personnel`
+**Access:** ADMIN, MANAGER
+**Plan:** `personnelManagement` — **Professional (PRO)** and above
+
+## Purpose
+
+The personnel module manages your team's **working time**: who clocked in/out and when (attendance), shift templates, the weekly schedule, and performance. It updates in real time (over WebSocket) — when a staff member clocks in, the screen reflects it instantly.
+
+<Callout type="info">
+  The personnel module is unlocked on **Professional (PRO)** and higher plans. If your
+  plan doesn't include it, Personnel is hidden from the menu and the direct URL shows an
+  upgrade card.
+
+  **Personnel ≠ Users:** this module is for **working time/shifts**. To open a system
+  account (role, email, password), use the **Operations → Users** (`/admin/users`)
+  screen.
+</Callout>
+
+## Tabs
+
+| Tab | What it does |
+| --- | --- |
+| **Attendance** | Clock-in/out records — who worked and when |
+| **Shift Templates** | Define recurring shifts (e.g. "Morning 09:00–17:00") |
+| **Schedule** | Assign templates to people/days — the weekly plan |
+| **Performance** | Staff performance metrics |
+
+## Typical usage
+
+1. Define your **shift templates** (morning/evening, etc.).
+2. From the **schedule**, place templates onto people and days.
+3. Track real clock-ins/outs in the **Attendance** tab; compare plan vs. reality.
+4. See team productivity in the **Performance** tab.
+
+## Tips
+
+- **Create users first:** if a staff member has no system account (from the Users screen), tracking their shifts/attendance is pointless — define the user with their role first.
+- **Template = recurring work:** instead of entering the same shift by hand every week, set up a template and assign it with one click in the schedule.
+- **Combine performance with reports:** the **Staff** tab on the Reports screen (shown by the same `personnelManagement` flag) gives sales-based performance; read the two screens together.
+
+## Related screens
+
+- **Users** (`/admin/users`) — system accounts, role and status management (on all plans).
+- **[Reports & Analytics](/en/admin-guide/reports)** — Staff performance report tab.

--- a/developer/pages/en/admin-guide/pos.mdx
+++ b/developer/pages/en/admin-guide/pos.mdx
@@ -1,0 +1,100 @@
+---
+title: POS (Sales Screen)
+description: The HummyTummy sales screen — table selection, cart, payment, table transfer/merge, bill splitting and takeaway mode. Purpose, usage and tips.
+---
+
+import { Callout, Steps } from 'nextra/components'
+
+# POS (Sales Screen)
+
+**Menu path:** Business → POS &nbsp;•&nbsp; **URL:** `/pos`
+**Access:** ADMIN, MANAGER, WAITER
+**Plan:** `posAccess` — **Starter (BASIC)** and above
+
+## Purpose
+
+The POS is your restaurant's **point-of-sale screen**: it takes orders from seated guests or takeaway customers, sends them to the kitchen, and collects payment. The entire sales flow runs here — from picking a table to closing the bill.
+
+<Callout type="info">
+  POS is only unlocked on **Starter (BASIC)** and higher plans. If your plan doesn't
+  include it, POS is hidden from the sidebar and visiting `/pos` shows an upgrade card.
+  The Kitchen Display (KDS), by contrast, is available on all plans.
+</Callout>
+
+## How the screen works
+
+POS has two steps:
+
+<Steps>
+### Step 1 — Table Selection
+
+On open you get a grid of tables. Each table card shows its **status** by color: **free** (green), **occupied** (amber), **reserved** (gray). If a table has a pending order, a waiter call, or a bill request, a **notification badge** appears on the corner (order = clock, waiter = person, bill = receipt icon).
+
+Tapping a table opens its order screen. If the table is free, a new order starts; if it's occupied, its open order is loaded.
+
+### Step 2 — Order Screen
+
+The **menu** (products by category) is on the left, the **cart** on the right. Tapping a product adds it to the cart. For products with required options (e.g. "rare / medium / well done") an **options modal** opens first.
+
+In the cart you can: change quantity, remove a line, apply a **discount**, enter a **customer name** and an **order note**. Then you send the order to the kitchen and/or move to payment.
+</Steps>
+
+<Callout type="info">
+  **Takeaway mode:** if "Tableless mode" is enabled in POS settings, the table-selection
+  step is skipped and you land straight on the order screen — no table required.
+</Callout>
+
+## Single-step vs. two-step payment
+
+The **"Two-step checkout"** option in POS settings decides the flow:
+
+- **Single-step (default):** as soon as you hit "Pay", the order is created and the payment screen opens — ideal for a quick café/takeaway counter.
+- **Two-step:** first **"Create Order"** sends the order to the kitchen; after the guest has eaten you **"Proceed to Payment"** to collect. If customers order from the QR menu, two-step mode is required automatically.
+
+<Callout type="warning">
+  In two-step mode, if you add items or change the discount after the order was created,
+  the system **re-saves and re-prices** the order before payment. This prevents charging
+  the stale amount; the newly added items appear on both the bill and the kitchen ticket.
+</Callout>
+
+## Payment
+
+The **Pay** button opens the **Payment Modal**. You pick the payment method (cash, card, etc.) and, where needed, enter a transaction id and customer phone. After collecting:
+
+- If no other open order remains on the table, the table is **freed automatically** (the system re-checks the latest order list at payment time — preventing another guest from sitting on top of an unpaid bill).
+- On the desktop (Tauri) POS terminal with a default printer configured, the **receipt prints automatically**; on a print failure you get a one-tap reprint option.
+
+<Callout type="info">
+  Every payment request carries an **idempotency key**: a double-tap or a retry after a
+  network drop won't charge the same payment twice.
+</Callout>
+
+## Table operations
+
+From the cart toolbar on the order screen:
+
+- **Transfer Table** — move an open order to another table (if the target has an order, a merge is offered).
+- **Merge Tables** — combine adjacent parties onto one bill; un-merge any time (single or all).
+- **Split Bill** — split a bill by amount or by guest.
+- **Progressive (Dutch) Payment** — collect each table's open order in a merged group separately, one at a time.
+
+## Live notification bar
+
+The notification bar at the top shows three queues live (over WebSocket):
+
+- **Pending orders** — orders that came in from the QR menu and are awaiting approval.
+- **Waiter calls** — "call the waiter" requests from tables.
+- **Bill requests** — "bring the bill" requests from tables.
+
+Tapping any of them opens the matching panel, where you act on them one by one.
+
+## Tips
+
+- **The cart isn't lost:** an in-progress order is persisted in the browser (for 12 hours) — if the tab closes by accident, your data survives.
+- **Tapping a reserved table:** if the system auto-held the table for an upcoming reservation, tapping it opens a dialog with the booking details and a one-tap **seat the guest**. If a table was marked reserved by hand with no booking, an unlock dialog appears instead.
+- **Tablet use:** a landscape tablet (≥768px) gets the desktop-style side-by-side menu+cart layout; on a phone the cart drops into a bottom drawer.
+- **Discount safety:** the discount can't exceed the subtotal; if you remove items but leave the discount, the system trims it automatically (no negative totals).
+
+## Related settings
+
+You manage POS behavior under **Settings → POS** and **Settings → QR Menu**: tableless mode, two-step checkout, customer self-pay (PayTR), the "served before payment" rule, product images and the default map view. Details: **[Settings](/en/admin-guide/settings)**.

--- a/developer/pages/en/admin-guide/qr-menu.mdx
+++ b/developer/pages/en/admin-guide/qr-menu.mdx
@@ -1,0 +1,72 @@
+---
+title: QR Menu (Management + Settings)
+description: HummyTummy QR menu management — generating/downloading/printing QR codes, the design editor and customer-ordering settings. Purpose, usage and tips.
+---
+
+import { Callout, Steps } from 'nextra/components'
+
+# QR Menu
+
+**Menu path:** Menu & Tables → QR Codes &nbsp;•&nbsp; **URL:** `/admin/qr-codes`
+**Access:** ADMIN, MANAGER
+**Plan:** Available on all plans
+
+## Purpose
+
+The QR Menu lets a customer **scan the QR code** at the table and view your menu on their phone — and, depending on settings, **place an order and pay**. On the admin side this screen does two jobs: **generate, download and print** your QR codes, and configure how the QR menu **looks**.
+
+<Callout type="info">
+  Customer-facing QR menu addresses:
+  - **Table/tenant QR:** `/qr-menu/:tenantId` (includes the cart, order-tracking and loyalty pages)
+  - **Subdomain access:** the same menu also opens via your own subdomain.
+  These pages are public; customers use them without signing in.
+</Callout>
+
+## Two tabs
+
+### 1. Codes
+
+Your QR codes are listed here. Each code has a **type** (e.g. `TABLE`) and a label.
+
+- **Download All** — downloads every code as an individual PNG (filed by restaurant name + table label).
+- **Print Table QRs** — opens the `TABLE`-type codes on a single printable sheet.
+
+### 2. Design
+
+The **design editor** lets you customize how the QR menu looks: colors, logo and visual layout. A preview shows the result instantly.
+
+## Customer-ordering settings
+
+The QR menu's **behavior** is managed separately, under **Settings → QR Menu** (`/admin/settings/qr-menu`):
+
+<Steps>
+### Enable customer ordering
+
+When **"Customer ordering"** is on, customers can submit orders from the menu; when off, the QR menu is **view-only** (orders are taken at the till).
+
+### Two-step checkout is enabled automatically
+
+Turning on customer ordering also auto-enables **two-step checkout** — because a customer's order must first reach the kitchen and be paid afterward.
+
+### Location and social/WiFi info
+
+You also enter the **location**, **WiFi** and **social media** details shown on the QR menu page here.
+</Steps>
+
+<Callout type="warning">
+  Customer self-pay (paying from the table via PayTR) is a separate POS setting. When
+  enabled, the customer can pay their own bill from the QR menu. This feature operates in
+  **TRY**.
+</Callout>
+
+## Tips
+
+- **A separate QR per table:** table-type QRs create table-bound orders — the order is written to that table automatically, so the waiter doesn't have to pick a table.
+- **When printing:** use "Print Table QRs" to print them all at once and stick them on the tables; even if the menu changes the QR stays the same (the menu loads dynamically, no need to reprint).
+- **Want a view-only menu?** Turn customer ordering off; the QR menu then behaves like a digital menu card.
+- **Order tracking:** after ordering, the customer can watch their order's status (preparing/ready) live at `/qr-menu/:tenantId/orders`.
+
+## Related screens
+
+- Menu content (categories, products, images, modifiers) is managed under **Menu & Tables → Menu** (`/admin/menu`) — the products shown in the QR menu come from there.
+- For branding (logo/colors): **[Settings](/en/admin-guide/settings)** (Branding tab, `customBranding` — PRO and above).

--- a/developer/pages/en/admin-guide/reports.mdx
+++ b/developer/pages/en/admin-guide/reports.mdx
@@ -1,0 +1,71 @@
+---
+title: Reports & Analytics
+description: HummyTummy reporting — sales, hourly, customers, inventory, staff and Z-reports; plus analytics with table utilization and AI insights. Purpose, usage and tips.
+---
+
+import { Callout } from 'nextra/components'
+
+# Reports & Analytics
+
+**Menu path:** Operations → Reports / Analytics
+**URL:** `/admin/reports` and `/admin/analytics`
+**Access:** ADMIN, MANAGER
+**Plan:** `advancedReports` — **Professional (PRO)** and above (or the `advanced_reports` add-on)
+
+## Purpose
+
+Both screens turn your business data into something readable:
+
+- **Reports** — sales, payment-method breakdown, top-selling products, customers, inventory, staff and **Z-reports**.
+- **Analytics** — table utilization, traffic/congestion analysis, customer behavior and **AI-powered insights**.
+
+<Callout type="info">
+  Both screens are tied to the `advancedReports` feature (**PRO and above**). To unlock
+  them without moving up to PRO, you can buy the **`advanced_reports`** marketplace
+  add-on. If your plan doesn't include it, both menu items are hidden and the direct URL
+  shows an upgrade card.
+</Callout>
+
+## Reports screen
+
+There are tabs at the top, plus a **date-range filter** (start–end) and, for multi-branch tenants, a **branch filter** (single-branch tenants don't see the branch filter; the report stays tenant-wide).
+
+| Tab | Contents | Visibility |
+| --- | --- | --- |
+| **Sales** | Total revenue, order count, average ticket, total discount; payment-method breakdown; daily sales; top-selling products | Always |
+| **Hourly** | Order distribution by hour of day | Always |
+| **Customers** | Customer analytics (per period) | Always |
+| **Inventory** | Stock report | Only if `inventoryTracking` is granted |
+| **Staff** | Staff performance | Only if `personnelManagement` is granted |
+| **Z-Reports** | End-of-day fiscal summaries (Z-reports) | Always |
+
+<Callout type="info">
+  The Inventory and Staff tabs depend on extra features — without them the **tab is
+  hidden** (it used to 403 on click). Sales/Hourly/Customers/Z-Report come with the
+  `advancedReports` that unlocks the page itself.
+</Callout>
+
+## Analytics screen
+
+| Tab | Contents |
+| --- | --- |
+| **Overview** | Average table utilization, period revenue, congestion score, active-insight count + actionable insights |
+| **Table Analytics** | Per-table utilization, revenue, session count, average ticket; underutilized tables |
+| **Traffic Flow** | Congestion score, hotspots and recommendations to improve flow |
+| **Customer Behavior** | Average dining time, idle time at the table, party size; peak arrival/departure hours |
+| **AI Insights** | All generated insights; you can mark each as "implemented / in progress / dismissed" |
+
+## Tips
+
+- **Keep the date range tight:** the default is the last 7 days; change the range and hit "Apply" to compare periods.
+- **Use the branch filter:** if you run multiple branches, compare per branch; leaving the filter empty covers all branches.
+- **Z-reports for end of day:** for tax/accounting compliance, track end-of-day closings from the Z-Reports tab.
+- **Work the AI insights:** marking analytics insights as "implemented/dismissed" keeps the list clean and shows which suggestion was actually tried.
+- **Idle table = lost turnover:** if "Customer Behavior" flags high idle time, presenting the bill proactively improves table turnover.
+
+## Related screens
+
+- **[Tables](/en/admin-guide/tables)** — the source of table-utilization analysis.
+- **[Stock](/en/admin-guide/stock)** — Inventory report tab.
+- **[Personnel](/en/admin-guide/personnel)** — Staff performance tab.
+- For invoices: **Operations → Invoices** (`/admin/invoices`).

--- a/developer/pages/en/admin-guide/reservations.mdx
+++ b/developer/pages/en/admin-guide/reservations.mdx
@@ -1,0 +1,79 @@
+---
+title: Reservations
+description: HummyTummy reservation management — confirming/rejecting incoming bookings, assigning tables, seating, no-shows and settings. Purpose, usage and tips.
+---
+
+import { Callout } from 'nextra/components'
+
+# Reservations
+
+**Menu path:** Menu & Tables → Reservations &nbsp;•&nbsp; **URL:** `/admin/reservations`
+**Access:** ADMIN, MANAGER
+**Plan:** `reservationSystem` — **Professional (PRO)** and above
+
+## Purpose
+
+The reservations screen manages table bookings — taken online (via the public reservation page) or by hand: you confirm them, assign tables, seat guests, and flag no-shows.
+
+<Callout type="info">
+  The reservation system is unlocked on **Professional (PRO)** and higher plans. If your
+  plan doesn't include it, Reservations is hidden from the menu and the direct URL shows
+  an upgrade card.
+
+  **Public (customer-facing) reservation pages:** `/reserve/:tenantId` (new reservation)
+  and `/reserve/:tenantId/lookup` (look up a reservation). Customers use them without
+  signing in.
+</Callout>
+
+## What's on the screen
+
+- **Date picker** — view a specific day's reservations (default: today).
+- **Status tabs** — All / Pending / Confirmed / Seated / Completed / Cancelled.
+- **Search** — filter by customer name/phone.
+- **Stats** — summary counts for the selected day.
+- **List + pagination** — each row shows the customer, time, party size, table and status; clicking a row opens the detail modal.
+
+## Reservation statuses and flow
+
+| Status | Meaning |
+| --- | --- |
+| `PENDING` | Waiting — needs approval |
+| `CONFIRMED` | Confirmed |
+| `SEATED` | Guest seated |
+| `COMPLETED` | Completed |
+| `REJECTED` | Rejected |
+| `CANCELLED` | Cancelled |
+| `NO_SHOW` | Didn't show |
+
+Typical flow: **Pending → Confirm → (on the day) Seat → Complete.** Flag no-shows as **No-show** and cancelled bookings as **Cancelled**. The confirm/reject/cancel/no-show actions are protected by a **confirmation dialog**.
+
+## Detail modal
+
+Clicking a reservation lets you:
+
+- **Assign a table** — bind a table to the reservation (shown in the table).
+- **Admin note** — add an internal note (not visible to the customer).
+
+## Integration with table auto-hold
+
+A confirmed reservation can automatically hold its table as **Reserved** as the start time approaches (governed by the "hold offset" in settings). When a waiter taps that table in POS, they get a dialog with the booking details and can **seat the guest with one tap** (the table moves to Occupied, the reservation to SEATED).
+
+## Settings
+
+Under **Settings → Reservations** (`/admin/settings/reservations`):
+
+- **Enabled/disabled** — turn reservation intake on/off.
+- **Require approval** — should incoming reservations auto-confirm, or be confirmed by hand?
+- **Time settings** — slot interval (15/30/60 min), minimum/maximum advance booking, default duration, table-hold offset (min).
+- **Capacity** — concurrent reservation capacity.
+
+## Tips
+
+- **Stop spam with "require approval":** instead of auto-confirming every online reservation, confirming by hand catches fake/duplicate bookings.
+- **Assign the table early:** binding the table at confirmation means auto-hold reserves the right table and the waiter can seat with one tap in POS.
+- **Flag no-shows:** mark no-shows as No-show; this both releases the held table and feeds future customer-behavior analytics.
+
+## Related screens
+
+- **[Tables](/en/admin-guide/tables)** — table holding and statuses.
+- **[POS](/en/admin-guide/pos)** — the seat dialog when tapping a reserved table.

--- a/developer/pages/en/admin-guide/settings.mdx
+++ b/developer/pages/en/admin-guide/settings.mdx
@@ -1,0 +1,72 @@
+---
+title: Settings
+description: The HummyTummy settings screen — POS, QR menu, reports, branding, integrations, webhooks, partner keys, reservation, SMS, online orders and accounting tabs; plus Plan & Access and the Desktop App.
+---
+
+import { Callout } from 'nextra/components'
+
+# Settings
+
+**Menu path:** Settings & Access → Settings &nbsp;•&nbsp; **URL:** `/admin/settings`
+**Access:** ADMIN, MANAGER
+**Plan:** Core tabs on all plans; advanced tabs depend on plan/add-on
+
+## Purpose
+
+Settings is the hub where you configure your restaurant's **behavior** and **integrations**. It has a left sub-menu (tabs); each tab manages one module's settings. If a tab isn't in your plan/add-ons it is **hidden** — visiting its URL directly shows an upgrade card.
+
+<Callout type="info">
+  Most settings are **saved automatically** (the moment you change them); success/failure
+  is shown via a toast. The "Settings & Access" section also has two standalone screens
+  next to Settings: **Plan & Access** and the **Desktop App** (below).
+</Callout>
+
+## Settings tabs
+
+| Tab | URL | What it configures | Requirement |
+| --- | --- | --- | --- |
+| **POS** | `/admin/settings/pos` | Tableless mode, two-step checkout, the "served before payment" rule, customer self-pay (PayTR), product images, default map view (2D/3D) | All plans |
+| **QR Menu** | `/admin/settings/qr-menu` | Customer ordering on/off, two-step checkout, location/WiFi/social info | All plans |
+| **Reports** | `/admin/settings/reports` | Report preferences | All plans |
+| **Branding** | `/admin/settings/branding` | Logo, colors, custom-brand look | `customBranding` — PRO+ |
+| **Integrations** | `/admin/settings/integrations` | API access settings | `apiAccess` — BUSINESS (or `api_access`) |
+| **Webhooks** | `/admin/settings/webhooks` | Event webhooks | `apiAccess` — BUSINESS (or `api_access`) |
+| **Partner Keys** | `/admin/settings/partner-keys` | API key for third-party screens/apps (Partner Display) | `externalDisplay` — BUSINESS |
+| **Reservation** | `/admin/settings/reservations` | Reservation rules (approval, slot, capacity) | `reservationSystem` — PRO+ |
+| **SMS** | `/admin/settings/sms` | SMS integration | `sms` integration add-on |
+| **Online Orders** | `/admin/settings/online-orders` | Delivery platforms (Yemeksepeti/Getir, etc.) | `deliveryIntegration` — PRO+ (or `delivery_*`) |
+| **Accounting** | `/admin/settings/accounting` | e-Invoice/accounting integration | `accounting` integration add-on |
+
+<Callout type="warning">
+  **The Subscription tab was removed.** Billing and plan changes now live on the top-level
+  **Plan & Access** page; the old `/admin/settings/subscription` URL redirects there.
+</Callout>
+
+## Other screens in "Settings & Access"
+
+### Plan & Access
+
+**URL:** `/admin/plan` — your current plan, your usage quotas (users/tables/branches/products/orders) and your active add-ons on one page. Changing plans, billing history, cancellation/reactivation start here. For plan selection and upgrades see **[Plans](/en/plans)**.
+
+### Desktop App
+
+**URL:** `/admin/desktop` — download and setup for the desktop (Tauri) POS terminal. Receipt-printer/hardware integration runs in the desktop app.
+
+### Branch-scoped integration screens
+
+Some integrations have their own full screens (they appear once you've bought the add-on):
+
+- **e-Invoice Recovery** (`/admin/fiscal-recovery`) — `fiscal` integration add-on.
+- **Caller ID Feed** (`/admin/caller-feed`) — `caller` integration add-on.
+
+## Tips
+
+- **POS + QR menu settings are linked:** enabling customer ordering auto-enables two-step checkout; manage it from the QR menu settings (you can't turn off two-step checkout from POS while customer ordering is on).
+- **Buy the integration from the marketplace first:** tabs like SMS/e-Invoice/Delivery/Caller don't appear until the matching add-on is bought — see **[Marketplace](/en/marketplace)**.
+- **Auto-save error:** if a setting didn't save, an error toast appears; most tabs retry with one click.
+
+## Related screens
+
+- **[Plans](/en/plans)** — plan/limit/price and Plan & Access.
+- **[Marketplace](/en/marketplace)** — integration and capacity add-ons.
+- **[Developer / Integration](/en/developer)** — API, webhook and Partner Display details.

--- a/developer/pages/en/admin-guide/stock.mdx
+++ b/developer/pages/en/admin-guide/stock.mdx
@@ -1,0 +1,57 @@
+---
+title: Stock & Inventory
+description: HummyTummy stock management — ingredients, recipes, suppliers, purchase orders, movements, waste and stock counts. Purpose, usage and tips.
+---
+
+import { Callout } from 'nextra/components'
+
+# Stock & Inventory
+
+**Menu path:** Operations → Stock &nbsp;•&nbsp; **URL:** `/admin/stock`
+**Access:** ADMIN, MANAGER
+**Plan:** `inventoryTracking` — **Starter (BASIC)** and above
+
+## Purpose
+
+The stock module tracks your kitchen ingredients (inventory) end to end: how much you have, what's running out, what's wasted, and the automatic drawdown from sales. Thanks to recipes, when a product is sold its ingredients can be deducted from stock automatically.
+
+<Callout type="info">
+  Inventory tracking is unlocked on **Starter (BASIC)** and higher plans. If your plan
+  doesn't include it, Stock is hidden from the sidebar and `/admin/stock` shows an
+  upgrade card.
+</Callout>
+
+## Tabs
+
+The screen is split into tabs, each a part of stock management:
+
+| Tab | What it does |
+| --- | --- |
+| **Dashboard** | Stock-status summary — low/critical levels, at-a-glance view |
+| **Ingredients** | Define stock items — unit, current quantity, critical threshold |
+| **Recipes** | Define how much of which ingredient a product contains |
+| **Suppliers** | Supplier records |
+| **Purchase Orders** | Create an order to a supplier, receive incoming goods into stock |
+| **Movements** | A log of every stock in/out movement |
+| **Waste Log** | Spoilage/waste records |
+| **Stock Count** | Physical counting and reconciliation with the system |
+
+## A typical workflow
+
+1. **Define ingredients** — flour, beef, milk, etc.; enter their unit and critical thresholds.
+2. **Attach recipes** — e.g. "Cheeseburger = 1 patty + 1 bun + 30g cheese". Now sales deduct ingredients automatically.
+3. **Supplier + purchasing** — define the supplier, add incoming goods to stock via a purchase order.
+4. **Waste & count** — record spoilage in the waste log; reconcile the system with a periodic physical count.
+5. **Track movements** — every in/out is auditable in the Movements tab.
+
+## Tips
+
+- **Set critical thresholds:** give each ingredient a critical level; the Dashboard surfaces low stock so you don't miss reorder time.
+- **Recipes are the key to auto-drawdown:** without a recipe, a sale won't reduce stock automatically — you'd have to enter a manual movement. Always define recipes for your best-sellers.
+- **Cancellation returns stock:** if a `PENDING` order is cancelled in the kitchen, stock is restored. So when answering "why is this short/over" during a count, account for cancellations too.
+- **Stock report:** the **Inventory** tab on the Reports screen (shown/hidden by the same `inventoryTracking` flag) gives you stock analysis.
+
+## Related screens
+
+- **[Menu](/en/admin-guide/qr-menu)** — recipes attach to products; the product definition lives in menu management.
+- **[Reports & Analytics](/en/admin-guide/reports)** — Inventory report tab.

--- a/developer/pages/en/admin-guide/tables.mdx
+++ b/developer/pages/en/admin-guide/tables.mdx
@@ -1,0 +1,57 @@
+---
+title: Tables & Floor Plan
+description: HummyTummy table management — add/edit/delete tables, capacity, one-tap status changes, occupancy stats and plan limits. Purpose, usage and tips.
+---
+
+import { Callout } from 'nextra/components'
+
+# Tables & Floor Plan
+
+**Menu path:** Menu & Tables → Tables &nbsp;•&nbsp; **URL:** `/admin/tables`
+**Access:** ADMIN, MANAGER
+**Plan:** Available on all plans (table count **depends on plan**)
+
+## Purpose
+
+This screen defines your restaurant's **tables** and manages their status. The tables you add are used in the POS table grid as well as in the QR menu and reservation flows.
+
+## What's on the screen
+
+- **Stats strip at the top:** total tables, **free**, **occupied**, **reserved** counts and a live **occupancy percentage** (share of seated tables).
+- **Table card grid:** each card shows the table number, status (colored badge), capacity and action buttons.
+- **Plan-limit banner:** warns you as you approach your plan's table limit; once the limit is reached "Add Table" is locked and an upgrade prompt appears.
+
+## Table statuses
+
+| Status | Color | Meaning |
+| --- | --- | --- |
+| **Free** (`AVAILABLE`) | Green | Available |
+| **Occupied** (`OCCUPIED`) | Red/Amber | Guest seated |
+| **Reserved** (`RESERVED`) | Gray/Amber | Reserved |
+
+## Usage
+
+- **Add / edit a table:** "Add Table" asks for the number, capacity and starting status. Editing an existing table (pencil icon) opens the same form.
+- **One-tap status:** each card has a **Free / Occupied / Reserved** segmented control — flip the table's status instantly without opening a modal.
+- **Delete:** the trash icon opens a confirmation dialog. If the table is **occupied** or has an **upcoming reservation**, the dialog warns you (so you don't orphan a seated guest / a booked slot).
+- **Upcoming-reservation badge:** if a confirmed/pending reservation starts soon (within ~2 hours), the card shows the time + customer name — staff can see at a glance which table has an incoming guest.
+
+<Callout type="info">
+  **The table limit depends on the plan:** Starter (BASIC) **20 tables**, Professional
+  (PRO) **50 tables**, Enterprise (BUSINESS) **unlimited**. Once at the limit you can't
+  add a new table; upgrade the plan or delete unused tables. For exact limits see
+  **[Plans](/en/plans)**.
+</Callout>
+
+## Tips
+
+- **Watch the occupancy percentage:** during peak hours the occupancy rate in the stats strip is a good capacity-planning signal; combine it with the "table utilization" report in Analytics.
+- **You can change status from POS too:** taking an order in POS auto-marks the table "occupied", and collecting payment auto-marks it "free". The one-tap control on this screen is for manual fixes without an order (e.g. cleaning / holding as reserved).
+- **Reserved by hand vs. automatic:** if you mark a table "Reserved" by hand (with no reservation record), a waiter tapping that table in POS gets an unlock dialog. Real reservations are managed from the **Reservations** screen.
+- **Before deleting:** deleting an occupied/reserved table may affect an active session or a booking — read the warning.
+
+## Related screens
+
+- **[POS](/en/admin-guide/pos)** — table selection, transfer, merge and bill splitting happen here.
+- **[Reservations](/en/admin-guide/reservations)** — table-based reservations and auto-hold (PRO).
+- **[Reports & Analytics](/en/admin-guide/reports)** — table utilization/occupancy analysis.

--- a/developer/pages/en/desktop/_meta.ts
+++ b/developer/pages/en/desktop/_meta.ts
@@ -1,0 +1,3 @@
+export default {
+  "index": "Overview"
+}

--- a/developer/pages/en/desktop/_meta.ts
+++ b/developer/pages/en/desktop/_meta.ts
@@ -1,3 +1,7 @@
 export default {
-  "index": "Overview"
+  "index": "Overview",
+  "install": "Install & download",
+  "auto-update": "Auto-update",
+  "hardware": "Hardware pairing",
+  "kds-mode": "KDS / kiosk mode"
 }

--- a/developer/pages/en/desktop/auto-update.mdx
+++ b/developer/pages/en/desktop/auto-update.mdx
@@ -1,0 +1,139 @@
+---
+title: Auto-update
+description: How the Tauri updater works with the HummyTummy server — the /api/desktop/updates endpoint, manifest format, minisign signature verification and version comparison.
+---
+
+import { Callout, Steps } from 'nextra/components'
+
+# Auto-update
+
+The desktop app uses the [Tauri updater](https://tauri.app) to fetch new versions from
+the server's release catalog on its own. The flow is fully server-controlled: the app
+reports the platform it runs on and its current version, and the server returns a
+**signed** update manifest if an upgradable release exists.
+
+## The updater endpoint
+
+```
+GET /api/desktop/updates/:platform/:currentVersion
+```
+
+| Parameter | Description | Example |
+| --- | --- | --- |
+| `:platform` | The platform key Tauri reports | `windows-x86_64` |
+| `:currentVersion` | The app's current version | `0.2.5` or `v0.2.5` |
+
+Valid platform keys: `windows-x86_64`, `darwin-aarch64`, `darwin-x86_64`,
+`linux-x86_64`. This endpoint is public and rate-limited to **60 requests/min**.
+
+<Callout type="info">
+  `:platform` must match `^[a-z0-9-]{1,32}$`; `:currentVersion` must match
+  `^v?\d+\.\d+\.\d+$` — otherwise the endpoint returns `400 Bad Request`.
+</Callout>
+
+## Responses
+
+- **Update available** → `200` with the manifest below.
+- **No update / not applicable** → the body is `null`. Tauri treats this as "up to date".
+  `null` is returned when:
+  - the current version equals or is newer than the latest published release,
+  - there is no published release,
+  - the requested platform is not present in the latest release (no URL, or unsigned).
+
+### Manifest format
+
+```json
+{
+  "version": "0.2.7",
+  "notes": "## What's New\n- Feature X",
+  "pub_date": "2026-06-20T15:00:00.000Z",
+  "platforms": {
+    "windows-x86_64": {
+      "url": "https://github.com/.../HummyTummy-POS_0.2.7_x64.msi",
+      "signature": "dW50cnVzdGVkIGNvbW1lbnQ6..."
+    },
+    "darwin-aarch64": { "url": "...", "signature": "..." },
+    "darwin-x86_64":  { "url": "...", "signature": "..." },
+    "linux-x86_64":   { "url": "...", "signature": "..." }
+  }
+}
+```
+
+The `platforms` object only includes platforms that have **both a URL and a valid
+signature** (see the security note below). The `notes` field is the release's
+`releaseNotes` text, and `pub_date` is the publication date in ISO format.
+
+## Version comparison
+
+The server compares versions as numeric semver: it splits the `major.minor.patch` parts,
+strips a leading `v` prefix, and compares numerically. An update is offered only when the
+latest published version is **strictly greater than** the supplied `currentVersion`; if
+equal or lower, it returns `null`.
+
+<Callout type="warning">
+  The comparison considers numeric parts only; **pre-release tags** (such as
+  `1.0.0-beta.1`) are not supported. Since the release catalog is operator/CI-controlled,
+  this is sufficient — published versions are always kept in plain `major.minor.patch`
+  form.
+</Callout>
+
+## Signature verification (security)
+
+The Tauri updater installs a binary only if its **minisign signature** verifies against a
+pinned public key. The server behaves to preserve that contract:
+
+- If a platform **has a URL but no signature** (empty/missing), that platform is **not
+  added** to the manifest — it is treated as not-installable and a warning is logged on
+  the server. A half-populated, unsigned entry is never emitted.
+- If a platform **has no URL** (the release was not built for that platform), it is
+  silently skipped.
+- If the requested platform ends up absent from `platforms`, the endpoint returns `null`.
+
+This guarantees the auto-updater never receives an unsigned (and therefore unverifiable)
+binary.
+
+<Callout type="warning">
+  The release catalog is a **platform-level** global list, and every restaurant's desktop
+  updater pulls from it. For that reason the management endpoints (create / publish /
+  delete) are accessible only with **SuperAdmin** or the **CI API key**; tenant admins
+  cannot modify the catalog. Otherwise a single tenant could swap the binary that every
+  restaurant's updater fetches.
+</Callout>
+
+## End-to-end flow
+
+<Steps>
+### The app queries on launch
+
+The Tauri updater hits the configured update endpoint with its platform and current
+version:
+
+```bash
+curl https://app.hummytummy.com/api/desktop/updates/windows-x86_64/0.2.5
+```
+
+### The server returns a manifest
+
+If a newer, signed release exists the manifest above is returned; otherwise `null`.
+
+### Tauri verifies the signature and installs
+
+The updater verifies the manifest's `signature` against the pinned public key, downloads
+the binary from `url`, and installs it if verification succeeds. If verification fails,
+no installation occurs.
+
+### (Optional) Report the download
+
+The client may increment the download counter for analytics:
+
+```bash
+curl -X POST https://app.hummytummy.com/api/desktop/releases/0.2.7/download/windows-x86_64
+```
+</Steps>
+
+<Callout type="info">
+  Which endpoint and which public key the updater uses are defined in the desktop app's
+  Tauri configuration (the updater block in `tauri.conf.json`). The server contract above
+  (manifest format, mandatory signature, version comparison) holds regardless of that
+  client configuration.
+</Callout>

--- a/developer/pages/en/desktop/hardware.mdx
+++ b/developer/pages/en/desktop/hardware.mdx
@@ -1,0 +1,257 @@
+---
+title: Hardware pairing
+description: Pair receipt printers, cash drawers and fiscal registers via device-mesh — the pair-code flow, device token, command queue and security rules.
+---
+
+import { Callout, Steps, Tabs } from 'nextra/components'
+
+# Hardware: printer, cash drawer, fiscal register
+
+Local hardware is managed through the **device-mesh** module. An admin creates a **device
+slot** from the panel; that slot shows a 6-character **pair code** on screen. The device
+(or the local bridge that drives the devices — `local_bridge`) enters that code to pair
+and receives a long-lived **device token** in return. From then on the server dispatches
+commands to the device — print a receipt, open the drawer, issue a fiscal receipt —
+through a **command queue**.
+
+All endpoints live under `/api/v1/devices/...`.
+
+## Device kinds
+
+The `kind` field is one value from a closed set:
+
+| `kind` | Description |
+| --- | --- |
+| `receipt_printer` | Receipt printer |
+| `kitchen_printer` | Kitchen printer |
+| `yazarkasa` | Fiscal register (mali / fiscal device) |
+| `pos_terminal` | Card payment terminal |
+| `kds_screen` / `bar_screen` | Kitchen / bar display |
+| `tablet_waiter` / `tablet_customer` | Waiter / customer tablet |
+| `caller_id` | Caller-ID device |
+| `scanner` | Barcode scanner |
+| `local_bridge` | Local bridge agent that drives multiple devices |
+
+The `capabilities` field is an array of free-form tags (max 32 items, each ≤ 64 chars) —
+e.g. a bridge that carries fiscal + printer + cash-drawer capabilities.
+
+## Two authorization surfaces
+
+device-mesh hosts two distinct surfaces in one controller:
+
+- **Admin (user session / Bearer JWT)** — tenant admins manage devices. The `ADMIN` or
+  `MANAGER` role is required. These routes are **branch-scoped** (`X-Branch-Id`).
+- **Device side (device token)** — the device itself talks here. It uses the
+  `Authorization: Device <token>` header (deliberately not `Bearer`, so HTTP
+  intermediaries that strip `Bearer` for user sessions do not clobber device auth).
+
+## Pairing flow
+
+<Steps>
+### An admin creates a device slot
+
+```bash
+curl -X POST https://app.hummytummy.com/api/v1/devices \
+  -H "Authorization: Bearer $JWT" \
+  -H "X-Branch-Id: $BRANCH_ID" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "kind": "receipt_printer",
+    "capabilities": ["escpos", "80mm"],
+    "model": "Epson TM-T20III",
+    "ownership": "byo"
+  }'
+```
+
+The response includes the **pair code** to show on screen:
+
+```json
+{
+  "id": "01J...",
+  "tenantId": "01J...",
+  "branchId": "01J...",
+  "kind": "receipt_printer",
+  "status": "unprovisioned",
+  "pairCode": "A4F9K2",
+  "pairCodeExpiresAt": "2026-06-22T10:10:00.000Z"
+}
+```
+
+<Callout type="info">
+  `branchId` is required. Because the route is branch-scoped, the server resolves it from
+  the `X-Branch-Id` header; you may also pass `branchId` in the body to set it explicitly.
+  The `ownership` field is one of `sold` / `rented` / `byo` (default `byo`).
+</Callout>
+
+### The device pairs with the pair code
+
+The device (or the `local_bridge` agent) reads the on-screen code and pairs:
+
+```bash
+curl -X POST https://app.hummytummy.com/api/v1/devices/pair \
+  -H "Content-Type: application/json" \
+  -d '{
+    "pairCode": "A4F9K2",
+    "model": "Epson TM-T20III",
+    "capabilities": ["escpos", "80mm"]
+  }'
+```
+
+The response contains the raw token, returned **exactly once**:
+
+```json
+{
+  "deviceId": "01J...",
+  "tenantId": "01J...",
+  "branchId": "01J...",
+  "kind": "receipt_printer",
+  "token": "018f....base64url",
+  "tokenExpiresAt": "2026-06-23T10:05:00.000Z",
+  "capabilities": ["escpos", "80mm"]
+}
+```
+
+### The device stores the token and sends heartbeats
+
+From now on the token is sent on every request in the `Authorization: Device <token>`
+header. The device sends regular **heartbeats** to stay online:
+
+```bash
+curl -X POST https://app.hummytummy.com/api/v1/devices/heartbeat \
+  -H "Authorization: Device $DEVICE_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{ "batteryPct": 100, "agentVersion": "1.0.0", "queueDepth": 0 }'
+```
+</Steps>
+
+### Notes on the pairing rules
+
+<Callout type="warning">
+  - **Pair code TTL** defaults to **10 minutes** (`DEVICE_PAIR_CODE_TTL_MS`). An expired
+    code is atomically cleared on first use and returns "Pair code expired — request a new
+    one".
+  - **Device token TTL** defaults to **24 hours** (`DEVICE_TOKEN_TTL_MS`). Tokens are
+    stored as a sha256 hash on the server; the raw token is never persisted and is
+    returned only once, at pair time.
+  - The `/pair` endpoint is rate-limited to **5 requests/min/IP** — making brute force of
+    the 6-character code (`[A-Z0-9]`, ~2.2 billion combinations) meaningless within the
+    TTL window.
+  - The pair code is **single-use**: if two devices enter the same code milliseconds
+    apart, the atomic claim (updateMany) only succeeds for the first; the second gets
+    "Pair code already claimed by another device or expired".
+</Callout>
+
+## Device statuses
+
+```
+unprovisioned → (slot created, awaiting code)
+paired        → (first pair, no heartbeat yet)
+online        → (within the heartbeat window)
+offline       → (no heartbeat for ~45s)
+retired       → (admin retired it; token revoked)
+```
+
+The heartbeat window is **45s**; a background sweeper (cron) flips online devices that
+exceed it to `offline`.
+
+## Command queue
+
+An admin drives hardware by sending commands to a device. Commands are held in a
+per-device FIFO + priority queue; the device pulls the next command via `next-command`,
+executes it, and reports the outcome via `ack`.
+
+### Command kinds (`kind`)
+
+| `kind` | Hardware action |
+| --- | --- |
+| `print_receipt` | Print a customer receipt |
+| `open_drawer` | Open the cash drawer |
+| `fiscal_receipt` | Issue a fiscal receipt on the register |
+| `fiscal_cancel` | Cancel a fiscal receipt (fiscal void) |
+| `charge_card` | Start a charge on the card terminal |
+| `show_order` / `clear_order` | Show / clear an order on screen |
+| `reboot` / `firmware_update` | Reboot the device / update firmware |
+| `capability_probe` / `noop` | Probe capabilities / no-op |
+
+### Sending a command (admin)
+
+```bash
+curl -X POST https://app.hummytummy.com/api/v1/devices/$DEVICE_ID/commands \
+  -H "Authorization: Bearer $JWT" \
+  -H "X-Branch-Id: $BRANCH_ID" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "kind": "print_receipt",
+    "payload": { "orderId": "01J...", "copies": 1 },
+    "priority": 0,
+    "idempotencyKey": "order-01J-receipt"
+  }'
+```
+
+- `kind` must be one of the closed set above; free-form aliases (such as `charge.card`)
+  are rejected with `400`.
+- `payload` must be an object (JSONB); `priority` is 0–1000 (0 default, higher = first).
+- If `idempotencyKey` is supplied, the command is deduplicated on `(deviceId,
+  idempotencyKey)`; resending returns the same command (no duplicate is created). **Always**
+  send a stable key when retrying.
+
+### Device side: claiming and acking
+
+```bash
+# Atomically claim the next command (returns null if none)
+curl https://app.hummytummy.com/api/v1/devices/next-command \
+  -H "Authorization: Device $DEVICE_TOKEN"
+
+# Report the outcome
+curl -X POST https://app.hummytummy.com/api/v1/devices/commands/$COMMAND_ID/ack \
+  -H "Authorization: Device $DEVICE_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{ "status": "done", "result": { "bytesPrinted": 412 } }'
+```
+
+`next-command` is atomic via `FOR UPDATE SKIP LOCKED` — even if a single device opens two
+connections, a command is never delivered twice. The `ack` status is `done` or `failed`;
+the `error` field (≤ 1000 chars) carries the failure reason.
+
+<Callout type="warning">
+  **Money-moving / artefact-producing commands are never auto-retried.** `charge_card`,
+  `fiscal_receipt`, `fiscal_cancel`, `open_drawer` and `print_receipt` are side-effecting:
+  if a command's ack is lost (the terminal charged → the app crashed → the result never
+  reached the server) and it were requeued, the customer would be **double-charged** or
+  the receipt **double-printed**. Such commands therefore terminate directly in `failed`
+  on failure; an operator reconciles with an explicit **compensating command** (e.g.
+  `fiscal_cancel`). Safe/idempotent commands (`show_order`, `clear_order`,
+  `capability_probe`, `reboot`, `noop`) follow the normal retry path (up to 5 attempts).
+</Callout>
+
+## Branch scope and security
+
+- Sending commands and inspecting the queue are **branch-scoped**: a `MANAGER` restricted
+  to one branch can only drive devices in that branch; they cannot send `charge_card` /
+  `open_drawer` / `fiscal_receipt` to another branch's terminal (an out-of-scope device
+  returns `404`). An `ADMIN` operates tenant-wide.
+- **Retiring** a device (`DELETE /api/v1/devices/:id`) is restricted to the `ADMIN` role;
+  it revokes the token.
+- Device-token endpoints (`heartbeat`, `next-command`, `ack`) are additionally
+  rate-limited (heartbeat 60/min; next-command and ack 120/min) — so a compromised token
+  cannot hammer the database.
+
+## Listing devices
+
+```bash
+curl "https://app.hummytummy.com/api/v1/devices?branchId=$BRANCH_ID&kind=receipt_printer&status=online" \
+  -H "Authorization: Bearer $JWT" \
+  -H "X-Branch-Id: $BRANCH_ID"
+```
+
+Filterable by `branchId`, `kind` and `status`. The list response returns identity +
+status information; sensitive fields such as `pairCode` and `tokenHash` are deliberately
+excluded from the list.
+
+<Callout type="info">
+  The Bluetooth/ESC/POS commands in the README (Tauri commands like `scan_devices`,
+  `connect_device`, `print_receipt`) are the desktop app's **local** BLE printer support
+  and run inside the client. The device-mesh here is the **server-side** device registry,
+  pairing and command queue. The two complement each other: a bridge can translate a
+  `print_receipt` command it received from the mesh into a local ESC/POS print job.
+</Callout>

--- a/developer/pages/en/desktop/index.mdx
+++ b/developer/pages/en/desktop/index.mdx
@@ -1,0 +1,7 @@
+---
+title: Desktop App
+---
+
+# Desktop App
+
+This section is being prepared.

--- a/developer/pages/en/desktop/index.mdx
+++ b/developer/pages/en/desktop/index.mdx
@@ -1,7 +1,57 @@
 ---
 title: Desktop App
+description: HummyTummy Desktop — a Tauri-based POS/KDS desktop app for Windows, macOS and Linux. Auto-update, hardware pairing and kiosk mode.
 ---
 
-# Desktop App
+import { Cards, Callout } from 'nextra/components'
 
-This section is being prepared.
+# HummyTummy Desktop
+
+**HummyTummy Desktop** is a cross-platform application built on [Tauri 1.5](https://tauri.app),
+designed to run the restaurant point-of-sale (POS) and kitchen display (KDS) as a desktop
+app. It presents the same interface as the web panel in a native window, and additionally
+provides access to local hardware (receipt printer, cash drawer, fiscal device) plus
+**automatic updates** delivered from the server.
+
+The application name (`productName`) is **HummyTummy POS** and the bundle identifier is
+`com.hummytummy.pos`.
+
+<Callout type="info">
+  The desktop app is an additional layer on top of the web panel; restaurant data still
+  lives in the cloud. You can reach the same POS/KDS screens from a browser too. What the
+  desktop build really adds is **local hardware access** and a full-screen **kiosk**
+  experience.
+</Callout>
+
+## Supported platforms
+
+| Platform | Tauri key | Installer |
+| --- | --- | --- |
+| Windows (x86_64) | `windows-x86_64` | `.msi` |
+| macOS (Apple Silicon / ARM) | `darwin-aarch64` | `.dmg` |
+| macOS (Intel) | `darwin-x86_64` | `.dmg` |
+| Linux (x86_64) | `linux-x86_64` | `.deb` / `.AppImage` |
+
+These four keys are used verbatim in the server's update manifest (`platforms`) and in
+each release's download URLs.
+
+## Sections
+
+<Cards>
+  <Cards.Card title="Install & download" href="/en/desktop/install" arrow />
+  <Cards.Card title="Auto-update" href="/en/desktop/auto-update" arrow />
+  <Cards.Card title="Hardware pairing" href="/en/desktop/hardware" arrow />
+  <Cards.Card title="KDS / kiosk mode" href="/en/desktop/kds-mode" arrow />
+</Cards>
+
+## Architecture at a glance
+
+- **Release catalog** — Every published installer lives in the server's `DesktopRelease`
+  catalog. The app reports which platform it runs on and the server returns the signed
+  binary URL for that platform. See [Install & download](/en/desktop/install).
+- **Auto-update** — On launch, the Tauri updater queries the server's
+  `GET /api/desktop/updates/...` endpoint; if a newer release exists it verifies the
+  minisign signature and downloads it. See [Auto-update](/en/desktop/auto-update).
+- **Hardware (device-mesh)** — Devices such as printers, cash drawers and fiscal
+  registers connect to the app from the panel via a **pair code**; commands are dispatched
+  to the device through a command queue. See [Hardware pairing](/en/desktop/hardware).

--- a/developer/pages/en/desktop/install.mdx
+++ b/developer/pages/en/desktop/install.mdx
@@ -1,0 +1,157 @@
+---
+title: Install & download
+description: Download and install HummyTummy Desktop from the release catalog — public /api/desktop endpoints, platform packages and download tracking.
+---
+
+import { Callout, Steps, Tabs } from 'nextra/components'
+
+# Install & download
+
+The desktop app's installers are kept in a server-side **release catalog**
+(`DesktopRelease`). The catalog is a single **platform-level** global list — every
+restaurant tenant sees the same published releases. A few endpoints are publicly
+accessible; publishing a release, however, is restricted to platform operators
+(SuperAdmin) or CI/CD.
+
+<Callout type="info">
+  All endpoints are served under the global `/api` prefix. The examples below use
+  `https://app.hummytummy.com` as the server root; substitute your own.
+</Callout>
+
+## Public endpoints
+
+These endpoints require no authentication (`@Public`) and are rate-limited (throttled).
+
+| Method & path | Description | Limit |
+| --- | --- | --- |
+| `GET /api/desktop/releases/latest` | Latest published release | 30/min |
+| `GET /api/desktop/releases/published` | All published releases (newest `pubDate` first) | 30/min |
+| `GET /api/desktop/updates/:platform/:currentVersion` | Tauri updater query | 60/min |
+| `POST /api/desktop/releases/:version/download/:platform` | Increment the download counter (analytics) | 10/min |
+
+`:platform` must match `^[a-z0-9-]{1,32}$` and `:version` / `:currentVersion` must match
+`^v?\d+\.\d+\.\d+$`; otherwise the endpoint returns `400 Bad Request`.
+
+## Get the latest release
+
+<Tabs items={['curl', 'JSON response']}>
+  <Tabs.Tab>
+```bash
+curl https://app.hummytummy.com/api/desktop/releases/latest
+```
+  </Tabs.Tab>
+  <Tabs.Tab>
+```json
+{
+  "id": "01J...",
+  "version": "0.2.6",
+  "releaseTag": "v0.2.6",
+  "published": true,
+  "pubDate": "2026-06-20T15:00:00.000Z",
+  "windowsUrl": "https://github.com/.../HummyTummy-POS_0.2.6_x64.msi",
+  "windowsSignature": "dW50cnVzdGVkIGNvbW1lbnQ6...",
+  "macArmUrl": "https://github.com/.../HummyTummy-POS_0.2.6_aarch64.dmg",
+  "macArmSignature": "dW50cnVzdGVkIGNvbW1lbnQ6...",
+  "macIntelUrl": "https://github.com/.../HummyTummy-POS_0.2.6_x64.dmg",
+  "macIntelSignature": "dW50cnVzdGVkIGNvbW1lbnQ6...",
+  "linuxUrl": "https://github.com/.../hummy-tummy-pos_0.2.6_amd64.AppImage",
+  "linuxSignature": "dW50cnVzdGVkIGNvbW1lbnQ6...",
+  "releaseNotes": "## What's New\n- Feature X\n- Bug fix Y",
+  "changelog": null,
+  "downloadCount": 134,
+  "createdAt": "2026-06-20T14:55:00.000Z",
+  "updatedAt": "2026-06-20T15:00:00.000Z"
+}
+```
+  </Tabs.Tab>
+</Tabs>
+
+If there is no published release, `releases/latest` returns `404`.
+
+## Installation steps
+
+<Steps>
+### Find the package for your platform
+
+From the `GET /api/desktop/releases/latest` response, pick the URL field that matches
+your platform:
+
+- **Windows** → `windowsUrl` (`.msi`)
+- **macOS (Apple Silicon)** → `macArmUrl` (`.dmg`)
+- **macOS (Intel)** → `macIntelUrl` (`.dmg`)
+- **Linux** → `linuxUrl` (`.deb` / `.AppImage`)
+
+If the URL for a given platform is `null`, that release was not built for that platform.
+
+### Download and install
+
+Open the URL in a browser or download it with `curl -L`, then follow your platform's
+normal install flow (Windows: the MSI wizard; macOS: open the DMG and drag the app into
+Applications; Linux: install the `.deb` package or make the `.AppImage` executable).
+
+### (Optional) Report the download
+
+You can increment the download counter for analytics:
+
+```bash
+curl -X POST https://app.hummytummy.com/api/desktop/releases/0.2.6/download/windows-x86_64
+# { "message": "Download tracked" }
+```
+
+This call is best-effort: if an unknown version is supplied it does not throw, it is just
+logged on the server.
+</Steps>
+
+<Callout type="warning">
+  Only releases with `published: true` are visible through the public endpoints. Draft
+  (unpublished) releases are listed only via the SuperAdmin management endpoints.
+</Callout>
+
+## Building from source
+
+To build from source (the Tauri CLI ships with npm):
+
+```bash
+npm install
+npm run tauri:dev    # run in development mode
+npm run tauri:build  # produce a production bundle
+```
+
+Output bundles are created under `src-tauri/target/release/bundle/` per platform
+(`msi/`, `dmg/`, `deb/`, `appimage/`). Development requires **Rust 1.70+** and
+**Node.js 18+**; on Linux you also need `libdbus-1-dev` and `pkg-config` (for Bluetooth
+printer support).
+
+## Publishing a release (operator / CI)
+
+A new release reaches the catalog through one of two routes:
+
+- **CI/CD (API key)** — `POST /api/desktop/ci/releases` and
+  `POST /api/desktop/ci/releases/:id/publish`. These endpoints expect the
+  `DESKTOP_RELEASE_API_KEY` value in the `x-api-key` (or `api-key`) header; GitHub Actions
+  uses them for automated publishing.
+- **SuperAdmin (Bearer)** — `POST /api/desktop/releases`, `PATCH /api/desktop/releases/:id`,
+  `POST /api/desktop/releases/:id/publish` / `.../unpublish`, `DELETE /api/desktop/releases/:id`.
+  Restricted to platform operators.
+
+Example — create a release via CI:
+
+```bash
+curl -X POST https://app.hummytummy.com/api/desktop/ci/releases \
+  -H "x-api-key: $DESKTOP_RELEASE_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "version": "0.2.7",
+    "releaseTag": "v0.2.7",
+    "releaseNotes": "## What'\''s New\n- ...",
+    "windowsUrl": "https://github.com/.../setup.msi",
+    "windowsSignature": "dW50cnVzdGVkIGNvbW1lbnQ6...",
+    "published": false
+  }'
+```
+
+<Callout type="warning">
+  `version` must be unique and in `\d+\.\d+\.\d+` form (plain semver, no `v` prefix).
+  Re-creating an existing version returns `400`. The publish step sets `pubDate`; the
+  updater's "latest release" ordering is based on that field.
+</Callout>

--- a/developer/pages/en/desktop/kds-mode.mdx
+++ b/developer/pages/en/desktop/kds-mode.mdx
@@ -1,0 +1,91 @@
+---
+title: KDS / kiosk mode
+description: Run HummyTummy Desktop as a kitchen display (KDS) and full-screen kiosk — window configuration, the KDS screen device and screen commands.
+---
+
+import { Callout } from 'nextra/components'
+
+# KDS / kiosk mode
+
+The desktop app runs the web panel's POS and **kitchen display (KDS)** interfaces in a
+native window. This is ideal for using the app as a single-purpose, full-screen **kiosk**
+at kitchen/bar stations.
+
+## Window configuration
+
+The app opens with a single main window defined in the Tauri configuration:
+
+| Setting | Value |
+| --- | --- |
+| Title | `HummyTummy POS` |
+| Initial size | 1280 × 720 |
+| Minimum size | 800 × 600 |
+| `resizable` | `true` |
+| `fullscreen` | `false` (default) |
+
+At KDS stations, putting the window into full screen (the kitchen display is usually a
+dedicated monitor) is the typical usage. The app is single-window; the same install can
+show both the POS and KDS screens — which screen opens depends on the signed-in user's
+role and the selected branch.
+
+<Callout type="info">
+  Like all restaurant data, KDS is fed from the cloud. A desktop kiosk is the clean way to
+  lock the screen to a single app, removing risks like a browser tab closing or accidental
+  navigation.
+</Callout>
+
+## Registering the KDS screen as a device
+
+Optionally, you can also register a KDS/bar screen as a device in device-mesh. This lets
+you monitor the screen's **online/offline** status from the panel and send it screen
+commands.
+
+Create the slot with `kind: "kds_screen"` (or `bar_screen`) and pair the device — the
+steps are identical to the [Hardware pairing](/en/desktop/hardware) page:
+
+```bash
+curl -X POST https://app.hummytummy.com/api/v1/devices \
+  -H "Authorization: Bearer $JWT" \
+  -H "X-Branch-Id: $BRANCH_ID" \
+  -H "Content-Type: application/json" \
+  -d '{ "kind": "kds_screen", "model": "Kitchen Display 1" }'
+```
+
+### Screen commands
+
+The following commands can be sent to a registered screen device:
+
+| `kind` | Action |
+| --- | --- |
+| `show_order` | Show an order on the screen |
+| `clear_order` | Clear the displayed order |
+| `reboot` | Reboot the screen device |
+| `capability_probe` | Probe capabilities |
+| `noop` | No-op (connectivity test) |
+
+Example — show an order on the kitchen display:
+
+```bash
+curl -X POST https://app.hummytummy.com/api/v1/devices/$SCREEN_ID/commands \
+  -H "Authorization: Bearer $JWT" \
+  -H "X-Branch-Id: $BRANCH_ID" \
+  -H "Content-Type: application/json" \
+  -d '{ "kind": "show_order", "payload": { "orderId": "01J..." } }'
+```
+
+<Callout type="info">
+  `show_order`, `clear_order`, `reboot`, `capability_probe` and `noop` are
+  **idempotent / safe** commands; on failure they follow the normal retry path (up to 5
+  attempts). Unlike the side-effecting commands (`charge_card`, `fiscal_receipt`,
+  `open_drawer`, `print_receipt`), updating a screen twice causes no harm.
+</Callout>
+
+## Practical tips
+
+- **Dedicated monitor + full screen:** Move the kitchen/bar display to a separate monitor
+  and put the window into full screen.
+- **Keep auto-update on:** KDS stations are rarely managed by hand; letting the Tauri
+  updater fetch new versions on its own keeps stations current. See
+  [Auto-update](/en/desktop/auto-update).
+- **Register it as a device:** Register the screen in device-mesh to monitor its online
+  status from the panel; when heartbeats stop the screen appears `offline` within ~45s.

--- a/developer/pages/en/developer/_meta.ts
+++ b/developer/pages/en/developer/_meta.ts
@@ -1,0 +1,3 @@
+export default {
+  "index": "Overview"
+}

--- a/developer/pages/en/developer/_meta.ts
+++ b/developer/pages/en/developer/_meta.ts
@@ -1,3 +1,6 @@
 export default {
-  "index": "Overview"
-}
+  "index": "Overview",
+  "api-fundamentals": "API Fundamentals",
+  "partner-display": "Partner Display API",
+  "webhooks": "Webhooks",
+};

--- a/developer/pages/en/developer/api-fundamentals.mdx
+++ b/developer/pages/en/developer/api-fundamentals.mdx
@@ -1,0 +1,230 @@
+---
+title: API Fundamentals
+description: Base URL, auth realms, branch scope, pagination, the error envelope, idempotency, and rate-limit tiers.
+---
+
+import { Callout, Tabs } from 'nextra/components'
+
+# API Fundamentals
+
+This page covers the conventions that apply across HummyTummy's entire REST
+surface: base URL, auth realms, branch scope, error shape, and rate limits. The
+Partner Display and Webhooks pages build on these rules.
+
+## Base URL and global prefix
+
+Every endpoint lives under the `/api` global prefix.
+
+```
+https://hummytummy.com/api
+```
+
+So when an endpoint is defined as `v1/webhooks/subscriptions`, the full path is
+`https://hummytummy.com/api/v1/webhooks/subscriptions`. Every example in these
+docs shows the full path.
+
+<Callout type="info">
+  Currency is **TRY** for all amounts. Self-service payment runs through PayTR
+  and only TR/TRY is supported.
+</Callout>
+
+## Auth realms
+
+HummyTummy recognizes four distinct auth realms. Each endpoint expects exactly
+one of them; the wrong realm returns `401`.
+
+### 1. Staff JWT — `Authorization: Bearer <jwt>`
+
+The main identity for the dashboard / management API. It is the JWT of the
+signed-in staff user. Partner API keys and webhook subscriptions are managed
+through **this realm** (ADMIN role required).
+
+```bash
+Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
+```
+
+<Callout type="warning">
+  Access/refresh tokens are deliberately not kept in `localStorage`; the refresh
+  token lives in an httpOnly cookie. For server-to-server integrations, use a
+  **Partner API key** instead of a JWT (below).
+</Callout>
+
+### 2. Customer session — QR-menu session token
+
+The session token of a guest arriving from the QR menu. It authorizes guest
+ordering and self-pay flows. Partner screens don't use this identity directly;
+instead a screen token is bound behind the scenes to a customer session
+(`orderingSessionId`).
+
+### 3. Partner key — `X-Partner-Key` + `X-Partner-Secret`
+
+The machine identity a **partner backend** uses to mint/refresh/revoke screen
+tokens. The key is issued by the restaurant ADMIN; it consists of a `keyId`
+(`pk_live_…`, safe to log) plus a `secret` shown **once**.
+
+```bash
+X-Partner-Key:    pk_live_xxxxx
+X-Partner-Secret: pk_live_secret_xxxxx
+```
+
+Detail: [Partner Display API](/en/developer/partner-display).
+
+### 4. Screen token — `Authorization: Screen <token>`
+
+The short-lived, scoped token a device (tablet/screen) presents when calling
+`/v1/display/*`. The token is formatted `<uuidv7>.<secret>`; the device never
+carries the API secret.
+
+```bash
+Authorization: Screen 0190a1b2-c3d4-... .Hk9...
+```
+
+## Branch scope — `X-Branch-Id`
+
+HummyTummy is multi-branch. Every branch-scoped endpoint expects an
+`X-Branch-Id` header indicating which branch context it operates in.
+
+```bash
+X-Branch-Id: <branch-uuid>
+```
+
+<Callout type="warning">
+  Calling a branch-scoped endpoint without `X-Branch-Id` returns `400`. By
+  contrast, **tenant-level** endpoints (e.g. webhook subscriptions at
+  `/v1/webhooks/subscriptions`, partner keys at `/v1/partner/api-keys`) don't
+  expect this header — they skip branch scope. For partner screens, the
+  branch/tenant context comes from inside the token; it's never sent in the body
+  or a header.
+</Callout>
+
+## Error envelope
+
+All errors come back in a standard envelope:
+
+```json
+{
+  "statusCode": 403,
+  "message": "The externalDisplay feature is not enabled for this tenant",
+  "error": "Forbidden",
+  "errorCode": "FEATURE_NOT_AVAILABLE",
+  "timestamp": "2026-06-23T08:30:00.000Z",
+  "path": "/api/v1/partner/screen-sessions",
+  "requestId": "1718500000000-ab12cd34e"
+}
+```
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `statusCode` | number | HTTP status code |
+| `message` | string \| string[] | User-facing message; may be an array on validation errors |
+| `error` | string | Human/category label (e.g. `Bad Request`, `Forbidden`); sometimes localized |
+| `errorCode` | string? | **Machine-readable, stable** code. Present only when the thrown exception attaches one; carries no PII and is returned in every environment |
+| `timestamp` | string | ISO-8601 request time |
+| `path` | string | Request path |
+| `requestId` | string | Request id for tracing |
+
+The `details` and `stack` fields are only populated in the development
+environment; they never appear in production.
+
+<Callout type="info">
+  Branch on **`errorCode`** client-side, not on `message` — `message` may be
+  localized, `errorCode` is stable. Example codes: `INVALID_CREDENTIALS`,
+  `TOKEN_EXPIRED`, `FORBIDDEN`, `INSUFFICIENT_PERMISSIONS`,
+  `FEATURE_NOT_AVAILABLE`, `SUBSCRIPTION_REQUIRED`, `QUOTA_EXCEEDED`,
+  `VALIDATION_ERROR`, `TOO_MANY_REQUESTS`.
+</Callout>
+
+### Common status codes
+
+| Code | Meaning |
+| --- | --- |
+| `400` | Invalid input / missing `X-Branch-Id` / validation error |
+| `401` | No identity, invalid, or expired token |
+| `403` | Not authorized, missing scope, or plan feature disabled |
+| `404` | Resource not found |
+| `409` | Conflict (e.g. concurrent-update conflict — retryable) |
+| `429` | Rate limit exceeded |
+
+Some database-driven outcomes are mapped automatically: a concurrent-update
+conflict (`409 ConcurrentUpdate`, retryable), a uniqueness violation (`409`),
+and a range/length overflow (`400 ValueOutOfRange`).
+
+## Pagination
+
+Listing endpoints use `page` and `limit` query parameters for offset-based
+pagination; the total record count is returned in the `X-Total-Count` response
+header (explicitly exposed via CORS).
+
+```bash
+GET /api/...?page=2&limit=50
+```
+
+```
+X-Total-Count: 137
+```
+
+<Callout type="info">
+  Not all list endpoints enforce pagination; some (e.g. the partner-key list,
+  the webhook-subscription list) return all rows. The relevant endpoint page
+  states the behavior.
+</Callout>
+
+## Idempotency
+
+Money-moving endpoints (the checkout/payment rail) are replay-safe: the same
+request arriving twice does not create a second charge. On the webhook
+**receiving** side, the same event may also arrive twice with the same `id`
+(at-least-once delivery) — dedup on `id` in your receiver. Detail on the
+[Webhooks](/en/developer/webhooks) page.
+
+## Rate-limit tiers
+
+Rate limiting is applied by a global throttler across three tiers:
+
+| Tier | Window | Limit |
+| --- | --- | --- |
+| `short` | 1 s | 10 requests |
+| `medium` | 10 s | 50 requests |
+| `long` | 60 s | 100 requests |
+
+Some machine endpoints add their own tighter limits — for example screen-token
+minting (`POST /v1/partner/screen-sessions`) is capped at 60 per 60 s, and the
+self-pay intent (`/v1/display/pay-intent`) at 5 per 60 s.
+
+<Callout type="info">
+  **Counted by key/screen-token:** the rate-limit bucket is keyed not just on
+  IP but also on the principal (partner key or screen token). That way the many
+  tablets behind a single NAT IP don't throttle each other. Each principal is
+  still counted under its own source IP, so you can't escape the IP limit by
+  forging fresh principals.
+</Callout>
+
+When the limit is exceeded you get `429` with `errorCode: TOO_MANY_REQUESTS`;
+honor the `Retry-After` header.
+
+## Quick example
+
+<Tabs items={['curl', 'TypeScript (fetch)']}>
+  <Tabs.Tab>
+```bash
+# A branch-scoped endpoint (staff JWT + branch scope)
+curl https://hummytummy.com/api/v1/orders \
+  -H "Authorization: Bearer $JWT" \
+  -H "X-Branch-Id: $BRANCH_ID"
+```
+  </Tabs.Tab>
+  <Tabs.Tab>
+```ts
+const res = await fetch("https://hummytummy.com/api/v1/orders", {
+  headers: {
+    Authorization: `Bearer ${jwt}`,
+    "X-Branch-Id": branchId,
+  },
+});
+if (res.status === 429) {
+  // honor Retry-After, then retry
+}
+const total = res.headers.get("X-Total-Count");
+```
+  </Tabs.Tab>
+</Tabs>

--- a/developer/pages/en/developer/index.mdx
+++ b/developer/pages/en/developer/index.mdx
@@ -1,7 +1,73 @@
 ---
 title: Developer / Integration
+description: Integrate with the HummyTummy REST API, the Partner Display API, and outbound webhooks.
 ---
+
+import { Cards, Callout } from 'nextra/components'
 
 # Developer / Integration
 
-This section is being prepared.
+Connect HummyTummy to your own systems: run your own screens/apps, stream order
+and payment events to your server, and access restaurant data over the REST API.
+Every endpoint lives under a single API base:
+
+```
+https://hummytummy.com/api
+```
+
+<Callout type="info">
+  All REST paths are served under the `/api` global prefix. Every example in
+  these docs shows the full path (e.g. `POST /api/v1/webhooks/subscriptions`).
+  Currency is always **TRY**.
+</Callout>
+
+## Which integration fits you?
+
+HummyTummy exposes three distinct integration surfaces; most integrators use
+more than one together.
+
+<Cards>
+  <Cards.Card title="API Fundamentals" href="/en/developer/api-fundamentals" arrow>
+    Base URL, auth realms (staff JWT / customer session / partner key / screen
+    token), the `X-Branch-Id` branch scope, pagination, the error envelope,
+    idempotency, and rate-limit tiers.
+  </Cards.Card>
+  <Cards.Card title="Partner Display API" href="/en/developer/partner-display" arrow>
+    Run your own screens, such as a table tablet: menu, ordering, waiter/bill
+    calls, self-service payment, and live order status. ADMIN key → screen token
+    → `/v1/display/*` + WebSocket.
+  </Cards.Card>
+  <Cards.Card title="Webhooks" href="/en/developer/webhooks" arrow>
+    Receive order, payment, and subscription events as HMAC-SHA256–signed POSTs
+    to your endpoint. Subscribe, verify signatures, event types, retries, and
+    SSRF protection.
+  </Cards.Card>
+</Cards>
+
+## Two directions: pull and push
+
+- **Pull** — you call the REST endpoints (read the menu, place an order, start a
+  payment). For auth and branch-scope rules, see
+  [API Fundamentals](/en/developer/api-fundamentals).
+- **Push** — when an event happens, we POST to your endpoint (outbound
+  webhooks). For setup and verification, see
+  [Webhooks](/en/developer/webhooks).
+
+## Authorization realms (at a glance)
+
+| Realm | How it authenticates | Typical use |
+| --- | --- | --- |
+| Staff JWT | `Authorization: Bearer <jwt>` | Dashboard / management API, key & webhook management |
+| Customer session | QR-menu session token | Guest ordering & self-pay |
+| Partner key | `X-Partner-Key` + `X-Partner-Secret` | Partner backend mints screen tokens |
+| Screen token | `Authorization: Screen <token>` | Device calls `/v1/display/*` |
+
+The full detail of each lives in
+[API Fundamentals](/en/developer/api-fundamentals).
+
+<Callout type="warning">
+  Partner Display and outbound webhooks are **plan-gated** features. Partner
+  Display requires the tenant's plan to include `externalDisplay`; webhook
+  subscriptions require `apiAccess` (API access). Otherwise the relevant
+  endpoints return `403`.
+</Callout>

--- a/developer/pages/en/developer/index.mdx
+++ b/developer/pages/en/developer/index.mdx
@@ -1,0 +1,7 @@
+---
+title: Developer / Integration
+---
+
+# Developer / Integration
+
+This section is being prepared.

--- a/developer/pages/en/developer/partner-display.mdx
+++ b/developer/pages/en/developer/partner-display.mdx
@@ -1,0 +1,334 @@
+---
+title: Partner Display API
+description: Run your own screens — menu, ordering, waiter/bill calls, self-pay, and live order status.
+---
+
+import { Callout, Steps, Tabs } from 'nextra/components'
+
+# Partner Display API
+
+Run your own screens/apps (e.g. a table tablet) that do what the built-in QR
+menu does — against a HummyTummy restaurant: browse the menu, place orders,
+self-pay, call a waiter / request the bill, and watch order status live.
+
+All paths are under the `/api` global prefix. Base URL:
+`https://hummytummy.com/api`.
+
+<Callout type="warning">
+  Partner Display requires the restaurant's plan to include the
+  **`externalDisplay`** feature. Both key issuance and token minting verify this
+  feature and a live subscription (`ACTIVE` / `TRIALING` / `PAST_DUE`);
+  otherwise they return `403`.
+</Callout>
+
+## Concepts
+
+- **Partner API key** — issued by the restaurant ADMIN (Settings → API &
+  Integrations). It consists of a `keyId` (`pk_live_…`, safe to log) plus a
+  `secret` shown **once**. Held only by your **backend**.
+- **Screen session token** — a short-lived, scoped token your backend mints per
+  screen. It is bound to a branch (and optionally a table). The device holds
+  only this token, never the API secret.
+- **Scopes** — `menu:read`, `orders:write`, `orders:read`, `payments:write`,
+  `requests:write`, `realtime:subscribe`. A screen's scopes are a subset of the
+  key's.
+
+## Architecture overview
+
+```
+ADMIN (dashboard)                  Partner backend                Device/Screen
+      │                                  │                              │
+      │ 1. Issue key (keyId+secret)      │                              │
+      ├─────────────────────────────────▶                              │
+      │                                  │ 2. Mint screen token         │
+      │                                  │   X-Partner-Key/Secret       │
+      │                                  ├──────────▶ HummyTummy        │
+      │                                  │   screenToken + refreshToken │
+      │                                  │ 3. Ship screenToken          │
+      │                                  ├──────────────────────────────▶
+      │                                  │            4. /v1/display/*  │
+      │                                  │               Authorization: │
+      │                                  │               Screen <token> │
+      │                                  │◀─────────────────────────────┤
+```
+
+## 1. Issue an API key (restaurant ADMIN, one-time, in-app)
+
+The restaurant owner creates a key in the dashboard. You can also do it as a
+machine: with a staff JWT (ADMIN role required).
+
+```bash
+curl -X POST https://hummytummy.com/api/v1/partner/api-keys \
+  -H "Authorization: Bearer $ADMIN_JWT" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "Table tablets",
+    "scopes": ["menu:read","orders:write","orders:read","payments:write","requests:write","realtime:subscribe"],
+    "allowedReturnOrigins": ["https://tablet.example-restaurant.com"],
+    "allowedBranchIds": ["<branch-uuid>"]
+  }'
+```
+
+Response — the `secret` is returned **once**:
+
+```json
+{
+  "id": "...",
+  "keyId": "pk_live_AbCdEf...",
+  "secret": "pk_live_secret_XyZ...",
+  "name": "Table tablets",
+  "scopes": ["menu:read", "orders:write", "orders:read", "payments:write", "requests:write", "realtime:subscribe"],
+  "allowedReturnOrigins": ["https://tablet.example-restaurant.com"],
+  "allowedBranchIds": ["<branch-uuid>"],
+  "status": "active"
+}
+```
+
+| Field | Description |
+| --- | --- |
+| `name` | Human label (required, 1–80 chars) |
+| `scopes` | Optional; if omitted, the key gets **all** scopes |
+| `allowedReturnOrigins` | PayTR self-pay return origins (`https` URLs only) |
+| `allowedBranchIds` | Restricts the key to specific branches (empty = all branches) |
+
+<Callout type="warning">
+  Store the `secret` securely on your **server** — it is never shown again and
+  cannot be re-derived. The `keyId` is safe to log. The default per-tenant
+  active-key cap is 10; exceeding it returns `400`.
+</Callout>
+
+List / revoke keys (staff JWT, ADMIN):
+
+```bash
+GET    /api/v1/partner/api-keys
+DELETE /api/v1/partner/api-keys/:id   # revoke — cascades to child screen sessions
+```
+
+## 2. Mint a screen token (your backend → us)
+
+Authenticate with your key over TLS:
+
+<Tabs items={['curl', 'TypeScript (fetch)']}>
+  <Tabs.Tab>
+```bash
+curl -X POST https://hummytummy.com/api/v1/partner/screen-sessions \
+  -H "X-Partner-Key: pk_live_AbCdEf..." \
+  -H "X-Partner-Secret: pk_live_secret_XyZ..." \
+  -H "Content-Type: application/json" \
+  -d '{
+    "branchId": "<branch-uuid>",
+    "tableId": "<table-uuid>",
+    "scopes": ["menu:read","orders:write","realtime:subscribe"]
+  }'
+```
+  </Tabs.Tab>
+  <Tabs.Tab>
+```ts
+const res = await fetch(
+  "https://hummytummy.com/api/v1/partner/screen-sessions",
+  {
+    method: "POST",
+    headers: {
+      "X-Partner-Key": process.env.PARTNER_KEY!,
+      "X-Partner-Secret": process.env.PARTNER_SECRET!,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      branchId,
+      tableId, // optional
+      scopes: ["menu:read", "orders:write", "realtime:subscribe"],
+    }),
+  },
+);
+const session = await res.json();
+// session.screenToken → the device; session.refreshToken → stays server-side
+```
+  </Tabs.Tab>
+</Tabs>
+
+Request body fields:
+
+| Field | Required | Description |
+| --- | --- | --- |
+| `branchId` | Yes (UUID) | Branch the screen binds to; must belong to the tenant, be active, and be within the key's `allowedBranchIds` |
+| `tableId` | No (UUID) | Table the screen binds to; if set, the branch/table match is validated |
+| `scopes` | No | Scopes for this screen (a subset of the key's); if omitted, all of the key's scopes |
+
+Response — **tokens are returned once**:
+
+```json
+{
+  "id": "...",
+  "screenToken": "<uuidv7>.<secret>",
+  "refreshToken": "<uuidv7>.<secret>",
+  "expiresAt": "...(≈1 hour)",
+  "refreshExpiresAt": "...(≈30 days)",
+  "scopes": ["menu:read", "orders:write", "realtime:subscribe"],
+  "tenantId": "...",
+  "branchId": "...",
+  "tableId": "...",
+  "orderingSessionId": "..."
+}
+```
+
+Ship `screenToken` to the device; keep `refreshToken` server-side. Before it
+expires (default access ≈1 hour), rotate it:
+
+```bash
+curl -X POST https://hummytummy.com/api/v1/partner/screen-sessions/refresh \
+  -H "X-Partner-Key: pk_live_AbCdEf..." \
+  -H "X-Partner-Secret: pk_live_secret_XyZ..." \
+  -H "Content-Type: application/json" \
+  -d '{ "refreshToken": "<uuidv7>.<secret>" }'
+# → new { screenToken, refreshToken, expiresAt, refreshExpiresAt }
+```
+
+<Callout type="info">
+  Refresh is **single-use**: a second call with the old `refreshToken` returns
+  `401 "Refresh token already used"`. Always store the newly returned
+  `refreshToken`. TTLs are operator-configurable: access ≈1 hour, refresh ≈30
+  days.
+</Callout>
+
+Revoke a single screen (key auth):
+
+```bash
+DELETE /api/v1/partner/screen-sessions/:id
+```
+
+<Callout type="warning">
+  Revoking the **API key** in the dashboard cascades — all its screen tokens die
+  and live socket connections are dropped. Revoking a single screen also closes
+  its backing customer session and immediately disconnects its live socket.
+</Callout>
+
+The per-branch active screen-session cap defaults to 50; exceeding it returns
+`400`.
+
+## 3. Drive the screen (device → us)
+
+Every `/display` call presents the screen token:
+
+```bash
+Authorization: Screen <screenToken>
+```
+
+| Method | Path | Scope | Purpose |
+| --- | --- | --- | --- |
+| GET | `/api/v1/display/menu` | `menu:read` | Branding + categories/products/modifiers + feature flags |
+| POST | `/api/v1/display/orders` | `orders:write` | Place an order `{ items:[{ productId, quantity, modifiers?, notes? }], type?, notes? }` |
+| GET | `/api/v1/display/orders` | `orders:read` | This screen's session's orders + statuses |
+| POST | `/api/v1/display/waiter-requests` | `requests:write` | Call a waiter `{ message? }` (requires a table-bound screen) |
+| POST | `/api/v1/display/bill-requests` | `requests:write` | Request the bill `{ message? }` |
+| GET | `/api/v1/display/payable-items` | `payments:write` | Unpaid items for the table |
+| POST | `/api/v1/display/pay-intent` | `payments:write` | PayTR hosted-payment intent `{ items:[{ orderItemId, quantity }], customerPhone? }` |
+| GET | `/api/v1/display/pay-status?oid=…` | `payments:write` | Poll a payment's status |
+
+<Callout type="info">
+  The screen's tenant/branch/table are taken from the **token** — never sent in
+  the body. A missing scope returns `403`. An expired / invalid token returns
+  `401`.
+</Callout>
+
+### Placing an order
+
+<Tabs items={['curl', 'TypeScript (fetch)']}>
+  <Tabs.Tab>
+```bash
+curl -X POST https://hummytummy.com/api/v1/display/orders \
+  -H "Authorization: Screen $SCREEN_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "items": [
+      { "productId": "<product-uuid>", "quantity": 2, "notes": "rare" }
+    ],
+    "notes": "table 5"
+  }'
+```
+  </Tabs.Tab>
+  <Tabs.Tab>
+```ts
+await fetch("https://hummytummy.com/api/v1/display/orders", {
+  method: "POST",
+  headers: {
+    Authorization: `Screen ${screenToken}`,
+    "Content-Type": "application/json",
+  },
+  body: JSON.stringify({
+    items: [{ productId, quantity: 2, notes: "rare" }],
+  }),
+});
+```
+  </Tabs.Tab>
+</Tabs>
+
+### Self-pay
+
+Self-pay is TR/TRY + PayTR. Open the returned `paymentLink` in a WebView; the
+return origin is taken from the key's `allowedReturnOrigins` (never from a
+client-supplied header). Flow: `payable-items` → `pay-intent` → WebView → poll
+`pay-status` (or `customer:payment-settled` over WebSocket).
+
+## 4. Live updates (device → us, WebSocket)
+
+With the `realtime:subscribe` scope, connect Socket.IO to the `/kds` namespace
+with the screen token:
+
+```js
+import { io } from "socket.io-client";
+
+const socket = io("https://hummytummy.com/kds", {
+  auth: { screenToken: "<screenToken>" },
+});
+
+socket.on("customer:order-created", (e) => {/* ... */});
+socket.on("customer:order-approved", (e) => {/* ... */});
+socket.on("customer:order-status-updated", (e) => {/* ... */});
+socket.on("customer:payment-settled", (e) => {/* ... */});
+```
+
+Events: `customer:order-created`, `customer:order-approved`,
+`customer:order-status-updated`, `customer:payment-settled`.
+
+<Callout type="info">
+  If the socket drops, fall back to polling `GET /display/orders` and
+  `GET /display/pay-status`. When a screen is revoked, its live socket is
+  disconnected immediately.
+</Callout>
+
+## End-to-end summary
+
+<Steps>
+
+### Issue a key
+The ADMIN issues a partner key from the dashboard (or as a machine with an ADMIN
+JWT). Store the `secret` on your server.
+
+### Mint a screen token
+Your backend mints a `screenToken` + `refreshToken` per screen with
+`X-Partner-Key`/`X-Partner-Secret`. Ship the `screenToken` to the device.
+
+### Drive the screen
+The device calls `/v1/display/*` with `Authorization: Screen <token>`; each
+endpoint requires its own scope.
+
+### Listen live
+The device connects to the `/kds` WebSocket (`realtime:subscribe`) and receives
+order/payment events live.
+
+### Refresh / revoke
+Rotate with the `refreshToken` before the token expires. When no longer needed,
+revoke a single screen or the whole key (cascade).
+
+</Steps>
+
+## Errors and limits
+
+- **Errors:** the standard
+  [envelope](/en/developer/api-fundamentals#error-envelope). `401` =
+  bad/expired token, `403` = missing scope or the tenant lacks `externalDisplay`
+  / the subscription isn't live, `429` = rate limited.
+- **Rate limits** are counted per key / per screen token (not per IP), so a
+  venue of tablets behind one NAT IP is fine. Screen-token minting is capped at
+  60 per 60 s, and the self-pay intent at 5 per 60 s.
+- **Token TTLs** (operator-configurable): access ≈1 hour, refresh ≈30 days.

--- a/developer/pages/en/developer/webhooks.mdx
+++ b/developer/pages/en/developer/webhooks.mdx
@@ -1,0 +1,297 @@
+---
+title: Webhooks
+description: Receive order, payment, and subscription events as HMAC-SHA256–signed POSTs to your endpoint.
+---
+
+import { Callout, Steps, Tabs } from 'nextra/components'
+
+# Webhooks (Outbound)
+
+When an event happens in your tenant, HummyTummy POSTs an HMAC-SHA256–signed
+HTTP request to your registered endpoint. This lets you react instantly to
+order, payment, and subscription events without polling.
+
+All paths are under the `/api` global prefix.
+
+<Callout type="warning">
+  Webhook subscriptions require the **API access** feature: the BUSINESS plan or
+  the `api_access` (apiAccess) add-on. Subscription endpoints expect a staff JWT
+  with the **ADMIN role**; if the feature is disabled they return `403`.
+</Callout>
+
+## Subscribe
+
+Create a subscription. The **`secret` is returned once** — store it securely; it
+is never shown again and cannot be re-derived.
+
+<Tabs items={['curl', 'TypeScript (fetch)']}>
+  <Tabs.Tab>
+```bash
+curl -X POST https://hummytummy.com/api/v1/webhooks/subscriptions \
+  -H "Authorization: Bearer $ADMIN_JWT" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "url": "https://hooks.example.com/hummytummy",
+    "events": ["order.created.v1", "payment.succeeded.v1"]
+  }'
+```
+  </Tabs.Tab>
+  <Tabs.Tab>
+```ts
+const res = await fetch(
+  "https://hummytummy.com/api/v1/webhooks/subscriptions",
+  {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${adminJwt}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      url: "https://hooks.example.com/hummytummy",
+      events: ["order.created.v1", "payment.succeeded.v1"],
+    }),
+  },
+);
+const { secret } = await res.json(); // returned ONCE — store securely
+```
+  </Tabs.Tab>
+</Tabs>
+
+Request body:
+
+| Field | Required | Description |
+| --- | --- | --- |
+| `url` | Yes | The `https` (or `http`) URL events are POSTed to. It passes the SSRF allowlist; the host is normalized to lowercase before storing |
+| `events` | No | Event types to subscribe to. If omitted, `["*"]` (all publishable events) |
+
+Response (excerpt):
+
+```json
+{
+  "id": "0190a1b2-...",
+  "tenantId": "...",
+  "url": "https://hooks.example.com/hummytummy",
+  "events": ["order.created.v1", "payment.succeeded.v1"],
+  "status": "active",
+  "secret": "whs_AbCdEf..."
+}
+```
+
+List / revoke subscriptions:
+
+```bash
+GET    /api/v1/webhooks/subscriptions
+DELETE /api/v1/webhooks/subscriptions/:id
+```
+
+<Callout type="info">
+  The default per-tenant active-subscription cap is 20 (only `active` rows are
+  counted); exceeding it returns `400`. Revoke unused subscriptions.
+</Callout>
+
+## Delivered payload
+
+Each delivery is a POST with a JSON body:
+
+```json
+{
+  "id": "0190a1b2-c3d4-...",
+  "type": "order.created.v1",
+  "tenantId": "...",
+  "payload": { "...event-specific fields..." }
+}
+```
+
+Plus these headers:
+
+| Header | Description |
+| --- | --- |
+| `Content-Type` | `application/json` |
+| `User-Agent` | `HummyTummy-Webhook/1` |
+| `X-HummyTummy-Event-Id` | The event `id` (for idempotency) |
+| `X-HummyTummy-Event-Type` | The event type (e.g. `order.created.v1`) |
+| `X-HummyTummy-Signature` | The signature: `t=<unix-ms>,v1=<hmac-sha256>` |
+
+<Callout type="info">
+  The same event may arrive more than once with the same `id` (at-least-once
+  delivery). **Dedup on `id`** (or `X-HummyTummy-Event-Id`) in your receiver.
+</Callout>
+
+## Verifying the signature
+
+The signature is a timestamped HMAC-SHA256 computed over the body:
+
+```
+X-HummyTummy-Signature: t=<unix-ms>,v1=<hmac-sha256-hex>
+```
+
+It is produced like this — the **signed string** is `"<timestamp>.<rawBody>"`,
+and the key is your `secret`:
+
+```
+v1 = HMAC_SHA256(secret, `${t}.${rawBody}`)  // hex
+```
+
+Verification steps (identical to HummyTummy's own `verify` logic):
+
+<Steps>
+
+### Parse the header
+Split on commas and extract the `t` and `v1` values.
+
+### Check the timestamp
+`t` must be numeric and within **±5 minutes** of now (replay protection).
+
+### Recompute the HMAC
+Compute HMAC-SHA256 over `"${t}.${rawBody}"` with your `secret`.
+
+### Compare in constant time
+Compare your computed hex against `v1` with a length + constant-time
+(timing-safe) comparison. If they match, the event is authentic.
+
+</Steps>
+
+<Callout type="warning">
+  Use the **raw body** — do NOT parse and re-serialize the JSON; that changes
+  the bytes and the signature won't match. Capture the raw body buffer in your
+  web framework.
+</Callout>
+
+### Node.js (Express) verification example
+
+```ts
+import express from "express";
+import { createHmac, timingSafeEqual } from "node:crypto";
+
+const app = express();
+
+// Capture the raw body — the signature is computed over the raw bytes.
+app.use(express.json({ verify: (req, _res, buf) => { (req as any).rawBody = buf; } }));
+
+function verify(
+  secret: string,
+  header: string,
+  rawBody: string,
+  toleranceMs = 5 * 60_000,
+): boolean {
+  const parts = Object.fromEntries(header.split(",").map((p) => p.split("=")));
+  const ts = Number(parts.t);
+  const v1 = String(parts.v1 ?? "");
+  if (!Number.isFinite(ts) || Math.abs(Date.now() - ts) > toleranceMs) return false;
+  const expected = createHmac("sha256", secret)
+    .update(`${ts}.${rawBody}`)
+    .digest("hex");
+  if (expected.length !== v1.length) return false;
+  return timingSafeEqual(Buffer.from(expected), Buffer.from(v1));
+}
+
+app.post("/hummytummy", (req, res) => {
+  const sig = req.header("X-HummyTummy-Signature") ?? "";
+  const raw = (req as any).rawBody.toString("utf8");
+  if (!verify(process.env.WEBHOOK_SECRET!, sig, raw)) {
+    return res.sendStatus(401); // invalid/stale signature
+  }
+  // Idempotency: don't process the same X-HummyTummy-Event-Id twice.
+  const eventId = req.header("X-HummyTummy-Event-Id");
+  // ... handle the event ...
+  res.sendStatus(200); // 2xx = successful delivery
+});
+```
+
+<Callout type="info">
+  Return **2xx** (200–299) for a successful delivery. Any non-2xx is treated as
+  a failure and retried.
+</Callout>
+
+## Event types
+
+List specific types in the `events` field, or use `"*"` to catch all publishable
+events. Types follow the `<area>.<action>.v<version>` shape.
+
+Example publishable types:
+
+| Event type | When |
+| --- | --- |
+| `order.created.v1` | A new order was created |
+| `order.updated.v1` | An order was updated |
+| `order.completed.v1` | An order completed |
+| `order.cancelled.v1` | An order was cancelled |
+| `payment.succeeded.v1` | A payment succeeded |
+| `payment.intent_created.v1` | A payment intent was created |
+| `payment.refund_completed.v1` | A refund completed |
+| `checkout.completed.v1` | A checkout completed |
+| `subscription.activated.v1` | A subscription activated |
+| `subscription.upgraded.v1` | A subscription was upgraded |
+| `subscription.cancelled.v1` | A subscription was cancelled |
+| `feature.entitlement.changed.v1` | A feature entitlement changed |
+
+### Blocked events
+
+Some sensitive events are kept internal and are **never** sent out — not even a
+`"*"` subscription receives them. Blocking is by **prefix**; no event whose type
+starts with the following prefixes is delivered:
+
+```
+user.password
+user.email_verification
+auth.
+subscription.upgrade.requested
+subscription.renewal.failed
+subscription.payment.
+kms.
+audit.
+```
+
+<Callout type="info">
+  New business events are publishable by default; only sensitive ones are added
+  to this list. The filter runs **before** subscription matching — even an
+  explicit, named subscription cannot opt into a blocked event.
+</Callout>
+
+## Retries and auto-pause
+
+Delivery is performed by a worker that runs every 30 seconds.
+
+- **Timeout:** a single delivery is capped at 15 seconds.
+- **Retry:** on a non-2xx response or network error, up to **5 attempts** with
+  increasing backoff (30 s, 2 m, 10 m, 1 h, 6 h); after that the delivery is
+  marked `failed`.
+- **Auto-pause:** a subscription is automatically set to `paused` after **20
+  consecutive failures**. This stops a dead endpoint from draining the worker;
+  you must fix it and create a new subscription.
+- **Success resets the counter:** a successful delivery resets the
+  consecutive-failure counter to 0.
+
+<Callout type="warning">
+  If the payload can't be loaded (e.g. the source event was purged by
+  retention), the delivery is marked `failed` with an actionable note (`source
+  event purged before delivery`) rather than silently losing data.
+</Callout>
+
+## SSRF protection (allowlist)
+
+Webhook URLs pass a safety gate both **at subscribe time** and **immediately
+before each delivery**. This prevents a tenant from self-fetching internal
+services or cloud metadata endpoints (e.g. `169.254.169.254`).
+
+What's blocked:
+
+- Non-public IPs: loopback, private/internal ranges, link-local, cloud-metadata
+  addresses, and their IPv4-mapped IPv6 equivalents.
+- Dangerous ports (Redis, Postgres, etc.).
+- Userinfo in the URL (`user:pass@host`).
+- Protocols other than `http`/`https`.
+
+<Callout type="info">
+  The re-check before delivery also closes **DNS-rebind** attacks (a DNS server
+  that answers "public IP" at subscribe and "private IP" at delivery). In that
+  case the delivery is marked `failed` without being retried.
+</Callout>
+
+## Best practices
+
+- **Always** verify the signature and dedup on `id`.
+- Return **2xx** quickly; queue heavy work (stay under the 15 s timeout).
+- Store the `secret` server-side, in an environment variable / secret vault.
+- If you find a subscription paused, fix your endpoint and **re-subscribe**.
+- Use an HTTPS endpoint where possible.

--- a/developer/pages/en/getting-started/_meta.ts
+++ b/developer/pages/en/getting-started/_meta.ts
@@ -1,0 +1,3 @@
+export default {
+  "index": "Overview"
+}

--- a/developer/pages/en/getting-started/_meta.ts
+++ b/developer/pages/en/getting-started/_meta.ts
@@ -1,3 +1,6 @@
 export default {
-  "index": "Overview"
+  "index": "Overview",
+  "concepts": "Core Concepts",
+  "create-account": "Create an Account",
+  "first-setup": "First-Time Setup",
 }

--- a/developer/pages/en/getting-started/concepts.mdx
+++ b/developer/pages/en/getting-started/concepts.mdx
@@ -1,0 +1,69 @@
+---
+title: Core Concepts
+description: Tenant, Branch, Roles, and the 7-day trial — the concepts to understand before working in HummyTummy.
+---
+
+import { Callout } from 'nextra/components'
+
+# Core Concepts
+
+Understanding four core concepts will make HummyTummy much easier to use: **Tenant**, **Branch**, **Roles**, and the **trial (TRIAL)**.
+
+## Tenant (Restaurant / Business)
+
+A **tenant** is your entire business as it lives in the system — that is, your restaurant. When you register, a tenant is created for you, and all of your data (menu, tables, orders, staff, reports) is stored under it.
+
+- Each tenant is **fully isolated**: you cannot see another business's data, and they cannot see yours.
+- A tenant has a **subscription status** (trial / active / etc.) and a **plan**.
+- The first user who creates the tenant is always an **ADMIN**.
+
+## Branch
+
+A **branch** is a physical location under your tenant. At registration, a default branch named **"Main"** is created automatically — so you have a branch without doing anything.
+
+- Single-location businesses run on one branch.
+- Multi-branch chains can add more branches (subject to plan limits).
+- A lot of data — menu, tables, orders, stock — is **branch-scoped**, meaning each branch has its own tables and its own orders.
+
+<Callout type="info">
+  Behind the scenes, branch-scoped requests carry a **branch context**
+  (`X-Branch-Id`). This is handled automatically when you select your active branch
+  in the UI — you don't need to do anything manually in day-to-day use.
+</Callout>
+
+## Roles
+
+Every user has a **role** that determines what they can access. There are five roles:
+
+| Role | Who? | Typical permissions |
+|---|---|---|
+| **ADMIN** | Owner / top-level admin | Everything: settings, plan/subscription, user management, all branches, reports |
+| **MANAGER** | Branch / operations manager | Operations, menu/tables/staff, reports (on assigned branches) |
+| **WAITER** | Waiter | Take orders from POS, table actions (in their own branch) |
+| **KITCHEN** | Kitchen staff | Kitchen Display (KDS): update order status |
+| **COURIER** | Courier | Delivery / courier flow |
+
+**Branch restriction:** the `WAITER`, `KITCHEN`, and `COURIER` roles are **pinned to a single branch** (their own home branch). They can only operate in that branch. `ADMIN` and `MANAGER` can switch between branches (`ADMIN` across all, `MANAGER` across branches assigned to them).
+
+<Callout type="info">
+  The first user to register (the business owner) is an **ADMIN** with access to all
+  branches. You add other staff and assign their roles later from the Admin panel.
+</Callout>
+
+## Trial (TRIAL — 7 days)
+
+Every newly registered tenant starts on a **dedicated 7-day trial plan (TRIAL)**:
+
+- **All premium features unlocked**, no charge, no card required.
+- The subscription status during the trial is **TRIALING**.
+- The trial is **one-time per tenant** (abuse is prevented).
+
+**What happens after 7 days?** The trial ends and the account **locks** (`TRIAL_ENDED`): to continue, you must choose a **paid plan**. It does not silently drop to a free tier — this is a deliberate design choice.
+
+<Callout type="warning">
+  When the trial ends, the UI redirects you to the plan-selection page and
+  branch-scoped actions are locked until a paid plan is activated. Your data is not
+  deleted; you pick up right where you left off as soon as a plan is activated.
+</Callout>
+
+For plan options and pricing, see the **[Plans](/plans)** page.

--- a/developer/pages/en/getting-started/create-account.mdx
+++ b/developer/pages/en/getting-started/create-account.mdx
@@ -1,0 +1,137 @@
+---
+title: Create an Account
+description: Opening a new restaurant account in HummyTummy — the sign-up form, required fields, and registering via the API.
+---
+
+import { Callout, Steps, Tabs } from 'nextra/components'
+
+# Create an Account
+
+Opening a new restaurant account is simply a matter of filling in the sign-up form. The moment registration completes, a **tenant**, a **"Main" branch**, your **ADMIN** user, and a **7-day free trial** are all provisioned for you automatically — no further steps required.
+
+## Required information
+
+The following fields are **required** to register:
+
+| Field | Description | Rule |
+|---|---|---|
+| **Email** | Used to sign in | Valid email, up to 254 characters |
+| **Password** | Account password | At least 8 characters; must contain **at least one lowercase letter, one uppercase letter, and one digit** (up to 128 characters) |
+| **First name** (`firstName`) | Your first name | Up to 100 characters |
+| **Last name** (`lastName`) | Your last name | Up to 100 characters |
+| **Phone** | For contact and payment | Enter in any natural format; the system converts it to **E.164** |
+| **Restaurant name** (`restaurantName`) | When creating a new business | Becomes your tenant's name, up to 120 characters |
+
+<Callout type="info">
+  **Why is phone required?** The payment provider (PayTR) requires a phone number at
+  checkout, so it is collected at registration. It accepts natural inputs like
+  `"0555 123 45 67"` or `"+90 555 123 45 67"` and normalizes them to the standard
+  `+905551234567` (E.164) format.
+</Callout>
+
+## Sign up step by step (UI)
+
+<Steps>
+
+### Open the sign-up page
+
+Click the **"Sign up"** link on the login screen.
+
+### Enter your details
+
+Fill in email, password, first name, last name, phone, and restaurant name. The password must contain uppercase, lowercase, and a digit.
+
+### Create the account
+
+Submit the form. Your account, your main branch, and your 7-day trial subscription are provisioned in one step, and you are signed in directly.
+
+### Complete the welcome flow
+
+On first login you are taken to a welcome screen and the dashboard. From there, move on to **[First-Time Setup](/getting-started/first-setup)**.
+
+</Steps>
+
+## Register via the API
+
+You can also register programmatically. The global API prefix is `/api`.
+
+**Endpoint:** `POST /api/auth/register`
+
+<Tabs items={['curl', 'Request body (JSON)']}>
+  <Tabs.Tab>
+
+```bash
+curl -X POST https://<server>/api/auth/register \
+  -H "Content-Type: application/json" \
+  -d '{
+    "email": "owner@myrestaurant.com",
+    "password": "Passw0rd!",
+    "firstName": "Ayse",
+    "lastName": "Yilmaz",
+    "phone": "0555 123 45 67",
+    "restaurantName": "Sultanahmet Cafe"
+  }'
+```
+
+  </Tabs.Tab>
+  <Tabs.Tab>
+
+```json
+{
+  "email": "owner@myrestaurant.com",
+  "password": "Passw0rd!",
+  "firstName": "Ayse",
+  "lastName": "Yilmaz",
+  "phone": "0555 123 45 67",
+  "restaurantName": "Sultanahmet Cafe"
+}
+```
+
+  </Tabs.Tab>
+</Tabs>
+
+**Successful response (`201 Created`):** returns an `accessToken` plus the user object. The phone is stored normalized as `+905551234567`.
+
+```json
+{
+  "accessToken": "<jwt>",
+  "user": {
+    "id": "…",
+    "email": "owner@myrestaurant.com",
+    "firstName": "Ayse",
+    "lastName": "Yilmaz",
+    "phone": "+905551234567",
+    "role": "ADMIN",
+    "tenantId": "…",
+    "primaryBranchId": "…",
+    "allowedBranchIds": []
+  }
+}
+```
+
+<Callout type="info">
+  The refresh token is **not** returned in the response body; for security it is sent
+  only as an `httpOnly` cookie. Use the `accessToken` on subsequent requests via the
+  `Authorization: Bearer <accessToken>` header.
+</Callout>
+
+**Error cases:**
+
+- `409 Conflict` — this email is already in use.
+- `400 Bad Request` — a field fails validation (e.g. weak password, invalid phone).
+
+<Callout type="warning">
+  **Rate limit:** the register endpoint is limited to **3 requests per hour per IP**.
+  Exceeding it returns `429 Too Many Requests`.
+</Callout>
+
+## What gets provisioned after registration
+
+When registration succeeds, the following are created inside a single database transaction:
+
+1. **Tenant** — named after your restaurant, with the 7-day trial window set.
+2. **Subscription** — in **TRIALING** status, on the 7-day TRIAL plan.
+3. **"Main" branch** — your default branch.
+4. **ADMIN user** — you (the business owner).
+
+From here, you can prepare your menu, tables, and settings via **[First-Time Setup](/getting-started/first-setup)**.

--- a/developer/pages/en/getting-started/first-setup.mdx
+++ b/developer/pages/en/getting-started/first-setup.mdx
@@ -1,0 +1,94 @@
+---
+title: First-Time Setup
+description: First login, the welcome flow, the setup checklist, and the recommended order — branch, menu, tables.
+---
+
+import { Callout, Steps } from 'nextra/components'
+
+# First-Time Setup
+
+After creating your account, your first login greets you with a welcome flow and the dashboard. This page explains the order to follow to get your restaurant operational.
+
+## First launch: welcome and guided tour
+
+On your first login, a **welcome modal** opens on the dashboard (`/dashboard`). You have two options here:
+
+- **Start the guided tour** — an interactive tour that walks you through the main screens (POS, menu, tables, etc.) step by step.
+- **Explore a sample restaurant (demo) first** — try the system in a pre-seeded demo restaurant without touching your own data. You can return to your own account at any time.
+
+<Callout type="info">
+  You can skip the tour; it won't be shown again. You can restart it later whenever
+  you like. The demo is a shared restaurant filled with real data — explore it freely.
+</Callout>
+
+### Complete your profile (if you used social sign-in)
+
+If you signed in with Google and your account has **no phone number**, the system first routes you to the **"Complete your account"** screen. There you provide:
+
+- **Phone** (required — needed for the payment step)
+- Business name, first/last name, tax ID / tax office, address, city
+- Time zone and language preference
+
+If you registered normally with email + password, this step is skipped, since the phone was already collected at registration.
+
+## Setup checklist
+
+Your dashboard shows a **setup checklist** banner until your restaurant is fully ready. Each item checks a real condition and links you to the page that resolves it; once every item is complete, the banner disappears on its own. The items:
+
+| Item | What it asks for | Where it goes |
+|---|---|---|
+| **Branch** | At least one branch exists | Branches |
+| **KDS screen** | A kitchen display (KDS) device is paired | Devices |
+| **Waiter tablet** | A waiter tablet device is paired | Devices |
+| **Bridge** | If you use a printer/fiscal device, a bridge is online | Bridges |
+| **Fiscal integration** | A fiscal integration is connected | Marketplace |
+
+<Callout type="info">
+  The checklist is **context-aware**: for example, if KDS isn't in your plan that item
+  isn't shown; if you haven't registered a printer/fiscal device, the "Bridge" item is
+  skipped. You only see the steps that are meaningful for you.
+</Callout>
+
+## Recommended setup order
+
+Before pairing devices, we recommend entering the core data that makes your restaurant operational in this order:
+
+<Steps>
+
+### 1. Branch settings
+
+Registration already created a **"Main"** branch for you. Review your branch's name, address, and time zone. If you'll run multiple locations (and your plan allows it), add your additional branches now.
+
+### 2. Menu
+
+From **Menu Management** in the Admin panel:
+
+- First create your **categories** (e.g. "Hot Drinks", "Desserts").
+- Then add **products** to each category (name, price, photo, description).
+- If needed, define **modifiers** (options) — e.g. "size: small/medium/large" or "extra cheese".
+
+The menu is the foundation for taking orders in POS and for the QR menu, which is why it comes before tables.
+
+### 3. Tables
+
+From **Table Management**, add your tables (name/number and capacity). If you operate takeaway-only, you can skip this and enable **takeaway** mode in settings instead.
+
+### 4. (Optional) QR codes and devices
+
+- Generate and print table QR codes from **QR Management**.
+- Pair your kitchen display (KDS) and waiter tablets from **Devices**.
+- If you use a printer/fiscal device, set up a **Bridge**.
+
+</Steps>
+
+<Callout type="info">
+  **The recommended logic:** branch first → then menu (categories, then products) →
+  then tables. Following this order lets you start taking orders in POS immediately,
+  publish the QR menu, and connect the kitchen display.
+</Callout>
+
+## What's next?
+
+- For a detailed walkthrough of every management screen, see the **[Admin Guide](/admin-guide)**
+- For plan limits and pricing, see **[Plans](/plans)**
+- For devices, bridges, and integrations, see **[Marketplace](/marketplace)** and **[Developer / Integration](/developer)**

--- a/developer/pages/en/getting-started/index.mdx
+++ b/developer/pages/en/getting-started/index.mdx
@@ -1,7 +1,54 @@
 ---
-title: Getting Started
+title: Getting Started — Overview
+description: What HummyTummy is, who it's for, and how to begin — an introduction for new restaurant owners and admins.
 ---
+
+import { Callout, Cards } from 'nextra/components'
 
 # Getting Started
 
-This section is being prepared.
+**HummyTummy** is a **cloud-based restaurant management system** built for cafés and restaurants. A single account combines QR menu, POS (cash register), kitchen display (KDS), order and table management, stock, reports, and multi-branch operations. It runs in the browser — no hardware setup or local software required.
+
+This section is written for a restaurant owner or admin starting from scratch: learn the concepts, create your account, and get your first branch, menu, and tables up and running in minutes.
+
+## Who is it for?
+
+- **Cafés, restaurants, patisseries, bars, fast-food** venues (from 1 table to 100+)
+- Owners and managers who want to run the business from **a single panel**
+- Anyone looking for a cloud-based, **setup-free** solution
+
+## What does it offer?
+
+- **POS / Cash register** — take dine-in or takeaway orders, payments, discounts
+- **Kitchen Display (KDS)** — orders land in the kitchen in real time
+- **QR Menu** — guests scan the table QR to view the menu and order
+- **Table & order management** — table status, transfers, pay-by-items
+- **Stock & recipes**, **reservations**, **staff**, **reports**, and **multi-branch**
+- **UI in 5 languages**: Turkish, English, Russian, Uzbek, Arabic
+- **Real-time (WebSocket) updates**: when a register writes an order, the kitchen sees it instantly
+
+<Callout type="info">
+  HummyTummy is a **multi-tenant** system: every business's data is fully isolated
+  from every other's. You only ever see your own restaurant's data. The currency is
+  **Turkish Lira (TRY)**.
+</Callout>
+
+## How do I begin?
+
+Every new business starts with a **7-day free trial (TRIAL)** — no card required, all features unlocked. When the trial ends, you choose a paid plan to continue.
+
+Follow these pages in order:
+
+<Cards>
+  <Cards.Card title="Core Concepts" href="/getting-started/concepts" arrow />
+  <Cards.Card title="Create an Account" href="/getting-started/create-account" arrow />
+  <Cards.Card title="First-Time Setup" href="/getting-started/first-setup" arrow />
+</Cards>
+
+## What's next?
+
+Once your account is set up:
+
+- For details on every management screen, see the **[Admin Guide](/admin-guide)**
+- For plan limits and pricing, see **[Plans](/plans)**
+- For APIs and integrations, see **[Developer / Integration](/developer)**

--- a/developer/pages/en/getting-started/index.mdx
+++ b/developer/pages/en/getting-started/index.mdx
@@ -1,0 +1,7 @@
+---
+title: Getting Started
+---
+
+# Getting Started
+
+This section is being prepared.

--- a/developer/pages/en/index.mdx
+++ b/developer/pages/en/index.mdx
@@ -1,0 +1,28 @@
+---
+title: HummyTummy Documentation
+description: HummyTummy — cloud-based restaurant management. Guides from setup to integration, plans to the desktop app.
+---
+
+import { Cards } from 'nextra/components'
+
+# HummyTummy Documentation
+
+**HummyTummy** is a cloud-based restaurant management system: QR menu, POS, kitchen display (KDS), order & table management, inventory, reports, multi-branch, and developer integrations — in one panel.
+
+This portal serves both **owners/admins** (pages, plans, desktop) and **developers/integrators** (API, Partner Display, webhooks).
+
+<Cards>
+  <Cards.Card title="Getting Started" href="/getting-started" arrow />
+  <Cards.Card title="Admin Guide" href="/admin-guide" arrow />
+  <Cards.Card title="Plans" href="/plans" arrow />
+  <Cards.Card title="Marketplace" href="/marketplace" arrow />
+  <Cards.Card title="Developer / Integration" href="/developer" arrow />
+  <Cards.Card title="Desktop App" href="/desktop" arrow />
+  <Cards.Card title="Reference" href="/reference" arrow />
+</Cards>
+
+## Quick start
+
+- **Restaurant owner:** [Getting Started](/en/getting-started) → [Admin Guide](/en/admin-guide) → [Plans](/en/plans)
+- **Integrator/developer:** [Developer / Integration](/en/developer) → [Partner Display API](/en/developer/partner-display) → [Webhooks](/en/developer/webhooks)
+- **Desktop setup:** [Desktop App](/en/desktop)

--- a/developer/pages/en/marketplace/_meta.ts
+++ b/developer/pages/en/marketplace/_meta.ts
@@ -1,0 +1,3 @@
+export default {
+  "index": "Overview"
+}

--- a/developer/pages/en/marketplace/_meta.ts
+++ b/developer/pages/en/marketplace/_meta.ts
@@ -1,3 +1,5 @@
 export default {
-  "index": "Overview"
-}
+  "index": "Overview",
+  "purchase-flow": "Purchase Flow",
+  "products": "Products (Add-ons)",
+};

--- a/developer/pages/en/marketplace/index.mdx
+++ b/developer/pages/en/marketplace/index.mdx
@@ -1,0 +1,7 @@
+---
+title: Marketplace
+---
+
+# Marketplace
+
+This section is being prepared.

--- a/developer/pages/en/marketplace/index.mdx
+++ b/developer/pages/en/marketplace/index.mdx
@@ -1,7 +1,101 @@
 ---
 title: Marketplace
+description: HummyTummy Marketplace add-on catalogue — capacity packs, integrations, software features, and services.
 ---
+
+import { Callout, Cards } from 'nextra/components'
 
 # Marketplace
 
-This section is being prepared.
+The Marketplace is the catalogue of add-ons you can buy **individually** on top of your plan.
+A plan gives you a feature/limit baseline; add-ons **raise** that baseline: an extra KDS
+screen, an extra branch, an e-Fatura integration, advanced reports, and so on.
+
+Buying an add-on writes a **TenantAddOn** row for your tenant, and the entitlement projector
+folds that row's `grants` map into your existing entitlement set. The fold rules are explicit:
+
+- **`limit.*`** (numeric) → **summed** (e.g. plan 2 KDS + 1 add-on = 3 KDS)
+- **`feature.*`** (boolean) → **OR** (enabled if any source enables it)
+- **`integration.*`** (list) → **union** (providers are added to the list)
+
+<Callout type="info">
+  All prices are in **TRY** and stored in the catalogue as **cents** (`priceCents`):
+  `9900` = ₺99.00. Add-on prices are shown KDV-inclusive (gross).
+</Callout>
+
+## Browse the add-ons
+
+<Cards>
+  <Cards.Card title="Purchase Flow" href="/en/marketplace/purchase-flow" arrow>
+    Marketplace → checkout → PayTR → grant. Fold rules, cancellation, and period-end behaviour.
+  </Cards.Card>
+  <Cards.Card title="Products (Add-on Details)" href="/en/marketplace/products" arrow>
+    Per sellable add-on: code, price, what it grants, recurring vs one-time, dependency.
+  </Cards.Card>
+  <Cards.Card title="Plans" href="/en/plans" arrow>
+    The base plans add-ons stack on top of (BASIC / PRO / BUSINESS).
+  </Cards.Card>
+</Cards>
+
+## Catalogue summary
+
+Every sellable add-on at a glance. For details and sample payloads see the
+[Products](/en/marketplace/products) page.
+
+| Code | Name | Kind | Billing | Price | Grants | Dependency |
+| --- | --- | --- | --- | --- | --- | --- |
+| `kds_extra_screen` | Extra KDS screen | capacity | Recurring | ₺99.00 | `limit.kdsScreens` +1 | — |
+| `kds_extra_station` | Extra KDS station | capacity | Recurring | ₺149.00 | `limit.kdsStations` +1 | — |
+| `extra_tablet` | Extra waiter tablet | capacity | Recurring | ₺79.00 | `limit.tablets` +1 | — |
+| `extra_branch` | Extra branch | capacity | Recurring | ₺399.00 | `limit.branches` +1, `feature.multiLocation` | — |
+| `fiscal_efatura` | e-Fatura / e-Arşiv | integration | Recurring | ₺199.00 | `integration.fiscal` += `efatura` | — |
+| `fiscal_hugin` | Hugin yazarkasa | integration | Recurring | ₺299.00 | `integration.fiscal` += `hugin` | **`plan:PRO`** |
+| `delivery_yemeksepeti` | Yemeksepeti | integration | Recurring | ₺249.00 | `integration.delivery` += `yemeksepeti` | — |
+| `delivery_getir` | Getir Yemek | integration | Recurring | ₺249.00 | `integration.delivery` += `getir` | — |
+| `delivery_trendyol_yemek` | Trendyol Yemek | integration | Recurring | ₺249.00 | `integration.delivery` += `trendyol_yemek` | — |
+| `caller_id_integration` | Caller ID / phone-order | integration | Recurring | ₺149.00 | `feature.callerIntegration` | — |
+| `advanced_reports` | Advanced reports | software | Recurring | ₺129.00 | `feature.advancedReports` | — |
+| `api_access` | API access | software | Recurring | ₺249.00 | `feature.apiAccess` | — |
+| `priority_support` | Priority support | support | Recurring | ₺199.00 | `feature.prioritySupport` | — |
+| `onsite_install_full` | On-site setup (one-time) | support | **One-time** | ₺7,500.00 | — (no entitlement, service line) | — |
+
+<Callout type="warning">
+  `onsite_install_full` is a **service** line: it is paid and invoiced but grants no
+  entitlement (`grants: {}`). It is one-time, not recurring.
+</Callout>
+
+## Fetching the catalogue from the API
+
+The catalogue is public (it also shows on the landing site); no authentication is required.
+
+```bash
+curl https://api.hummytummy.com/api/v1/marketplace/addons
+```
+
+You can filter by `kind` (`capacity` | `integration` | `software` | `support`):
+
+```bash
+curl "https://api.hummytummy.com/api/v1/marketplace/addons?kind=integration"
+```
+
+Only `published` add-ons are returned; each row is trimmed for the UI:
+
+```json
+[
+  {
+    "code": "kds_extra_screen",
+    "name": "Extra KDS screen",
+    "description": "Adds one additional kitchen display screen slot to your branch.",
+    "kind": "capacity",
+    "billing": "recurring",
+    "priceCents": 9900,
+    "currency": "TRY",
+    "deps": []
+  }
+]
+```
+
+<Callout type="info">
+  All endpoints sit under the global `/api` prefix. The `grants` field is **not returned in
+  the public catalogue** — only the superadmin surface and the seed file carry the grant map.
+</Callout>

--- a/developer/pages/en/marketplace/products.mdx
+++ b/developer/pages/en/marketplace/products.mdx
@@ -1,0 +1,264 @@
+---
+title: Products (Add-ons)
+description: A detailed card per sellable add-on — what it does, what it grants, recurring vs one-time, dependency, how to buy.
+---
+
+import { Callout } from 'nextra/components'
+
+# Products (Add-ons)
+
+Every sellable item in the catalogue is documented below, one by one. Each card lists: **what
+it does**, **what it grants** (feature / limit / integration), **recurring vs one-time**,
+**dependency**, and **how to buy**.
+
+<Callout type="info">
+  The purchase path is the same for every add-on: add it to a mixed cart and call
+  `POST /v1/checkout/intent` → PayTR → webhook → grant. See
+  [Purchase Flow](/en/marketplace/purchase-flow). Prices are TRY, KDV-inclusive.
+</Callout>
+
+---
+
+## Capacity packs
+
+### `kds_extra_screen` — Extra KDS screen
+
+Adds **one** additional kitchen display (KDS) screen slot to your branch.
+
+| Field | Value |
+| --- | --- |
+| Kind (`kind`) | `capacity` |
+| Billing (`billing`) | `recurring` |
+| Price | ₺99.00 (`priceCents: 9900`) |
+| Grants (`grants`) | `limit.kdsScreens` **+1** |
+| Dependency | — |
+
+### `kds_extra_station` — Extra KDS station
+
+Adds **one** routing station (bar / grill / dessert) on top of the default kitchen.
+
+| Field | Value |
+| --- | --- |
+| Kind | `capacity` |
+| Billing | `recurring` |
+| Price | ₺149.00 (`priceCents: 14900`) |
+| Grants | `limit.kdsStations` **+1** |
+| Dependency | — |
+
+### `extra_tablet` — Extra waiter tablet
+
+Increases your waiter-tablet seat limit by **one**.
+
+| Field | Value |
+| --- | --- |
+| Kind | `capacity` |
+| Billing | `recurring` |
+| Price | ₺79.00 (`priceCents: 7900`) |
+| Grants | `limit.tablets` **+1** |
+| Dependency | — |
+
+### `extra_branch` — Extra branch
+
+Adds **one** branch beyond your plan limit. Required for chains. A single purchase unlocks two
+things: it raises the branch limit **and** enables the multi-location feature.
+
+| Field | Value |
+| --- | --- |
+| Kind | `capacity` |
+| Billing | `recurring` |
+| Price | ₺399.00 (`priceCents: 39900`) |
+| Grants | `limit.branches` **+1** **and** `feature.multiLocation: true` |
+| Dependency | — |
+
+<Callout type="info">
+  `extra_branch` carries both a **limit** (SUM) and a **feature** (OR) grant in a single
+  purchase: `{ "limit.branches": 1, "feature.multiLocation": true }`.
+</Callout>
+
+---
+
+## Integrations
+
+### `fiscal_efatura` — e-Fatura / e-Arşiv
+
+Issue tax-compliant electronic invoices (cloud-side, no hardware required).
+
+| Field | Value |
+| --- | --- |
+| Kind | `integration` |
+| Billing | `recurring` |
+| Price | ₺199.00 (`priceCents: 19900`) |
+| Grants | `efatura` added to the `integration.fiscal` list |
+| Dependency | — |
+
+### `fiscal_hugin` — Hugin yazarkasa integration
+
+Drive a Hugin fiscal device via the Local Bridge Agent.
+
+| Field | Value |
+| --- | --- |
+| Kind | `integration` |
+| Billing | `recurring` |
+| Price | ₺299.00 (`priceCents: 29900`) |
+| Grants | `hugin` added to the `integration.fiscal` list |
+| Dependency | **`plan:PRO`** — requires the PRO plan |
+
+<Callout type="warning">
+  `fiscal_hugin` is the **only** add-on in the catalogue with a dependency. If you are not on
+  PRO, the purchase is rejected with `Add-on requires: plan:PRO`.
+</Callout>
+
+### `delivery_yemeksepeti` — Yemeksepeti integration
+
+Receive Yemeksepeti orders directly into your KDS.
+
+| Field | Value |
+| --- | --- |
+| Kind | `integration` |
+| Billing | `recurring` |
+| Price | ₺249.00 (`priceCents: 24900`) |
+| Grants | `yemeksepeti` added to the `integration.delivery` list |
+| Dependency | — |
+
+### `delivery_getir` — Getir Yemek integration
+
+Receive Getir Yemek orders directly into your KDS.
+
+| Field | Value |
+| --- | --- |
+| Kind | `integration` |
+| Billing | `recurring` |
+| Price | ₺249.00 (`priceCents: 24900`) |
+| Grants | `getir` added to the `integration.delivery` list |
+| Dependency | — |
+
+### `delivery_trendyol_yemek` — Trendyol Yemek integration
+
+Receive Trendyol Yemek orders directly into your KDS.
+
+| Field | Value |
+| --- | --- |
+| Kind | `integration` |
+| Billing | `recurring` |
+| Price | ₺249.00 (`priceCents: 24900`) |
+| Grants | `trendyol_yemek` added to the `integration.delivery` list |
+| Dependency | — |
+
+<Callout type="info">
+  All three delivery integrations write to the `integration.delivery` key and are **union**-ed.
+  Buying all of them gives you `integration.delivery: ["getir", "trendyol_yemek", "yemeksepeti"]`.
+</Callout>
+
+### `caller_id_integration` — Caller ID / phone-order integration
+
+Open a customer card automatically on every inbound call.
+
+| Field | Value |
+| --- | --- |
+| Kind | `integration` |
+| Billing | `recurring` |
+| Price | ₺149.00 (`priceCents: 14900`) |
+| Grants | `feature.callerIntegration: true` |
+| Dependency | — |
+
+<Callout type="info">
+  Although its `kind` is "integration", its grant is a **feature** flag
+  (`feature.callerIntegration`), not an `integration.*` list.
+</Callout>
+
+---
+
+## Software / features
+
+### `advanced_reports` — Advanced reports
+
+Cohort analysis, custom reports, scheduled email delivery.
+
+| Field | Value |
+| --- | --- |
+| Kind | `software` |
+| Billing | `recurring` |
+| Price | ₺129.00 (`priceCents: 12900`) |
+| Grants | `feature.advancedReports: true` |
+| Dependency | — |
+
+### `api_access` — API access
+
+A public API key + outbound webhooks for your integrations.
+
+| Field | Value |
+| --- | --- |
+| Kind | `software` |
+| Billing | `recurring` |
+| Price | ₺249.00 (`priceCents: 24900`) |
+| Grants | `feature.apiAccess: true` |
+| Dependency | — |
+
+---
+
+## Support
+
+### `priority_support` — Priority support
+
+A 24-hour SLA on critical tickets. Direct line during business hours.
+
+| Field | Value |
+| --- | --- |
+| Kind | `support` |
+| Billing | `recurring` |
+| Price | ₺199.00 (`priceCents: 19900`) |
+| Grants | `feature.prioritySupport: true` |
+| Dependency | — |
+
+### `onsite_install_full` — On-site setup (one-time)
+
+A HummyTummy technician comes to your venue, installs the bridge + devices, and trains your
+staff.
+
+| Field | Value |
+| --- | --- |
+| Kind | `support` |
+| Billing | **`oneTime`** |
+| Price | ₺7,500.00 (`priceCents: 750000`) |
+| Grants | **Nothing** — `grants: {}` (just a service / invoice line) |
+| Dependency | — |
+
+<Callout type="warning">
+  This item grants no entitlement delta; it is paid and invoiced but does not change your
+  entitlement set. It is one-time, **not** recurring, and gets no period-end window
+  (`currentPeriodEnd` is `null`).
+</Callout>
+
+---
+
+## How to buy (example)
+
+Every add-on goes through the same mixed-cart checkout rail. A sample intent body:
+
+```json
+{
+  "cart": {
+    "items": [
+      { "type": "addon", "code": "kds_extra_screen", "qty": 1 },
+      { "type": "addon", "code": "fiscal_efatura", "qty": 1 }
+    ]
+  },
+  "buyer": {
+    "email": "owner@restaurant.com",
+    "name": "Ali Veli",
+    "phone": "+905551112233",
+    "address": "..."
+  },
+  "returnUrl": "https://app.hummytummy.com/checkout/done"
+}
+```
+
+```bash
+curl -X POST https://api.hummytummy.com/api/v1/checkout/intent \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d @intent.json
+```
+
+The response returns a PayTR iframe token + payment link; once payment is confirmed the webhook
+provisions the grants. Step-by-step: [Purchase Flow](/en/marketplace/purchase-flow).

--- a/developer/pages/en/marketplace/purchase-flow.mdx
+++ b/developer/pages/en/marketplace/purchase-flow.mdx
@@ -1,0 +1,181 @@
+---
+title: Purchase Flow
+description: Marketplace → checkout → PayTR → grant. Fold rules, idempotency, cancellation, and period-end behaviour.
+---
+
+import { Callout, Steps, Tabs } from 'nextra/components'
+
+# Purchase Flow
+
+The **only** way to buy an add-on is the checkout (PayTR) rail. There is **no** tenant-facing
+"free grant" endpoint — it was removed. A paid add-on is never provisioned without proof of
+payment (`paymentRef`).
+
+<Callout type="warning">
+  The legacy `POST /v1/marketplace/addons/purchase` endpoint was **removed** (deep-review C2).
+  It was guarded only by `@Roles(ADMIN)` and called `purchase()` with no `paymentRef` — so any
+  restaurant owner could activate a paid add-on for free via curl. The paid flow is now
+  mandatory; operator comps are issued only from the superadmin surface.
+</Callout>
+
+## End-to-end flow
+
+<Steps>
+
+### List the catalogue
+
+The user picks an add-on in the Marketplace. The catalogue comes from
+`GET /v1/marketplace/addons` (public, `published` rows only).
+
+### Start a checkout intent
+
+The frontend submits the selected add-ons (plus any plan/hardware/service lines) as a single
+**mixed cart** to `POST /v1/checkout/intent`. Roles: **ADMIN, MANAGER**.
+
+The server **re-prices** the cart (it never trusts client totals), mints a `paymentRef` of the
+form `CK-<uuid7>`, freezes the cart onto a `CheckoutIntent` row, and returns a PayTR iframe
+token + payment link.
+
+### Pay via PayTR
+
+The buyer pays on the PayTR hosted iframe. Each cart line is shown to the buyer as a separate
+basket entry (e.g. *"Extra KDS screen (monthly)"*).
+
+### Settlement via webhook
+
+The PayTR webhook carries only `merchant_oid` + `total_amount`. The dispatcher sees the `CK-`
+prefix and routes the callback to **CheckoutSettlementService**. There the `CheckoutIntent` is
+found, the frozen cart is read, and **CheckoutService.confirmAndProvision** runs.
+
+### Grants are provisioned
+
+For each add-on line `confirmAndProvision` calls `TenantMarketplaceService.purchase()` **with
+the settled `paymentRef`** inside the checkout transaction. That creates a `TenantAddOn` row
+and appends an `AddOnPurchased` event to the outbox.
+
+### The entitlement projector folds
+
+The projector consumes `AddOnPurchased` and folds the add-on's `grants` map into your current
+entitlement set. Guards and the UI now see the new limit/feature/integration.
+
+</Steps>
+
+## Fold rules
+
+The projector reduces the plan + all active add-on `grants` rows into **one** entitlement set.
+The combine rule depends on the key prefix:
+
+| Prefix | Type | Combine | Example |
+| --- | --- | --- | --- |
+| `limit.*` | number | **SUM** | Plan `limit.kdsScreens: 2` + 1× `kds_extra_screen` (+1) = **3** |
+| `feature.*` | boolean | **OR** | If any source sets `feature.advancedReports: true` → enabled |
+| `integration.*` | string[] | **UNION** | `efatura` add-on + `hugin` add-on → `integration.fiscal: ["efatura", "hugin"]` |
+
+<Callout type="info">
+  For `limit.*`, `-1` is the "unlimited" sentinel: if any source grants `-1`, the result is
+  unlimited and summing stops (adding capacity to an already-unlimited cap is a no-op).
+</Callout>
+
+Buying the same capacity add-on twice to double a limit is blocked: if an active row already
+exists for the same `(tenantId, addOnId, branchId)`, the second purchase is rejected. Two
+concurrent purchases are caught by a **Serializable** transaction; the loser gets a retryable
+**409** (the card is not charged twice).
+
+## Dependencies (deps)
+
+Some add-ons require something else to already be in place. Every entry in the `deps` array
+must currently **apply** to the tenant at purchase time:
+
+- `plan:PRO` → the tenant's active plan name must be `PRO` (`Tenant.currentPlan.name`).
+- An add-on code (e.g. `caller_id_integration`) → that add-on must be **active** on the tenant.
+
+Today the only add-on in the catalogue with `deps` is **`fiscal_hugin`** (`["plan:PRO"]`). If
+you are not on PRO, the purchase is rejected with:
+
+```
+Add-on requires: plan:PRO. Upgrade your plan or purchase the required add-ons first.
+```
+
+## Idempotency
+
+PayTR retries aggressively (it retries even after a 200 OK if the body isn't "OK"/"FAIL").
+There are multiple layers of protection against double provisioning:
+
+1. The **`CheckoutIntent.status`** check — if `provisioned`/`failed`, nothing is touched.
+2. **`confirmAndProvision`** is independently idempotent on `(tenantId, paymentRef)`.
+3. **`purchase()`** returns the existing `TenantAddOn` row for the same `paymentRef` (without
+   re-emitting an event).
+
+## My current add-ons
+
+Lists the add-ons the tenant currently holds. Roles: **ADMIN, MANAGER**.
+
+```bash
+curl https://api.hummytummy.com/api/v1/marketplace/addons/mine \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+Each row carries the add-on catalogue (`addOn`) plus its status/period fields:
+
+```json
+[
+  {
+    "id": "ta_01J...",
+    "tenantId": "t_01J...",
+    "addOnId": "ao_01J...",
+    "branchId": null,
+    "quantity": 1,
+    "status": "active",
+    "activatedAt": "2026-06-22T10:00:00.000Z",
+    "currentPeriodStart": "2026-06-22T10:00:00.000Z",
+    "currentPeriodEnd": "2026-07-22T10:00:00.000Z",
+    "paymentRef": "CK-018f...",
+    "addOn": { "code": "kds_extra_screen", "name": "Extra KDS screen", "...": "..." }
+  }
+]
+```
+
+<Callout type="info">
+  Recurring add-ons get a 30-day `currentPeriodEnd` window (so the cancellation flow has a
+  meaningful period end). The real billing cycle aligns to the parent Subscription cycle.
+</Callout>
+
+## Cancellation and period-end behaviour
+
+Cancellation is **ADMIN-only** (it's a billing decision):
+
+<Tabs items={['Cancel at period end (default)', 'Cancel immediately']}>
+<Tabs.Tab>
+
+```bash
+curl -X DELETE \
+  https://api.hummytummy.com/api/v1/marketplace/addons/$TENANT_ADDON_ID \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+The row is set to `cancelAtPeriodEnd: true` and **stays active**. The limit/feature/integration
+entitlements it grants keep living until the nightly sweeper / billing-cycle close transitions
+the row to `cancelled`.
+
+</Tabs.Tab>
+<Tabs.Tab>
+
+```bash
+curl -X DELETE \
+  "https://api.hummytummy.com/api/v1/marketplace/addons/$TENANT_ADDON_ID?immediate=true" \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+The row becomes `cancelled` immediately (`endedAt` is stamped), an `AddOnCancelled` event is
+appended to the outbox, and **entitlements are revoked right away**. The emit runs inside the
+cancel transaction — if the append fails, the cancellation rolls back (no half-revoked
+entitlement is left behind).
+
+</Tabs.Tab>
+</Tabs>
+
+<Callout type="warning">
+  Two concurrent cancel calls converge on a single transition (a `status = 'active'`-scoped
+  `updateMany`). The loser gets `Cancel raced with another request — refresh and retry`; the
+  `AddOnCancelled` event is **not** emitted twice.
+</Callout>

--- a/developer/pages/en/plans/_meta.ts
+++ b/developer/pages/en/plans/_meta.ts
@@ -1,0 +1,3 @@
+export default {
+  "index": "Overview"
+}

--- a/developer/pages/en/plans/_meta.ts
+++ b/developer/pages/en/plans/_meta.ts
@@ -1,3 +1,6 @@
 export default {
-  "index": "Overview"
-}
+  "index": "Overview",
+  "feature-matrix": "Feature matrix",
+  "choosing-and-upgrading": "Choosing & upgrading",
+  "trial-and-billing": "Trial & billing",
+};

--- a/developer/pages/en/plans/choosing-and-upgrading.mdx
+++ b/developer/pages/en/plans/choosing-and-upgrading.mdx
@@ -1,0 +1,152 @@
+---
+title: Choosing & upgrading
+description: Choosing a plan, upgrading (proration), downgrading (at period end), and payment flows (PayTR / bank transfer).
+---
+
+import { Callout, Steps, Tabs } from 'nextra/components'
+
+# Choosing & upgrading
+
+Plan selection and changes run through two screens:
+
+- **Plan selection screen** (`SubscriptionPlansPage`) — lists the plans, lets you pick monthly/yearly.
+- **Change plan screen** (`ChangePlanPage`) — upgrades/downgrades a live subscription.
+
+All prices are **TRY** and **VAT-inclusive**. Only the **ADMIN** and **MANAGER** roles can call the payment/checkout endpoints; the endpoints that actually write a plan change are restricted to **ADMIN**.
+
+## Listing sellable plans
+
+The plan catalog is public (`@Public`) and returns only **active + public** plans — that is, Basic / Pro / Business. The Trial (`isPublic=false`) and the retired Free (`isActive=false`) plans never appear in the list.
+
+```bash
+curl https://app.hummytummy.com/api/subscriptions/plans
+```
+
+For each plan, the response includes `id`, `name`, `displayName`, `monthlyPrice`, `yearlyPrice`, `currency`, `trialDays`, `limits`, `features`, and (if any) an active `discount`. Any advertised discounted price is computed with the **same** `resolvePlanAmount` the charge rails use, so the price shown equals the price charged.
+
+## Selection flow: which path is taken?
+
+The plan selection screen branches on the business's current subscription status:
+
+<Steps>
+
+### Live subscription (ACTIVE / TRIALING), different plan
+The user is routed to the **Change plan** screen. Upgrade/downgrade proration only makes sense within a live billing period.
+
+```text
+/subscription/change-plan?newPlanId=<PLAN_ID>&billingCycle=MONTHLY
+```
+
+### Live subscription, same plan
+No-op.
+
+### PAST_DUE / EXPIRED / CANCELLED / no subscription
+The fresh **checkout** flow is used. Because proration over a finished period would produce a negative amount, these cases start a new full-period subscription instead.
+
+```text
+/subscription/checkout?planId=<PLAN_ID>&billingCycle=MONTHLY
+```
+
+### Trial-eligible business
+The backend short-circuits to the TRIAL response inside `/payments/create-intent`; the checkout screen handles this case specially.
+
+</Steps>
+
+## Upgrade (with proration)
+
+Switching to a more expensive plan on a live subscription counts as an **upgrade**. `POST /subscriptions/:id/change-plan` returns a **prorated quote** based on the days remaining in the period — this call does not write a mutation; it only computes the amount to charge.
+
+<Tabs items={['Flow', 'curl', 'Response']}>
+<Tabs.Tab>
+
+1. The user selects the new (more expensive) plan.
+2. The backend returns an `upgrade` quote with `requiresPayment` and `prorationAmount`.
+3. Payment is collected via the PayTR (or bank transfer) rail; the upgrade is then applied.
+
+</Tabs.Tab>
+<Tabs.Tab>
+
+```bash
+curl -X POST https://app.hummytummy.com/api/subscriptions/<SUB_ID>/change-plan \
+  -H "Authorization: Bearer <ADMIN_TOKEN>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "newPlanId": "<NEW_PLAN_ID>",
+    "billingCycle": "MONTHLY"
+  }'
+```
+
+</Tabs.Tab>
+<Tabs.Tab>
+
+```json
+{
+  "type": "upgrade",
+  "requiresPayment": true,
+  "paymentInfo": {
+    "subscriptionId": "sub_...",
+    "newPlanId": "plan_...",
+    "billingCycle": "MONTHLY",
+    "prorationAmount": 533.42,
+    "newAmount": 1299,
+    "currency": "TRY"
+  }
+}
+```
+
+</Tabs.Tab>
+</Tabs>
+
+<Callout type="info">
+  Proration is computed from the ratio of days remaining until `currentPeriodEnd` to the total days in the period. If `prorationAmount` is greater than 0, `requiresPayment: true` is returned and the upgrade is applied only after payment is collected.
+</Callout>
+
+## Downgrade (applied at period end)
+
+Switching to a cheaper plan counts as a **downgrade** and is **not applied immediately** — it is **scheduled** for the end of the current billing period. The same call behaves as follows:
+
+- Current usage is first validated against the target plan's limits (`assertDowngradeAllowed`). For example, if you have 4 branches you cannot downgrade to Basic's 1-branch limit.
+- The change is recorded as `scheduledDowngradePlanId`, written atomically with a compound `WHERE ... scheduledDowngradePlanId IS NULL` to guard against races.
+- The response includes `type: "downgrade"`, `requiresPayment: false`, and `scheduledFor` (the period-end date).
+
+```bash
+# Query a scheduled downgrade
+curl https://app.hummytummy.com/api/subscriptions/<SUB_ID>/scheduled-downgrade \
+  -H "Authorization: Bearer <ADMIN_OR_MANAGER_TOKEN>"
+
+# Cancel a scheduled downgrade (ADMIN only)
+curl -X DELETE https://app.hummytummy.com/api/subscriptions/<SUB_ID>/scheduled-downgrade \
+  -H "Authorization: Bearer <ADMIN_TOKEN>"
+```
+
+<Callout type="warning">
+  If you try to make a new change while one is already scheduled, the request is rejected ("cancel the existing change first"). Cross-currency plan changes are also unsupported (the system is TRY-only).
+</Callout>
+
+## Payment rails: PayTR and bank transfer
+
+Payment for a new subscription or an upgrade can be collected via two rails:
+
+- **PayTR (card)** — the default. PayTR collects **TRY** only. `POST /payments/create-intent` creates a PENDING payment; once confirmed by webhook the subscription activates. Limited to 5 attempts per minute (`@Throttle`).
+- **Bank transfer (havale/EFT, manual)** — an alternative method. `GET /payments/bank-transfer/details` returns the platform bank details, and `POST /payments/bank-transfer/intent` reserves a bank-transfer payment. A bank-transfer payment is **activated by superadmin confirmation** (not a webhook). If a superadmin hasn't set an IBAN, the bank-transfer screen is disabled.
+
+```bash
+# Start a card (PayTR) subscription payment
+curl -X POST https://app.hummytummy.com/api/payments/create-intent \
+  -H "Authorization: Bearer <ADMIN_TOKEN>" \
+  -H "Content-Type: application/json" \
+  -d '{ "planId": "<PLAN_ID>", "billingCycle": "YEARLY" }'
+```
+
+<Callout type="info">
+  Marketplace add-on purchases use the **same PayTR checkout rail** (`POST /api/v1/checkout/intent` → `CK-`-prefixed webhook → `confirmAndProvision`). Add-ons activate only after payment. See [Marketplace](/en/marketplace).
+</Callout>
+
+## Acquiring features later
+
+When you need a feature later, there are two paths:
+
+1. **Plan upgrade** — move to a higher tier to unlock the full feature set and higher limits (the upgrade flow on this page).
+2. **Marketplace add-on** — add a single capability without changing plans. See [Marketplace](/en/marketplace).
+
+> A superadmin override (manually unlocking a feature) is an internal operation only; it is not a customer-facing flow.

--- a/developer/pages/en/plans/feature-matrix.mdx
+++ b/developer/pages/en/plans/feature-matrix.mdx
@@ -1,0 +1,63 @@
+---
+title: Feature matrix
+description: Full feature and limit comparison across the Basic, Pro, and Business plans.
+---
+
+import { Callout } from 'nextra/components'
+
+# Feature matrix
+
+The tables below show every feature flag and usage limit for the three sellable plans (**Basic / Pro / Business**). Source: `subscription-plans.const.ts`.
+
+## Features
+
+| Feature | Flag | Basic | Pro | Business |
+| --- | --- | :---: | :---: | :---: |
+| POS access | `posAccess` | ✓ | ✓ | ✓ |
+| KDS (kitchen display) integration | `kdsIntegration` | ✓ | ✓ | ✓ |
+| Inventory tracking | `inventoryTracking` | ✓ | ✓ | ✓ |
+| Advanced reports | `advancedReports` | ✗ | ✓ | ✓ |
+| Multi-location | `multiLocation` | ✗ | ✓ | ✓ |
+| Custom branding | `customBranding` | ✗ | ✓ | ✓ |
+| Priority support | `prioritySupport` | ✗ | ✓ | ✓ |
+| Reservation system | `reservationSystem` | ✗ | ✓ | ✓ |
+| Personnel management | `personnelManagement` | ✗ | ✓ | ✓ |
+| Delivery integration | `deliveryIntegration` | ✗ | ✓ | ✓ |
+| API access | `apiAccess` | ✗ | ✗ | ✓ |
+| External display (Partner Display) | `externalDisplay` | ✗ | ✗ | ✓ |
+
+<Callout type="info">
+  **API access** and **external display (Partner Display API)** are exclusive to the Business plan. These two capabilities cover third-party integrations and remote/desktop screen sessions.
+</Callout>
+
+## Limits
+
+A value of `-1` means **unlimited** (the `isUnlimited` helper compares against `-1`).
+
+| Limit | Field | Basic | Pro | Business |
+| --- | --- | :---: | :---: | :---: |
+| Max users | `maxUsers` | 5 | 15 | ∞ |
+| Max tables | `maxTables` | 20 | 50 | ∞ |
+| Max branches | `maxBranches` | 1 | 3 | ∞ |
+| Max products | `maxProducts` | 100 | 500 | ∞ |
+| Max categories | `maxCategories` | 20 | 50 | ∞ |
+| Max monthly orders | `maxMonthlyOrders` | 500 | 2,000 | ∞ |
+
+## The Trial (TRIAL) plan
+
+The **Trial** plan that every new business starts on has **all of Business's features and unlimited limits** for 7 days. It is not sellable (`isPublic=false`), so it is not listed on the plan-selection screen and is excluded from the pricing comparison. For details, see [Trial & billing](/en/plans/trial-and-billing).
+
+<Callout type="warning">
+  When a feature flag changes, **all three places** must stay in sync: the Prisma schema, the projector columns (`FEATURE_COLUMNS`), and the `getEffectiveFeatures` fallback. The table on this page mirrors `subscription-plans.const.ts`, from which those sources are derived.
+</Callout>
+
+## Querying entitled features
+
+You can read a business's currently effective features via the API. This endpoint merges plan features, any marketplace add-on upgrades, and superadmin overrides.
+
+```bash
+curl https://app.hummytummy.com/api/subscriptions/effective-features \
+  -H "Authorization: Bearer <ADMIN_OR_MANAGER_TOKEN>"
+```
+
+> The response returns the business's actual access based on the `feature.*` and `limit.*` projections — not just the plan default.

--- a/developer/pages/en/plans/index.mdx
+++ b/developer/pages/en/plans/index.mdx
@@ -1,7 +1,47 @@
 ---
 title: Plans
+description: HummyTummy subscription plans — pricing, scope, and which plan is right for you.
 ---
+
+import { Callout, Cards } from 'nextra/components'
 
 # Plans
 
-This section is being prepared.
+HummyTummy offers three sellable plans: **Basic (BASIC)**, **Pro (PRO)**, and **Business (BUSINESS)**. Every new business starts on a **7-day full-featured Trial (TRIAL)** at sign-up; when the trial ends you must choose a paid plan to keep going.
+
+All prices are in **Turkish Lira (TRY)** and are **VAT-inclusive**.
+
+## Plans and pricing
+
+| Plan | Monthly | Yearly | Best for |
+| --- | --- | --- | --- |
+| **Basic** (BASIC) | **₺499/mo** | **₺4,490/yr** | Cafés and small restaurants needing core POS + inventory |
+| **Pro** (PRO) | **₺1,299/mo** | **₺12,990/yr** | City-center restaurants needing reservations + delivery + staff management |
+| **Business** (BUSINESS) | **₺2,999/mo** | **₺29,990/yr** | Multi-branch chains — unlimited + API access + priority support |
+
+<Callout type="info">
+  Paying yearly saves you ~17%: you pay the yearly amount instead of 12 monthly charges (e.g. on Basic, ₺4,490 instead of 12 × ₺499 = ₺5,988).
+</Callout>
+
+## What's in every plan?
+
+All three plans include the core modules you need to run a restaurant:
+
+- **POS access** (`posAccess`) — order taking and sales screen
+- **KDS integration** (`kdsIntegration`) — kitchen display
+- **Inventory tracking** (`inventoryTracking`) — product and ingredient stock
+
+As you move up the tiers, capabilities like advanced reports, multi-location, reservations, staff management, delivery integration, custom branding, and API access unlock, and your usage limits (users, tables, branches, products, orders) increase.
+
+<Callout type="warning">
+  **The Free (FREE) plan has been retired.** Its enum value is kept only for backward compatibility with legacy tenants; it is not sellable and no new business ever lands on it. Businesses whose trial ends move to `TRIAL_ENDED` status and the app is locked until a plan is chosen — see [Trial & billing](/en/plans/trial-and-billing).
+</Callout>
+
+## Continue
+
+<Cards>
+  <Cards.Card title="Feature matrix" href="/en/plans/feature-matrix" />
+  <Cards.Card title="Choosing & upgrading" href="/en/plans/choosing-and-upgrading" />
+  <Cards.Card title="Trial & billing" href="/en/plans/trial-and-billing" />
+  <Cards.Card title="Marketplace add-ons" href="/en/marketplace" />
+</Cards>

--- a/developer/pages/en/plans/index.mdx
+++ b/developer/pages/en/plans/index.mdx
@@ -1,0 +1,7 @@
+---
+title: Plans
+---
+
+# Plans
+
+This section is being prepared.

--- a/developer/pages/en/plans/trial-and-billing.mdx
+++ b/developer/pages/en/plans/trial-and-billing.mdx
@@ -1,0 +1,102 @@
+---
+title: Trial & billing
+description: The 7-day trial, the TRIAL_ENDED lock, the billing cycle, and VAT-inclusive pricing.
+---
+
+import { Callout, Steps } from 'nextra/components'
+
+# Trial & billing
+
+## 7-day trial (TRIAL)
+
+Every new business is automatically placed on the **Trial (TRIAL)** plan at sign-up:
+
+- **Duration:** 7 days (`trialDays: 7`).
+- **Scope:** all of Business's features and **unlimited** limits (every limit is `-1`).
+- **Not sellable:** because `isPublic=false`, it never appears on the plan-selection screen. The trial is not tied to any paid plan — it is assigned at sign-up.
+
+The trial runs as a **dedicated onboarding plan**, not on top of the Business plan as in the old design. This keeps the trial from depending on a plan's `trialDays` value and prevents silent transitions.
+
+## The TRIAL_ENDED lock
+
+If the trial period elapses **without a paid plan being chosen**, the business moves to `TRIAL_ENDED` status and is **locked**. This is an explicit lock rather than a silent downgrade to FREE.
+
+<Steps>
+
+### Backend (default-deny)
+The global `SubscriptionStatusGuard` rejects **every tenant-scoped route** with a 403 for any business that lacks a live subscription (`ACTIVE` / `TRIALING` / `PAST_DUE`). The response:
+
+```json
+{
+  "statusCode": 403,
+  "error": "Plan Selection Required",
+  "errorCode": "PLAN_SELECTION_REQUIRED",
+  "message": "Deneme süreniz sona erdi. Devam etmek için bir plan seçin."
+}
+```
+
+### Allowlisted recovery paths
+A locked business can still call these prefixes: `/auth`, `/me`, `/users/me`, `/profile`, `/subscriptions`, `/payments`, `/checkout`, `/legal`, `/entitlements`, `/webhooks`, `/health`. In other words it can read the plan catalog and make a payment — nothing else.
+
+### Frontend redirect
+On the SPA side, `SubscriptionGate` redirects the user to the plan-selection screen (`/choose-plan`) in response to the `PLAN_SELECTION_REQUIRED` code.
+
+</Steps>
+
+<Callout type="warning">
+  The lock is not only for `TRIAL_ENDED`: `EXPIRED` and `CANCELLED` businesses are also considered "not live" and are locked the same way. A subscription in `PAST_DUE` is treated as live during its 7-day grace period.
+</Callout>
+
+## Billing cycle
+
+The billing cycle has two options (`BillingCycle`): **MONTHLY** and **YEARLY**. The chosen cycle determines the period length and the amount charged on subscription creation, upgrade, and downgrade. Paying yearly is cheaper than 12× the monthly amount (~17% savings).
+
+You can read your invoices via the API:
+
+```bash
+# All of a tenant's invoices (paginated)
+curl "https://app.hummytummy.com/api/subscriptions/tenant/invoices?page=1&pageSize=20" \
+  -H "Authorization: Bearer <ADMIN_OR_MANAGER_TOKEN>"
+
+# Invoices for a specific subscription
+curl "https://app.hummytummy.com/api/subscriptions/<SUB_ID>/invoices?page=1&pageSize=20" \
+  -H "Authorization: Bearer <ADMIN_OR_MANAGER_TOKEN>"
+```
+
+## VAT-inclusive pricing
+
+All advertised plan prices are **gross** (VAT-inclusive) amounts, and the customer is charged exactly that amount. When an invoice is issued, `BillingService` reverse-engineers the VAT (KDV) out of the gross amount:
+
+- The default VAT rate is **20%** (`DEFAULT_KDV_RATE = 0.2`). It can be overridden with the `KDV_RATE` environment variable (e.g. `0.10`).
+- The split is performed only for TRY invoices; net and tax are derived as:
+
+```text
+subtotal = total / (1 + rate)
+tax      = total - subtotal
+```
+
+Subtracting guarantees `subtotal + tax == total` **to the cent**, regardless of rounding choices.
+
+**Example — Pro monthly ₺1,299 (VAT 20%):**
+
+| Line | Amount |
+| --- | --- |
+| Subtotal (net) | ₺1,082.50 |
+| VAT (20%) | ₺216.50 |
+| **Total (charged)** | **₺1,299.00** |
+
+<Callout type="info">
+  The business's tax ID (`taxId`) is snapshotted on the invoice **as it was at issuance time**. Even if it is changed later, past invoices are unaffected.
+</Callout>
+
+## Cancellation and reactivation
+
+- `POST /subscriptions/:id/cancel` — cancels the subscription (ADMIN only). The body may include `immediate` (now vs. at period end) and a `reason` of up to 500 characters.
+- `POST /subscriptions/:id/reactivate` — reactivates a cancelled subscription (ADMIN only).
+
+```bash
+curl -X POST https://app.hummytummy.com/api/subscriptions/<SUB_ID>/cancel \
+  -H "Authorization: Bearer <ADMIN_TOKEN>" \
+  -H "Content-Type: application/json" \
+  -d '{ "immediate": false, "reason": "End-of-season closure" }'
+```

--- a/developer/pages/en/reference/_meta.ts
+++ b/developer/pages/en/reference/_meta.ts
@@ -1,0 +1,3 @@
+export default {
+  "index": "Overview"
+}

--- a/developer/pages/en/reference/_meta.ts
+++ b/developer/pages/en/reference/_meta.ts
@@ -1,3 +1,7 @@
 export default {
-  "index": "Overview"
+  "index": "Overview",
+  "error-codes": "Error Codes",
+  "partner-scopes": "Partner Scopes",
+  "plan-matrix": "Plan Matrix",
+  "glossary": "Glossary"
 }

--- a/developer/pages/en/reference/error-codes.mdx
+++ b/developer/pages/en/reference/error-codes.mdx
@@ -1,0 +1,199 @@
+---
+title: Error Codes
+description: The standard error envelope, machine-readable errorCode values, and how Prisma database errors map to HTTP status codes.
+---
+
+import { Callout, Tabs } from 'nextra/components'
+
+# Error Codes
+
+Every error in the HummyTummy API is returned through a single, standard
+**error envelope**. On the client, branch on the stable `errorCode` field —
+not on the human-readable message.
+
+## Error envelope
+
+Every error response follows this shape:
+
+```json
+{
+  "statusCode": 409,
+  "message": "A record with this email already exists",
+  "error": "UniqueConstraintViolation",
+  "errorCode": "RESOURCE_ALREADY_EXISTS",
+  "timestamp": "2026-06-23T08:14:05.123Z",
+  "path": "/api/v1/auth/register",
+  "requestId": "1750665245123-a1b2c3d4e"
+}
+```
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `statusCode` | `number` | HTTP status code. |
+| `message` | `string \| string[]` | User-facing message. May be an array for validation errors. |
+| `error` | `string` | A human/category label (sometimes localized, or class-validator's `"Bad Request"`). **Do not branch on this.** |
+| `errorCode` | `string?` | The stable, machine-readable code. **The client should branch only on this.** Present only when the thrown exception attaches one. |
+| `timestamp` | `string` | Request timestamp (ISO 8601). |
+| `path` | `string` | Request path. |
+| `requestId` | `string?` | Tracking id — include it in support requests. |
+| `details` | `any?` | Present only in the `development` environment. |
+| `stack` | `string?` | Present only in the `development` environment. |
+
+<Callout type="info">
+  `errorCode` carries **no PII**, so it is surfaced in every environment
+  (production included). `details` and `stack`, by contrast, appear only in the
+  `development` environment.
+</Callout>
+
+<Callout type="warning">
+  The `error` field may be localized or fall back to a framework-generated
+  label. **Always** branch behaviour on `errorCode`; when `errorCode` is
+  absent, fall back to `statusCode`.
+</Callout>
+
+## errorCode values
+
+The following codes come from the `ErrorCode` enum and are attached to business
+logic exceptions (`BusinessException`).
+
+### Authentication
+
+| `errorCode` | Meaning |
+| --- | --- |
+| `INVALID_CREDENTIALS` | Email or password is wrong. |
+| `TOKEN_EXPIRED` | The token has expired. |
+| `TOKEN_INVALID` | The token is invalid/malformed. |
+| `UNAUTHORIZED` | Authentication is required. |
+
+### Authorization
+
+| `errorCode` | Meaning |
+| --- | --- |
+| `FORBIDDEN` | Access denied. |
+| `INSUFFICIENT_PERMISSIONS` | The role/permission is insufficient for this action. |
+
+### Resource
+
+| `errorCode` | Meaning |
+| --- | --- |
+| `RESOURCE_NOT_FOUND` | The requested record does not exist. |
+| `RESOURCE_ALREADY_EXISTS` | The same record already exists (e.g. duplicate email). |
+| `RESOURCE_CONFLICT` | Conflicts with the resource's current state. |
+
+### Validation
+
+| `errorCode` | Meaning |
+| --- | --- |
+| `VALIDATION_ERROR` | Generic input validation failed. |
+| `INVALID_INPUT` | An input value is invalid. |
+| `MISSING_REQUIRED_FIELD` | A required field is missing. |
+
+### Business logic
+
+| `errorCode` | Meaning |
+| --- | --- |
+| `INSUFFICIENT_STOCK` | Not enough stock for the product. `details`: `{ productName, available, requested }`. |
+| `ORDER_ALREADY_PAID` | The order is already paid. |
+| `TABLE_OCCUPIED` | The table is occupied. |
+| `INVALID_ORDER_STATUS` | The action isn't allowed in the order's current status. |
+| `SUBSCRIPTION_REQUIRED` | An active subscription is required (HTTP 402). |
+| `FEATURE_NOT_AVAILABLE` | The feature isn't on the current plan; an upgrade is required (HTTP 402). |
+| `QUOTA_EXCEEDED` | A plan limit was exceeded (HTTP 402). |
+
+### Payment
+
+| `errorCode` | Meaning |
+| --- | --- |
+| `PAYMENT_FAILED` | The payment failed. |
+| `PAYMENT_PROCESSING_ERROR` | An error occurred while processing the payment. |
+| `INVALID_PAYMENT_METHOD` | Invalid payment method. |
+
+### System
+
+| `errorCode` | Meaning |
+| --- | --- |
+| `INTERNAL_SERVER_ERROR` | Unexpected server error. |
+| `SERVICE_UNAVAILABLE` | The service is temporarily unavailable. |
+| `DATABASE_ERROR` | A database error. |
+| `EXTERNAL_SERVICE_ERROR` | An external service error (e.g. the payment provider). |
+
+### Rate limiting
+
+| `errorCode` | Meaning |
+| --- | --- |
+| `TOO_MANY_REQUESTS` | Too many requests (HTTP 429). |
+
+### Tenant
+
+| `errorCode` | Meaning |
+| --- | --- |
+| `TENANT_NOT_FOUND` | Tenant not found. |
+| `INVALID_TENANT` | Invalid tenant. |
+
+## Database errors → HTTP
+
+Prisma's known database errors (`PrismaClientKnownRequestError`) are translated
+to meaningful HTTP status codes in the global exception filter. In these
+responses the `error` field carries the category label; `errorCode` is **not**
+present here (these are not `BusinessException`s).
+
+| Prisma code | HTTP | `error` | Meaning |
+| --- | --- | --- | --- |
+| `P2002` | `409 Conflict` | `UniqueConstraintViolation` | Unique constraint violation (duplicate record). |
+| `P2025` | `404 Not Found` | `RecordNotFound` | Record not found. |
+| `P2003` | `400 Bad Request` | `ForeignKeyConstraintViolation` | Related record missing, or can't delete due to dependencies. |
+| `P2014` | `400 Bad Request` | `RequiredRelationViolation` | The change would violate a required relation. |
+| `P2016` | `400 Bad Request` | `InvalidQuery` | Invalid query parameters. |
+| `P2021` | `500 Internal Server Error` | `DatabaseConfigError` | Table does not exist (configuration error). |
+| `P2024` | `503 Service Unavailable` | `DatabaseTimeout` | Database connection timeout. |
+| `P2034` | `409 Conflict` | `ConcurrentUpdate` | Serializable transaction conflict (Postgres `40001`). The transaction **did not commit**; the request is safe to retry. |
+| `P2000`, `P2020` | `400 Bad Request` | `ValueOutOfRange` | A value is out of the allowed range or too long. |
+| (other) | `500 Internal Server Error` | `DatabaseError` | An unmapped database error. |
+
+<Callout type="info">
+  `P2034` (`ConcurrentUpdate`, 409) is the expected "loser" outcome of a
+  Serializable transaction under contention (checkout settlement, marketplace
+  purchase, etc.), and your request did **not** take effect. If you receive it,
+  you can safely resend the request as-is.
+</Callout>
+
+## Handling errors on the client
+
+<Tabs items={['Pseudo-code', 'curl']}>
+  <Tabs.Tab>
+```ts
+const res = await fetch('/api/v1/display/orders', { method: 'POST', /* … */ });
+if (!res.ok) {
+  const err = await res.json(); // ErrorResponse
+  switch (err.errorCode) {
+    case 'QUOTA_EXCEEDED':
+    case 'FEATURE_NOT_AVAILABLE':
+    case 'SUBSCRIPTION_REQUIRED':
+      // Send the user to the upgrade flow (HTTP 402)
+      break;
+    case undefined:
+      // No errorCode → branch on statusCode (e.g. 409 ConcurrentUpdate → retry)
+      break;
+    default:
+      showToast(err.message);
+  }
+}
+```
+  </Tabs.Tab>
+  <Tabs.Tab>
+```bash
+curl -i -X POST https://api.hummytummy.com/api/v1/display/orders \
+  -H "Authorization: Bearer <SCREEN_TOKEN>" \
+  -H "Content-Type: application/json" \
+  -d '{ "items": [], "type": "DINE_IN" }'
+
+# HTTP/1.1 409 Conflict
+# {
+#   "statusCode": 409,
+#   "error": "ConcurrentUpdate",
+#   "message": "Concurrent update conflict — please retry. Your request did not take effect.",
+#   ...
+# }
+```
+  </Tabs.Tab>
+</Tabs>

--- a/developer/pages/en/reference/glossary.mdx
+++ b/developer/pages/en/reference/glossary.mdx
@@ -1,0 +1,74 @@
+---
+title: Glossary
+description: Definitions of the core terms used across HummyTummy — Tenant, Branch, Role, KDS, POS, QR menu, Self-pay, Scope, Screen token, Webhook, Outbox, Entitlement, Add-on.
+---
+
+# Glossary
+
+Short definitions of terms that appear frequently in the HummyTummy API and
+docs.
+
+### Tenant
+The top-level account that represents a restaurant business (customer account).
+It owns the subscription, the plan, and all data. Tenant resolution is done via
+the `tenantId` in the JWT, not by host name.
+
+### Branch
+A physical location/branch belonging to a tenant. Tables, orders, stock, and
+most operational data are tied to a branch. Branch-scoped endpoints require the
+`X-Branch-Id` header.
+
+### Role
+A user's permission level. Roles: `ADMIN`, `MANAGER`, `WAITER`, `KITCHEN`,
+`COURIER`. `WAITER`, `KITCHEN`, and `COURIER` are "hard-restricted" roles —
+they are pinned to a single branch (a `primaryBranchId` is mandatory) and
+cannot target any other branch.
+
+### KDS (Kitchen Display System)
+The screen that mirrors incoming orders to kitchen/prep stations in real time.
+Depends on the `kdsIntegration` feature.
+
+### POS (Point of Sale)
+The till interface for taking orders, payments, and managing tables. Depends on
+the `posAccess` feature.
+
+### QR menu
+The public menu and ordering interface a guest reaches by scanning the QR code
+at the table. It drives the ordering and self-pay flows through an ordering
+session.
+
+### Self-pay
+A guest paying their own bill from their own device (or the table screen),
+without a waiter. It runs by creating a PayTR hosted-iframe pay intent and
+requires the `payments:write` scope.
+
+### Scope
+A unit of permission carried by a partner API key and a screen token
+(e.g. `menu:read`, `orders:write`). Each `/display` endpoint requires a
+specific scope. See [Partner Scopes](/en/reference/partner-scopes).
+
+### Screen token
+An access token minted from a partner API key and bound to a specific
+screen/device session. It is bound to a tenant, an optional table, and a branch;
+its effective scopes are a subset of the parent key's.
+
+### Webhook
+An event notification sent outward from the server. For example, the PayTR
+payment provider's callback reporting a payment result; a payment is only
+provisioned after the webhook confirms it (`confirmAndProvision`).
+
+### Outbox
+A pattern where an event record is written in the same transaction as the
+database change and then reliably published afterwards. It keeps side effects
+(event publication) atomic with the primary data and provides at-least-once
+delivery.
+
+### Entitlement
+The effective set of features and limits derived from a tenant's active plan
+(and its add-ons). It is recomputed (re-projected) when the plan changes, and
+feature gates (`PlanFeatureGuard`) consult it.
+
+### Add-on
+An extra feature or capacity added to a plan and purchased separately. It is
+bought through the marketplace via the PayTR payment rail and added to the
+entitlement once the payment is confirmed.

--- a/developer/pages/en/reference/index.mdx
+++ b/developer/pages/en/reference/index.mdx
@@ -1,7 +1,38 @@
 ---
 title: Reference
+description: The error codes, partner scopes, plan matrix, and glossary you'll keep returning to while integrating the HummyTummy API.
 ---
+
+import { Cards, Callout } from 'nextra/components'
 
 # Reference
 
-This section is being prepared.
+This section gathers the stable lookup tables you'll keep returning to while
+integrating the HummyTummy API: the standard error envelope and machine-readable
+error codes, the scopes carried by partner screen tokens, the feature × plan
+matrix, and a glossary of system terms.
+
+<Callout type="info">
+  All REST endpoints are served under the global `/api` prefix
+  (e.g. `POST /api/v1/display/orders`). The currency is always **TRY**.
+</Callout>
+
+## Pages
+
+<Cards>
+  <Cards.Card title="Error Codes" href="/en/reference/error-codes" arrow>
+    The standard error envelope, the `errorCode` field, and the Prisma → HTTP
+    mappings (P2002 → 409, P2025 → 404 …).
+  </Cards.Card>
+  <Cards.Card title="Partner Scopes" href="/en/reference/partner-scopes" arrow>
+    The 6 scopes a partner API key and its screen tokens may carry, and which
+    `/display` endpoint each one unlocks.
+  </Cards.Card>
+  <Cards.Card title="Plan Matrix" href="/en/reference/plan-matrix" arrow>
+    The feature × plan table and the plan limits (users, branches, products …).
+  </Cards.Card>
+  <Cards.Card title="Glossary" href="/en/reference/glossary" arrow>
+    Definitions of terms like Tenant, Branch, KDS, Self-pay, Scope, Outbox,
+    Entitlement.
+  </Cards.Card>
+</Cards>

--- a/developer/pages/en/reference/index.mdx
+++ b/developer/pages/en/reference/index.mdx
@@ -1,0 +1,7 @@
+---
+title: Reference
+---
+
+# Reference
+
+This section is being prepared.

--- a/developer/pages/en/reference/partner-scopes.mdx
+++ b/developer/pages/en/reference/partner-scopes.mdx
@@ -1,0 +1,51 @@
+---
+title: Partner Scopes
+description: The 6 scopes a partner API key and its screen tokens may carry, and which /display endpoint each one unlocks.
+---
+
+import { Callout } from 'nextra/components'
+
+# Partner Scopes
+
+A **partner API key** — and the **screen tokens** (screen sessions) it mints —
+carry scopes that determine what they can do. There are 6 scopes in total. Each
+`/display` endpoint requires a single scope via `@RequireScope`, and
+`ScreenScopeGuard` validates it against the scopes the token carries.
+
+<Callout type="info">
+  A screen token's effective scopes are **always** a subset of its parent API
+  key's scopes. A scope the key doesn't hold can never be granted to the token.
+</Callout>
+
+## Scope list
+
+| Scope | What it grants | Endpoint(s) |
+| --- | --- | --- |
+| `menu:read` | Read the public menu for the screen's tenant (and table, if any). | `GET /api/v1/display/menu` |
+| `orders:read` | Read the orders placed by the screen's ordering session. | `GET /api/v1/display/orders` |
+| `orders:write` | Place an order from the screen. | `POST /api/v1/display/orders` |
+| `requests:write` | Call a waiter and request the bill. | `POST /api/v1/display/waiter-requests`, `POST /api/v1/display/bill-requests` |
+| `payments:write` | Self-pay: payable items, create a PayTR hosted-iframe pay intent, and poll its status. | `GET /api/v1/display/payable-items`, `POST /api/v1/display/pay-intent`, `GET /api/v1/display/pay-status` |
+| `realtime:subscribe` | Subscribe to the realtime WebSocket stream (order/status updates). | KDS realtime gateway (WebSocket) |
+
+<Callout type="warning">
+  Calling an endpoint without its required scope is rejected by
+  `ScreenScopeGuard` with **403 Forbidden**. For the WebSocket connection, a
+  screen session without `realtime:subscribe` is rejected at connect time.
+</Callout>
+
+## Least-privilege
+
+Grant each screen/device only the scopes it needs:
+
+- **Menu-only tablet** → `menu:read`
+- **Ordering + waiter calls** → `menu:read`, `orders:write`, `orders:read`, `requests:write`
+- **Self-pay at the table** → the above + `payments:write`
+- **Live status updates** → additionally `realtime:subscribe`
+
+<Callout type="info">
+  `payments:write` unlocks three endpoints at once: listing payable items,
+  creating a pay intent, and polling the intent's status. The pay intent's
+  return origin is taken from the key's `allowedReturnOrigins` allowlist, never
+  from a client-supplied value.
+</Callout>

--- a/developer/pages/en/reference/plan-matrix.mdx
+++ b/developer/pages/en/reference/plan-matrix.mdx
@@ -1,0 +1,75 @@
+---
+title: Plan Matrix
+description: The feature × plan table, plan limits, and prices (TRY). The onboarding TRIAL plan and the Starter / Professional / Enterprise tiers.
+---
+
+import { Callout } from 'nextra/components'
+
+# Plan Matrix
+
+This page is a compact recap of which features and limits each plan carries.
+For plan details, pricing changes, and the purchase flow, see
+[Plans](/en/plans).
+
+<Callout type="info">
+  New tenants start on a 7-day, fully-featured **TRIAL** plan. When the trial
+  ends, the tenant moves to **TRIAL_ENDED** and the app is locked to the
+  plan-selection + checkout flow — a paid plan must be chosen to continue. The
+  old **FREE** plan is retired (kept only as an enum tombstone; no tenant lands
+  on FREE).
+</Callout>
+
+## Prices
+
+All prices are in **TRY** and are **KDV-inclusive** (the advertised gross). The
+KDV split is reverse-engineered at invoicing time.
+
+| Plan | `name` | Monthly | Yearly | Trial |
+| --- | --- | --- | --- | --- |
+| Trial | `TRIAL` | ₺0 | ₺0 | 7 days |
+| Starter | `BASIC` | ₺499 | ₺4,490 | 14 days |
+| Professional | `PRO` | ₺1,299 | ₺12,990 | 14 days |
+| Enterprise | `BUSINESS` | ₺2,999 | ₺29,990 | 14 days |
+
+## Limits
+
+`-1` = unlimited.
+
+| Limit | TRIAL | BASIC | PRO | BUSINESS |
+| --- | --- | --- | --- | --- |
+| `maxUsers` | ∞ | 5 | 15 | ∞ |
+| `maxBranches` | ∞ | 1 | 3 | ∞ |
+| `maxTables` | ∞ | 20 | 50 | ∞ |
+| `maxProducts` | ∞ | 100 | 500 | ∞ |
+| `maxCategories` | ∞ | 20 | 50 | ∞ |
+| `maxMonthlyOrders` | ∞ | 500 | 2,000 | ∞ |
+
+## Feature × plan
+
+| Feature (`flag`) | TRIAL | BASIC | PRO | BUSINESS |
+| --- | --- | --- | --- | --- |
+| POS access (`posAccess`) | ✅ | ✅ | ✅ | ✅ |
+| KDS integration (`kdsIntegration`) | ✅ | ✅ | ✅ | ✅ |
+| Inventory tracking (`inventoryTracking`) | ✅ | ✅ | ✅ | ✅ |
+| Advanced reports (`advancedReports`) | ✅ | ❌ | ✅ | ✅ |
+| Multi-location (`multiLocation`) | ✅ | ❌ | ✅ | ✅ |
+| Custom branding (`customBranding`) | ✅ | ❌ | ✅ | ✅ |
+| Reservation system (`reservationSystem`) | ✅ | ❌ | ✅ | ✅ |
+| Personnel management (`personnelManagement`) | ✅ | ❌ | ✅ | ✅ |
+| Delivery integration (`deliveryIntegration`) | ✅ | ❌ | ✅ | ✅ |
+| Priority support (`prioritySupport`) | ✅ | ❌ | ✅ | ✅ |
+| API access (`apiAccess`) | ✅ | ❌ | ❌ | ✅ |
+| External display / Partner Display (`externalDisplay`) | ✅ | ❌ | ❌ | ✅ |
+
+<Callout type="warning">
+  The **Partner Display API** (external display, third-party tablets) depends on
+  the `externalDisplay` feature and is available only on **BUSINESS** (and on the
+  onboarding TRIAL). It gates partner API-key issuance and screen-token minting.
+  Likewise, `apiAccess` exists only on BUSINESS.
+</Callout>
+
+<Callout type="info">
+  The TRIAL plan unlocks **all** premium features and unlimited limits for 7
+  days so a tenant can fully evaluate the product. It is not a permanent tier —
+  a paid plan must be chosen when it expires.
+</Callout>

--- a/developer/pages/tr/_meta.ts
+++ b/developer/pages/tr/_meta.ts
@@ -1,0 +1,10 @@
+export default {
+  "index": "Ana Sayfa",
+  "getting-started": "Başlangıç",
+  "admin-guide": "Yönetici Rehberi",
+  "plans": "Planlar",
+  "marketplace": "Marketplace",
+  "developer": "Geliştirici / Entegrasyon",
+  "desktop": "Desktop Uygulaması",
+  "reference": "Referans"
+}

--- a/developer/pages/tr/admin-guide/_meta.ts
+++ b/developer/pages/tr/admin-guide/_meta.ts
@@ -1,3 +1,15 @@
 export default {
-  "index": "Genel Bakış"
-}
+  "index": "Genel Bakış",
+  "pos": "POS (Satış Ekranı)",
+  "qr-menu": "QR Menü",
+  "kitchen": "Mutfak Ekranı (KDS)",
+  "tables": "Masalar & Kat Planı",
+  "orders": "Siparişler",
+  "stock": "Stok & Envanter",
+  "reports": "Raporlar & Analitik",
+  "reservations": "Rezervasyonlar",
+  "personnel": "Personel",
+  "customers": "Müşteriler",
+  "branches": "Şubeler",
+  "settings": "Ayarlar",
+};

--- a/developer/pages/tr/admin-guide/_meta.ts
+++ b/developer/pages/tr/admin-guide/_meta.ts
@@ -1,0 +1,3 @@
+export default {
+  "index": "Genel Bakış"
+}

--- a/developer/pages/tr/admin-guide/branches.mdx
+++ b/developer/pages/tr/admin-guide/branches.mdx
@@ -1,0 +1,58 @@
+---
+title: Şubeler
+description: HummyTummy çoklu şube yönetimi — şube ekleme, kullanım/limit takibi, şube kapsamı ve bridge/cihaz/sağlık ekranları. Amacı, kullanımı ve ipuçları.
+---
+
+import { Callout } from 'nextra/components'
+
+# Şubeler
+
+**Menü yolu:** Çoklu Şube → Şubeler &nbsp;•&nbsp; **URL:** `/admin/branches`
+**Erişim:** ADMIN, MANAGER
+**Plan:** `multiLocation` — **Profesyonel (PRO)** ve üzeri (veya `extra_branch` eklentisi)
+
+## Amacı
+
+Şubeler ekranı, **restoran zincirinizin tüm şubelerini** tek panelden yönetir. Her şubenin kendi masaları, menüsü, siparişleri ve raporları vardır; yönetici şubeler arasında geçiş yapar ve toplam tabloyu görür.
+
+<Callout type="info">
+  Çoklu şube **Profesyonel (PRO)** ve üzeri planlarda açıktır. PRO **3 şube**, Kurumsal
+  (BUSINESS) **sınırsız** şube verir. PRO'ya çıkmadan ek şube isterseniz **`extra_branch`**
+  marketplace eklentisini alabilirsiniz (her biri şube limitini artırır). Tam limitler:
+  **[Planlar](/tr/plans)**.
+</Callout>
+
+## Ekranda neler var?
+
+- **Kullanım rozeti:** "X / Y şube" — kaç şube kullandığınız ve limitiniz. Sınırsızda **∞** gösterilir.
+- **Şube listesi:** Her şube adı, kodu, saat dilimi ve **durumu** (aktif / askıda / arşivli).
+- **Şube ekle:** Ad, kod ve saat dilimi (varsayılan `Europe/Istanbul`) ile yeni şube. Limite ulaşıldıysa ekleme **kilitlenir** ve eklenti önerisi çıkar.
+
+## Şube kapsamı (Branch scope)
+
+HummyTummy her şube-bazlı isteği aktif şubeye göre filtreler. Üst çubuktaki **şube seçici (BranchPicker)** ile çalıştığınız şubeyi değiştirirsiniz; POS, masalar, siparişler, stok gibi ekranlar o şubenin verisini gösterir. Şube değiştirince önbellek temizlenir — eski şubenin verisi karışmaz.
+
+<Callout type="warning">
+  Bazı ekranlar **tenant geneli**dir (şubeye bağlı değildir): profil, abonelik/plan,
+  faturalandırma gibi. Bu ekranlar şube seçiminden etkilenmez.
+</Callout>
+
+## Aynı bölümdeki ilgili ekranlar
+
+"Çoklu Şube" menüsü altında ayrıca:
+
+- **Cihazlar** (`/admin/devices`) — şubeye bağlı POS/yazıcı/ekran cihazları. (Tüm planlarda erişilebilir.)
+- **Bridge'ler** (`/admin/bridges`) — yerel donanım köprüleri. (`multiLocation` ile gizlenir/görünür.)
+- **Sağlık** (`/admin/health`) — sistem/şube sağlık durumu. (Tüm planlarda.)
+
+## İpuçları
+
+- **Saat dilimini doğru seçin:** Raporlar ve gün sonu (Z-rapor) kapanışları şube saat dilimine göre hesaplanır — yanlış dilim gün sonunu kaydırır.
+- **Kullanılmayan şubeyi arşivleyin:** Kapanan/duran şubeyi silmek yerine durumunu değiştirin; geçmiş veri korunur.
+- **Şube bazlı raporlama:** Raporlar ekranındaki şube filtresiyle şubeleri kıyaslayın; hangi şube hangi üründe güçlü görün.
+
+## İlgili ekranlar
+
+- **[Raporlar & Analitik](/tr/admin-guide/reports)** — şube filtresi ile karşılaştırma.
+- **[Planlar](/tr/plans)** — şube limitleri ve `extra_branch` eklentisi.
+- **[Marketplace](/tr/marketplace)** — ek şube ve diğer eklentiler.

--- a/developer/pages/tr/admin-guide/customers.mdx
+++ b/developer/pages/tr/admin-guide/customers.mdx
@@ -1,0 +1,41 @@
+---
+title: Müşteriler
+description: HummyTummy müşteri yönetimi — müşteri ekleme/düzenleme, harcama/sipariş/sadakat puanı özetleri ve müşteri detay sayfası. Amacı, kullanımı ve ipuçları.
+---
+
+import { Callout } from 'nextra/components'
+
+# Müşteriler
+
+**Menü yolu:** İşletme → Müşteriler &nbsp;•&nbsp; **URL:** `/customers`
+**Erişim:** ADMIN, MANAGER, WAITER
+**Plan:** Tüm planlarda açık
+
+## Amacı
+
+Müşteriler ekranı, restoranınızın **müşteri kayıtlarını** (CRM) tutar: ad, e-posta, telefon ile birlikte her müşterinin **toplam harcaması**, **toplam siparişi** ve **sadakat puanı**. Tekrar eden misafirleri tanır, sadakat programınızı bu veriye dayandırırsınız.
+
+## Ekranda neler var?
+
+- **Özet istatistikler:** Toplam müşteri, toplam harcama, toplam sipariş, toplam sadakat puanı.
+- **Arama:** Ad, e-posta veya telefonla filtreleme.
+- **Müşteri listesi:** Her satır temel bilgiler + harcama/sipariş/puan; satıra tıklayınca **müşteri detay sayfasına** (`/customers/:id`) gidersiniz.
+- **Ekle / Düzenle / Sil:** Yeni müşteri formu, düzenleme ve onay diyaloglu silme.
+
+<Callout type="info">
+  Müşteri yönetimi **tüm planlarda** açıktır. POS'ta sipariş alırken müşteri adı/telefonu
+  girilirse kayıtlarla ilişkilendirilebilir; QR menüden self-pay yapan müşteriler de
+  telefonlarıyla eşleşebilir.
+</Callout>
+
+## İpuçları
+
+- **Telefonu doğru girin:** Sadakat puanı ve geçmiş sipariş eşleşmesi genelde telefon üzerinden yürür — POS'ta müşteri telefonunu girmeyi alışkanlık hâline getirin.
+- **En değerli müşteriyi bulun:** Listeyi harcama/sipariş ile karşılaştırıp düzenli misafirleri belirleyin; kampanyaları onlara hedefleyin.
+- **Analitikle birleştirin:** Raporlar ekranındaki **Müşteriler** sekmesi dönem bazlı müşteri analitiği verir; bu ekran tekil müşteri kaydını, o sekme toplulaştırılmış davranışı gösterir.
+
+## İlgili ekranlar
+
+- **[POS](/tr/admin-guide/pos)** — siparişte müşteri adı/telefonu girilir.
+- **[Raporlar & Analitik](/tr/admin-guide/reports)** — Müşteri analitiği sekmesi.
+- **[QR Menü](/tr/admin-guide/qr-menu)** — sadakat sayfası (`/qr-menu/:tenantId/loyalty`).

--- a/developer/pages/tr/admin-guide/index.mdx
+++ b/developer/pages/tr/admin-guide/index.mdx
@@ -1,7 +1,71 @@
 ---
-title: Yönetici Rehberi
+title: Yönetici Rehberi — Genel Bakış
+description: HummyTummy yönetim panelinin tüm ekranları — POS, QR menü, mutfak, masalar, stok, raporlar ve daha fazlası. Her ekranın amacı, kullanımı ve hangi planla açıldığı.
 ---
+
+import { Callout, Cards } from 'nextra/components'
 
 # Yönetici Rehberi
 
-Bu bölüm hazırlanıyor.
+Bu bölüm, HummyTummy **yönetim panelini** (giriş yaptıktan sonra gördüğünüz uygulama) ekran ekran anlatır. Her sayfanın **amacını**, **ne yaptığınızı** ve günlük işte işinize yarayacak **ipuçlarını** içerir.
+
+Hedef kitle: restoran **sahibi (ADMIN)** ve **yöneticisi (MANAGER)**. Bazı ekranlar garson (WAITER) ve mutfak (KITCHEN) rollerine de açıktır; her sayfanın başında hangi rollerin erişebileceğini belirtiyoruz.
+
+<Callout type="info">
+  Para birimi **Türk Lirası (TRY)**'dir. Sol menü (Sidebar) ekranları altı bölüme
+  ayırır: **İşletme**, **Menü & Masa**, **Operasyon**, **Çoklu Şube**, **Pazaryeri**
+  ve **Ayarlar & Erişim**. Bir ekran sizin planınızda yoksa menüde **hiç görünmez**
+  (403 hatası almazsınız) — yükseltince kendiliğinden belirir.
+</Callout>
+
+## Ekranlar
+
+<Cards>
+  <Cards.Card title="POS (Satış Ekranı)" href="/tr/admin-guide/pos" arrow />
+  <Cards.Card title="QR Menü" href="/tr/admin-guide/qr-menu" arrow />
+  <Cards.Card title="Mutfak Ekranı (KDS)" href="/tr/admin-guide/kitchen" arrow />
+  <Cards.Card title="Masalar & Kat Planı" href="/tr/admin-guide/tables" arrow />
+  <Cards.Card title="Siparişler" href="/tr/admin-guide/orders" arrow />
+  <Cards.Card title="Stok & Envanter" href="/tr/admin-guide/stock" arrow />
+  <Cards.Card title="Raporlar & Analitik" href="/tr/admin-guide/reports" arrow />
+  <Cards.Card title="Rezervasyonlar" href="/tr/admin-guide/reservations" arrow />
+  <Cards.Card title="Personel" href="/tr/admin-guide/personnel" arrow />
+  <Cards.Card title="Müşteriler" href="/tr/admin-guide/customers" arrow />
+  <Cards.Card title="Şubeler" href="/tr/admin-guide/branches" arrow />
+  <Cards.Card title="Ayarlar" href="/tr/admin-guide/settings" arrow />
+</Cards>
+
+## Hangi ekran hangi planla açılır?
+
+Her gelişmiş ekran bir **plan özelliği bayrağına** bağlıdır. Aşağıdaki tablo, ekranın hangi paketten itibaren açıldığını ve alternatif olarak hangi **marketplace eklentisiyle** açılabileceğini gösterir.
+
+| Ekran | Özellik bayrağı | En düşük plan | Eklenti alternatifi |
+| --- | --- | --- | --- |
+| POS (Satış Ekranı) | `posAccess` | **Başlangıç (BASIC)** | — |
+| Mutfak Ekranı (KDS) | `kdsIntegration` | **Tüm planlar** | — |
+| QR Menü | — | **Tüm planlar** | — |
+| Masalar & Kat Planı | — | **Tüm planlar** (limit plana bağlı) | — |
+| Müşteriler | — | **Tüm planlar** | — |
+| Stok & Envanter | `inventoryTracking` | **Başlangıç (BASIC)** | — |
+| Raporlar | `advancedReports` | **Profesyonel (PRO)** | `advanced_reports` |
+| Analitik | `advancedReports` | **Profesyonel (PRO)** | `advanced_reports` |
+| Rezervasyonlar | `reservationSystem` | **Profesyonel (PRO)** | — |
+| Personel | `personnelManagement` | **Profesyonel (PRO)** | — |
+| Şubeler / Bridge'ler | `multiLocation` | **Profesyonel (PRO)** | `extra_branch` |
+| Özel Marka (Branding) | `customBranding` | **Profesyonel (PRO)** | — |
+| Entegrasyonlar / Webhook'lar | `apiAccess` | **Kurumsal (BUSINESS)** | `api_access` |
+| Partner Display API anahtarları | `externalDisplay` | **Kurumsal (BUSINESS)** | — |
+
+<Callout type="info">
+  Planların tam karşılaştırması, fiyatlar ve kullanım limitleri için
+  **[Planlar](/tr/plans)** bölümüne bakın. Delivery (Yemeksepeti/Getir), SMS,
+  e-Fatura ve Çağrı Kimliği gibi **entegrasyonlar** ayrı eklentilerle açılır —
+  bkz. **[Marketplace](/tr/marketplace)**.
+</Callout>
+
+<Callout type="warning">
+  Plan kapısı (FeatureGate) yalnızca **görsel** bir korumadır — gerçek yetki kontrolü
+  her zaman sunucudadır. Bir ekranı tarayıcı hilesiyle açsanız bile arka uç
+  (PlanFeatureGuard) yetkisiz isteği reddeder. Bu yüzden planınızda olmayan bir
+  modülü "açmaya" çalışmak işe yaramaz; doğru yol planı yükseltmektir.
+</Callout>

--- a/developer/pages/tr/admin-guide/index.mdx
+++ b/developer/pages/tr/admin-guide/index.mdx
@@ -1,0 +1,7 @@
+---
+title: Yönetici Rehberi
+---
+
+# Yönetici Rehberi
+
+Bu bölüm hazırlanıyor.

--- a/developer/pages/tr/admin-guide/kitchen.mdx
+++ b/developer/pages/tr/admin-guide/kitchen.mdx
@@ -1,0 +1,70 @@
+---
+title: Mutfak Ekranı (KDS)
+description: HummyTummy mutfak ekranı — siparişlerin gerçek zamanlı düşmesi, üç sütunlu kuyruk (bekliyor / hazırlanıyor / hazır), kiosk modu ve güvenli iptal. Amacı, kullanımı ve ipuçları.
+---
+
+import { Callout } from 'nextra/components'
+
+# Mutfak Ekranı (KDS)
+
+**Menü yolu:** İşletme → Mutfak &nbsp;•&nbsp; **URL:** `/kitchen`
+**Erişim:** ADMIN, MANAGER, KITCHEN
+**Plan:** `kdsIntegration` — **tüm planlarda** açık
+
+## Amacı
+
+KDS (Kitchen Display System / Mutfak Ekran Sistemi), kasadan veya QR menüden gelen siparişlerin **mutfağa gerçek zamanlı düştüğü** ekrandır. Kâğıt fişin yerini alır: aşçı siparişi görür, hazırlamaya başlar, hazırladığında "hazır" işaretler. Tüm güncellemeler WebSocket ile anında akar — kasa sipariş yazdığı an mutfak görür.
+
+<Callout type="info">
+  KDS **tüm planlarda** açıktır (en düşük paket olan Başlangıç dahil). POS'tan farklı
+  olarak ayrı bir plan kapısı yoktur.
+</Callout>
+
+## Ekran düzeni
+
+Mutfak ekranı, siparişleri **üç duruma** göre sütunlara böler:
+
+| Sütun | Durum | Anlamı |
+| --- | --- | --- |
+| **Bekliyor** | `PENDING` | Yeni geldi, henüz hazırlanmaya başlanmadı |
+| **Hazırlanıyor** | `PREPARING` | Aşçı işe başladı |
+| **Hazır** | `READY` | Hazır, servise/teslime bekliyor |
+
+- **Masaüstü (≥1024px):** üç sütun yan yana görünür.
+- **Tablet/telefon:** üç sekme olarak görünür; her sekmede o durumun sayacı vardır.
+
+Üstteki **istatistik başlığı** anlık durumu (bağlantı durumu, sipariş sayıları) ve **yenile** butonunu içerir. Her sipariş kartı **bekleme süresine** göre yaşlanır; acil (uzun bekleyen) siparişler **kırmızı bir uyarı noktasıyla** öne çıkar ve sekme rozetinde gösterilir.
+
+## Kullanım
+
+Aşçı bir kartta tek dokunuşla siparişi bir sonraki duruma ilerletir:
+
+1. **Bekliyor → Hazırlanıyor** (işe başla)
+2. **Hazırlanıyor → Hazır** (servise hazır)
+
+Hazır siparişler kasa tarafında "ödeme bekleyen" listesinde görünür ve servis/tahsilat sonrası kapanır.
+
+<Callout type="warning">
+  **Güvenli iptal:** Sadece **Bekliyor** durumundaki bir sipariş iptal edilebilir ve
+  iptal, 5 saniyelik bir **geri-al** penceresinin ardından işlenir. Bu sırada başka bir
+  istasyon siparişi ilerletmiş olabilir — sistem iptali işlerken siparişin hâlâ
+  "Bekliyor" olduğunu yeniden doğrular. Değilse iptal edilmez ("Sipariş artık beklemede
+  değil" uyarısı çıkar). İptal sunucuda **stoğu geri yazar** (kalemler stoğa iade edilir).
+</Callout>
+
+## Kiosk modu
+
+Üstteki kiosk düğmesi ekranı **tam ekran, koyu temalı** bir mutfak panosuna çevirir — uzaktan okunabilir, dikkat dağıtan arayüz öğeleri gizlenir. Mutfağa sabit bir ekran/tablet astıysanız kiosk modunda bırakın.
+
+## Bağlantı kopması ve dayanıklılık
+
+- Canlı bağlantı (WebSocket) düşerse ekran ~10 saniyede bir **otomatik yoklama (polling)** yaparak güncel kalır; bağlantı geri gelince yoklama durur.
+- Son bilinen siparişler ekranda tutulur (geçici hata anında pano **boşalmaz**).
+- Bir veri çekme hatası olursa kırmızı bir **uyarı bandı** çıkar ve son başarılı senkronizasyon saatini gösterir; tek tıkla yenilersiniz.
+- İlk açılışta veri henüz gelmemişse boş sütun yerine **iskelet (skeleton)** gösterilir — "hâlâ yükleniyor" ile "mutfak boş" karışmaz.
+
+## İpuçları
+
+- Mutfağa **adanmış bir ekran/tablet** koyup kiosk modunu açın; KITCHEN rolüyle bir kullanıcı tanımlayın (yetkisi yalnızca mutfak ekranı + panoya yeter).
+- "Acil" kırmızı nokta uzun bekleyen siparişi işaret eder — yoğun saatte önceliklendirme için kullanın.
+- Sipariş yanlış geldiyse (müşteri vazgeçti) **sadece Bekliyor**'dayken iptal edin; hazırlanmaya başlandıysa kasadan yönetin.

--- a/developer/pages/tr/admin-guide/orders.mdx
+++ b/developer/pages/tr/admin-guide/orders.mdx
@@ -1,0 +1,76 @@
+---
+title: Siparişler
+description: HummyTummy sipariş yaşam döngüsü — durumlar, sipariş tipleri, QR menü onay kuyruğu, garson ve hesap istekleri. Siparişlerin nerede yönetildiği ve ipuçları.
+---
+
+import { Callout } from 'nextra/components'
+
+# Siparişler
+
+**Nerede yönetilir:** **[POS](/tr/admin-guide/pos)** (`/pos`) ve **[Mutfak Ekranı](/tr/admin-guide/kitchen)** (`/kitchen`)
+**Erişim:** ADMIN, MANAGER, WAITER, KITCHEN (role göre)
+**Plan:** Sipariş alma POS gerektirir (`posAccess`, BASIC+); mutfak akışı tüm planlarda
+
+## Amacı
+
+HummyTummy'de **ayrı bir "Siparişler" sayfası yoktur** — siparişler oluşturuldukları ve işlendikleri yerde, yani **POS** ve **Mutfak Ekranı (KDS)** içinde yönetilir. Bu sayfa, sipariş **yaşam döngüsünü** ve siparişlerin uygulamada nerede göründüğünü tek yerde toplar.
+
+## Sipariş yaşam döngüsü (durumlar)
+
+Bir sipariş şu durumlardan geçer:
+
+| Durum | Anlamı | Nerede görünür |
+| --- | --- | --- |
+| `PENDING_APPROVAL` | QR menüden gelen, **onay bekleyen** sipariş | POS bildirim çubuğu → "Bekleyen siparişler" |
+| `PENDING` | Onaylanmış, mutfakta **bekliyor** | Mutfak ekranı "Bekliyor" sütunu |
+| `PREPARING` | Aşçı **hazırlıyor** | Mutfak ekranı "Hazırlanıyor" sütunu |
+| `READY` | **Hazır**, servise/ödemeye bekliyor | Mutfak "Hazır" + POS "ödeme bekleyen" |
+| `SERVED` | **Servis edildi**, ödeme bekliyor | POS "ödeme bekleyen" |
+| `PAID` | **Ödendi**, kapandı | Raporlar/Z-Rapor |
+| `CANCELLED` | **İptal** (stok geri yazılır) | — |
+
+<Callout type="info">
+  Mutfak ekranı sadece aktif kuyruğu (`PENDING`, `PREPARING`, `READY`) gösterir.
+  `SERVED` ve `PAID` siparişler kasada/raporlarda izlenir. İptal (`CANCELLED`) terminaldir
+  ve sunucuda stoğu geri alır.
+</Callout>
+
+## Sipariş tipleri
+
+| Tip | Anlamı |
+| --- | --- |
+| `DINE_IN` | Masada (içeride) servis |
+| `TAKEAWAY` | Gel-al |
+| `DELIVERY` | Adrese teslim (delivery entegrasyonu) |
+| `COUNTER` | Masasız self-pay / tezgah siparişi (Z-raporda ayrı gruplanır) |
+
+## QR menü onay kuyruğu ve istekler
+
+POS ekranının üstündeki **canlı bildirim çubuğu** üç kuyruğu gerçek zamanlı gösterir:
+
+- **Bekleyen siparişler** — QR menüden gelen, `PENDING_APPROVAL` durumundaki siparişler. Panelden onaylayınca mutfağa düşer.
+- **Garson çağrıları** — masadan gelen "garson çağır" istekleri.
+- **Hesap istekleri** — masadan gelen "hesabı getir" istekleri.
+
+Her biri ayrı bir panel açar; oradan tek tek işlem yaparsınız. Tüm bunlar WebSocket ile anında akar.
+
+## Siparişlerle ilgili POS işlemleri
+
+- **Masa transferi** — açık siparişi başka masaya taşı.
+- **Masa birleştirme** — birden çok masanın siparişini tek hesapta topla.
+- **Hesap bölme (split)** — bir hesabı tutar/kişi bazında parçala.
+- **Aşamalı (Dutch) ödeme** — birleşik gruptaki her masanın siparişini sırayla tahsil et.
+
+Ayrıntılar: **[POS](/tr/admin-guide/pos)**.
+
+## İpuçları
+
+- **QR siparişlerini onaylamayı unutmayın:** "Bekleyen siparişler" panelindeki sayaç, onay bekleyen müşteri siparişlerini gösterir — yoğun saatte gözden kaçmaması için bildirim çubuğunu izleyin.
+- **İptal sadece "Bekliyor"da güvenlidir:** Mutfak hazırlamaya başladıysa siparişi kasadan yönetin; iptal stoğu geri yazdığı için yanlış iptal hem hesabı hem stoğu bozar.
+- **Satış geçmişi raporlarda:** Kapanmış (`PAID`) siparişlerin özetleri, ödeme yöntemi kırılımı ve günlük/saatlik dağılım için **[Raporlar](/tr/admin-guide/reports)** sayfasına bakın.
+
+## İlgili ekranlar
+
+- **[POS](/tr/admin-guide/pos)** — sipariş alma, onay kuyruğu, ödeme, masa işlemleri.
+- **[Mutfak Ekranı (KDS)](/tr/admin-guide/kitchen)** — sipariş durum akışı.
+- **[Raporlar & Analitik](/tr/admin-guide/reports)** — satış ve sipariş raporları.

--- a/developer/pages/tr/admin-guide/personnel.mdx
+++ b/developer/pages/tr/admin-guide/personnel.mdx
@@ -1,0 +1,52 @@
+---
+title: Personel
+description: HummyTummy personel yönetimi — devamlılık (yoklama), vardiya şablonları, çizelge ve performans. Kullanıcı yönetiminden farkı, amacı ve ipuçları.
+---
+
+import { Callout } from 'nextra/components'
+
+# Personel
+
+**Menü yolu:** Operasyon → Personel &nbsp;•&nbsp; **URL:** `/admin/personnel`
+**Erişim:** ADMIN, MANAGER
+**Plan:** `personnelManagement` — **Profesyonel (PRO)** ve üzeri
+
+## Amacı
+
+Personel modülü, ekibinizin **çalışma zamanını** yönetir: kim ne zaman geldi/çıktı (yoklama), vardiya şablonları, haftalık çizelge ve performans. Gerçek zamanlı (WebSocket) güncellenir — bir personel giriş yaptığında ekran anında yansıtır.
+
+<Callout type="info">
+  Personel modülü **Profesyonel (PRO)** ve üzeri planlarda açıktır. Planınızda yoksa
+  menüde Personel görünmez ve doğrudan URL yükseltme kartı gösterir.
+
+  **Personel ≠ Kullanıcılar:** Bu modül **çalışma vakti/vardiya** içindir. Sistem
+  hesabı açmak (rol, e-posta, şifre) için **Operasyon → Kullanıcılar** (`/admin/users`)
+  ekranını kullanın.
+</Callout>
+
+## Sekmeler
+
+| Sekme | Ne yapar? |
+| --- | --- |
+| **Devamlılık (Attendance)** | Giriş/çıkış (yoklama) kayıtları — kim ne zaman çalıştı |
+| **Vardiya Şablonları (Shift Templates)** | Tekrar eden vardiyaları tanımlayın (örn. "Sabah 09:00–17:00") |
+| **Çizelge (Schedule)** | Şablonları kişilere/günlere atayın — haftalık plan |
+| **Performans (Performance)** | Personel performans göstergeleri |
+
+## Tipik kullanım
+
+1. **Vardiya şablonlarını** tanımlayın (sabah/akşam vb.).
+2. **Çizelgeden** şablonları kişilere ve günlere yerleştirin.
+3. **Devamlılık** sekmesinde gerçek giriş/çıkışları izleyin; planla gerçeği karşılaştırın.
+4. **Performans** sekmesinden ekibin verimini görün.
+
+## İpuçları
+
+- **Önce kullanıcıları açın:** Personelin sistemde hesabı (Kullanıcılar ekranından) yoksa vardiya/yoklama izlemek anlamsız kalır — önce rolüyle birlikte kullanıcıyı tanımlayın.
+- **Şablon = tekrar eden iş:** Aynı vardiyayı her hafta elle girmek yerine şablon kurun, çizelgede tek tıkla atayın.
+- **Performansı raporlarla birleştirin:** Raporlar ekranındaki **Personel** sekmesi (aynı `personnelManagement` ile görünür) satışa dayalı performansı gösterir; iki ekranı birlikte okuyun.
+
+## İlgili ekranlar
+
+- **Kullanıcılar** (`/admin/users`) — sistem hesabı, rol ve durum yönetimi (tüm planlarda).
+- **[Raporlar & Analitik](/tr/admin-guide/reports)** — Personel performans rapor sekmesi.

--- a/developer/pages/tr/admin-guide/pos.mdx
+++ b/developer/pages/tr/admin-guide/pos.mdx
@@ -1,0 +1,101 @@
+---
+title: POS (Satış Ekranı)
+description: HummyTummy satış ekranı — masa seçimi, sepet, ödeme, masa transferi/birleştirme, hesap bölme ve gel-al modu. Amacı, kullanımı ve ipuçları.
+---
+
+import { Callout, Steps } from 'nextra/components'
+
+# POS (Satış Ekranı)
+
+**Menü yolu:** İşletme → POS &nbsp;•&nbsp; **URL:** `/pos`
+**Erişim:** ADMIN, MANAGER, WAITER
+**Plan:** `posAccess` — **Başlangıç (BASIC)** ve üzeri
+
+## Amacı
+
+POS, restoranınızın **kasa ekranıdır**: masaya oturan misafire veya gel-al (takeaway) müşterisine sipariş alır, mutfağa gönderir ve ödemeyi tahsil eder. Tüm satış akışı buradan döner — masa seçiminden hesap kapatmaya kadar.
+
+<Callout type="info">
+  POS yalnızca **Başlangıç (BASIC)** ve üzeri planlarda açıktır. Planınızda yoksa
+  hem sol menüde POS görünmez hem de `/pos` adresine gittiğinizde yükseltme kartı
+  çıkar. Mutfak ekranı (KDS) ise tüm planlarda açıktır.
+</Callout>
+
+## Ekran nasıl çalışır?
+
+POS iki adımdan oluşur:
+
+<Steps>
+### Adım 1 — Masa Seçimi
+
+Açılışta masa ızgarası gelir. Her masa kartı **durumunu** renkle gösterir: **boş** (yeşil), **dolu** (sarı/amber), **rezerve** (gri). Bir masada bekleyen sipariş, garson çağrısı veya hesap isteği varsa kartın köşesinde **bildirim rozeti** belirir (sipariş = saat, garson = kişi, hesap = fiş ikonu).
+
+Masaya tıklayınca o masanın sipariş ekranına geçersiniz. Masa boşsa yeni sipariş başlar; doluysa açık siparişi yüklenir.
+
+### Adım 2 — Sipariş Ekranı
+
+Solda **menü** (kategorilere göre ürünler), sağda **sepet** vardır. Ürüne dokununca sepete eklenir. Zorunlu seçenekli ürünlerde (örn. "az pişmiş / orta / iyi pişmiş") önce **seçenek modalı** açılır.
+
+Sepette: adet artır/azalt, satır silme, **indirim**, **müşteri adı** ve **sipariş notu** girilir. Ardından siparişi mutfağa gönderir ve/veya ödemeye geçersiniz.
+</Steps>
+
+<Callout type="info">
+  **Gel-al (Takeaway) modu:** POS ayarlarından "Masasız mod" açılırsa masa seçim
+  adımı atlanır; doğrudan sipariş ekranına düşersiniz. Masa zorunluluğu kalkar.
+</Callout>
+
+## Tek adımlı vs. iki adımlı ödeme
+
+POS ayarlarındaki **"İki adımlı ödeme"** seçeneği akışı belirler:
+
+- **Tek adımlı (varsayılan):** "Öde" der demez sipariş oluşur ve ödeme ekranı açılır — hızlı kafe/gel-al için idealdir.
+- **İki adımlı:** Önce **"Siparişi Oluştur"** ile sipariş mutfağa gönderilir; misafir yedikten sonra **"Ödemeye Geç"** ile tahsil edilir. QR menüden müşteri kendi sipariş veriyorsa iki adımlı mod otomatik gerekir.
+
+<Callout type="warning">
+  İki adımlı modda siparişi oluşturduktan sonra sepete ürün ekler/indirimi
+  değiştirirseniz, sistem ödemeye geçmeden önce siparişi **yeniden kaydeder ve yeniden
+  fiyatlandırır**. Böylece eski (bayat) tutar üzerinden tahsilat yapılmaz; yeni
+  eklenen ürünler hem hesaba hem mutfak fişine yansır.
+</Callout>
+
+## Ödeme
+
+**Öde** butonu **Ödeme Modalı**'nı açar. Ödeme yöntemini (nakit, kart, vb.) seçer, gerekiyorsa işlem numarası ve müşteri telefonu girersiniz. Tahsilat sonrası:
+
+- Masada başka açık sipariş kalmadıysa masa **otomatik boşa** çekilir (sistem, ödeme anında en güncel sipariş listesini kontrol eder — başka misafirin açık hesabın üstüne oturmasını engeller).
+- Masaüstü (Tauri) POS terminalinde varsayılan yazıcı tanımlıysa **fiş otomatik basılır**; basım hatasında tek dokunuşla yeniden bas seçeneği çıkar.
+
+<Callout type="info">
+  Her ödeme isteğine bir **idempotency anahtarı** eklenir: çift tıklama veya ağ
+  kopması sonrası tekrar denemede aynı ödeme iki kez işlenmez.
+</Callout>
+
+## Masa işlemleri
+
+Sipariş ekranındaki sepet araç çubuğundan:
+
+- **Masa Transferi** — açık siparişi başka masaya taşıyın (hedef masada sipariş varsa birleştirme önerilir).
+- **Masa Birleştirme** — yan yana oturan grupları tek hesapta toplayın; istediğinizde tekrar ayırın (tekli veya toplu).
+- **Hesap Bölme (Split)** — bir hesabı tutar/kişi bazında parçalayın.
+- **Aşamalı (Dutch) Ödeme** — birleşik masadaki her masanın açık siparişini ayrı ayrı, sırayla tahsil edin.
+
+## Canlı bildirim çubuğu
+
+Ekranın üstündeki bildirim çubuğu üç kuyruğu canlı (WebSocket) gösterir:
+
+- **Bekleyen siparişler** — QR menüden gelen ve onay bekleyen siparişler.
+- **Garson çağrıları** — masadan "garson çağır" istekleri.
+- **Hesap istekleri** — masadan "hesabı getir" istekleri.
+
+Her birine tıklayınca ilgili panel açılır; oradan tek tek işlem yaparsınız.
+
+## İpuçları
+
+- **Sepet kaybolmaz:** Devam eden sipariş tarayıcıya (12 saat) kaydedilir — sekme yanlışlıkla kapanırsa veriniz durur.
+- **Rezerve masaya dokunmak:** Sistem yaklaşan bir rezervasyon için masayı otomatik tuttuysa, dokununca rezervasyon detayını gösteren bir diyalog açılır ve tek dokunuşla **misafiri oturtursunuz**. Rezervasyon olmadan elle "rezerve" işaretlenmiş masada ise kilidi açma diyaloğu çıkar.
+- **Tablet kullanımı:** Yatay tablet (≥768px) masaüstü gibi yan yana menü+sepet düzenini alır; telefonda sepet alttaki çekmeceye iner.
+- **İndirim güvenliği:** İndirim ara toplamı geçemez; ürün çıkarıp indirimi olduğu gibi bırakırsanız sistem indirimi otomatik kısar (eksi tutar oluşmaz).
+
+## İlgili ayarlar
+
+POS davranışını **Ayarlar → POS** ve **Ayarlar → QR Menü** altından yönetirsiniz: masasız mod, iki adımlı ödeme, ücretsiz self-pay (PayTR), "ödemeden önce servis edilmiş olsun" kuralı, ürün görselleri ve varsayılan harita görünümü. Ayrıntı: **[Ayarlar](/tr/admin-guide/settings)**.

--- a/developer/pages/tr/admin-guide/qr-menu.mdx
+++ b/developer/pages/tr/admin-guide/qr-menu.mdx
@@ -1,0 +1,71 @@
+---
+title: QR Menü (Yönetim + Ayarlar)
+description: HummyTummy QR menü yönetimi — QR kod üretme/indirme/yazdırma, tasarım editörü ve müşteri sipariş ayarları. Amacı, kullanımı ve ipuçları.
+---
+
+import { Callout, Steps } from 'nextra/components'
+
+# QR Menü
+
+**Menü yolu:** Menü & Masa → QR Kodlar &nbsp;•&nbsp; **URL:** `/admin/qr-codes`
+**Erişim:** ADMIN, MANAGER
+**Plan:** Tüm planlarda açık
+
+## Amacı
+
+QR Menü, müşterinin masadaki **QR kodu okutup** menünüzü telefonunda görmesini — ve ayara bağlı olarak **sipariş verip ödemesini** — sağlar. Yönetici tarafında bu ekran iki işi yapar: QR kodlarını **üretip indirmek/yazdırmak** ve QR menünün **görünümünü** ayarlamak.
+
+<Callout type="info">
+  Müşteri tarafındaki QR menü adresleri:
+  - **Masa/Tenant QR:** `/qr-menu/:tenantId` (sepet, sipariş takibi, sadakat sayfaları dahil)
+  - **Alan adı (subdomain) erişimi:** kendi subdomain'iniz üzerinden de aynı menü açılır.
+  Bu sayfalar herkese açıktır; müşteri giriş yapmadan kullanır.
+</Callout>
+
+## İki sekme
+
+### 1. Kodlar (Codes)
+
+QR kodlarınız burada listelenir. Her kodun bir **türü** (örn. `TABLE` — masa) ve etiketi vardır.
+
+- **Tümünü İndir** — tüm kodları tek tek PNG olarak indirir (restoran adı + masa etiketiyle dosyalanır).
+- **Masa QR'larını Yazdır** — `TABLE` türündeki kodları toplu yazdırılabilir bir sayfada açar.
+
+### 2. Tasarım (Design)
+
+**Tasarım editörü** ile QR menünün görünümünü özelleştirirsiniz: renkler, logo ve görsel düzen. Önizleme ile sonucu anında görürsünüz.
+
+## Müşteri sipariş ayarları
+
+QR menünün **davranışı** ayrı bir yerden, **Ayarlar → QR Menü** (`/admin/settings/qr-menu`) altından yönetilir:
+
+<Steps>
+### Müşteri siparişini aç
+
+**"Müşteri siparişi"** açıkken müşteri menüden sipariş gönderebilir; kapalıyken QR menü yalnızca **görüntüleme** içindir (sipariş kasadan alınır).
+
+### İki adımlı ödeme otomatik gelir
+
+Müşteri siparişini açtığınızda **iki adımlı ödeme** de otomatik etkinleşir — çünkü müşteri siparişi önce mutfağa düşmeli, ödeme sonra alınmalıdır.
+
+### Konum ve sosyal/WiFi bilgileri
+
+QR menü sayfasında gösterilecek **konum**, **WiFi** ve **sosyal medya** bilgilerini de buradan girersiniz.
+</Steps>
+
+<Callout type="warning">
+  Müşteri self-pay (PayTR ile masadan ödeme) ayrı bir POS ayarıdır. Açtığınızda müşteri
+  QR menüden kendi hesabını ödeyebilir. Bu özellik **TRY** ile çalışır.
+</Callout>
+
+## İpuçları
+
+- **Her masaya ayrı QR:** Masa türündeki QR'lar masaya bağlı sipariş üretir — sipariş otomatik o masaya yazılır, garson masa seçmek zorunda kalmaz.
+- **Yazdırırken:** "Masa QR'larını Yazdır" ile hepsini tek seferde basıp masalara yapıştırın; menü güncellense bile QR aynı kalır (menü dinamik yüklenir, QR'ı yeniden basmanız gerekmez).
+- **Sadece görüntüleme menüsü mü istiyorsunuz?** Müşteri siparişini kapatın; QR menü dijital bir menü kartı gibi davranır.
+- **Sipariş takibi:** Müşteri sipariş verdikten sonra `/qr-menu/:tenantId/orders` üzerinden siparişinin durumunu (hazırlanıyor/hazır) canlı izleyebilir.
+
+## İlgili ekranlar
+
+- Menü içeriği (kategoriler, ürünler, görseller, modifier'lar) **Menü & Masa → Menü** (`/admin/menu`) altından yönetilir — QR menüde görünen ürünler oradan gelir.
+- Markalama (logo/renk) için: **[Ayarlar](/tr/admin-guide/settings)** (Branding sekmesi, `customBranding` — PRO ve üzeri).

--- a/developer/pages/tr/admin-guide/reports.mdx
+++ b/developer/pages/tr/admin-guide/reports.mdx
@@ -1,0 +1,70 @@
+---
+title: Raporlar & Analitik
+description: HummyTummy raporlama — satış, saatlik, müşteri, envanter, personel ve Z-raporlar; ayrıca masa kullanımı ve AI öngörüleri içeren analitik. Amacı, kullanımı ve ipuçları.
+---
+
+import { Callout } from 'nextra/components'
+
+# Raporlar & Analitik
+
+**Menü yolu:** Operasyon → Raporlar / Analitik
+**URL:** `/admin/reports` ve `/admin/analytics`
+**Erişim:** ADMIN, MANAGER
+**Plan:** `advancedReports` — **Profesyonel (PRO)** ve üzeri (veya `advanced_reports` eklentisi)
+
+## Amacı
+
+İki ekran da işletme verinizi okunabilir hâle getirir:
+
+- **Raporlar** — satış, ödeme yöntemi kırılımı, en çok satan ürünler, müşteri, envanter, personel ve **Z-raporları**.
+- **Analitik** — masa kullanımı, trafik/yoğunluk analizi, müşteri davranışı ve **AI destekli öngörüler**.
+
+<Callout type="info">
+  İki ekran da `advancedReports` özelliğine bağlıdır (**PRO ve üzeri**). PRO'ya
+  çıkmadan açmak isterseniz **`advanced_reports`** marketplace eklentisini alabilirsiniz.
+  Planınızda yoksa her iki menü öğesi gizlenir ve doğrudan URL yükseltme kartı gösterir.
+</Callout>
+
+## Raporlar ekranı
+
+Üstte sekmeler, üstte de bir **tarih aralığı filtresi** (başlangıç–bitiş) ve çok şubeli tenant'larda bir **şube filtresi** vardır (tek şubede şube filtresi görünmez, rapor tenant geneli kalır).
+
+| Sekme | İçerik | Görünürlük |
+| --- | --- | --- |
+| **Satış (Sales)** | Toplam ciro, sipariş sayısı, ortalama sepet, toplam indirim; ödeme yöntemi kırılımı; günlük satış; en çok satan ürünler | Her zaman |
+| **Saatlik (Hourly)** | Günün saatlerine göre sipariş dağılımı | Her zaman |
+| **Müşteriler** | Müşteri analitiği (dönem bazlı) | Her zaman |
+| **Envanter (Inventory)** | Stok raporu | Yalnızca `inventoryTracking` varsa |
+| **Personel (Staff)** | Personel performansı | Yalnızca `personnelManagement` varsa |
+| **Z-Raporları** | Gün sonu mali özetler (Z-raporlar) | Her zaman |
+
+<Callout type="info">
+  Envanter ve Personel sekmeleri ek özelliklere bağlıdır — yoksa **sekme görünmez**
+  (eskiden tıklayınca 403 düşüyordu). Satış/Saatlik/Müşteri/Z-Rapor, sayfayı açan
+  `advancedReports` ile birlikte gelir.
+</Callout>
+
+## Analitik ekranı
+
+| Sekme | İçerik |
+| --- | --- |
+| **Overview** | Ortalama masa kullanımı, dönem cirosu, yoğunluk skoru, aktif öngörü sayısı + aksiyon alınabilir öngörüler |
+| **Table Analytics** | Masa bazında kullanım, ciro, oturum sayısı, ortalama sepet; yetersiz kullanılan masalar |
+| **Traffic Flow** | Yoğunluk skoru, sıcak noktalar ve akışı iyileştirme önerileri |
+| **Customer Behavior** | Ortalama yemek süresi, masada atıl kalma, parti büyüklüğü; pik varış/ayrılış saatleri |
+| **AI Insights** | Üretilen tüm öngörüler; her birini "uygulandı / devam ediyor / yoksay" olarak işaretleyebilirsiniz |
+
+## İpuçları
+
+- **Tarih aralığını dar tutun:** Varsayılan son 7 gündür; karşılaştırma için aralığı değiştirip "Uygula" deyin.
+- **Şube filtresini kullanın:** Çok şubeliyseniz şube bazında karşılaştırma yapın; filtre boşsa rapor tüm şubeleri kapsar.
+- **Z-raporları gün sonu için:** Vergi/muhasebe uyumu açısından gün sonu kapanışlarını Z-Raporları sekmesinden izleyin.
+- **AI öngörülerini işleyin:** Analitikteki öngörüleri "uygulandı/yoksay" diye işaretlemek listeyi temiz tutar ve hangi önerinin gerçekten denendiğini gösterir.
+- **Atıl masa = devir kaybı:** "Customer Behavior" yüksek atıl süre uyarısı verirse, hesabı proaktif sunmak masa devrini artırır.
+
+## İlgili ekranlar
+
+- **[Masalar](/tr/admin-guide/tables)** — masa kullanım analizinin kaynağı.
+- **[Stok](/tr/admin-guide/stock)** — Envanter rapor sekmesi.
+- **[Personel](/tr/admin-guide/personnel)** — Personel performans sekmesi.
+- Faturalar için: **Operasyon → Faturalar** (`/admin/invoices`).

--- a/developer/pages/tr/admin-guide/reservations.mdx
+++ b/developer/pages/tr/admin-guide/reservations.mdx
@@ -1,0 +1,77 @@
+---
+title: Rezervasyonlar
+description: HummyTummy rezervasyon yönetimi — gelen rezervasyonları onaylama/reddetme, masa atama, oturtma, no-show ve ayarlar. Amacı, kullanımı ve ipuçları.
+---
+
+import { Callout } from 'nextra/components'
+
+# Rezervasyonlar
+
+**Menü yolu:** Menü & Masa → Rezervasyonlar &nbsp;•&nbsp; **URL:** `/admin/reservations`
+**Erişim:** ADMIN, MANAGER
+**Plan:** `reservationSystem` — **Profesyonel (PRO)** ve üzeri
+
+## Amacı
+
+Rezervasyon ekranı, müşterilerin online (genel rezervasyon sayfası üzerinden) veya elle alınan masa rezervasyonlarını yönetir: onaylar, masa atar, misafiri oturtur ve gelmeyenleri (no-show) işaretlersiniz.
+
+<Callout type="info">
+  Rezervasyon sistemi **Profesyonel (PRO)** ve üzeri planlarda açıktır. Planınızda yoksa
+  menüde Rezervasyonlar görünmez ve doğrudan URL yükseltme kartı gösterir.
+
+  **Genel (müşteriye açık) rezervasyon sayfaları:** `/reserve/:tenantId` (yeni rezervasyon)
+  ve `/reserve/:tenantId/lookup` (rezervasyon sorgulama). Müşteri giriş yapmadan kullanır.
+</Callout>
+
+## Ekranda neler var?
+
+- **Tarih seçici** — belirli bir günün rezervasyonlarını görürsünüz (varsayılan: bugün).
+- **Durum sekmeleri** — Tümü / Bekliyor / Onaylı / Oturdu / Tamamlandı / İptal.
+- **Arama** — müşteri adı/telefon ile filtreleme.
+- **İstatistikler** — seçili güne ait özet sayılar.
+- **Liste + sayfalama** — her satır müşteri, saat, kişi sayısı, masa ve durumu gösterir; satıra tıklayınca detay modalı açılır.
+
+## Rezervasyon durumları ve akış
+
+| Durum | Anlamı |
+| --- | --- |
+| `PENDING` | Bekliyor — onay gerekiyor |
+| `CONFIRMED` | Onaylandı |
+| `SEATED` | Misafir oturtuldu |
+| `COMPLETED` | Tamamlandı |
+| `REJECTED` | Reddedildi |
+| `CANCELLED` | İptal edildi |
+| `NO_SHOW` | Gelmedi |
+
+Tipik akış: **Bekliyor → Onayla → (gün gelince) Oturt → Tamamla.** Gelmeyenleri **No-show**, iptal edilenleri **İptal** olarak işaretlersiniz. Onay/red/iptal/no-show işlemleri bir **onay diyaloğuyla** korunur.
+
+## Detay modalı
+
+Bir rezervasyona tıklayınca:
+
+- **Masa ataması** — rezervasyona bir masa bağlarsınız (tabloda gösterilir).
+- **Yönetici notu** — iç not (müşteri görmez) ekleyebilirsiniz.
+
+## Masa tutma (auto-hold) ile entegrasyon
+
+Onaylı bir rezervasyon, başlangıç saatine yaklaştıkça ilgili masayı otomatik **Rezerve** olarak tutabilir (ayarlardaki "tutma süresi" ile). POS'ta o masaya dokunan garson, rezervasyon detayını gösteren bir diyalogla karşılaşır ve **tek dokunuşla misafiri oturtur** (masa Dolu'ya, rezervasyon SEATED'a geçer).
+
+## Ayarlar
+
+**Ayarlar → Rezervasyonlar** (`/admin/settings/reservations`) altından:
+
+- **Etkin/pasif** — rezervasyon alımını aç/kapat.
+- **Onay zorunluluğu** — gelen rezervasyonlar otomatik onaylansın mı, yoksa elle mi?
+- **Zaman ayarları** — slot aralığı (15/30/60 dk), minimum/maksimum ön rezervasyon, varsayılan süre, masa tutma offset'i (dk).
+- **Kapasite** — eşzamanlı rezervasyon kapasitesi.
+
+## İpuçları
+
+- **"Onay zorunlu" ile spam'i engelleyin:** Online rezervasyonların hepsini otomatik onaylamak yerine elle onaylarsanız sahte/çift kayıtları yakalarsınız.
+- **Masayı erken atayın:** Onayda masayı bağlarsanız, auto-hold doğru masayı tutar ve garson POS'ta tek dokunuşla oturtur.
+- **No-show'u işaretleyin:** Gelmeyenleri No-show yapın; bu hem masa tutmayı serbest bırakır hem de ileride müşteri davranış analizine veri sağlar.
+
+## İlgili ekranlar
+
+- **[Masalar](/tr/admin-guide/tables)** — masa tutma ve durumlar.
+- **[POS](/tr/admin-guide/pos)** — rezerve masaya dokununca oturtma diyaloğu.

--- a/developer/pages/tr/admin-guide/settings.mdx
+++ b/developer/pages/tr/admin-guide/settings.mdx
@@ -1,0 +1,73 @@
+---
+title: Ayarlar
+description: HummyTummy ayarlar ekranı — POS, QR menü, raporlar, marka, entegrasyonlar, webhook'lar, partner anahtarları, rezervasyon, SMS, online sipariş ve muhasebe sekmeleri; ayrıca Plan & Erişim ve Masaüstü Uygulaması.
+---
+
+import { Callout } from 'nextra/components'
+
+# Ayarlar
+
+**Menü yolu:** Ayarlar & Erişim → Ayarlar &nbsp;•&nbsp; **URL:** `/admin/settings`
+**Erişim:** ADMIN, MANAGER
+**Plan:** Çekirdek sekmeler tüm planlarda; gelişmiş sekmeler plana/eklentiye bağlı
+
+## Amacı
+
+Ayarlar, restoranınızın **davranışını** ve **entegrasyonlarını** ayarladığınız merkezdir. Sol bir alt menü (sekmeler) içerir; her sekme bir modülün ayarını yönetir. Bir sekme planınızda/eklentinizde yoksa **görünmez** — doğrudan URL'e giderseniz yükseltme kartı çıkar.
+
+<Callout type="info">
+  Çoğu ayar **otomatik kaydedilir** (değiştirdiğiniz an); başarı/başarısızlık bir
+  bildirimle (toast) gösterilir. Ayrıca "Ayarlar & Erişim" bölümünde, Ayarlar'ın yanında
+  iki bağımsız ekran daha vardır: **Plan & Erişim** ve **Masaüstü Uygulaması** (aşağıda).
+</Callout>
+
+## Ayar sekmeleri
+
+| Sekme | URL | Ne ayarlar? | Gereksinim |
+| --- | --- | --- | --- |
+| **POS** | `/admin/settings/pos` | Masasız mod, iki adımlı ödeme, "ödemeden önce servis edilmiş olsun" kuralı, müşteri self-pay (PayTR), ürün görselleri, varsayılan harita görünümü (2D/3D) | Tüm planlar |
+| **QR Menü** | `/admin/settings/qr-menu` | Müşteri siparişi aç/kapat, iki adımlı ödeme, konum/WiFi/sosyal bilgileri | Tüm planlar |
+| **Raporlar** | `/admin/settings/reports` | Rapor tercihleri | Tüm planlar |
+| **Marka (Branding)** | `/admin/settings/branding` | Logo, renkler, özel marka görünümü | `customBranding` — PRO+ |
+| **Entegrasyonlar** | `/admin/settings/integrations` | API erişim ayarları | `apiAccess` — BUSINESS (veya `api_access`) |
+| **Webhook'lar** | `/admin/settings/webhooks` | Olay webhook'ları | `apiAccess` — BUSINESS (veya `api_access`) |
+| **Partner Anahtarları** | `/admin/settings/partner-keys` | Üçüncü taraf ekran/uygulama için API anahtarı (Partner Display) | `externalDisplay` — BUSINESS |
+| **Rezervasyon** | `/admin/settings/reservations` | Rezervasyon kuralları (onay, slot, kapasite) | `reservationSystem` — PRO+ |
+| **SMS** | `/admin/settings/sms` | SMS entegrasyonu | `sms` entegrasyon eklentisi |
+| **Online Sipariş** | `/admin/settings/online-orders` | Delivery platformları (Yemeksepeti/Getir vb.) | `deliveryIntegration` — PRO+ (veya `delivery_*`) |
+| **Muhasebe** | `/admin/settings/accounting` | e-Fatura/muhasebe entegrasyonu | `accounting` entegrasyon eklentisi |
+
+<Callout type="warning">
+  **Abonelik sekmesi kaldırıldı.** Faturalandırma ve plan değişimi artık üst seviyedeki
+  **Plan & Erişim** sayfasındadır; eski `/admin/settings/subscription` adresi oraya
+  yönlendirir.
+</Callout>
+
+## "Ayarlar & Erişim" bölümündeki diğer ekranlar
+
+### Plan & Erişim
+
+**URL:** `/admin/plan` — Mevcut planınız, kullanım kotalarınız (kullanıcı/masa/şube/ürün/sipariş) ve aktif eklentileriniz tek sayfada. Plan değiştirme, fatura geçmişi, iptal/yeniden etkinleştirme buradan başlar. Plan seçimi ve yükseltme için **[Planlar](/tr/plans)**.
+
+### Masaüstü Uygulaması
+
+**URL:** `/admin/desktop` — Masaüstü (Tauri) POS terminali için indirme ve kurulum. Fiş yazıcısı/donanım entegrasyonu masaüstü uygulamasında çalışır.
+
+### Şube-bazlı entegrasyon ekranları
+
+Bazı entegrasyonların kendi tam ekranları vardır (eklenti aldıysanız görünür):
+
+- **e-Fatura Kurtarma** (`/admin/fiscal-recovery`) — `fiscal` entegrasyon eklentisi.
+- **Çağrı Kimliği Akışı** (`/admin/caller-feed`) — `caller` entegrasyon eklentisi.
+
+## İpuçları
+
+- **POS + QR menü ayarları birbirine bağlıdır:** Müşteri siparişini açınca iki adımlı ödeme otomatik gelir; bunu QR menü ayarından yönetin (POS'tan iki adımlı ödemeyi kapatamazsınız).
+- **Entegrasyonu önce marketplace'ten alın:** SMS/e-Fatura/Delivery/Çağrı gibi sekmeler ilgili eklenti alınmadan görünmez — bkz. **[Marketplace](/tr/marketplace)**.
+- **Otomatik kayıt hatası:** Bir ayar kaydedilmediyse hata bildirimi çıkar; çoğu sekmede tek tıkla yeniden dener.
+
+## İlgili ekranlar
+
+- **[Planlar](/tr/plans)** — plan/limit/fiyat ve Plan & Erişim.
+- **[Marketplace](/tr/marketplace)** — entegrasyon ve kapasite eklentileri.
+- **[Geliştirici / Entegrasyon](/tr/developer)** — API, webhook ve Partner Display detayları.

--- a/developer/pages/tr/admin-guide/stock.mdx
+++ b/developer/pages/tr/admin-guide/stock.mdx
@@ -1,0 +1,56 @@
+---
+title: Stok & Envanter
+description: HummyTummy stok yönetimi — malzemeler, reçeteler, tedarikçiler, satın alma siparişleri, hareketler, fire ve stok sayımı. Amacı, kullanımı ve ipuçları.
+---
+
+import { Callout } from 'nextra/components'
+
+# Stok & Envanter
+
+**Menü yolu:** Operasyon → Stok &nbsp;•&nbsp; **URL:** `/admin/stock`
+**Erişim:** ADMIN, MANAGER
+**Plan:** `inventoryTracking` — **Başlangıç (BASIC)** ve üzeri
+
+## Amacı
+
+Stok modülü, mutfak malzemelerinizi (envanter) baştan sona izler: ne kadar var, ne tükeniyor, ne fire veriyor ve satışla otomatik düşüşü. Reçeteler sayesinde bir ürün satıldığında içindeki malzemeler stoktan otomatik düşülebilir.
+
+<Callout type="info">
+  Stok takibi **Başlangıç (BASIC)** ve üzeri planlarda açıktır. Planınızda yoksa sol
+  menüde Stok görünmez ve `/admin/stock` adresi yükseltme kartı gösterir.
+</Callout>
+
+## Sekmeler
+
+Ekran sekmelere ayrılır; her biri stok yönetiminin bir parçasıdır:
+
+| Sekme | Ne yapar? |
+| --- | --- |
+| **Genel Bakış (Dashboard)** | Stok durumu özeti — düşük/kritik seviyeler, anlık görünüm |
+| **Malzemeler (Ingredients)** | Stok kalemlerini tanımla — birim, mevcut miktar, kritik eşik |
+| **Reçeteler (Recipes)** | Bir ürünün hangi malzemelerden ne kadar içerdiğini tanımla |
+| **Tedarikçiler (Suppliers)** | Tedarikçi kayıtları |
+| **Satın Alma Siparişleri (Purchase Orders)** | Tedarikçiye sipariş oluştur, gelen malı stoğa al |
+| **Hareketler (Movements)** | Tüm stok giriş/çıkış hareketlerinin kaydı |
+| **Fire (Waste Log)** | Zayi/fire kayıtları |
+| **Stok Sayımı (Stock Count)** | Fiziksel sayım ve sistemle uzlaştırma |
+
+## Tipik kullanım akışı
+
+1. **Malzemeleri tanımla** — un, et, süt vb.; birim ve kritik eşiklerini gir.
+2. **Reçete bağla** — "Cheeseburger = 1 köfte + 1 ekmek + 30g peynir" gibi. Böylece satışta malzeme otomatik düşer.
+3. **Tedarikçi + satın alma** — tedarikçiyi tanımla, satın alma siparişiyle gelen malı stoğa ekle.
+4. **Fire & sayım** — zayi olanı fire kaydına gir; dönemsel fiziksel sayımla sistemi uzlaştır.
+5. **Hareketleri izle** — tüm giriş/çıkışlar Hareketler sekmesinde denetlenebilir.
+
+## İpuçları
+
+- **Kritik eşik belirleyin:** Her malzemeye kritik seviye girin; Genel Bakış düşük stokları öne çıkarır, sipariş zamanını kaçırmazsınız.
+- **Reçeteler otomatik düşüşün anahtarı:** Reçete tanımlamazsanız satış stoğu otomatik düşmez — manuel hareket girmeniz gerekir. Çok satan ürünler için reçeteyi mutlaka tanımlayın.
+- **İptal stok iade eder:** Mutfakta `PENDING` bir sipariş iptal edilirse stok geri yazılır. Bu yüzden sayımda "neden eksik/fazla" sorusunu yanıtlarken iptalleri de göz önünde bulundurun.
+- **Stok raporu:** Raporlar ekranındaki **Envanter** sekmesi (aynı `inventoryTracking` ile gizlenir/görünür) stok analizini sunar.
+
+## İlgili ekranlar
+
+- **[Menü](/tr/admin-guide/qr-menu)** — reçeteler ürünlere bağlanır; ürün tanımı menü yönetiminde.
+- **[Raporlar & Analitik](/tr/admin-guide/reports)** — Envanter raporu sekmesi.

--- a/developer/pages/tr/admin-guide/tables.mdx
+++ b/developer/pages/tr/admin-guide/tables.mdx
@@ -1,0 +1,56 @@
+---
+title: Masalar & Kat Planı
+description: HummyTummy masa yönetimi — masa ekleme/düzenleme/silme, kapasite, tek dokunuşla durum değişimi, doluluk istatistikleri ve plan limitleri. Amacı, kullanımı ve ipuçları.
+---
+
+import { Callout } from 'nextra/components'
+
+# Masalar & Kat Planı
+
+**Menü yolu:** Menü & Masa → Masalar &nbsp;•&nbsp; **URL:** `/admin/tables`
+**Erişim:** ADMIN, MANAGER
+**Plan:** Tüm planlarda açık (masa sayısı **plana bağlı**)
+
+## Amacı
+
+Bu ekran restoranınızın **masalarını** tanımlar ve durumlarını yönetir. Eklediğiniz masalar hem POS satış ekranındaki masa ızgarasında hem de QR menü ve rezervasyon akışında kullanılır.
+
+## Ekranda neler var?
+
+- **Üst istatistik şeridi:** Toplam masa, **boş**, **dolu**, **rezerve** sayıları ve canlı bir **doluluk yüzdesi** (dolu masaların oranı).
+- **Masa kartları ızgarası:** Her kart masa numarasını, durumunu (renkli rozet), kapasitesini ve eylem butonlarını gösterir.
+- **Plan limiti bilgi bandı:** Planınızın masa limitine yaklaşıyorsanız bilgilendirir; limit dolduğunda "Masa Ekle" kilitlenir ve yükseltme önerisi çıkar.
+
+## Masa durumları
+
+| Durum | Renk | Anlamı |
+| --- | --- | --- |
+| **Boş** (`AVAILABLE`) | Yeşil | Müsait |
+| **Dolu** (`OCCUPIED`) | Kırmızı/Amber | Misafir oturuyor |
+| **Rezerve** (`RESERVED`) | Gri/Amber | Rezerve edilmiş |
+
+## Kullanım
+
+- **Masa ekle / düzenle:** "Masa Ekle" ile numara, kapasite ve başlangıç durumunu girersiniz. Var olan masada düzenleme (kalem ikonu) aynı formu açar.
+- **Tek dokunuşla durum:** Her kartta **Boş / Dolu / Rezerve** segment düğmesi vardır — modal açmadan masanın durumunu anında çevirirsiniz.
+- **Silme:** Çöp ikonu onay diyaloğu açar. Masa **dolu**ysa veya **yaklaşan bir rezervasyonu** varsa diyalog uyarır (oturan misafiri/rezerve slotu sahipsiz bırakmamak için).
+- **Yaklaşan rezervasyon rozeti:** Masada yakında (~2 saat içinde) başlayacak onaylı/bekleyen bir rezervasyon varsa kartta saat + müşteri adı gösterilir — staff bir bakışta hangi masaya misafir geleceğini görür.
+
+<Callout type="info">
+  **Masa limiti plana bağlıdır:** Başlangıç (BASIC) **20 masa**, Profesyonel (PRO)
+  **50 masa**, Kurumsal (BUSINESS) **sınırsız**. Limite ulaşınca yeni masa ekleyemezsiniz;
+  planı yükseltin veya kullanılmayan masaları silin. Tam limitler için **[Planlar](/tr/plans)**.
+</Callout>
+
+## İpuçları
+
+- **Doluluk yüzdesini takip edin:** Yoğun saatlerde üst şeritteki doluluk oranı kapasite planlaması için iyi bir göstergedir; analitikteki "masa kullanımı" raporuyla birleştirin.
+- **Durumu POS'tan da çevirebilirsiniz:** POS'ta sipariş alınınca masa otomatik "dolu", ödeme alınınca otomatik "boş" olur. Bu ekrandaki tek dokunuşlu kontrol, sipariş olmadan elle düzeltme içindir (örn. temizlik/rezerve tutma).
+- **Rezerve elle vs. otomatik:** Bir masayı elle "Rezerve" yaparsanız (rezervasyon kaydı olmadan), POS'ta o masaya dokunan garson kilidi açma diyaloğuyla karşılaşır. Gerçek rezervasyonlar **Rezervasyonlar** ekranından yönetilir.
+- **Silmeden önce:** Dolu/rezerve masayı silmek aktif oturumu veya booking'i etkileyebilir — uyarıyı okuyun.
+
+## İlgili ekranlar
+
+- **[POS](/tr/admin-guide/pos)** — masa seçimi, transfer, birleştirme ve hesap bölme buradan yapılır.
+- **[Rezervasyonlar](/tr/admin-guide/reservations)** — masa bazlı rezervasyon ve otomatik tutma (PRO).
+- **[Raporlar & Analitik](/tr/admin-guide/reports)** — masa kullanım/doluluk analizi.

--- a/developer/pages/tr/desktop/_meta.ts
+++ b/developer/pages/tr/desktop/_meta.ts
@@ -1,0 +1,3 @@
+export default {
+  "index": "Genel Bakış"
+}

--- a/developer/pages/tr/desktop/_meta.ts
+++ b/developer/pages/tr/desktop/_meta.ts
@@ -1,3 +1,7 @@
 export default {
-  "index": "Genel Bakış"
+  "index": "Genel Bakış",
+  "kurulum": "Kurulum & indirme",
+  "otomatik-guncelleme": "Otomatik güncelleme",
+  "donanim": "Donanım eşleştirme",
+  "kds-modu": "KDS / kiosk modu"
 }

--- a/developer/pages/tr/desktop/donanim.mdx
+++ b/developer/pages/tr/desktop/donanim.mdx
@@ -1,0 +1,257 @@
+---
+title: Donanım eşleştirme
+description: Fiş yazıcısı, nakit çekmece ve yazarkasa'yı device-mesh ile eşleştirme — pair-code akışı, cihaz token'ı, komut kuyruğu ve güvenlik kuralları.
+---
+
+import { Callout, Steps, Tabs } from 'nextra/components'
+
+# Donanım: yazıcı, nakit çekmece, yazarkasa
+
+Yerel donanım, **device-mesh** modülü üzerinden yönetilir. Yönetici panelden bir
+**cihaz yuvası** (device slot) oluşturur; bu yuva ekranda 6 haneli bir **eşleştirme
+kodu** gösterir. Cihaz (ya da cihazları sürücüleyen yerel köprü — `local_bridge`) bu
+kodu girerek eşleşir ve karşılığında kalıcı bir **cihaz token'ı** alır. Sonrasında
+sunucu, cihaza fiş yazdırma, çekmece açma ya da fiş kesme gibi komutları bir **komut
+kuyruğu** üzerinden iletir.
+
+Tüm uç noktalar `/api/v1/devices/...` altındadır.
+
+## Cihaz türleri
+
+`kind` alanı şu kapalı kümeden bir değerdir:
+
+| `kind` | Açıklama |
+| --- | --- |
+| `receipt_printer` | Fiş yazıcısı |
+| `kitchen_printer` | Mutfak yazıcısı |
+| `yazarkasa` | Yazarkasa (mali / fiscal cihaz) |
+| `pos_terminal` | Kart ödeme terminali |
+| `kds_screen` / `bar_screen` | Mutfak / bar ekranı |
+| `tablet_waiter` / `tablet_customer` | Garson / müşteri tableti |
+| `caller_id` | Çağrı kimliği cihazı |
+| `scanner` | Barkod okuyucu |
+| `local_bridge` | Birden çok cihazı sürücüleyen yerel köprü ajanı |
+
+`capabilities` alanı serbest etiketler içeren bir dizidir (en çok 32 öğe, her biri
+≤ 64 karakter) — örn. yazarkasa + yazıcı + çekmece yeteneklerini taşıyan bir köprü.
+
+## İki yetkilendirme yüzeyi
+
+device-mesh tek controller'da iki ayrı yüzey barındırır:
+
+- **Admin (kullanıcı oturumu / Bearer JWT)** — kiracı yöneticileri cihazları yönetir.
+  `ADMIN` veya `MANAGER` rolü gerekir. Bu rotalar **şube kapsamlıdır** (`X-Branch-Id`).
+- **Cihaz tarafı (cihaz token'ı)** — cihazın kendisi konuşur. `Authorization: Device <token>`
+  başlığı kullanılır (bilerek `Bearer` değil; ara katmanların `Bearer`'ı temizlemesinden
+  etkilenmemek için).
+
+## Eşleştirme akışı
+
+<Steps>
+### Yönetici bir cihaz yuvası oluşturur
+
+```bash
+curl -X POST https://app.hummytummy.com/api/v1/devices \
+  -H "Authorization: Bearer $JWT" \
+  -H "X-Branch-Id: $BRANCH_ID" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "kind": "receipt_printer",
+    "capabilities": ["escpos", "80mm"],
+    "model": "Epson TM-T20III",
+    "ownership": "byo"
+  }'
+```
+
+Yanıt, ekranda gösterilecek **pair code**'u içerir:
+
+```json
+{
+  "id": "01J...",
+  "tenantId": "01J...",
+  "branchId": "01J...",
+  "kind": "receipt_printer",
+  "status": "unprovisioned",
+  "pairCode": "A4F9K2",
+  "pairCodeExpiresAt": "2026-06-22T10:10:00.000Z"
+}
+```
+
+<Callout type="info">
+  `branchId` zorunludur. Rota şube kapsamlı olduğundan sunucu bunu `X-Branch-Id`
+  başlığından çözer; gövdede `branchId` vererek de açıkça geçebilirsiniz. `ownership`
+  alanı `sold` / `rented` / `byo` (varsayılan `byo`) değerlerinden biridir.
+</Callout>
+
+### Cihaz, pair code ile eşleşir
+
+Cihaz (veya `local_bridge` ajanı) ekrandaki kodu okur ve eşleşir:
+
+```bash
+curl -X POST https://app.hummytummy.com/api/v1/devices/pair \
+  -H "Content-Type: application/json" \
+  -d '{
+    "pairCode": "A4F9K2",
+    "model": "Epson TM-T20III",
+    "capabilities": ["escpos", "80mm"]
+  }'
+```
+
+Yanıt, yalnızca **bir kez** dönen ham token'ı içerir:
+
+```json
+{
+  "deviceId": "01J...",
+  "tenantId": "01J...",
+  "branchId": "01J...",
+  "kind": "receipt_printer",
+  "token": "018f....base64url",
+  "tokenExpiresAt": "2026-06-23T10:05:00.000Z",
+  "capabilities": ["escpos", "80mm"]
+}
+```
+
+### Cihaz token'ını saklar ve heartbeat gönderir
+
+Token bundan sonra her istekte `Authorization: Device <token>` başlığında gönderilir.
+Cihaz düzenli **heartbeat** atarak çevrimiçi kalır:
+
+```bash
+curl -X POST https://app.hummytummy.com/api/v1/devices/heartbeat \
+  -H "Authorization: Device $DEVICE_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{ "batteryPct": 100, "agentVersion": "1.0.0", "queueDepth": 0 }'
+```
+</Steps>
+
+### Eşleştirme kurallarına dair notlar
+
+<Callout type="warning">
+  - **Pair code TTL** varsayılan **10 dakikadır** (`DEVICE_PAIR_CODE_TTL_MS`). Süresi
+    dolan kod ilk denemede atomik olarak temizlenir ve "Pair code expired — request a
+    new one" hatası döner.
+  - **Cihaz token'ı TTL** varsayılan **24 saattir** (`DEVICE_TOKEN_TTL_MS`). Token'lar
+    sunucuda sha256 hash'i olarak tutulur; ham token asla saklanmaz, yalnızca eşleşme
+    anında bir kez döner.
+  - `/pair` uç noktası **5 istek/dk/IP** ile sınırlıdır — 6 haneli kod (`[A-Z0-9]`,
+    ~2,2 milyar olasılık) için kaba kuvvet bütçesini TTL penceresinde anlamsız kılar.
+  - Pair code **tek kullanımlıktır**: aynı kodu milisaniyeler arayla iki cihaz girerse,
+    atomik claim (updateMany) yalnızca ilkini başarılı sayar; ikincisi "Pair code already
+    claimed by another device or expired" hatası alır.
+</Callout>
+
+## Cihaz durumları
+
+```
+unprovisioned → (yuva oluşturuldu, kod bekliyor)
+paired        → (ilk eşleşme, henüz heartbeat yok)
+online        → (heartbeat penceresi içinde)
+offline       → (heartbeat ~45sn'den uzun süredir gelmiyor)
+retired       → (yönetici emekliye ayırdı; token iptal)
+```
+
+Heartbeat penceresi **45 sn**'dir; arka plan süpürücüsü (cron) bu süreyi aşan
+çevrimiçi cihazları `offline`'a çevirir.
+
+## Komut kuyruğu
+
+Yönetici, bir cihaza komut göndererek donanımı sürücüler. Komutlar cihaz-başına FIFO +
+öncelikli bir kuyrukta tutulur; cihaz `next-command` ile sıradaki komutu çeker, çalıştırır
+ve `ack` ile sonuç bildirir.
+
+### Komut türleri (`kind`)
+
+| `kind` | Donanım eylemi |
+| --- | --- |
+| `print_receipt` | Müşteri fişi yazdır |
+| `open_drawer` | Nakit çekmeceyi aç |
+| `fiscal_receipt` | Yazarkasa mali fişi kes |
+| `fiscal_cancel` | Mali fişi iptal et (fiscal void) |
+| `charge_card` | Kart terminalinden tahsilat başlat |
+| `show_order` / `clear_order` | Ekranda sipariş göster / temizle |
+| `reboot` / `firmware_update` | Cihazı yeniden başlat / firmware güncelle |
+| `capability_probe` / `noop` | Yetenek yokla / boş komut |
+
+### Komut gönderme (admin)
+
+```bash
+curl -X POST https://app.hummytummy.com/api/v1/devices/$DEVICE_ID/commands \
+  -H "Authorization: Bearer $JWT" \
+  -H "X-Branch-Id: $BRANCH_ID" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "kind": "print_receipt",
+    "payload": { "orderId": "01J...", "copies": 1 },
+    "priority": 0,
+    "idempotencyKey": "order-01J-receipt"
+  }'
+```
+
+- `kind` yukarıdaki kapalı kümeden olmalıdır; serbest takma adlar (`charge.card` gibi)
+  `400` ile reddedilir.
+- `payload` bir nesne (JSONB) olmalıdır; `priority` 0–1000 arası (0 varsayılan, yüksek =
+  önce).
+- `idempotencyKey` verilirse `(deviceId, idempotencyKey)` üzerinde tekilleştirilir;
+  tekrar gönderim aynı komutu döndürür (çift komut yaratmaz). Yeniden denerken
+  **mutlaka** sabit bir anahtar gönderin.
+
+### Cihaz tarafı: komut çekme ve ack
+
+```bash
+# Sıradaki komutu atomik olarak çek (yoksa null döner)
+curl https://app.hummytummy.com/api/v1/devices/next-command \
+  -H "Authorization: Device $DEVICE_TOKEN"
+
+# Sonucu bildir
+curl -X POST https://app.hummytummy.com/api/v1/devices/commands/$COMMAND_ID/ack \
+  -H "Authorization: Device $DEVICE_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{ "status": "done", "result": { "bytesPrinted": 412 } }'
+```
+
+`next-command`, `FOR UPDATE SKIP LOCKED` ile atomik çalışır — aynı cihaz iki bağlantı
+açsa bile komut iki kez teslim edilmez. `ack` durumu `done` ya da `failed` olabilir;
+`error` alanı (≤ 1000 karakter) başarısızlık nedenini taşır.
+
+<Callout type="warning">
+  **Para taşıyan / kalıcı çıktı üreten komutlar asla otomatik yeniden denenmez.**
+  `charge_card`, `fiscal_receipt`, `fiscal_cancel`, `open_drawer` ve `print_receipt`
+  yan etkilidir: ack kaybolan bir komut (terminal tahsilatı yaptı → uygulama çöktü →
+  sonuç sunucuya ulaşmadı) tekrar kuyruğa konulursa müşteriyi **çift çeker** ya da fişi
+  **çift basar**. Bu nedenle bu komutlar başarısızlıkta doğrudan `failed` durumunda
+  sonlanır; operatör açık bir **telafi komutu** (örn. `fiscal_cancel`) ile uzlaştırır.
+  Güvenli/idempotent komutlar (`show_order`, `clear_order`, `capability_probe`,
+  `reboot`, `noop`) ise normal yeniden deneme yolunu izler (en çok 5 deneme).
+</Callout>
+
+## Şube kapsamı ve güvenlik
+
+- Komut gönderme ve kuyruğu görüntüleme **şube kapsamına** bağlıdır: tek şubeye kısıtlı
+  bir `MANAGER`, yalnızca o şubedeki cihazları sürücüleyebilir; başka şubenin terminaline
+  `charge_card` / `open_drawer` / `fiscal_receipt` gönderemez (kapsam dışı cihaz `404`
+  döner). `ADMIN` kiracı genelinde çalışır.
+- Cihazı **emekliye ayırma** (`DELETE /api/v1/devices/:id`) yalnızca `ADMIN` rolüne
+  açıktır; token'ı iptal eder.
+- Cihaz token uç noktaları (`heartbeat`, `next-command`, `ack`) ayrıca hız sınırlıdır
+  (heartbeat 60/dk; next-command ve ack 120/dk) — ele geçmiş bir token'ın DB'yi
+  yormasını engeller.
+
+## Cihazları listeleme
+
+```bash
+curl "https://app.hummytummy.com/api/v1/devices?branchId=$BRANCH_ID&kind=receipt_printer&status=online" \
+  -H "Authorization: Bearer $JWT" \
+  -H "X-Branch-Id: $BRANCH_ID"
+```
+
+`branchId`, `kind` ve `status` ile filtrelenebilir. Liste yanıtı kimlik + durum
+bilgisini döndürür; `pairCode` ve `tokenHash` gibi hassas alanlar bilinçli olarak
+listeden çıkarılmıştır.
+
+<Callout type="info">
+  README'deki Bluetooth/ESC/POS komutları (`scan_devices`, `connect_device`,
+  `print_receipt` gibi Tauri komutları), masaüstü uygulamasının **yerel** BLE yazıcı
+  desteğidir ve istemci içinde çalışır. Buradaki device-mesh ise **sunucu tarafı**
+  cihaz kaydı, eşleştirme ve komut kuyruğudur. İkisi birbirini tamamlar: köprü, mesh'ten
+  aldığı `print_receipt` komutunu yerel ESC/POS yazıcıya dönüştürebilir.
+</Callout>

--- a/developer/pages/tr/desktop/index.mdx
+++ b/developer/pages/tr/desktop/index.mdx
@@ -1,0 +1,7 @@
+---
+title: Desktop Uygulaması
+---
+
+# Desktop Uygulaması
+
+Bu bölüm hazırlanıyor.

--- a/developer/pages/tr/desktop/index.mdx
+++ b/developer/pages/tr/desktop/index.mdx
@@ -1,7 +1,56 @@
 ---
 title: Desktop Uygulaması
+description: HummyTummy Desktop — Windows, macOS ve Linux için Tauri tabanlı POS/KDS masaüstü uygulaması. Otomatik güncelleme, donanım eşleştirme ve kiosk modu.
 ---
 
-# Desktop Uygulaması
+import { Cards, Callout } from 'nextra/components'
 
-Bu bölüm hazırlanıyor.
+# HummyTummy Desktop
+
+**HummyTummy Desktop**, restoran kasasını (POS) ve mutfak ekranını (KDS) bir masaüstü
+uygulaması olarak çalıştırmak için tasarlanmış, [Tauri 1.5](https://tauri.app) tabanlı
+çapraz platform bir uygulamadır. Web paneliyle aynı arayüzü yerel bir pencerede sunar;
+ek olarak yerel donanıma (fiş yazıcısı, nakit çekmece, yazarkasa) erişim ve
+sunucu üzerinden **otomatik güncelleme** sağlar.
+
+Uygulama adı (`productName`) **HummyTummy POS**, paket tanımlayıcısı (bundle identifier)
+`com.hummytummy.pos`'tur.
+
+<Callout type="info">
+  Masaüstü uygulaması web paneline ek bir katmandır; restoran verileri yine de bulutta
+  tutulur. Tarayıcıdan da aynı POS/KDS ekranlarına erişebilirsiniz. Masaüstü sürümünün
+  asıl kazandırdığı şey **yerel donanım erişimi** ve **tam ekran kiosk** kullanımıdır.
+</Callout>
+
+## Desteklenen platformlar
+
+| Platform | Tauri anahtarı | Kurulum paketi |
+| --- | --- | --- |
+| Windows (x86_64) | `windows-x86_64` | `.msi` |
+| macOS (Apple Silicon / ARM) | `darwin-aarch64` | `.dmg` |
+| macOS (Intel) | `darwin-x86_64` | `.dmg` |
+| Linux (x86_64) | `linux-x86_64` | `.deb` / `.AppImage` |
+
+Bu dört anahtar, sunucudaki güncelleme manifestinde (`platforms`) ve her sürümdeki
+indirme URL'lerinde birebir kullanılır.
+
+## Bölümler
+
+<Cards>
+  <Cards.Card title="Kurulum & indirme" href="/tr/desktop/kurulum" arrow />
+  <Cards.Card title="Otomatik güncelleme" href="/tr/desktop/otomatik-guncelleme" arrow />
+  <Cards.Card title="Donanım eşleştirme" href="/tr/desktop/donanim" arrow />
+  <Cards.Card title="KDS / kiosk modu" href="/tr/desktop/kds-modu" arrow />
+</Cards>
+
+## Mimari özet
+
+- **Sürüm kataloğu** — Tüm yayınlanmış kurulum paketleri sunucudaki `DesktopRelease`
+  kataloğunda tutulur. Uygulama hangi platformda olduğunu bildirir, sunucu o platforma
+  ait imzalı binary URL'sini döndürür. Bkz. [Kurulum & indirme](/tr/desktop/kurulum).
+- **Otomatik güncelleme** — Tauri updater, açılışta sunucudaki `GET /api/desktop/updates/...`
+  uç noktasını sorgular; yeni bir sürüm varsa minisign imzasını doğrulayıp indirir.
+  Bkz. [Otomatik güncelleme](/tr/desktop/otomatik-guncelleme).
+- **Donanım (device-mesh)** — Yazıcı, nakit çekmece ve yazarkasa gibi cihazlar
+  panelden bir **eşleştirme kodu** ile uygulamaya bağlanır; komutlar bir komut kuyruğu
+  üzerinden cihaza iletilir. Bkz. [Donanım eşleştirme](/tr/desktop/donanim).

--- a/developer/pages/tr/desktop/kds-modu.mdx
+++ b/developer/pages/tr/desktop/kds-modu.mdx
@@ -1,0 +1,91 @@
+---
+title: KDS / kiosk modu
+description: HummyTummy Desktop'u mutfak ekranı (KDS) ve tam ekran kiosk olarak kullanma — pencere yapılandırması, KDS ekran cihazı ve ekran komutları.
+---
+
+import { Callout } from 'nextra/components'
+
+# KDS / kiosk modu
+
+Masaüstü uygulaması, web panelindeki POS ve **mutfak ekranı (KDS)** arayüzlerini yerel
+bir pencerede çalıştırır. Bu, özellikle mutfak/bar istasyonlarında uygulamayı tek amaçlı,
+tam ekran bir **kiosk** olarak kullanmak için idealdir.
+
+## Pencere yapılandırması
+
+Uygulama, Tauri yapılandırmasındaki tek bir ana pencereyle açılır:
+
+| Ayar | Değer |
+| --- | --- |
+| Başlık | `HummyTummy POS` |
+| Başlangıç boyutu | 1280 × 720 |
+| En küçük boyut | 800 × 600 |
+| `resizable` | `true` |
+| `fullscreen` | `false` (varsayılan) |
+
+KDS istasyonlarında pencereyi tam ekrana almak (mutfak ekranı genelde adanmış bir
+monitördür) tipik kullanım biçimidir. Uygulama tek pencerelidir; aynı kurulum hem POS
+hem KDS ekranlarını gösterebilir — hangi ekranın açılacağı oturum açan kullanıcının
+rolüne ve seçtiği şubeye bağlıdır.
+
+<Callout type="info">
+  KDS, restoran verileri gibi buluttan beslenir. Masaüstü kiosk, tarayıcı sekmesi
+  kapanması / yanlışlıkla gezinme gibi riskleri ortadan kaldırıp ekranı tek bir
+  uygulamaya kilitlemenin temiz yoludur.
+</Callout>
+
+## KDS ekranını bir cihaz olarak kaydetmek
+
+İsteğe bağlı olarak, bir KDS/bar ekranını device-mesh'te bir cihaz olarak da
+kaydedebilirsiniz. Bu, ekranın **çevrimiçi/çevrimdışı** durumunu panelden izlemenize ve
+ona ekran komutları göndermenize olanak tanır.
+
+Yuvayı `kind: "kds_screen"` (ya da `bar_screen`) ile oluşturun ve cihazı eşleştirin —
+adımlar [Donanım eşleştirme](/tr/desktop/donanim) sayfasıyla birebir aynıdır:
+
+```bash
+curl -X POST https://app.hummytummy.com/api/v1/devices \
+  -H "Authorization: Bearer $JWT" \
+  -H "X-Branch-Id: $BRANCH_ID" \
+  -H "Content-Type: application/json" \
+  -d '{ "kind": "kds_screen", "model": "Mutfak Ekranı 1" }'
+```
+
+### Ekran komutları
+
+Kayıtlı bir ekran cihazına şu komutlar gönderilebilir:
+
+| `kind` | Eylem |
+| --- | --- |
+| `show_order` | Ekranda bir siparişi göster |
+| `clear_order` | Gösterilen siparişi temizle |
+| `reboot` | Ekran cihazını yeniden başlat |
+| `capability_probe` | Yetenekleri yokla |
+| `noop` | Boş komut (bağlantı testi) |
+
+Örnek — bir siparişi mutfak ekranında göstermek:
+
+```bash
+curl -X POST https://app.hummytummy.com/api/v1/devices/$SCREEN_ID/commands \
+  -H "Authorization: Bearer $JWT" \
+  -H "X-Branch-Id: $BRANCH_ID" \
+  -H "Content-Type: application/json" \
+  -d '{ "kind": "show_order", "payload": { "orderId": "01J..." } }'
+```
+
+<Callout type="info">
+  `show_order`, `clear_order`, `reboot`, `capability_probe` ve `noop` **idempotent /
+  güvenli** komutlardır; başarısızlıkta normal yeniden deneme yolunu izlerler (en çok 5
+  deneme). Yan etkili komutların (`charge_card`, `fiscal_receipt`, `open_drawer`,
+  `print_receipt`) aksine ekranı çift güncellemek zarar vermez.
+</Callout>
+
+## Pratik öneriler
+
+- **Adanmış monitör + tam ekran:** Mutfak/bar ekranını ayrı bir monitöre alın ve
+  pencereyi tam ekrana getirin.
+- **Otomatik güncelleme açık kalsın:** KDS istasyonları nadiren elle yönetilir; Tauri
+  updater'ın yeni sürümleri kendi çekmesi, istasyonların güncel kalmasını sağlar. Bkz.
+  [Otomatik güncelleme](/tr/desktop/otomatik-guncelleme).
+- **Cihaz olarak kaydedin:** Ekranı device-mesh'e kaydederek panelden çevrimiçi durumunu
+  izleyin; heartbeat kesildiğinde ekran ~45 sn içinde `offline` görünür.

--- a/developer/pages/tr/desktop/kurulum.mdx
+++ b/developer/pages/tr/desktop/kurulum.mdx
@@ -1,0 +1,159 @@
+---
+title: Kurulum & indirme
+description: HummyTummy Desktop'u sürüm kataloğundan indirme ve kurma — public /api/desktop uç noktaları, platform paketleri ve indirme takibi.
+---
+
+import { Callout, Steps, Tabs } from 'nextra/components'
+
+# Kurulum & indirme
+
+Masaüstü uygulamasının kurulum paketleri, sunucu tarafındaki **sürüm kataloğunda**
+(`DesktopRelease`) tutulur. Katalog **platform düzeyinde** tek bir küresel listedir —
+her restoran kiracısı (tenant) aynı yayınlanmış sürümleri görür. Kataloğa kimliksiz
+(public) erişilebilen birkaç uç nokta vardır; sürüm yayınlama ise yalnızca platform
+operatörlerine (SuperAdmin) veya CI/CD'ye açıktır.
+
+<Callout type="info">
+  Tüm uç noktalar global `/api` ön ekiyle yayınlanır. Aşağıdaki örneklerde sunucu kökü
+  `https://app.hummytummy.com` olarak gösterilmiştir; kendi ortamınızda değiştirin.
+</Callout>
+
+## Public uç noktalar
+
+Bu uç noktalar kimlik doğrulaması gerektirmez (`@Public`) ve hız sınırlıdır (throttle).
+
+| Metot & yol | Açıklama | Limit |
+| --- | --- | --- |
+| `GET /api/desktop/releases/latest` | En son yayınlanmış sürüm | 30/dk |
+| `GET /api/desktop/releases/published` | Yayınlanmış tüm sürümler (pubDate'e göre azalan) | 30/dk |
+| `GET /api/desktop/updates/:platform/:currentVersion` | Tauri updater sorgusu | 60/dk |
+| `POST /api/desktop/releases/:version/download/:platform` | İndirme sayacını artırır (analitik) | 10/dk |
+
+`:platform` değeri `^[a-z0-9-]{1,32}$` desenine, `:version`/`:currentVersion`
+değeri `^v?\d+\.\d+\.\d+$` desenine uymalıdır; aksi halde `400 Bad Request` döner.
+
+## En son sürümü almak
+
+<Tabs items={['curl', 'JSON yanıt']}>
+  <Tabs.Tab>
+```bash
+curl https://app.hummytummy.com/api/desktop/releases/latest
+```
+  </Tabs.Tab>
+  <Tabs.Tab>
+```json
+{
+  "id": "01J...",
+  "version": "0.2.6",
+  "releaseTag": "v0.2.6",
+  "published": true,
+  "pubDate": "2026-06-20T15:00:00.000Z",
+  "windowsUrl": "https://github.com/.../HummyTummy-POS_0.2.6_x64.msi",
+  "windowsSignature": "dW50cnVzdGVkIGNvbW1lbnQ6...",
+  "macArmUrl": "https://github.com/.../HummyTummy-POS_0.2.6_aarch64.dmg",
+  "macArmSignature": "dW50cnVzdGVkIGNvbW1lbnQ6...",
+  "macIntelUrl": "https://github.com/.../HummyTummy-POS_0.2.6_x64.dmg",
+  "macIntelSignature": "dW50cnVzdGVkIGNvbW1lbnQ6...",
+  "linuxUrl": "https://github.com/.../hummy-tummy-pos_0.2.6_amd64.AppImage",
+  "linuxSignature": "dW50cnVzdGVkIGNvbW1lbnQ6...",
+  "releaseNotes": "## Yenilikler\n- Özellik X\n- Düzeltme Y",
+  "changelog": null,
+  "downloadCount": 134,
+  "createdAt": "2026-06-20T14:55:00.000Z",
+  "updatedAt": "2026-06-20T15:00:00.000Z"
+}
+```
+  </Tabs.Tab>
+</Tabs>
+
+Yayınlanmış sürüm yoksa `releases/latest` uç noktası `404` döner.
+
+## Kurulum adımları
+
+<Steps>
+### Platformunuza uygun paketi bulun
+
+`GET /api/desktop/releases/latest` yanıtından platformunuza karşılık gelen URL alanını
+seçin:
+
+- **Windows** → `windowsUrl` (`.msi`)
+- **macOS (Apple Silicon)** → `macArmUrl` (`.dmg`)
+- **macOS (Intel)** → `macIntelUrl` (`.dmg`)
+- **Linux** → `linuxUrl` (`.deb` / `.AppImage`)
+
+İlgili platform için URL `null` ise o sürüm o platforma derlenmemiştir.
+
+### Paketi indirin ve kurun
+
+URL'yi tarayıcıda açın veya `curl -L` ile indirin, ardından platformunuzun normal
+kurulum akışını izleyin (Windows: MSI sihirbazı; macOS: DMG'yi açıp uygulamayı
+Applications'a sürükleyin; Linux: `.deb` paketini kurun veya `.AppImage`'i
+çalıştırılabilir yapın).
+
+### (İsteğe bağlı) İndirmeyi raporlayın
+
+Analitik için indirme sayacını artırabilirsiniz:
+
+```bash
+curl -X POST https://app.hummytummy.com/api/desktop/releases/0.2.6/download/windows-x86_64
+# { "message": "Download tracked" }
+```
+
+Bu çağrı en iyi-çaba (best-effort) çalışır: bilinmeyen bir sürüm gönderilirse hata
+fırlatmaz, yalnızca sunucuda loglanır.
+</Steps>
+
+<Callout type="warning">
+  Yalnızca `published: true` olan sürümler public uç noktalardan görünür. Taslak
+  (yayınlanmamış) sürümler yalnızca SuperAdmin yönetim uç noktalarından listelenir.
+</Callout>
+
+## Geliştirme ortamından derleme
+
+Kaynaktan derlemek için (Tauri CLI npm ile birlikte gelir):
+
+```bash
+npm install
+npm run tauri:dev    # geliştirme modunda çalıştır
+npm run tauri:build  # üretim paketi üret
+```
+
+Çıktı paketleri `src-tauri/target/release/bundle/` altında platforma göre
+(`msi/`, `dmg/`, `deb/`, `appimage/`) oluşturulur. Geliştirme için **Rust 1.70+** ve
+**Node.js 18+** gerekir; Linux'ta ayrıca `libdbus-1-dev` ve `pkg-config` paketleri
+kuruludur (Bluetooth yazıcı desteği için).
+
+## Sürüm yayınlama (operatör / CI)
+
+Yeni bir sürümü kataloğa eklemek iki rotadan yapılır:
+
+- **CI/CD (API anahtarı)** — `POST /api/desktop/ci/releases` ve
+  `POST /api/desktop/ci/releases/:id/publish`. Bu uç noktalar `x-api-key` (veya `api-key`)
+  başlığında `DESKTOP_RELEASE_API_KEY` değerini bekler; GitHub Actions otomatik
+  yayınlama için kullanır.
+- **SuperAdmin (Bearer)** — `POST /api/desktop/releases`, `PATCH /api/desktop/releases/:id`,
+  `POST /api/desktop/releases/:id/publish` / `.../unpublish`, `DELETE /api/desktop/releases/:id`.
+  Yalnızca platform operatörleri erişebilir.
+
+Bir CI sürümü oluşturma örneği:
+
+```bash
+curl -X POST https://app.hummytummy.com/api/desktop/ci/releases \
+  -H "x-api-key: $DESKTOP_RELEASE_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "version": "0.2.7",
+    "releaseTag": "v0.2.7",
+    "releaseNotes": "## Yenilikler\n- ...",
+    "windowsUrl": "https://github.com/.../setup.msi",
+    "windowsSignature": "dW50cnVzdGVkIGNvbW1lbnQ6...",
+    "published": false
+  }'
+```
+
+<Callout type="warning">
+  `version` benzersiz olmalı ve `\d+\.\d+\.\d+` (saf semver, `v` öneki olmadan) biçiminde
+  olmalıdır. Var olan bir sürümü tekrar oluşturmaya çalışmak `400` döner. Yayınlama
+  adımı `pubDate` alanını set eder; updater'ın "en son sürüm" sıralaması bu alana göre
+  yapılır.
+</Callout>

--- a/developer/pages/tr/desktop/otomatik-guncelleme.mdx
+++ b/developer/pages/tr/desktop/otomatik-guncelleme.mdx
@@ -1,0 +1,138 @@
+---
+title: Otomatik güncelleme
+description: Tauri updater'ın HummyTummy sunucusuyla nasıl çalıştığı — /api/desktop/updates uç noktası, manifest biçimi, minisign imza doğrulaması ve sürüm karşılaştırma.
+---
+
+import { Callout, Steps } from 'nextra/components'
+
+# Otomatik güncelleme
+
+Masaüstü uygulaması, [Tauri updater](https://tauri.app)'ı kullanarak sunucudaki sürüm
+kataloğundan yeni sürümleri kendisi indirir. Akış tamamen sunucu kontrollüdür: uygulama
+bulunduğu platformu ve mevcut sürümünü bildirir, sunucu güncellenebilir bir sürüm varsa
+**imzalı** bir güncelleme manifesti döndürür.
+
+## Updater uç noktası
+
+```
+GET /api/desktop/updates/:platform/:currentVersion
+```
+
+| Parametre | Açıklama | Örnek |
+| --- | --- | --- |
+| `:platform` | Tauri'nin bildirdiği platform anahtarı | `windows-x86_64` |
+| `:currentVersion` | Uygulamanın şu anki sürümü | `0.2.5` veya `v0.2.5` |
+
+Geçerli platform anahtarları: `windows-x86_64`, `darwin-aarch64`, `darwin-x86_64`,
+`linux-x86_64`. Bu uç nokta public'tir ve **60 istek/dk** ile sınırlıdır.
+
+<Callout type="info">
+  `:platform`, `^[a-z0-9-]{1,32}$`; `:currentVersion`, `^v?\d+\.\d+\.\d+$` desenine
+  uymalıdır — uymazsa `400 Bad Request` döner.
+</Callout>
+
+## Yanıtlar
+
+- **Güncelleme var** → `200` ve aşağıdaki manifest.
+- **Güncelleme yok / uygun değil** → gövde `null` döner. Tauri bunu "güncel" olarak
+  yorumlar. Şu durumlarda `null` döner:
+  - mevcut sürüm en son yayınlanmış sürümle aynı ya da daha yeni,
+  - hiç yayınlanmış sürüm yok,
+  - istenen platform en son sürümde mevcut değil (URL yok ya da imzasız).
+
+### Manifest biçimi
+
+```json
+{
+  "version": "0.2.7",
+  "notes": "## Yenilikler\n- Özellik X",
+  "pub_date": "2026-06-20T15:00:00.000Z",
+  "platforms": {
+    "windows-x86_64": {
+      "url": "https://github.com/.../HummyTummy-POS_0.2.7_x64.msi",
+      "signature": "dW50cnVzdGVkIGNvbW1lbnQ6..."
+    },
+    "darwin-aarch64": { "url": "...", "signature": "..." },
+    "darwin-x86_64":  { "url": "...", "signature": "..." },
+    "linux-x86_64":   { "url": "...", "signature": "..." }
+  }
+}
+```
+
+`platforms` nesnesi yalnızca **hem URL'si hem geçerli imzası olan** platformları içerir
+(aşağıdaki güvenlik notuna bakın). `notes` alanı sürümün `releaseNotes` metnidir,
+`pub_date` ise yayınlama tarihinin ISO biçimidir.
+
+## Sürüm karşılaştırma
+
+Sunucu sürümleri sayısal semver olarak karşılaştırır: `major.minor.patch` parçalarını
+ayırır, baştaki `v` önekini yok sayar ve sayısal olarak kıyaslar. En son yayınlanmış
+sürüm, gönderilen `currentVersion`'dan **kesinlikle büyükse** güncelleme sunulur; eşit
+ya da küçükse `null` döner.
+
+<Callout type="warning">
+  Karşılaştırma yalnızca sayısal parçaları dikkate alır; **ön-sürüm etiketleri**
+  (`1.0.0-beta.1` gibi) desteklenmez. Sürüm kataloğu operatör/CI kontrolünde olduğundan
+  bu kısıt yeterlidir — yayınlanan sürümler daima saf `major.minor.patch` biçiminde
+  tutulur.
+</Callout>
+
+## İmza doğrulama (güvenlik)
+
+Tauri updater, yalnızca **minisign imzası** sabitlenmiş public anahtarla doğrulanan bir
+binary'yi kurar. Sunucu bu sözleşmeyi koruyacak şekilde davranır:
+
+- Bir platformun **URL'si varsa ama imzası yoksa** (boş/eksik), o platform manifeste
+  **eklenmez** — kurulamaz kabul edilir ve sunucuda uyarı loglanır. Yarı dolu, imzasız
+  bir kayıt asla yayımlanmaz.
+- Bir platformun **URL'si yoksa** (o sürüm o platforma derlenmemişse) sessizce atlanır.
+- İstenen platform sonuçta `platforms` içinde yoksa uç nokta `null` döner.
+
+Bu sayede otomatik güncelleyici hiçbir zaman imzasız (dolayısıyla doğrulanamayan) bir
+binary almaz.
+
+<Callout type="warning">
+  Sürüm kataloğu **platform düzeyinde** küresel bir listedir ve her restoranın masaüstü
+  güncelleyicisi buradan çeker. Bu nedenle yönetim uç noktaları (oluştur / yayınla /
+  sil) yalnızca **SuperAdmin** veya **CI API anahtarı** ile erişilebilir; kiracı
+  yöneticileri bu kataloğu değiştiremez. Aksi halde tek bir kiracı, tüm restoranların
+  güncelleyicisinin çektiği binary'yi değiştirebilirdi.
+</Callout>
+
+## Uçtan uca akış
+
+<Steps>
+### Uygulama açılışta sorgular
+
+Tauri updater, yapılandırılmış güncelleme uç noktasına bulunduğu platform ve mevcut
+sürümle istek atar:
+
+```bash
+curl https://app.hummytummy.com/api/desktop/updates/windows-x86_64/0.2.5
+```
+
+### Sunucu manifesti döndürür
+
+Daha yeni, imzalı bir sürüm varsa yukarıdaki manifest döner; yoksa `null`.
+
+### Tauri imzayı doğrular ve kurar
+
+Updater, manifestteki `signature`'ı sabitlenmiş public anahtarla doğrular, binary'yi
+`url`'den indirir ve doğrulama başarılıysa kurar. Doğrulama başarısız olursa kurulum
+yapılmaz.
+
+### (İsteğe bağlı) İndirme raporlanır
+
+İstemci, analitik için indirme sayacını artırabilir:
+
+```bash
+curl -X POST https://app.hummytummy.com/api/desktop/releases/0.2.7/download/windows-x86_64
+```
+</Steps>
+
+<Callout type="info">
+  Updater'ın hangi uç noktayı ve hangi public anahtarı kullanacağı masaüstü uygulamasının
+  Tauri yapılandırmasında (`tauri.conf.json` içindeki updater bölümü) tanımlanır. Yukarıdaki
+  sunucu sözleşmesi (manifest biçimi, imza zorunluluğu, sürüm karşılaştırma) bu istemci
+  yapılandırmasından bağımsız olarak geçerlidir.
+</Callout>

--- a/developer/pages/tr/developer/_meta.ts
+++ b/developer/pages/tr/developer/_meta.ts
@@ -1,3 +1,6 @@
 export default {
-  "index": "Genel Bakış"
-}
+  "index": "Genel Bakış",
+  "api-temelleri": "API Temelleri",
+  "partner-display": "Partner Display API",
+  "webhooks": "Webhook'lar",
+};

--- a/developer/pages/tr/developer/_meta.ts
+++ b/developer/pages/tr/developer/_meta.ts
@@ -1,0 +1,3 @@
+export default {
+  "index": "Genel Bakış"
+}

--- a/developer/pages/tr/developer/api-temelleri.mdx
+++ b/developer/pages/tr/developer/api-temelleri.mdx
@@ -1,0 +1,230 @@
+---
+title: API Temelleri
+description: Taban URL, kimlik gerçeklikleri, şube kapsamı, sayfalama, hata zarfı, idempotency ve rate-limit katmanları.
+---
+
+import { Callout, Tabs } from 'nextra/components'
+
+# API Temelleri
+
+Bu sayfa, HummyTummy'nin tüm REST yüzeyinde geçerli olan ortak kuralları
+açıklar: taban URL, kimlik doğrulama realm'leri, şube kapsamı, hata biçimi ve
+rate-limit'ler. Partner Display ve Webhook sayfaları bu kuralların üzerine
+kurulur.
+
+## Taban URL ve global ön ek
+
+Tüm uçlar `/api` global ön eki altındadır.
+
+```
+https://hummytummy.com/api
+```
+
+Yani bir uç `v1/webhooks/subscriptions` olarak tanımlandığında tam yol
+`https://hummytummy.com/api/v1/webhooks/subscriptions` olur. Bu dokümandaki her
+örnek tam yolu gösterir.
+
+<Callout type="info">
+  Para birimi tüm tutarlar için **TRY**'dir. Self-servis ödeme PayTR üzerinden
+  yürür ve yalnızca TR/TRY desteklenir.
+</Callout>
+
+## Kimlik gerçeklikleri (auth realms)
+
+HummyTummy dört ayrı kimlik realm'i tanır. Her uç bunlardan tam olarak birini
+bekler; yanlış realm `401` döner.
+
+### 1. Personel JWT — `Authorization: Bearer <jwt>`
+
+Dashboard / yönetim API'sinin ana kimliği. Giriş yapan personel kullanıcısının
+JWT'sidir. Partner API anahtarlarını ve webhook aboneliklerini **bu realm**
+yönetir (ADMIN rolü gerekir).
+
+```bash
+Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
+```
+
+<Callout type="warning">
+  Erişim/yenileme token'ları kasıtlı olarak `localStorage`'da tutulmaz; yenileme
+  token'ı httpOnly çerezdedir. Sunucu-sunucu entegrasyonlarında JWT yerine
+  **Partner API anahtarı** kullanın (aşağıda).
+</Callout>
+
+### 2. Müşteri oturumu — QR menü oturum token'ı
+
+QR menüden gelen misafirin oturum token'ı. Misafir sipariş ve self-pay
+akışlarını yetkilendirir. Partner ekranları bu kimliği doğrudan kullanmaz; bunun
+yerine ekran token'ı arka planda bir müşteri oturumuna (`orderingSessionId`)
+bağlanır.
+
+### 3. Partner anahtarı — `X-Partner-Key` + `X-Partner-Secret`
+
+Bir **partner backend'in** ekran token'ı üretmek/yenilemek/iptal etmek için
+kullandığı makine kimliği. Anahtar restoran ADMIN'i tarafından üretilir; `keyId`
+(`pk_live_…`, loglanması güvenli) + bir kez gösterilen `secret`'tan oluşur.
+
+```bash
+X-Partner-Key:    pk_live_xxxxx
+X-Partner-Secret: pk_live_secret_xxxxx
+```
+
+Ayrıntı: [Partner Display API](/tr/developer/partner-display).
+
+### 4. Ekran token'ı — `Authorization: Screen <token>`
+
+Bir cihazın (tablet/ekran) `/v1/display/*` uçlarını çağırırken sunduğu kısa
+ömürlü, kapsamlı token. Token `<uuidv7>.<secret>` biçimindedir; cihaz API
+secret'ını asla taşımaz.
+
+```bash
+Authorization: Screen 0190a1b2-c3d4-... .Hk9...
+```
+
+## Şube kapsamı — `X-Branch-Id`
+
+HummyTummi çok şubeli bir sistemdir. Şubeye-bağlı (branch-scoped) her uç,
+hangi şube bağlamında çalıştığını belirten bir `X-Branch-Id` başlığı bekler.
+
+```bash
+X-Branch-Id: <branch-uuid>
+```
+
+<Callout type="warning">
+  Şubeye-bağlı bir uca `X-Branch-Id` olmadan istek atarsanız `400` alırsınız.
+  Buna karşılık **tenant-seviyesi** uçlar (örn. webhook abonelikleri
+  `/v1/webhooks/subscriptions`, partner anahtarları `/v1/partner/api-keys`) bu
+  başlığı beklemez — şube kapsamını atlarlar. Partner ekranları için şube/tenant
+  bilgisi token'ın içinden gelir; gövdede veya başlıkta gönderilmez.
+</Callout>
+
+## Hata zarfı
+
+Tüm hatalar standart bir zarf içinde döner:
+
+```json
+{
+  "statusCode": 403,
+  "message": "The externalDisplay feature is not enabled for this tenant",
+  "error": "Forbidden",
+  "errorCode": "FEATURE_NOT_AVAILABLE",
+  "timestamp": "2026-06-23T08:30:00.000Z",
+  "path": "/api/v1/partner/screen-sessions",
+  "requestId": "1718500000000-ab12cd34e"
+}
+```
+
+| Alan | Tip | Açıklama |
+| --- | --- | --- |
+| `statusCode` | number | HTTP durum kodu |
+| `message` | string \| string[] | Kullanıcıya dönük mesaj; doğrulama hatalarında dizi olabilir |
+| `error` | string | İnsan/kategori etiketi (örn. `Bad Request`, `Forbidden`); bazen yerelleştirilir |
+| `errorCode` | string? | **Makine-okunur, kararlı** kod. Yalnızca fırlatan istisna eklediğinde bulunur; PII içermez ve her ortamda döner |
+| `timestamp` | string | ISO-8601 istek zamanı |
+| `path` | string | İstek yolu |
+| `requestId` | string | İzleme için istek kimliği |
+
+`details` ve `stack` alanları yalnızca development ortamında doldurulur;
+production'da görünmezler.
+
+<Callout type="info">
+  İstemci tarafında **`errorCode`** üzerinden dallanın, `message` üzerinden
+  değil — `message` yerelleştirilebilir, `errorCode` kararlıdır. Örnek kodlar:
+  `INVALID_CREDENTIALS`, `TOKEN_EXPIRED`, `FORBIDDEN`,
+  `INSUFFICIENT_PERMISSIONS`, `FEATURE_NOT_AVAILABLE`, `SUBSCRIPTION_REQUIRED`,
+  `QUOTA_EXCEEDED`, `VALIDATION_ERROR`, `TOO_MANY_REQUESTS`.
+</Callout>
+
+### Sık karşılaşılan durum kodları
+
+| Kod | Anlamı |
+| --- | --- |
+| `400` | Geçersiz girdi / eksik `X-Branch-Id` / doğrulama hatası |
+| `401` | Kimlik yok, geçersiz ya da süresi dolmuş token |
+| `403` | Yetki yok, eksik scope ya da plan özelliği kapalı |
+| `404` | Kaynak bulunamadı |
+| `409` | Çakışma (örn. eşzamanlı güncelleme çatışması — yeniden denenebilir) |
+| `429` | Rate limit aşıldı |
+
+Veritabanı kaynaklı bazı durumlar otomatik eşlenir: eşzamanlı güncelleme
+çatışması (`409 ConcurrentUpdate`, yeniden denenebilir), benzersizlik ihlali
+(`409`), aralık/uzunluk taşması (`400 ValueOutOfRange`).
+
+## Sayfalama
+
+Listeleme uçları, ofset tabanlı sayfalamada `page` ve `limit` sorgu
+parametrelerini kullanır; toplam kayıt sayısı `X-Total-Count` yanıt başlığında
+döner (CORS'ta açıkça expose edilir).
+
+```bash
+GET /api/...?page=2&limit=50
+```
+
+```
+X-Total-Count: 137
+```
+
+<Callout type="info">
+  Tüm liste uçları sayfalamayı zorlamaz; bazıları (örn. partner anahtar listesi,
+  webhook abonelik listesi) tüm satırları döner. İlgili uç sayfası, davranışı
+  belirtir.
+</Callout>
+
+## Idempotency
+
+Para hareketi içeren uçlar (checkout/ödeme rayı) tekrar-güvenlidir: aynı isteğin
+iki kez ulaşması ikinci bir tahsilat yaratmaz. Webhook **alımı** tarafında da
+aynı olay aynı `id` ile iki kez gelebilir (en-az-bir-kez teslim) — alıcı tarafta
+`id` üzerinden dedup yapın. Ayrıntı [Webhook'lar](/tr/developer/webhooks)
+sayfasında.
+
+## Rate-limit katmanları
+
+Rate limit, global throttler ile üç katmanda uygulanır:
+
+| Katman | Pencere | Limit |
+| --- | --- | --- |
+| `short` | 1 sn | 10 istek |
+| `medium` | 10 sn | 50 istek |
+| `long` | 60 sn | 100 istek |
+
+Bazı makine uçları kendi sıkı limitlerini ekler — örneğin ekran token'ı üretimi
+(`POST /v1/partner/screen-sessions`) 60 sn'de 60, self-pay intent
+(`/v1/display/pay-intent`) 60 sn'de 5 ile sınırlıdır.
+
+<Callout type="info">
+  **Anahtara/ekran token'ına göre** sayım: rate limit bucket'ı yalnızca IP'ye
+  değil, prensibe (partner anahtarı veya ekran token'ı) göre de bölünür. Böylece
+  tek bir NAT IP'sinin arkasındaki çok sayıda tablet birbirini boğmaz. Yine de
+  her prensip kendi kaynak IP'si altında sayılır, böylece sahte prensip üreterek
+  IP limitinden kaçılamaz.
+</Callout>
+
+Limit aşıldığında `429` ve `errorCode: TOO_MANY_REQUESTS` döner; `Retry-After`
+başlığına saygı gösterin.
+
+## Hızlı örnek
+
+<Tabs items={['curl', 'TypeScript (fetch)']}>
+  <Tabs.Tab>
+```bash
+# Şubeye-bağlı bir uç (personel JWT + şube kapsamı)
+curl https://hummytummy.com/api/v1/orders \
+  -H "Authorization: Bearer $JWT" \
+  -H "X-Branch-Id: $BRANCH_ID"
+```
+  </Tabs.Tab>
+  <Tabs.Tab>
+```ts
+const res = await fetch("https://hummytummy.com/api/v1/orders", {
+  headers: {
+    Authorization: `Bearer ${jwt}`,
+    "X-Branch-Id": branchId,
+  },
+});
+if (res.status === 429) {
+  // Retry-After'a saygı göster, sonra yeniden dene
+}
+const total = res.headers.get("X-Total-Count");
+```
+  </Tabs.Tab>
+</Tabs>

--- a/developer/pages/tr/developer/index.mdx
+++ b/developer/pages/tr/developer/index.mdx
@@ -1,0 +1,7 @@
+---
+title: Geliştirici / Entegrasyon
+---
+
+# Geliştirici / Entegrasyon
+
+Bu bölüm hazırlanıyor.

--- a/developer/pages/tr/developer/index.mdx
+++ b/developer/pages/tr/developer/index.mdx
@@ -1,7 +1,72 @@
 ---
 title: Geliştirici / Entegrasyon
+description: HummyTummy REST API, Partner Display API ve giden webhook'lar ile entegrasyon kurun.
 ---
+
+import { Cards, Callout } from 'nextra/components'
 
 # Geliştirici / Entegrasyon
 
-Bu bölüm hazırlanıyor.
+HummyTummy'yi kendi sistemlerinize bağlayın: kendi ekranlarınızı/uygulamalarınızı
+çalıştırın, sipariş ve ödeme olaylarını sunucunuza akıtın, REST API üzerinden
+restoran verisine erişin. Tüm uçlar tek bir API tabanı altında toplanır:
+
+```
+https://hummytummy.com/api
+```
+
+<Callout type="info">
+  Tüm REST yolları `/api` global ön ekiyle servis edilir. Bu dokümandaki her
+  örnekte tam yol gösterilir (örn. `POST /api/v1/webhooks/subscriptions`). Para
+  birimi her zaman **TRY**'dir.
+</Callout>
+
+## Hangi entegrasyon size uygun?
+
+HummyTummy üç ayrı entegrasyon yüzeyi sunar; çoğu entegratör birden fazlasını
+birlikte kullanır.
+
+<Cards>
+  <Cards.Card title="API Temelleri" href="/tr/developer/api-temelleri" arrow>
+    Taban URL, kimlik gerçeklikleri (personel JWT / müşteri oturumu / partner
+    anahtarı / ekran token'ı), `X-Branch-Id` şube kapsamı, sayfalama, hata
+    zarfı, idempotency ve rate-limit katmanları.
+  </Cards.Card>
+  <Cards.Card title="Partner Display API" href="/tr/developer/partner-display" arrow>
+    Masa tableti gibi kendi ekranlarınızı çalıştırın: menü, sipariş, garson/hesap
+    çağrısı, self-servis ödeme ve canlı sipariş durumu. ADMIN anahtarı → ekran
+    token'ı → `/v1/display/*` + WebSocket.
+  </Cards.Card>
+  <Cards.Card title="Webhook'lar" href="/tr/developer/webhooks" arrow>
+    Sipariş, ödeme ve abonelik olaylarını HMAC-SHA256 imzalı POST'larla kendi
+    uç noktanıza alın. Abonelik, imza doğrulama, olay tipleri, yeniden deneme ve
+    SSRF koruması.
+  </Cards.Card>
+</Cards>
+
+## İki yön: çekme (pull) ve itme (push)
+
+- **Çekme** — REST uçlarını siz çağırırsınız (menü okuma, sipariş oluşturma,
+  ödeme başlatma). Kimlik ve şube kapsamı kuralları için
+  [API Temelleri](/tr/developer/api-temelleri).
+- **İtme** — bir olay olduğunda biz sizin uç noktanıza POST atarız (giden
+  webhook'lar). Kurulum ve doğrulama için [Webhook'lar](/tr/developer/webhooks).
+
+## Yetkilendirme katmanları (kısa özet)
+
+| Realm | Nasıl kimlik doğrular | Tipik kullanım |
+| --- | --- | --- |
+| Personel JWT | `Authorization: Bearer <jwt>` | Dashboard / yönetim API'si, anahtar & webhook yönetimi |
+| Müşteri oturumu | QR menü oturum token'ı | Misafir sipariş & self-pay |
+| Partner anahtarı | `X-Partner-Key` + `X-Partner-Secret` | Partner backend'i ekran token'ı üretir |
+| Ekran token'ı | `Authorization: Screen <token>` | Cihaz `/v1/display/*` çağırır |
+
+Her birinin tam ayrıntısı [API Temelleri](/tr/developer/api-temelleri)
+sayfasında.
+
+<Callout type="warning">
+  Partner Display ve giden webhook'lar **plana bağlı** özelliklerdir. Partner
+  Display için tenant planının `externalDisplay`, webhook abonelikleri için
+  `apiAccess` (API erişimi) özelliğini içermesi gerekir. Aksi halde ilgili uçlar
+  `403` döner.
+</Callout>

--- a/developer/pages/tr/developer/partner-display.mdx
+++ b/developer/pages/tr/developer/partner-display.mdx
@@ -1,0 +1,334 @@
+---
+title: Partner Display API
+description: Kendi ekranlarınızı çalıştırın — menü, sipariş, garson/hesap çağrısı, self-pay ve canlı sipariş durumu.
+---
+
+import { Callout, Steps, Tabs } from 'nextra/components'
+
+# Partner Display API
+
+QR menünün yaptığı her şeyi yapan kendi ekranlarınızı/uygulamalarınızı (örneğin
+bir masa tableti) bir HummyTummy restoranına karşı çalıştırın: menüyü
+gözatın, sipariş verin, self-servis ödeyin, garson çağırın / hesap isteyin ve
+sipariş durumunu canlı izleyin.
+
+Tüm yollar `/api` global ön eki altındadır. Taban URL:
+`https://hummytummy.com/api`.
+
+<Callout type="warning">
+  Partner Display, restoran planının **`externalDisplay`** özelliğini içermesini
+  gerektirir. Hem anahtar üretimi hem token üretimi bu özelliği ve canlı bir
+  aboneliği (`ACTIVE` / `TRIALING` / `PAST_DUE`) doğrular; aksi halde `403`
+  döner.
+</Callout>
+
+## Kavramlar
+
+- **Partner API anahtarı** — restoran ADMIN'i tarafından üretilir (Ayarlar → API
+  & Entegrasyonlar). Bir `keyId` (`pk_live_…`, loglanması güvenli) + **bir kez**
+  gösterilen bir `secret`'tan oluşur. Yalnızca **backend'inizde** tutulur.
+- **Ekran oturum token'ı** — backend'inizin her ekran için ürettiği kısa ömürlü,
+  kapsamlı bir token. Bir şubeye (ve isteğe bağlı bir masaya) bağlıdır. Cihaz
+  yalnızca bu token'ı tutar, API secret'ını asla.
+- **Scope'lar** — `menu:read`, `orders:write`, `orders:read`, `payments:write`,
+  `requests:write`, `realtime:subscribe`. Bir ekranın scope'ları, anahtarın
+  scope'larının alt kümesidir.
+
+## Mimari özeti
+
+```
+ADMIN (dashboard)                  Partner backend                Cihaz/Ekran
+      │                                  │                              │
+      │ 1. Anahtar üret (keyId+secret)   │                              │
+      ├─────────────────────────────────▶                              │
+      │                                  │ 2. Ekran token'ı üret        │
+      │                                  │   X-Partner-Key/Secret       │
+      │                                  ├──────────▶ HummyTummy        │
+      │                                  │   screenToken + refreshToken │
+      │                                  │ 3. screenToken'ı cihaza ver  │
+      │                                  ├──────────────────────────────▶
+      │                                  │            4. /v1/display/*  │
+      │                                  │               Authorization: │
+      │                                  │               Screen <token> │
+      │                                  │◀─────────────────────────────┤
+```
+
+## 1. API anahtarı üretin (restoran ADMIN, bir kez, uygulama içinde)
+
+Restoran sahibi dashboard'da bir anahtar oluşturur. Bunu makine olarak da
+yapabilirsiniz: personel JWT'si ile (ADMIN rolü gerekir).
+
+```bash
+curl -X POST https://hummytummy.com/api/v1/partner/api-keys \
+  -H "Authorization: Bearer $ADMIN_JWT" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "Masa tabletleri",
+    "scopes": ["menu:read","orders:write","orders:read","payments:write","requests:write","realtime:subscribe"],
+    "allowedReturnOrigins": ["https://tablet.ornek-restoran.com"],
+    "allowedBranchIds": ["<branch-uuid>"]
+  }'
+```
+
+Yanıt — `secret` **yalnızca bir kez** döner:
+
+```json
+{
+  "id": "...",
+  "keyId": "pk_live_AbCdEf...",
+  "secret": "pk_live_secret_XyZ...",
+  "name": "Masa tabletleri",
+  "scopes": ["menu:read", "orders:write", "orders:read", "payments:write", "requests:write", "realtime:subscribe"],
+  "allowedReturnOrigins": ["https://tablet.ornek-restoran.com"],
+  "allowedBranchIds": ["<branch-uuid>"],
+  "status": "active"
+}
+```
+
+| Alan | Açıklama |
+| --- | --- |
+| `name` | İnsan etiketi (zorunlu, 1–80 karakter) |
+| `scopes` | İsteğe bağlı; verilmezse anahtar **tüm** scope'ları alır |
+| `allowedReturnOrigins` | Self-pay sonrası PayTR dönüş origin'leri (yalnızca `https` URL) |
+| `allowedBranchIds` | Anahtarı belirli şubelerle sınırlar (boş = tüm şubeler) |
+
+<Callout type="warning">
+  `secret`'ı güvenli biçimde **sunucunuzda** saklayın — bir daha asla
+  gösterilmez ve geri türetilemez. `keyId` loglanması güvenlidir. Tenant başına
+  varsayılan aktif anahtar limiti 10'dur; aşılırsa `400` döner.
+</Callout>
+
+Anahtarları listeleyin / iptal edin (personel JWT, ADMIN):
+
+```bash
+GET    /api/v1/partner/api-keys
+DELETE /api/v1/partner/api-keys/:id   # iptal — child ekran oturumlarına cascade eder
+```
+
+## 2. Ekran token'ı üretin (backend'iniz → biz)
+
+Anahtarınızla TLS üzerinden kimlik doğrulayın:
+
+<Tabs items={['curl', 'TypeScript (fetch)']}>
+  <Tabs.Tab>
+```bash
+curl -X POST https://hummytummy.com/api/v1/partner/screen-sessions \
+  -H "X-Partner-Key: pk_live_AbCdEf..." \
+  -H "X-Partner-Secret: pk_live_secret_XyZ..." \
+  -H "Content-Type: application/json" \
+  -d '{
+    "branchId": "<branch-uuid>",
+    "tableId": "<table-uuid>",
+    "scopes": ["menu:read","orders:write","realtime:subscribe"]
+  }'
+```
+  </Tabs.Tab>
+  <Tabs.Tab>
+```ts
+const res = await fetch(
+  "https://hummytummy.com/api/v1/partner/screen-sessions",
+  {
+    method: "POST",
+    headers: {
+      "X-Partner-Key": process.env.PARTNER_KEY!,
+      "X-Partner-Secret": process.env.PARTNER_SECRET!,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      branchId,
+      tableId, // isteğe bağlı
+      scopes: ["menu:read", "orders:write", "realtime:subscribe"],
+    }),
+  },
+);
+const session = await res.json();
+// session.screenToken → cihaza; session.refreshToken → sunucuda kalır
+```
+  </Tabs.Tab>
+</Tabs>
+
+İstek gövdesi alanları:
+
+| Alan | Zorunlu | Açıklama |
+| --- | --- | --- |
+| `branchId` | Evet (UUID) | Ekranın bağlanacağı şube; tenant'a ait ve aktif olmalı, anahtarın `allowedBranchIds`'i içinde olmalı |
+| `tableId` | Hayır (UUID) | Ekranın bağlanacağı masa; verilirse şube/masa eşleşmesi doğrulanır |
+| `scopes` | Hayır | Bu ekranın scope'ları (anahtarın alt kümesi); verilmezse anahtarın tüm scope'ları |
+
+Yanıt — **token'lar yalnızca bir kez** döner:
+
+```json
+{
+  "id": "...",
+  "screenToken": "<uuidv7>.<secret>",
+  "refreshToken": "<uuidv7>.<secret>",
+  "expiresAt": "...(≈1 saat)",
+  "refreshExpiresAt": "...(≈30 gün)",
+  "scopes": ["menu:read", "orders:write", "realtime:subscribe"],
+  "tenantId": "...",
+  "branchId": "...",
+  "tableId": "...",
+  "orderingSessionId": "..."
+}
+```
+
+`screenToken`'ı cihaza gönderin; `refreshToken`'ı sunucu tarafında saklayın.
+Süresi (varsayılan erişim ≈1 saat) dolmadan önce döndürün:
+
+```bash
+curl -X POST https://hummytummy.com/api/v1/partner/screen-sessions/refresh \
+  -H "X-Partner-Key: pk_live_AbCdEf..." \
+  -H "X-Partner-Secret: pk_live_secret_XyZ..." \
+  -H "Content-Type: application/json" \
+  -d '{ "refreshToken": "<uuidv7>.<secret>" }'
+# → yeni { screenToken, refreshToken, expiresAt, refreshExpiresAt }
+```
+
+<Callout type="info">
+  Yenileme **tek kullanımlıktır**: eski `refreshToken` ile ikinci bir çağrı
+  `401 "Refresh token already used"` döner. Daima yeni dönen `refreshToken`'ı
+  saklayın. TTL'ler operatörce ayarlanabilir: erişim ≈1 saat, yenileme ≈30 gün.
+</Callout>
+
+Tek bir ekranı iptal edin (anahtar kimliğiyle):
+
+```bash
+DELETE /api/v1/partner/screen-sessions/:id
+```
+
+<Callout type="warning">
+  Dashboard'da **API anahtarını** iptal etmek cascade eder — o anahtarın tüm
+  ekran token'ları geçersizleşir, canlı socket bağlantıları da düşürülür. Tek
+  bir ekranı iptal etmek arkadaki müşteri oturumunu da kapatır ve canlı socket'i
+  hemen koparır.
+</Callout>
+
+Şube başına aktif ekran oturumu limiti varsayılan 50'dir; aşılırsa `400` döner.
+
+## 3. Ekranı yönetin (cihaz → biz)
+
+Her `/display` çağrısı ekran token'ını sunar:
+
+```bash
+Authorization: Screen <screenToken>
+```
+
+| Metot | Yol | Scope | Amaç |
+| --- | --- | --- | --- |
+| GET | `/api/v1/display/menu` | `menu:read` | Marka + kategori/ürün/modifier + özellik bayrakları |
+| POST | `/api/v1/display/orders` | `orders:write` | Sipariş ver `{ items:[{ productId, quantity, modifiers?, notes? }], type?, notes? }` |
+| GET | `/api/v1/display/orders` | `orders:read` | Bu ekranın oturumunun siparişleri + durumları |
+| POST | `/api/v1/display/waiter-requests` | `requests:write` | Garson çağır `{ message? }` (masaya bağlı ekran gerekir) |
+| POST | `/api/v1/display/bill-requests` | `requests:write` | Hesap iste `{ message? }` |
+| GET | `/api/v1/display/payable-items` | `payments:write` | Masanın ödenmemiş kalemleri |
+| POST | `/api/v1/display/pay-intent` | `payments:write` | PayTR hosted-payment intent `{ items:[{ orderItemId, quantity }], customerPhone? }` |
+| GET | `/api/v1/display/pay-status?oid=…` | `payments:write` | Bir ödemenin durumunu sorgula |
+
+<Callout type="info">
+  Ekranın tenant/şube/masa bilgisi **token'dan** alınır — gövdede asla
+  gönderilmez. Eksik scope `403` döner. Süresi dolmuş / geçersiz token `401`
+  döner.
+</Callout>
+
+### Sipariş verme örneği
+
+<Tabs items={['curl', 'TypeScript (fetch)']}>
+  <Tabs.Tab>
+```bash
+curl -X POST https://hummytummy.com/api/v1/display/orders \
+  -H "Authorization: Screen $SCREEN_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "items": [
+      { "productId": "<product-uuid>", "quantity": 2, "notes": "az pişmiş" }
+    ],
+    "notes": "masa 5"
+  }'
+```
+  </Tabs.Tab>
+  <Tabs.Tab>
+```ts
+await fetch("https://hummytummy.com/api/v1/display/orders", {
+  method: "POST",
+  headers: {
+    Authorization: `Screen ${screenToken}`,
+    "Content-Type": "application/json",
+  },
+  body: JSON.stringify({
+    items: [{ productId, quantity: 2, notes: "az pişmiş" }],
+  }),
+});
+```
+  </Tabs.Tab>
+</Tabs>
+
+### Self-pay (self-servis ödeme)
+
+Self-pay TR/TRY + PayTR'dir. Dönen `paymentLink`'i bir WebView'da açın; dönüş
+origin'i anahtarın `allowedReturnOrigins`'inden alınır (istemcinin gönderdiği
+bir başlıktan değil). Akış: `payable-items` → `pay-intent` → WebView →
+`pay-status` ile sorgula (ya da WebSocket'ten `customer:payment-settled`).
+
+## 4. Canlı güncellemeler (cihaz → biz, WebSocket)
+
+`realtime:subscribe` scope'u ile Socket.IO'yu `/kds` namespace'ine ekran
+token'ıyla bağlayın:
+
+```js
+import { io } from "socket.io-client";
+
+const socket = io("https://hummytummy.com/kds", {
+  auth: { screenToken: "<screenToken>" },
+});
+
+socket.on("customer:order-created", (e) => {/* ... */});
+socket.on("customer:order-approved", (e) => {/* ... */});
+socket.on("customer:order-status-updated", (e) => {/* ... */});
+socket.on("customer:payment-settled", (e) => {/* ... */});
+```
+
+Olaylar: `customer:order-created`, `customer:order-approved`,
+`customer:order-status-updated`, `customer:payment-settled`.
+
+<Callout type="info">
+  Socket düşerse `GET /display/orders` ve `GET /display/pay-status`'ı
+  yoklayarak (polling) geri düşün. Bir ekran iptal edildiğinde canlı socket'i
+  derhal koparılır.
+</Callout>
+
+## Uçtan uca özet
+
+<Steps>
+
+### Anahtar üretin
+ADMIN dashboard'dan (veya ADMIN JWT ile makine olarak) bir partner anahtarı
+üretir. `secret`'ı sunucunuzda saklayın.
+
+### Ekran token'ı üretin
+Backend'iniz `X-Partner-Key`/`X-Partner-Secret` ile her ekran için bir
+`screenToken` + `refreshToken` üretir. `screenToken`'ı cihaza verin.
+
+### Ekranı yönetin
+Cihaz `Authorization: Screen <token>` ile `/v1/display/*` uçlarını çağırır;
+her uç kendi scope'unu gerektirir.
+
+### Canlı dinleyin
+Cihaz `/kds` WebSocket'ine bağlanır (`realtime:subscribe`) ve sipariş/ödeme
+olaylarını canlı alır.
+
+### Yenileyin / iptal edin
+Token süresi dolmadan `refreshToken` ile döndürün. İhtiyaç bittiğinde tek ekranı
+veya tüm anahtarı (cascade) iptal edin.
+
+</Steps>
+
+## Hatalar ve limitler
+
+- **Hatalar:** standart [zarf](/tr/developer/api-temelleri#hata-zarfı). `401` =
+  hatalı/süresi dolmuş token, `403` = eksik scope ya da tenant'ta
+  `externalDisplay` kapalı / abonelik canlı değil, `429` = rate limit.
+- **Rate limit** anahtar/ekran token'ı başına sayılır (yalnızca IP başına
+  değil), böylece tek NAT IP'sinin arkasındaki bir tablet filosu sorun çıkarmaz.
+  Ekran token'ı üretimi 60 sn'de 60, self-pay intent 60 sn'de 5 ile sınırlıdır.
+- **Token TTL'leri** (operatörce ayarlanabilir): erişim ≈1 saat, yenileme ≈30
+  gün.

--- a/developer/pages/tr/developer/webhooks.mdx
+++ b/developer/pages/tr/developer/webhooks.mdx
@@ -1,0 +1,299 @@
+---
+title: Webhook'lar
+description: Sipariş, ödeme ve abonelik olaylarını HMAC-SHA256 imzalı POST'larla uç noktanıza alın.
+---
+
+import { Callout, Steps, Tabs } from 'nextra/components'
+
+# Webhook'lar (Giden)
+
+HummyTummy, tenant'ınızda bir olay olduğunda kayıtlı uç noktanıza HMAC-SHA256
+imzalı bir HTTP POST atar. Böylece sipariş, ödeme ve abonelik olaylarına anlık
+tepki verebilir; yoklamaya (polling) ihtiyaç duymazsınız.
+
+Tüm yollar `/api` global ön eki altındadır.
+
+<Callout type="warning">
+  Webhook abonelikleri **API erişimi** özelliği gerektirir: BUSINESS planı ya da
+  `api_access` (apiAccess) eklentisi. Abonelik uçları **ADMIN rolü** ile
+  personel JWT'si bekler; özellik kapalıysa `403` döner.
+</Callout>
+
+## Abone olun
+
+Bir abonelik oluşturun. **`secret` yalnızca bir kez** döner — onu güvenli biçimde
+saklayın; bir daha gösterilmez ve geri türetilemez.
+
+<Tabs items={['curl', 'TypeScript (fetch)']}>
+  <Tabs.Tab>
+```bash
+curl -X POST https://hummytummy.com/api/v1/webhooks/subscriptions \
+  -H "Authorization: Bearer $ADMIN_JWT" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "url": "https://hooks.ornek.com/hummytummy",
+    "events": ["order.created.v1", "payment.succeeded.v1"]
+  }'
+```
+  </Tabs.Tab>
+  <Tabs.Tab>
+```ts
+const res = await fetch(
+  "https://hummytummy.com/api/v1/webhooks/subscriptions",
+  {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${adminJwt}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      url: "https://hooks.ornek.com/hummytummy",
+      events: ["order.created.v1", "payment.succeeded.v1"],
+    }),
+  },
+);
+const { secret } = await res.json(); // SADECE bir kez döner — güvenli sakla
+```
+  </Tabs.Tab>
+</Tabs>
+
+İstek gövdesi:
+
+| Alan | Zorunlu | Açıklama |
+| --- | --- | --- |
+| `url` | Evet | Olayların POST edileceği `https` (ya da `http`) URL. SSRF allowlist'inden geçer; host küçük harfe normalize edilerek saklanır |
+| `events` | Hayır | Abone olunacak olay tipleri. Verilmezse `["*"]` (tüm yayınlanabilir olaylar) |
+
+Yanıt (özet):
+
+```json
+{
+  "id": "0190a1b2-...",
+  "tenantId": "...",
+  "url": "https://hooks.ornek.com/hummytummy",
+  "events": ["order.created.v1", "payment.succeeded.v1"],
+  "status": "active",
+  "secret": "whs_AbCdEf..."
+}
+```
+
+Abonelikleri listeleyin / iptal edin:
+
+```bash
+GET    /api/v1/webhooks/subscriptions
+DELETE /api/v1/webhooks/subscriptions/:id
+```
+
+<Callout type="info">
+  Tenant başına varsayılan aktif abonelik limiti 20'dir (sadece `active` satırlar
+  sayılır); aşılırsa `400` döner. Kullanılmayan abonelikleri iptal edin.
+</Callout>
+
+## Teslim edilen yük (payload)
+
+Her teslim, JSON gövdesiyle bir POST'tur:
+
+```json
+{
+  "id": "0190a1b2-c3d4-...",
+  "type": "order.created.v1",
+  "tenantId": "...",
+  "payload": { "...olaya-özgü alanlar..." }
+}
+```
+
+Ayrıca şu başlıklar gelir:
+
+| Başlık | Açıklama |
+| --- | --- |
+| `Content-Type` | `application/json` |
+| `User-Agent` | `HummyTummy-Webhook/1` |
+| `X-HummyTummy-Event-Id` | Olayın `id`'si (idempotency için) |
+| `X-HummyTummy-Event-Type` | Olay tipi (örn. `order.created.v1`) |
+| `X-HummyTummy-Signature` | İmza: `t=<unix-ms>,v1=<hmac-sha256>` |
+
+<Callout type="info">
+  Aynı olay aynı `id` ile birden çok kez ulaşabilir (en-az-bir-kez teslim).
+  Alıcı tarafta **`id` (veya `X-HummyTummy-Event-Id`) üzerinden dedup** yapın.
+</Callout>
+
+## İmza doğrulama
+
+İmza, gövde üzerinden hesaplanan zaman damgalı bir HMAC-SHA256'dır:
+
+```
+X-HummyTummy-Signature: t=<unix-ms>,v1=<hmac-sha256-hex>
+```
+
+İmza şu şekilde üretilir — **imzalanan metin** `"<timestamp>.<rawBody>"`'dir,
+anahtar ise sizin `secret`'ınız:
+
+```
+v1 = HMAC_SHA256(secret, `${t}.${rawBody}`)  // hex
+```
+
+Doğrulama adımları (HummyTummy'nin `verify` mantığıyla birebir aynı):
+
+<Steps>
+
+### Başlığı ayrıştırın
+`t` ve `v1` değerlerini virgülle ayırıp çıkarın.
+
+### Zaman damgasını kontrol edin
+`t` sayısal olmalı ve şu ana göre **±5 dakika** içinde olmalı (replay
+koruması).
+
+### HMAC'i yeniden hesaplayın
+`secret` ile `"${t}.${rawBody}"` üzerinde HMAC-SHA256 hesaplayın.
+
+### Sabit-zamanlı karşılaştırın
+Hesapladığınız hex'i `v1` ile uzunluk + sabit-zamanlı (timing-safe)
+karşılaştırın. Eşitse olay gerçektir.
+
+</Steps>
+
+<Callout type="warning">
+  **Ham gövdeyi** kullanın — JSON'u parse edip yeniden serialize ETMEYİN; aksi
+  halde byte'lar değişir ve imza tutmaz. Web framework'ünüzde ham body
+  buffer'ını saklayın.
+</Callout>
+
+### Node.js (Express) doğrulama örneği
+
+```ts
+import express from "express";
+import { createHmac, timingSafeEqual } from "node:crypto";
+
+const app = express();
+
+// Ham gövdeyi sakla — imza ham byte'lar üzerinden hesaplanır.
+app.use(express.json({ verify: (req, _res, buf) => { (req as any).rawBody = buf; } }));
+
+function verify(
+  secret: string,
+  header: string,
+  rawBody: string,
+  toleranceMs = 5 * 60_000,
+): boolean {
+  const parts = Object.fromEntries(header.split(",").map((p) => p.split("=")));
+  const ts = Number(parts.t);
+  const v1 = String(parts.v1 ?? "");
+  if (!Number.isFinite(ts) || Math.abs(Date.now() - ts) > toleranceMs) return false;
+  const expected = createHmac("sha256", secret)
+    .update(`${ts}.${rawBody}`)
+    .digest("hex");
+  if (expected.length !== v1.length) return false;
+  return timingSafeEqual(Buffer.from(expected), Buffer.from(v1));
+}
+
+app.post("/hummytummy", (req, res) => {
+  const sig = req.header("X-HummyTummy-Signature") ?? "";
+  const raw = (req as any).rawBody.toString("utf8");
+  if (!verify(process.env.WEBHOOK_SECRET!, sig, raw)) {
+    return res.sendStatus(401); // imza geçersiz/eski
+  }
+  // İdempotency: aynı X-HummyTummy-Event-Id'yi iki kez işleme.
+  const eventId = req.header("X-HummyTummy-Event-Id");
+  // ... olayı işle ...
+  res.sendStatus(200); // 2xx = başarılı teslim
+});
+```
+
+<Callout type="info">
+  Başarılı teslim için **2xx** (200–299) dönün. 2xx dışı her durum başarısızlık
+  sayılır ve yeniden denenir.
+</Callout>
+
+## Olay tipleri
+
+`events` alanında belirli tipleri listeleyin ya da `"*"` ile tüm yayınlanabilir
+olayları yakalayın. Tipler `<alan>.<eylem>.v<sürüm>` biçimindedir.
+
+Örnek yayınlanabilir tipler:
+
+| Olay tipi | Ne zaman |
+| --- | --- |
+| `order.created.v1` | Yeni sipariş oluştu |
+| `order.updated.v1` | Sipariş güncellendi |
+| `order.completed.v1` | Sipariş tamamlandı |
+| `order.cancelled.v1` | Sipariş iptal edildi |
+| `payment.succeeded.v1` | Ödeme başarılı |
+| `payment.intent_created.v1` | Ödeme niyeti oluştu |
+| `payment.refund_completed.v1` | İade tamamlandı |
+| `checkout.completed.v1` | Checkout tamamlandı |
+| `subscription.activated.v1` | Abonelik aktifleşti |
+| `subscription.upgraded.v1` | Abonelik yükseltildi |
+| `subscription.cancelled.v1` | Abonelik iptal edildi |
+| `feature.entitlement.changed.v1` | Özellik hakkı değişti |
+
+### Engelli (BLOCKED) olaylar
+
+Bazı hassas olaylar dahili tutulur ve **hiçbir koşulda** dışarı verilmez —
+`"*"` aboneliği bile bunları almaz. Engelleme **ön ek** bazlıdır; aşağıdaki ön
+ekle başlayan hiçbir olay teslim edilmez:
+
+```
+user.password
+user.email_verification
+auth.
+subscription.upgrade.requested
+subscription.renewal.failed
+subscription.payment.
+kms.
+audit.
+```
+
+<Callout type="info">
+  Yeni iş olayları varsayılan olarak yayınlanabilir; yalnızca hassas olanlar bu
+  listeye eklenir. Bu filtre, abonelik eşlemesinden **önce** çalışır — açıkça
+  isimle abone olsanız bile engellenen bir olayı alamazsınız.
+</Callout>
+
+## Yeniden deneme ve otomatik duraklatma
+
+Teslim, her 30 saniyede bir çalışan bir worker tarafından yapılır.
+
+- **Zaman aşımı:** tek teslim 15 saniyeyle sınırlıdır.
+- **Yeniden deneme:** 2xx dışı yanıt veya ağ hatasında artan beklemelerle (30
+  sn, 2 dk, 10 dk, 1 saat, 6 saat) en fazla **5 deneme**; ardından teslim
+  `failed` işaretlenir.
+- **Otomatik duraklatma:** bir abonelik **20 ardışık başarısızlıktan** sonra
+  otomatik `paused`'a alınır. Ölü bir uç noktanın worker'ı tüketmesini engeller;
+  yeniden çalışır hale getirip yeni bir abonelik oluşturmanız gerekir.
+- **Başarı sayacı sıfırlama:** başarılı bir teslim ardışık-başarısızlık
+  sayacını 0'a çeker.
+
+<Callout type="warning">
+  Yük taşınamazsa (ör. kaynak olay retention tarafından temizlenmişse) teslim
+  `failed` ile sessizce-veri-kaybı yerine açıklayıcı bir not (`source event
+  purged before delivery`) ile işaretlenir.
+</Callout>
+
+## SSRF koruması (allowlist)
+
+Webhook URL'leri hem **abone olurken** hem de **her teslimden hemen önce** bir
+güvenlik kapısından geçer. Bu, tenant'ın iç servislere ya da bulut metadata uç
+noktalarına (örn. `169.254.169.254`) self-fetch yapmasını engeller.
+
+Engellenenler:
+
+- Genel (public) olmayan IP'ler: loopback, özel/dahili aralıklar, link-local,
+  cloud metadata adresleri ve bunların IPv4-mapped IPv6 karşılıkları.
+- Tehlikeli portlar (Redis, Postgres, vb.).
+- URL içinde userinfo (`user:pass@host`).
+- `http`/`https` dışı protokoller.
+
+<Callout type="info">
+  Teslim öncesi tekrar doğrulama, **DNS-rebind** saldırılarını da kapatır
+  (abone olurken "public IP", teslimde "private IP" döndüren bir DNS sunucusu).
+  Böyle bir durumda teslim yeniden denenmeden `failed` işaretlenir.
+</Callout>
+
+## En iyi pratikler
+
+- İmzayı **her zaman** doğrulayın ve `id` üzerinden dedup yapın.
+- Hızlıca **2xx** dönün; ağır işi kuyruğa alın (15 sn timeout'u aşmayın).
+- `secret`'ı sunucu tarafında, ortam değişkeninde/kasada saklayın.
+- Bir aboneliği duraklatıldı bulursanız uç noktanızı onarın ve **yeniden** abone
+  olun.
+- Mümkünse HTTPS uç noktası kullanın.

--- a/developer/pages/tr/getting-started/_meta.ts
+++ b/developer/pages/tr/getting-started/_meta.ts
@@ -1,3 +1,6 @@
 export default {
-  "index": "Genel Bakış"
+  "index": "Genel Bakış",
+  "kavramlar": "Temel Kavramlar",
+  "hesap-olusturma": "Hesap Oluşturma",
+  "ilk-kurulum": "İlk Kurulum",
 }

--- a/developer/pages/tr/getting-started/_meta.ts
+++ b/developer/pages/tr/getting-started/_meta.ts
@@ -1,0 +1,3 @@
+export default {
+  "index": "Genel Bakış"
+}

--- a/developer/pages/tr/getting-started/hesap-olusturma.mdx
+++ b/developer/pages/tr/getting-started/hesap-olusturma.mdx
@@ -1,0 +1,137 @@
+---
+title: Hesap Oluşturma
+description: HummyTummy'de yeni bir restoran hesabı açma — kayıt formu, zorunlu alanlar ve API ile kayıt.
+---
+
+import { Callout, Steps, Tabs } from 'nextra/components'
+
+# Hesap Oluşturma
+
+Yeni bir restoran hesabı açmak, kayıt formunu doldurmaktan ibarettir. Kayıt tamamlandığı anda sizin için bir **tenant**, bir **"Main" şube**, **ADMIN** kullanıcınız ve **7 günlük ücretsiz deneme** otomatik kurulur — başka bir adım gerekmez.
+
+## Zorunlu bilgiler
+
+Kayıt için aşağıdaki alanlar **zorunludur**:
+
+| Alan | Açıklama | Kural |
+|---|---|---|
+| **E-posta** | Giriş için kullanılır | Geçerli e-posta, en fazla 254 karakter |
+| **Şifre** | Hesap şifresi | En az 8 karakter; **en az bir küçük harf, bir büyük harf ve bir rakam** içermeli (en fazla 128 karakter) |
+| **Ad** (`firstName`) | Adınız | En fazla 100 karakter |
+| **Soyad** (`lastName`) | Soyadınız | En fazla 100 karakter |
+| **Telefon** | İletişim ve ödeme için | Herhangi bir doğal formatta girebilirsiniz; sistem **E.164**'e çevirir |
+| **Restoran adı** (`restaurantName`) | Yeni işletme açarken | Tenant'ınızın adı olur, en fazla 120 karakter |
+
+<Callout type="info">
+  **Telefon neden zorunlu?** Ödeme sağlayıcısı (PayTR) checkout sırasında telefon
+  numarası ister. Bu yüzden telefon kayıtta alınır. `"0555 123 45 67"` veya
+  `"+90 555 123 45 67"` gibi doğal yazımları kabul eder ve standart
+  `+905551234567` (E.164) biçimine çevirir.
+</Callout>
+
+## Adım adım kayıt (arayüz)
+
+<Steps>
+
+### Kayıt sayfasını açın
+
+Giriş ekranındaki **"Kayıt ol"** bağlantısına tıklayın.
+
+### Bilgileri girin
+
+E-posta, şifre, ad, soyad, telefon ve restoran adını doldurun. Şifre, büyük/küçük harf ve rakam içermelidir.
+
+### Hesabı oluşturun
+
+Formu gönderin. Hesabınız, ana şubeniz ve 7 günlük deneme aboneliğiniz tek seferde kurulur ve doğrudan sisteme giriş yaparsınız.
+
+### Karşılama akışını tamamlayın
+
+İlk girişte sizi karşılayan ekrana ve kontrol paneline yönlendirilirsiniz. Buradan **[İlk Kurulum](/getting-started/ilk-kurulum)** adımlarına geçin.
+
+</Steps>
+
+## API ile kayıt
+
+Kaydı programatik olarak da yapabilirsiniz. Global API ön eki `/api`'dir.
+
+**Uç nokta:** `POST /api/auth/register`
+
+<Tabs items={['curl', 'İstek gövdesi (JSON)']}>
+  <Tabs.Tab>
+
+```bash
+curl -X POST https://<sunucu>/api/auth/register \
+  -H "Content-Type: application/json" \
+  -d '{
+    "email": "sahip@restoranim.com",
+    "password": "Passw0rd!",
+    "firstName": "Ayşe",
+    "lastName": "Yılmaz",
+    "phone": "0555 123 45 67",
+    "restaurantName": "Sultanahmet Kafe"
+  }'
+```
+
+  </Tabs.Tab>
+  <Tabs.Tab>
+
+```json
+{
+  "email": "sahip@restoranim.com",
+  "password": "Passw0rd!",
+  "firstName": "Ayşe",
+  "lastName": "Yılmaz",
+  "phone": "0555 123 45 67",
+  "restaurantName": "Sultanahmet Kafe"
+}
+```
+
+  </Tabs.Tab>
+</Tabs>
+
+**Başarılı yanıt (`201 Created`):** Bir `accessToken` ile kullanıcı bilgisini döner. Telefon `+905551234567` biçiminde normalize edilmiş olarak saklanır.
+
+```json
+{
+  "accessToken": "<jwt>",
+  "user": {
+    "id": "…",
+    "email": "sahip@restoranim.com",
+    "firstName": "Ayşe",
+    "lastName": "Yılmaz",
+    "phone": "+905551234567",
+    "role": "ADMIN",
+    "tenantId": "…",
+    "primaryBranchId": "…",
+    "allowedBranchIds": []
+  }
+}
+```
+
+<Callout type="info">
+  Yenileme jetonu (refresh token) yanıt gövdesinde **dönmez**; güvenlik için yalnızca
+  `httpOnly` çerez olarak gönderilir. Erişim jetonunu (`accessToken`) sonraki
+  isteklerde `Authorization: Bearer <accessToken>` başlığıyla kullanın.
+</Callout>
+
+**Hata durumları:**
+
+- `409 Conflict` — bu e-posta zaten kullanımda.
+- `400 Bad Request` — alanlardan biri kuralları sağlamıyor (örn. zayıf şifre, geçersiz telefon).
+
+<Callout type="warning">
+  **Hız sınırı:** Kayıt uç noktası IP başına **saatte 3 istek** ile sınırlıdır.
+  Aşıldığında `429 Too Many Requests` döner.
+</Callout>
+
+## Kayıttan sonra otomatik kurulan şeyler
+
+Kayıt başarıyla tamamlandığında, tek bir veritabanı işlemi (transaction) içinde şunlar oluşturulur:
+
+1. **Tenant** — restoran adınızla, 7 günlük deneme süresi ayarlı.
+2. **Abonelik** — **TRIALING** durumunda, 7 günlük TRIAL planında.
+3. **"Main" şube** — varsayılan ana şubeniz.
+4. **ADMIN kullanıcı** — siz (işletme sahibi).
+
+Bu noktadan sonra **[İlk Kurulum](/getting-started/ilk-kurulum)** adımlarıyla menünüzü, masalarınızı ve ayarlarınızı hazırlayabilirsiniz.

--- a/developer/pages/tr/getting-started/ilk-kurulum.mdx
+++ b/developer/pages/tr/getting-started/ilk-kurulum.mdx
@@ -1,0 +1,95 @@
+---
+title: İlk Kurulum
+description: İlk giriş, karşılama akışı, kurulum kontrol listesi ve önerilen sıra — şube, menü, masa.
+---
+
+import { Callout, Steps } from 'nextra/components'
+
+# İlk Kurulum
+
+Hesabınızı oluşturduktan sonra ilk girişte sizi bir karşılama akışı ve kontrol paneli karşılar. Bu sayfa, restoranınızı çalışır hale getirmek için izlemeniz gereken sırayı anlatır.
+
+## İlk açılış: karşılama ve rehberli tur
+
+İlk girişinizde kontrol panelinde (`/dashboard`) bir **karşılama penceresi** açılır. Burada iki seçeneğiniz vardır:
+
+- **Rehberli turu başlat** — sistemin ana ekranlarını (POS, menü, masalar vb.) adım adım gezdiren interaktif bir tur.
+- **Önce örnek bir restoranı (demo) keşfet** — kendi verinize dokunmadan, hazır kurulmuş bir demo restoranda sistemi deneyebilirsiniz. İstediğiniz an kendi hesabınıza geri dönersiniz.
+
+<Callout type="info">
+  Turu atlayabilirsiniz; bir daha gösterilmez. Daha sonra istediğinizde tekrar
+  başlatabilirsiniz. Demo, gerçek verilerle dolu paylaşımlı bir restorandır —
+  güvenle keşfedebilirsiniz.
+</Callout>
+
+### Profilini tamamla (sosyal giriş kullandıysanız)
+
+Google ile giriş yaptıysanız ve hesabınızda **telefon numarası yoksa**, sistem sizi önce **"Hesabını tamamla"** ekranına yönlendirir. Burada:
+
+- **Telefon** (zorunlu — ödeme adımı için gerekli)
+- İşletme adı, ad-soyad, vergi no / vergi dairesi, adres, şehir
+- Saat dilimi ve dil tercihi
+
+bilgilerini girersiniz. E-posta + şifre ile normal kayıt yaptıysanız bu adım atlanır, çünkü telefon zaten kayıtta alınmıştır.
+
+## Kurulum kontrol listesi
+
+Kontrol panelinizde, restoranınız tam hazır olana kadar bir **kurulum kontrol listesi** banner'ı görünür. Her madde gerçek bir koşulu kontrol eder ve sizi ilgili sayfaya yönlendirir; tüm maddeler tamamlanınca banner kendiliğinden kaybolur. Maddeler:
+
+| Madde | Ne ister? | Nereye gider? |
+|---|---|---|
+| **Şube** | En az bir şube olması | Şubeler |
+| **KDS ekranı** | Bir mutfak ekranı (KDS) cihazının eşleştirilmesi | Cihazlar |
+| **Garson tableti** | Bir garson tableti cihazının eşleştirilmesi | Cihazlar |
+| **Köprü (Bridge)** | Yazıcı/yazarkasa varsa bir bridge'in çevrimiçi olması | Köprüler |
+| **Mali entegrasyon** | Mali (fiscal) entegrasyonun bağlanması | Marketplace |
+
+<Callout type="info">
+  Kontrol listesi **bağlama duyarlıdır**: örneğin KDS özelliği planınızda yoksa o
+  madde gösterilmez; yazıcı/yazarkasa cihazı tanımlamadıysanız "Köprü" maddesi
+  atlanır. Yani yalnızca sizin için anlamlı adımları görürsünüz.
+</Callout>
+
+## Önerilen kurulum sırası
+
+Cihaz eşleştirmeden önce, restoranınızı operasyonel hale getirecek temel veriyi şu sırayla girmenizi öneririz:
+
+<Steps>
+
+### 1. Şube ayarları
+
+Kayıtta otomatik bir **"Main"** şubeniz oluşturulmuştur. Şubenizin adını, adresini ve saat dilimini gözden geçirin. Çok lokasyonlu çalışacaksanız (planınız izin veriyorsa) ek şubelerinizi şimdi ekleyin.
+
+### 2. Menü
+
+Yönetici panelindeki **Menü Yönetimi**'nden:
+
+- Önce **kategorileri** oluşturun (örn. "Sıcak İçecekler", "Tatlılar").
+- Ardından her kategoriye **ürünleri** ekleyin (ad, fiyat, fotoğraf, açıklama).
+- Gerekiyorsa **modifier** (seçenek) tanımlayın — örn. "boyut: küçük/orta/büyük" veya "ekstra peynir".
+
+Menü, POS'ta sipariş alabilmenizin ve QR menünün temelidir; bu yüzden masalardan önce gelir.
+
+### 3. Masalar
+
+**Masa Yönetimi**'nden masalarınızı ekleyin (ad/numara ve kapasite). Masasız (yalnız gel-al) çalışıyorsanız bu adımı atlayıp ayarlardan **takeaway** modunu açabilirsiniz.
+
+### 4. (İsteğe bağlı) QR kodları ve cihazlar
+
+- **QR Yönetimi**'nden masa QR kodlarını oluşturup yazdırın.
+- Mutfak ekranı (KDS) ve garson tabletlerini **Cihazlar**'dan eşleştirin.
+- Yazıcı/yazarkasa kullanıyorsanız bir **Köprü (Bridge)** kurun.
+
+</Steps>
+
+<Callout type="info">
+  **Önerilen mantık:** önce **şube** → sonra **menü** (kategori, ardından ürün) →
+  sonra **masa**. Bu sırayla ilerlediğinizde POS'ta hemen sipariş alabilir, QR
+  menüyü yayına alabilir ve mutfak ekranını bağlayabilirsiniz.
+</Callout>
+
+## Sırada ne var?
+
+- Tüm yönetim ekranlarının detaylı anlatımı için **[Yönetici Rehberi](/admin-guide)**
+- Plan limitleri ve fiyatlar için **[Planlar](/plans)**
+- Cihazlar, köprü ve entegrasyonlar için **[Marketplace](/marketplace)** ve **[Geliştirici / Entegrasyon](/developer)**

--- a/developer/pages/tr/getting-started/index.mdx
+++ b/developer/pages/tr/getting-started/index.mdx
@@ -1,7 +1,54 @@
 ---
-title: Başlangıç
+title: Başlangıç — Genel Bakış
+description: HummyTummy nedir, kimler için, nasıl başlanır — yeni restoran sahipleri ve yöneticiler için giriş.
 ---
+
+import { Callout, Cards } from 'nextra/components'
 
 # Başlangıç
 
-Bu bölüm hazırlanıyor.
+**HummyTummy**, kafe ve restoranlar için tasarlanmış **bulut tabanlı bir restoran yönetim sistemidir**. Tek bir hesapta QR menü, POS (kasa), mutfak ekranı (KDS), sipariş ve masa yönetimi, stok, raporlar ve çoklu şube yönetimini birleştirir. Tarayıcı tabanlıdır — herhangi bir donanım kurulumu veya yerel yazılım gerektirmez.
+
+Bu bölüm, sıfırdan başlayan bir restoran sahibi veya yönetici için hazırlanmıştır: kavramları öğrenin, hesabınızı oluşturun ve ilk şubenizi, menünüzü, masalarınızı dakikalar içinde ayağa kaldırın.
+
+## Kimler için?
+
+- **Kafe, restoran, pastane, bar, fast-food** işletmeleri (1 masadan 100+ masaya)
+- İşletmesini **tek panelden** yönetmek isteyen sahipler ve yöneticiler
+- Bulut tabanlı, **kurulumsuz** bir çözüm arayanlar
+
+## Neler sunar?
+
+- **POS / Kasa** — masadan veya gel-al (takeaway) sipariş alma, ödeme, indirim
+- **Mutfak Ekranı (KDS)** — siparişlerin mutfağa gerçek zamanlı düşmesi
+- **QR Menü** — müşterinin masadaki QR'ı okuyup menüyü görmesi ve sipariş vermesi
+- **Masa & Sipariş yönetimi** — masa durumu, transfer, parça parça ödeme
+- **Stok & Reçete**, **Rezervasyon**, **Personel**, **Raporlar** ve **çoklu şube**
+- **5 dilde arayüz**: Türkçe, İngilizce, Rusça, Özbekçe, Arapça
+- **Gerçek zamanlı (WebSocket) güncelleme**: bir kasa sipariş yazınca aynı anda mutfak görür
+
+<Callout type="info">
+  HummyTummy **çok kiracılı (multi-tenant)** bir sistemdir: her işletmenin verisi
+  birbirinden tamamen izoledir. Sadece kendi restoranınızın verisini görürsünüz.
+  Para birimi **Türk Lirası (TRY)** olarak çalışır.
+</Callout>
+
+## Nasıl başlanır?
+
+Yeni kaydolan her işletme **7 günlük ücretsiz deneme (TRIAL)** ile başlar — kart bilgisi istenmez, tüm özellikler açıktır. Deneme bitince devam etmek için bir ücretli plan seçersiniz.
+
+Aşağıdaki sayfaları sırayla izleyin:
+
+<Cards>
+  <Cards.Card title="Temel Kavramlar" href="/getting-started/kavramlar" arrow />
+  <Cards.Card title="Hesap Oluşturma" href="/getting-started/hesap-olusturma" arrow />
+  <Cards.Card title="İlk Kurulum" href="/getting-started/ilk-kurulum" arrow />
+</Cards>
+
+## Sırada ne var?
+
+Hesabınızı kurduktan sonra:
+
+- Tüm yönetim ekranlarının detayı için **[Yönetici Rehberi](/admin-guide)**
+- Plan limitleri ve fiyatlandırma için **[Planlar](/plans)**
+- API ve entegrasyonlar için **[Geliştirici / Entegrasyon](/developer)**

--- a/developer/pages/tr/getting-started/index.mdx
+++ b/developer/pages/tr/getting-started/index.mdx
@@ -1,0 +1,7 @@
+---
+title: Başlangıç
+---
+
+# Başlangıç
+
+Bu bölüm hazırlanıyor.

--- a/developer/pages/tr/getting-started/kavramlar.mdx
+++ b/developer/pages/tr/getting-started/kavramlar.mdx
@@ -1,0 +1,69 @@
+---
+title: Temel Kavramlar
+description: Tenant, Şube, Roller ve 7 günlük deneme — HummyTummy'de işinizi anlamadan önce bilmeniz gereken kavramlar.
+---
+
+import { Callout } from 'nextra/components'
+
+# Temel Kavramlar
+
+HummyTummy'yi kullanmadan önce dört temel kavramı anlamak işinizi kolaylaştırır: **Tenant**, **Şube (Branch)**, **Roller** ve **Deneme (TRIAL)**.
+
+## Tenant (Restoran / İşletme)
+
+**Tenant**, sisteme kaydolan işletmenizin tamamıdır — yani restoranınız. Kayıt olduğunuzda sizin için bir tenant oluşturulur ve tüm verileriniz (menü, masalar, siparişler, personel, raporlar) bu tenant altında saklanır.
+
+- Her tenant **tamamen izoledir**: başka bir işletmenin verisini göremezsiniz, onlar da sizinkini göremez.
+- Bir tenant'ın bir **abonelik durumu** (deneme / aktif / vb.) ve bir **planı** vardır.
+- Tenant'ı kuran ilk kullanıcı her zaman **ADMIN** rolündedir.
+
+## Şube (Branch)
+
+**Şube**, tenant'ınız altındaki fiziksel bir lokasyondur. Kayıt sırasında otomatik olarak **"Main"** adında bir ana şube oluşturulur — yani hiçbir şey yapmadan zaten bir şubeniz olur.
+
+- Tek lokasyonlu işletmeler tek şube ile çalışır.
+- Çok şubeli zincirler birden fazla şube ekleyebilir (plan limitlerine bağlı).
+- Menü, masa, sipariş ve stok gibi pek çok veri **şube bazlıdır** — yani her şubenin kendi masaları, kendi siparişleri olur.
+
+<Callout type="info">
+  Sistem, şube bazlı isteklerde arka planda bir **şube bağlamı** (`X-Branch-Id`)
+  kullanır. Arayüzde aktif şubenizi seçtiğinizde bu otomatik yönetilir — günlük
+  kullanımda elle bir şey yapmanız gerekmez.
+</Callout>
+
+## Roller
+
+Her kullanıcının bir **rolü** vardır. Rol, kullanıcının nelere erişebileceğini belirler. Beş rol vardır:
+
+| Rol | Kim? | Tipik yetkiler |
+|---|---|---|
+| **ADMIN** | İşletme sahibi / üst yönetici | Her şey: ayarlar, plan/abonelik, kullanıcı yönetimi, tüm şubeler, raporlar |
+| **MANAGER** | Şube/operasyon müdürü | Operasyon yönetimi, menü/masa/personel, raporlar (atandığı şubelerde) |
+| **WAITER** | Garson | POS'tan sipariş alma, masa işlemleri (kendi şubesinde) |
+| **KITCHEN** | Mutfak personeli | Mutfak ekranı (KDS): sipariş durumu güncelleme |
+| **COURIER** | Kurye | Teslimat / kurye akışı |
+
+**Şube kısıtı:** `WAITER`, `KITCHEN` ve `COURIER` rolleri **tek bir şubeye sabitlenir** (kendi ana şubeleri). Yalnızca o şubede çalışabilirler. `ADMIN` ve `MANAGER` ise birden fazla şube arasında geçiş yapabilir (`ADMIN` tüm şubelere, `MANAGER` kendisine atanan şubelere).
+
+<Callout type="info">
+  İlk kaydolan kullanıcı (işletme sahibi) **ADMIN**'dir ve tüm şubelere erişebilir.
+  Diğer personeli daha sonra Yönetici panelinden ekleyip rol atarsınız.
+</Callout>
+
+## Deneme (TRIAL — 7 gün)
+
+Yeni kaydolan her tenant, **özel 7 günlük deneme planı (TRIAL)** ile başlar:
+
+- **Tüm premium özellikler açık**, ücret alınmaz, kart bilgisi istenmez.
+- Abonelik durumu deneme boyunca **TRIALING**'dir.
+- Deneme **tenant başına tek seferliktir** (kötüye kullanım engellenir).
+
+**7 gün dolunca ne olur?** Deneme biter ve hesap **kilitlenir** (`TRIAL_ENDED`): devam etmek için bir **ücretli plan** seçmeniz gerekir. Otomatik olarak ücretsiz bir plana düşmez — bilinçli bir tasarım kararıdır.
+
+<Callout type="warning">
+  Deneme bittiğinde, ücretli bir plan seçilene kadar arayüz sizi plan seçim
+  sayfasına yönlendirir ve şube-bazlı işlemler kilitlenir. Verileriniz silinmez;
+  plan aktive edilir edilmez kaldığınız yerden devam edersiniz.
+</Callout>
+
+Plan seçenekleri ve fiyatlandırma için **[Planlar](/plans)** sayfasına bakın.

--- a/developer/pages/tr/index.mdx
+++ b/developer/pages/tr/index.mdx
@@ -1,0 +1,28 @@
+---
+title: HummyTummy Dokümantasyon
+description: HummyTummy — bulut tabanlı restoran yönetim sistemi. Kurulumdan entegrasyona, planlardan desktop uygulamasına kadar tüm rehberler.
+---
+
+import { Cards } from 'nextra/components'
+
+# HummyTummy Dokümantasyon
+
+**HummyTummy**, restoranlar için bulut tabanlı bir yönetim sistemidir: QR menü, POS, mutfak ekranı (KDS), sipariş & masa yönetimi, stok, raporlar, çoklu şube ve geliştirici entegrasyonları — tek panelde.
+
+Bu portal hem **yöneticiler/kullanıcılar** (sayfalar, planlar, desktop) hem de **geliştiriciler/entegratörler** (API, Partner Display, webhooks) içindir.
+
+<Cards>
+  <Cards.Card title="Başlangıç" href="/getting-started" arrow />
+  <Cards.Card title="Yönetici Rehberi" href="/admin-guide" arrow />
+  <Cards.Card title="Planlar" href="/plans" arrow />
+  <Cards.Card title="Marketplace" href="/marketplace" arrow />
+  <Cards.Card title="Geliştirici / Entegrasyon" href="/developer" arrow />
+  <Cards.Card title="Desktop Uygulaması" href="/desktop" arrow />
+  <Cards.Card title="Referans" href="/reference" arrow />
+</Cards>
+
+## Hızlı başlangıç
+
+- **Restoran sahibiyseniz:** [Başlangıç](/getting-started) → [Yönetici Rehberi](/admin-guide) → [Planlar](/plans)
+- **Entegratör/geliştiriciyseniz:** [Geliştirici / Entegrasyon](/developer) → [Partner Display API](/developer/partner-display) → [Webhooks](/developer/webhooks)
+- **Masaüstü kurulumu:** [Desktop Uygulaması](/desktop)

--- a/developer/pages/tr/marketplace/_meta.ts
+++ b/developer/pages/tr/marketplace/_meta.ts
@@ -1,3 +1,5 @@
 export default {
-  "index": "Genel Bakış"
-}
+  "index": "Genel Bakış",
+  "satin-alma-akisi": "Satın Alma Akışı",
+  "urunler": "Ürünler (Add-on'lar)",
+};

--- a/developer/pages/tr/marketplace/_meta.ts
+++ b/developer/pages/tr/marketplace/_meta.ts
@@ -1,0 +1,3 @@
+export default {
+  "index": "Genel Bakış"
+}

--- a/developer/pages/tr/marketplace/index.mdx
+++ b/developer/pages/tr/marketplace/index.mdx
@@ -1,7 +1,101 @@
 ---
 title: Marketplace
+description: HummyTummy Marketplace add-on kataloğu — kapasite paketleri, entegrasyonlar, yazılım özellikleri ve hizmetler.
 ---
+
+import { Callout, Cards } from 'nextra/components'
 
 # Marketplace
 
-Bu bölüm hazırlanıyor.
+Marketplace, planınızın üzerine **tek tek satın alınabilen** eklentilerin (add-on) kataloğudur.
+Bir plan size bir özellik/limit tabanı verir; add-on'lar bu tabanı **artırır**: ekstra KDS ekranı,
+ekstra şube, e-Fatura entegrasyonu, gelişmiş raporlar gibi.
+
+Her add-on'un satın alınmasıyla tenant'ınıza bir **TenantAddOn** kaydı düşer ve entitlement
+projektörü bu kaydın `grants` alanını mevcut hak setinize katar (fold). Katma kuralları nettir:
+
+- **`limit.*`** (sayısal) → **toplanır** (örn. plan 2 KDS + 1 add-on = 3 KDS)
+- **`feature.*`** (boolean) → **OR** (herhangi bir kaynak açıyorsa açık)
+- **`integration.*`** (liste) → **birleşim / union** (sağlayıcılar listeye eklenir)
+
+<Callout type="info">
+  Tüm fiyatlar **TRY** cinsindendir ve kataloğda **kuruş** (`priceCents`) olarak tutulur:
+  `9900` = ₺99,00. Add-on fiyatları KDV dahil (gross) görüntülenir.
+</Callout>
+
+## Add-on'lara göz at
+
+<Cards>
+  <Cards.Card title="Satın Alma Akışı" href="/tr/marketplace/satin-alma-akisi" arrow>
+    Marketplace → checkout → PayTR → grant. Hak katma kuralları, iptal ve dönem-sonu davranışı.
+  </Cards.Card>
+  <Cards.Card title="Ürünler (Add-on Detayları)" href="/tr/marketplace/urunler" arrow>
+    Her sellable add-on için kod, fiyat, ne açtığı (grant), tekrarlayan/tek seferlik, bağımlılık.
+  </Cards.Card>
+  <Cards.Card title="Planlar" href="/tr/plans" arrow>
+    Add-on'ların üzerine bindiği taban planlar (BASIC / PRO / BUSINESS).
+  </Cards.Card>
+</Cards>
+
+## Katalog özeti
+
+Tüm sellable add-on'lar tek bakışta. Detaylar ve örnek payload'lar için
+[Ürünler](/tr/marketplace/urunler) sayfasına bakın.
+
+| Kod | Ad | Tür | Fatura | Fiyat | Açtığı (grant) | Bağımlılık |
+| --- | --- | --- | --- | --- | --- | --- |
+| `kds_extra_screen` | Ekstra KDS ekranı | capacity | Tekrarlayan | ₺99,00 | `limit.kdsScreens` +1 | — |
+| `kds_extra_station` | Ekstra KDS istasyonu | capacity | Tekrarlayan | ₺149,00 | `limit.kdsStations` +1 | — |
+| `extra_tablet` | Ekstra garson tableti | capacity | Tekrarlayan | ₺79,00 | `limit.tablets` +1 | — |
+| `extra_branch` | Ekstra şube | capacity | Tekrarlayan | ₺399,00 | `limit.branches` +1, `feature.multiLocation` | — |
+| `fiscal_efatura` | e-Fatura / e-Arşiv | integration | Tekrarlayan | ₺199,00 | `integration.fiscal` += `efatura` | — |
+| `fiscal_hugin` | Hugin yazarkasa | integration | Tekrarlayan | ₺299,00 | `integration.fiscal` += `hugin` | **`plan:PRO`** |
+| `delivery_yemeksepeti` | Yemeksepeti | integration | Tekrarlayan | ₺249,00 | `integration.delivery` += `yemeksepeti` | — |
+| `delivery_getir` | Getir Yemek | integration | Tekrarlayan | ₺249,00 | `integration.delivery` += `getir` | — |
+| `delivery_trendyol_yemek` | Trendyol Yemek | integration | Tekrarlayan | ₺249,00 | `integration.delivery` += `trendyol_yemek` | — |
+| `caller_id_integration` | Caller ID / telefon-sipariş | integration | Tekrarlayan | ₺149,00 | `feature.callerIntegration` | — |
+| `advanced_reports` | Gelişmiş raporlar | software | Tekrarlayan | ₺129,00 | `feature.advancedReports` | — |
+| `api_access` | API erişimi | software | Tekrarlayan | ₺249,00 | `feature.apiAccess` | — |
+| `priority_support` | Öncelikli destek | support | Tekrarlayan | ₺199,00 | `feature.prioritySupport` | — |
+| `onsite_install_full` | Yerinde kurulum (tek seferlik) | support | **Tek seferlik** | ₺7.500,00 | — (hak vermez, hizmet satırı) | — |
+
+<Callout type="warning">
+  `onsite_install_full` bir **hizmet** kalemidir: ödenir, faturalanır ama hiçbir
+  entitlement vermez (`grants: {}`). Tekrarlayan değil, tek seferliktir.
+</Callout>
+
+## Kataloğu API'den çekmek
+
+Katalog herkese açıktır (landing sitesinde de görünür); kimlik doğrulama gerektirmez.
+
+```bash
+curl https://api.hummytummy.com/api/v1/marketplace/addons
+```
+
+`kind` ile filtreleyebilirsiniz (`capacity` | `integration` | `software` | `support`):
+
+```bash
+curl "https://api.hummytummy.com/api/v1/marketplace/addons?kind=integration"
+```
+
+Yalnızca `published` durumundaki add-on'lar döner; her satır UI için kırpılmıştır:
+
+```json
+[
+  {
+    "code": "kds_extra_screen",
+    "name": "Extra KDS screen",
+    "description": "Adds one additional kitchen display screen slot to your branch.",
+    "kind": "capacity",
+    "billing": "recurring",
+    "priceCents": 9900,
+    "currency": "TRY",
+    "deps": []
+  }
+]
+```
+
+<Callout type="info">
+  Tüm endpoint'ler global `/api` öneki altındadır. `grants` alanı **public katalogda
+  döndürülmez** — yalnızca süperadmin yüzeyi ve seed dosyası hak haritasını taşır.
+</Callout>

--- a/developer/pages/tr/marketplace/index.mdx
+++ b/developer/pages/tr/marketplace/index.mdx
@@ -1,0 +1,7 @@
+---
+title: Marketplace
+---
+
+# Marketplace
+
+Bu bölüm hazırlanıyor.

--- a/developer/pages/tr/marketplace/satin-alma-akisi.mdx
+++ b/developer/pages/tr/marketplace/satin-alma-akisi.mdx
@@ -1,0 +1,181 @@
+---
+title: Satın Alma Akışı
+description: Marketplace → checkout → PayTR → grant. Hak katma kuralları, idempotensi, iptal ve dönem-sonu davranışı.
+---
+
+import { Callout, Steps, Tabs } from 'nextra/components'
+
+# Satın Alma Akışı
+
+Bir add-on satın almanın **tek** yolu checkout (PayTR) hattıdır. Tenant tarafında "bedava grant"
+veren bir endpoint **yoktur** — kaldırıldı. Ücretli bir add-on, ödeme kanıtı (`paymentRef`)
+olmadan asla provize edilmez.
+
+<Callout type="warning">
+  Eski `POST /v1/marketplace/addons/purchase` endpoint'i **kaldırıldı** (deep-review C2).
+  Sadece `@Roles(ADMIN)` ile korunuyordu ve `paymentRef` olmadan `purchase()` çağırıyordu —
+  yani herhangi bir restoran sahibi curl ile ücretli add-on'u bedavaya açabiliyordu. Artık
+  ödemeli akış zorunludur; operatör bedavaları (comp) yalnızca süperadmin yüzeyinden verilir.
+</Callout>
+
+## Uçtan uca akış
+
+<Steps>
+
+### Kataloğu listele
+
+Kullanıcı Marketplace'ten bir add-on seçer. Katalog `GET /v1/marketplace/addons`
+ile gelir (public, yalnızca `published` satırlar).
+
+### Checkout intent başlat
+
+Frontend, seçilen add-on'ları (artı varsa plan/donanım/hizmet) tek bir **karma sepet**
+(mixed cart) olarak `POST /v1/checkout/intent`'e gönderir. Yetki: **ADMIN, MANAGER**.
+
+Sunucu sepeti **yeniden fiyatlandırır** (istemci toplamına güvenilmez), `CK-<uuid7>`
+biçiminde bir `paymentRef` üretir, sepeti `CheckoutIntent` satırına dondurur ve PayTR
+iframe token'ı + ödeme linki döner.
+
+### PayTR'da öde
+
+Buyer, PayTR hosted iframe'inde ödemesini yapar. Sepetin her satırı buyer'a ayrı kalem
+olarak gösterilir (ör. *"Ekstra KDS ekranı (aylık)"*).
+
+### Webhook ile yerleşim (settlement)
+
+PayTR webhook'u yalnızca `merchant_oid` + `total_amount` taşır. Dispatcher `CK-` önekini
+görüp çağrıyı **CheckoutSettlementService**'e yönlendirir. Burada `CheckoutIntent` bulunur,
+dondurulmuş sepet okunur ve **CheckoutService.confirmAndProvision** çalışır.
+
+### Grant'lar yerleşir
+
+`confirmAndProvision`, her add-on satırı için `TenantMarketplaceService.purchase()`'ı
+**ödemeli `paymentRef` ile** ve checkout'un transaction'ı içinde çağırır. Bu da bir
+`TenantAddOn` satırı oluşturur ve outbox'a `AddOnPurchased` event'i yazar.
+
+### Entitlement projektörü fold eder
+
+Projektör `AddOnPurchased`'ı tüketir, add-on'un `grants` haritasını mevcut hak setinize
+katar. Guard'lar ve UI artık yeni limit/feature/integration'ı görür.
+
+</Steps>
+
+## Hak katma (fold) kuralları
+
+Projektör, plan + tüm aktif add-on'ların `grants` satırlarını **tek** bir hak setine indirger.
+Anahtar önekine göre kombinleme kuralı değişir:
+
+| Önek | Tip | Kombinleme | Örnek |
+| --- | --- | --- | --- |
+| `limit.*` | sayı | **SUM (toplama)** | Plan `limit.kdsScreens: 2` + 1× `kds_extra_screen` (+1) = **3** |
+| `feature.*` | boolean | **OR** | Herhangi bir kaynak `feature.advancedReports: true` veriyorsa → açık |
+| `integration.*` | string[] | **UNION (birleşim)** | `efatura` add-on + `hugin` add-on → `integration.fiscal: ["efatura", "hugin"]` |
+
+<Callout type="info">
+  `limit.*` için `-1` "sınırsız" sentinel'idir: herhangi bir kaynak `-1` verirse, sonuç
+  sınırsız olur ve toplama durur (sınırsız bir cap'e kapasite eklemek no-op'tur).
+</Callout>
+
+İki kez aynı kapasite add-on'unu alıp limiti ikiye katlamak engellenir: aynı
+`(tenantId, addOnId, branchId)` için aktif bir satır varsa ikinci satın alma reddedilir.
+Eş zamanlı iki satın alma, **Serializable** transaction ile yakalanır; kaybeden işlem
+yeniden denenebilir bir **409** alır (kart çift çekilmez).
+
+## Bağımlılıklar (deps)
+
+Bazı add-on'lar başka bir şeyin önceden mevcut olmasını ister. `deps` dizisindeki her
+giriş, satın alma anında o tenant için **geçerli** olmalıdır:
+
+- `plan:PRO` → tenant'ın aktif planının adı `PRO` olmalı (`Tenant.currentPlan.name`).
+- Bir add-on kodu (ör. `caller_id_integration`) → o add-on'un tenant'ta **aktif** olması.
+
+Şu an kataloğda tek `deps` taşıyan add-on **`fiscal_hugin`** (`["plan:PRO"]`). PRO planında
+değilseniz satın alma şu hatayla reddedilir:
+
+```
+Add-on requires: plan:PRO. Upgrade your plan or purchase the required add-ons first.
+```
+
+## İdempotensi
+
+PayTR retry'leri agresiftir (200 OK dönse bile gövde "OK"/"FAIL" değilse tekrar dener).
+Çift provizyona karşı çok katmanlı koruma vardır:
+
+1. **`CheckoutIntent.status`** kontrolü — `provisioned`/`failed` ise dokunulmaz.
+2. **`confirmAndProvision`**, `(tenantId, paymentRef)` üzerinde bağımsız idempotent'tir.
+3. **`purchase()`**, aynı `paymentRef`'li mevcut `TenantAddOn` satırını bulursa onu döner
+   (yeniden event yazmadan).
+
+## Mevcut add-on'larım
+
+Tenant'ın elindeki add-on'ları listeler. Yetki: **ADMIN, MANAGER**.
+
+```bash
+curl https://api.hummytummy.com/api/v1/marketplace/addons/mine \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+Her satır add-on kataloğunu (`addOn`) ve durum/dönem alanlarını taşır:
+
+```json
+[
+  {
+    "id": "ta_01J...",
+    "tenantId": "t_01J...",
+    "addOnId": "ao_01J...",
+    "branchId": null,
+    "quantity": 1,
+    "status": "active",
+    "activatedAt": "2026-06-22T10:00:00.000Z",
+    "currentPeriodStart": "2026-06-22T10:00:00.000Z",
+    "currentPeriodEnd": "2026-07-22T10:00:00.000Z",
+    "paymentRef": "CK-018f...",
+    "addOn": { "code": "kds_extra_screen", "name": "Extra KDS screen", "...": "..." }
+  }
+]
+```
+
+<Callout type="info">
+  Tekrarlayan add-on'lar 30 günlük bir `currentPeriodEnd` penceresi alır (iptal akışının
+  anlamlı bir dönem sonu olması için). Gerçek faturalama döngüsü, parent Subscription
+  döngüsüyle hizalanır.
+</Callout>
+
+## İptal ve dönem-sonu davranışı
+
+İptal yalnızca **ADMIN**'e açıktır (faturalandırma kararı):
+
+<Tabs items={['Dönem sonunda iptal (varsayılan)', 'Hemen iptal']}>
+<Tabs.Tab>
+
+```bash
+curl -X DELETE \
+  https://api.hummytummy.com/api/v1/marketplace/addons/$TENANT_ADDON_ID \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+Satır `cancelAtPeriodEnd: true` olur ve **aktif kalır**. Verdiği limit/feature/integration
+hakları, gece taraması (sweeper) / faturalama döngüsü kapanışı satırı `cancelled`'a
+çevirene kadar yaşamaya devam eder.
+
+</Tabs.Tab>
+<Tabs.Tab>
+
+```bash
+curl -X DELETE \
+  "https://api.hummytummy.com/api/v1/marketplace/addons/$TENANT_ADDON_ID?immediate=true" \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+Satır anında `cancelled` olur (`endedAt` damgalanır), outbox'a `AddOnCancelled` yazılır
+ve **haklar hemen geri alınır**. Emit, iptal transaction'ı içinde çalışır — append
+başarısız olursa iptal geri alınır (yarım kalmış hak bırakılmaz).
+
+</Tabs.Tab>
+</Tabs>
+
+<Callout type="warning">
+  İki eşzamanlı iptal çağrısı tek bir geçişe yakınsar (`status = 'active'` koşullu
+  `updateMany`). Kaybeden çağrı `Cancel raced with another request — refresh and retry`
+  hatası alır; `AddOnCancelled` event'i **iki kez** yazılmaz.
+</Callout>

--- a/developer/pages/tr/marketplace/urunler.mdx
+++ b/developer/pages/tr/marketplace/urunler.mdx
@@ -1,0 +1,264 @@
+---
+title: Ürünler (Add-on'lar)
+description: Her sellable add-on için detaylı kart — ne işe yarar, neyi açar, tekrarlayan mı, bağımlılık, nasıl satın alınır.
+---
+
+import { Callout } from 'nextra/components'
+
+# Ürünler (Add-on'lar)
+
+Kataloğun her sellable kalemi aşağıda tek tek belgelenmiştir. Her kartta: **ne işe yarar**,
+**neyi açar** (grant: feature / limit / integration), **tekrarlayan mı tek seferlik mi**,
+**bağımlılık** ve **nasıl satın alınır**.
+
+<Callout type="info">
+  Satın alma yolu her add-on için aynıdır: karma sepete ekleyip
+  `POST /v1/checkout/intent` → PayTR → webhook → grant. Ayrıntı için
+  [Satın Alma Akışı](/tr/marketplace/satin-alma-akisi). Fiyatlar TRY, KDV dahil.
+</Callout>
+
+---
+
+## Kapasite paketleri
+
+### `kds_extra_screen` — Ekstra KDS ekranı
+
+Şubenize **bir adet** ek mutfak ekranı (KDS) slotu ekler.
+
+| Alan | Değer |
+| --- | --- |
+| Tür (`kind`) | `capacity` |
+| Fatura (`billing`) | `recurring` (tekrarlayan) |
+| Fiyat | ₺99,00 (`priceCents: 9900`) |
+| Açtığı (`grants`) | `limit.kdsScreens` **+1** |
+| Bağımlılık | — |
+
+### `kds_extra_station` — Ekstra KDS istasyonu
+
+Varsayılan mutfağın üstüne **bir adet** yönlendirme istasyonu (bar / ızgara / tatlı) ekler.
+
+| Alan | Değer |
+| --- | --- |
+| Tür | `capacity` |
+| Fatura | `recurring` |
+| Fiyat | ₺149,00 (`priceCents: 14900`) |
+| Açtığı | `limit.kdsStations` **+1** |
+| Bağımlılık | — |
+
+### `extra_tablet` — Ekstra garson tableti
+
+Garson-tablet koltuk (seat) limitinizi **bir** artırır.
+
+| Alan | Değer |
+| --- | --- |
+| Tür | `capacity` |
+| Fatura | `recurring` |
+| Fiyat | ₺79,00 (`priceCents: 7900`) |
+| Açtığı | `limit.tablets` **+1** |
+| Bağımlılık | — |
+
+### `extra_branch` — Ekstra şube
+
+Plan limitinizin ötesine **bir** şube ekler. Zincirler için gereklidir. Tek başına iki şey
+açar: hem şube limitini artırır hem de çoklu-lokasyon özelliğini etkinleştirir.
+
+| Alan | Değer |
+| --- | --- |
+| Tür | `capacity` |
+| Fatura | `recurring` |
+| Fiyat | ₺399,00 (`priceCents: 39900`) |
+| Açtığı | `limit.branches` **+1** **ve** `feature.multiLocation: true` |
+| Bağımlılık | — |
+
+<Callout type="info">
+  `extra_branch` tek satın almada hem **limit** (SUM) hem **feature** (OR) grant'i taşır:
+  `{ "limit.branches": 1, "feature.multiLocation": true }`.
+</Callout>
+
+---
+
+## Entegrasyonlar
+
+### `fiscal_efatura` — e-Fatura / e-Arşiv
+
+Vergi-uyumlu elektronik fatura kesmenizi sağlar (bulut tabanlı, donanım gerekmez).
+
+| Alan | Değer |
+| --- | --- |
+| Tür | `integration` |
+| Fatura | `recurring` |
+| Fiyat | ₺199,00 (`priceCents: 19900`) |
+| Açtığı | `integration.fiscal` listesine `efatura` eklenir |
+| Bağımlılık | — |
+
+### `fiscal_hugin` — Hugin yazarkasa entegrasyonu
+
+Local Bridge Agent üzerinden bir Hugin yazarkasa cihazını sürer.
+
+| Alan | Değer |
+| --- | --- |
+| Tür | `integration` |
+| Fatura | `recurring` |
+| Fiyat | ₺299,00 (`priceCents: 29900`) |
+| Açtığı | `integration.fiscal` listesine `hugin` eklenir |
+| Bağımlılık | **`plan:PRO`** — PRO planı gerekir |
+
+<Callout type="warning">
+  `fiscal_hugin`, kataloğdaki **tek** bağımlılığı olan add-on'dur. PRO planında değilseniz
+  satın alma `Add-on requires: plan:PRO` hatasıyla reddedilir.
+</Callout>
+
+### `delivery_yemeksepeti` — Yemeksepeti entegrasyonu
+
+Yemeksepeti siparişlerini doğrudan KDS'inize alır.
+
+| Alan | Değer |
+| --- | --- |
+| Tür | `integration` |
+| Fatura | `recurring` |
+| Fiyat | ₺249,00 (`priceCents: 24900`) |
+| Açtığı | `integration.delivery` listesine `yemeksepeti` eklenir |
+| Bağımlılık | — |
+
+### `delivery_getir` — Getir Yemek entegrasyonu
+
+Getir Yemek siparişlerini doğrudan KDS'inize alır.
+
+| Alan | Değer |
+| --- | --- |
+| Tür | `integration` |
+| Fatura | `recurring` |
+| Fiyat | ₺249,00 (`priceCents: 24900`) |
+| Açtığı | `integration.delivery` listesine `getir` eklenir |
+| Bağımlılık | — |
+
+### `delivery_trendyol_yemek` — Trendyol Yemek entegrasyonu
+
+Trendyol Yemek siparişlerini doğrudan KDS'inize alır.
+
+| Alan | Değer |
+| --- | --- |
+| Tür | `integration` |
+| Fatura | `recurring` |
+| Fiyat | ₺249,00 (`priceCents: 24900`) |
+| Açtığı | `integration.delivery` listesine `trendyol_yemek` eklenir |
+| Bağımlılık | — |
+
+<Callout type="info">
+  Üç teslimat entegrasyonu da `integration.delivery` anahtarına yazar ve **union** edilir.
+  Hepsini alırsanız hak setiniz `integration.delivery: ["getir", "trendyol_yemek", "yemeksepeti"]`
+  olur.
+</Callout>
+
+### `caller_id_integration` — Caller ID / telefon-sipariş entegrasyonu
+
+Her gelen çağrıda otomatik olarak bir müşteri kartı açar.
+
+| Alan | Değer |
+| --- | --- |
+| Tür | `integration` |
+| Fatura | `recurring` |
+| Fiyat | ₺149,00 (`priceCents: 14900`) |
+| Açtığı | `feature.callerIntegration: true` |
+| Bağımlılık | — |
+
+<Callout type="info">
+  Adı "integration" `kind`'inde olsa da grant'i bir **feature** flag'idir
+  (`feature.callerIntegration`), `integration.*` listesi değil.
+</Callout>
+
+---
+
+## Yazılım / özellikler
+
+### `advanced_reports` — Gelişmiş raporlar
+
+Kohort analizi, özel raporlar, zamanlanmış e-posta teslimi.
+
+| Alan | Değer |
+| --- | --- |
+| Tür | `software` |
+| Fatura | `recurring` |
+| Fiyat | ₺129,00 (`priceCents: 12900`) |
+| Açtığı | `feature.advancedReports: true` |
+| Bağımlılık | — |
+
+### `api_access` — API erişimi
+
+Entegrasyonlarınız için public API anahtarı + giden (outbound) webhook'lar.
+
+| Alan | Değer |
+| --- | --- |
+| Tür | `software` |
+| Fatura | `recurring` |
+| Fiyat | ₺249,00 (`priceCents: 24900`) |
+| Açtığı | `feature.apiAccess: true` |
+| Bağımlılık | — |
+
+---
+
+## Destek
+
+### `priority_support` — Öncelikli destek
+
+Kritik destek talepleri için 24 saatlik SLA. Mesai saatlerinde doğrudan hat.
+
+| Alan | Değer |
+| --- | --- |
+| Tür | `support` |
+| Fatura | `recurring` |
+| Fiyat | ₺199,00 (`priceCents: 19900`) |
+| Açtığı | `feature.prioritySupport: true` |
+| Bağımlılık | — |
+
+### `onsite_install_full` — Yerinde kurulum (tek seferlik)
+
+Bir HummyTummy teknisyeni mekânınıza gelir, bridge + cihazları kurar ve personelinizi eğitir.
+
+| Alan | Değer |
+| --- | --- |
+| Tür | `support` |
+| Fatura | **`oneTime` (tek seferlik)** |
+| Fiyat | ₺7.500,00 (`priceCents: 750000`) |
+| Açtığı | **Hiçbir şey** — `grants: {}` (sadece bir hizmet/fatura satırı) |
+| Bağımlılık | — |
+
+<Callout type="warning">
+  Bu kalem bir entitlement deltası vermez; ödenir ve faturalanır ama hak setinizi değiştirmez.
+  Tekrarlayan değil, **tek seferliktir** ve dönem sonu (`currentPeriodEnd`) penceresi de
+  almaz (`null`).
+</Callout>
+
+---
+
+## Nasıl satın alınır (örnek)
+
+Tüm add-on'lar aynı karma-sepet checkout hattından geçer. Örnek bir intent gövdesi:
+
+```json
+{
+  "cart": {
+    "items": [
+      { "type": "addon", "code": "kds_extra_screen", "qty": 1 },
+      { "type": "addon", "code": "fiscal_efatura", "qty": 1 }
+    ]
+  },
+  "buyer": {
+    "email": "owner@restoran.com",
+    "name": "Ali Veli",
+    "phone": "+905551112233",
+    "address": "..."
+  },
+  "returnUrl": "https://app.hummytummy.com/checkout/done"
+}
+```
+
+```bash
+curl -X POST https://api.hummytummy.com/api/v1/checkout/intent \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d @intent.json
+```
+
+Yanıt PayTR iframe token'ı + ödeme linki döner; ödeme onaylandığında webhook grant'ları
+yerleştirir. Adım adım anlatım: [Satın Alma Akışı](/tr/marketplace/satin-alma-akisi).

--- a/developer/pages/tr/plans/_meta.ts
+++ b/developer/pages/tr/plans/_meta.ts
@@ -1,3 +1,6 @@
 export default {
-  "index": "Genel Bakış"
-}
+  "index": "Genel Bakış",
+  "ozellik-matrisi": "Özellik matrisi",
+  "plan-secimi-ve-yukseltme": "Plan seçimi ve yükseltme",
+  "deneme-ve-faturalama": "Deneme ve faturalama",
+};

--- a/developer/pages/tr/plans/_meta.ts
+++ b/developer/pages/tr/plans/_meta.ts
@@ -1,0 +1,3 @@
+export default {
+  "index": "Genel Bakış"
+}

--- a/developer/pages/tr/plans/deneme-ve-faturalama.mdx
+++ b/developer/pages/tr/plans/deneme-ve-faturalama.mdx
@@ -1,0 +1,102 @@
+---
+title: Deneme ve faturalama
+description: 7 günlük deneme, TRIAL_ENDED kilidi, faturalama döngüsü ve KDV dahil fiyatlandırma.
+---
+
+import { Callout, Steps } from 'nextra/components'
+
+# Deneme ve faturalama
+
+## 7 günlük deneme (TRIAL)
+
+Her yeni işletme, kayıt anında otomatik olarak **Deneme (TRIAL)** paketine alınır:
+
+- **Süre:** 7 gün (`trialDays: 7`).
+- **Kapsam:** Kurumsal'ın tüm özellikleri ve **sınırsız** limitler (tüm limitler `-1`).
+- **Satılamaz:** `isPublic=false` olduğu için plan seçim ekranında görünmez. Deneme, herhangi bir ücretli pakete bağlı değildir — kayıt anında atanır.
+
+Deneme, eski tasarımdaki gibi BUSINESS paketi üzerinde değil, **ayrı bir onboarding paketi** olarak çalışır. Bu, denemenin bir paketin `trialDays` değerine bağlı kalmasını ve sessiz geçişleri engeller.
+
+## TRIAL_ENDED kilidi
+
+Deneme süresi **ücretli bir paket seçilmeden** dolarsa, işletme `TRIAL_ENDED` durumuna geçer ve **kilitlenir**. Bu, kademeli olarak FREE'ye düşürme yerine açık bir kilittir.
+
+<Steps>
+
+### Backend (varsayılan-reddet)
+Global `SubscriptionStatusGuard`, canlı bir abonelik (`ACTIVE` / `TRIALING` / `PAST_DUE`) olmayan her işletmenin **tenant kapsamlı tüm rotalarını** 403 ile reddeder. Yanıt:
+
+```json
+{
+  "statusCode": 403,
+  "error": "Plan Selection Required",
+  "errorCode": "PLAN_SELECTION_REQUIRED",
+  "message": "Deneme süreniz sona erdi. Devam etmek için bir plan seçin."
+}
+```
+
+### Kurtarma için izinli yollar
+Kilitli bir işletme yine de şu önekleri çağırabilir: `/auth`, `/me`, `/users/me`, `/profile`, `/subscriptions`, `/payments`, `/checkout`, `/legal`, `/entitlements`, `/webhooks`, `/health`. Yani plan kataloğunu okuyabilir ve ödeme yapabilir — başka hiçbir şey yapamaz.
+
+### Frontend yönlendirmesi
+SPA tarafındaki `SubscriptionGate`, `PLAN_SELECTION_REQUIRED` koduna karşılık kullanıcıyı plan seçim ekranına (`/choose-plan`) yönlendirir.
+
+</Steps>
+
+<Callout type="warning">
+  Kilit yalnızca `TRIAL_ENDED` için değildir: `EXPIRED` ve `CANCELLED` işletmeler de "canlı değil" sayılır ve aynı şekilde kilitlenir. `PAST_DUE` durumundaki bir abonelik 7 günlük ödemesiz dönem (grace) boyunca canlı kabul edilir.
+</Callout>
+
+## Faturalama döngüsü
+
+Faturalama döngüsü iki seçenektir (`BillingCycle`): **MONTHLY** (aylık) ve **YEARLY** (yıllık). Seçilen döngü, abonelik oluşturma, yükseltme ve düşürmede dönem uzunluğunu ve tahsil edilecek tutarı belirler. Yıllık ödeme, aylık tutarın 12 katından daha düşüktür (~%17 tasarruf).
+
+Faturalarınızı API'den okuyabilirsiniz:
+
+```bash
+# Tenant'ın tüm faturaları (sayfalı)
+curl "https://app.hummytummy.com/api/subscriptions/tenant/invoices?page=1&pageSize=20" \
+  -H "Authorization: Bearer <ADMIN_VEYA_MANAGER_TOKEN>"
+
+# Belirli bir aboneliğin faturaları
+curl "https://app.hummytummy.com/api/subscriptions/<SUB_ID>/invoices?page=1&pageSize=20" \
+  -H "Authorization: Bearer <ADMIN_VEYA_MANAGER_TOKEN>"
+```
+
+## KDV dahil fiyatlandırma
+
+İlan edilen tüm paket fiyatları **brüt** (KDV dahil) tutarlardır ve müşteriden tam olarak bu tutar tahsil edilir. Fatura kesilirken `BillingService`, brüt tutardan KDV'yi **geriye doğru** ayrıştırır:
+
+- Varsayılan KDV oranı **%20** (`DEFAULT_KDV_RATE = 0.2`). `KDV_RATE` ortam değişkeniyle (ör. `0.10`) override edilebilir.
+- Ayrıştırma yalnızca TRY faturalar için yapılır; net ve vergi şöyle türetilir:
+
+```text
+subtotal = total / (1 + oran)
+tax      = total - subtotal
+```
+
+Çıkarma yöntemi, yuvarlamadan bağımsız olarak `subtotal + tax == total` eşitliğini **kuruşuna kadar** garanti eder.
+
+**Örnek — Profesyonel aylık ₺1.299 (KDV %20):**
+
+| Kalem | Tutar |
+| --- | --- |
+| Ara toplam (net) | ₺1.082,50 |
+| KDV (%20) | ₺216,50 |
+| **Toplam (tahsil edilen)** | **₺1.299,00** |
+
+<Callout type="info">
+  Faturada işletmenin vergi numarası (`taxId`) **fatura kesim anındaki haliyle** anlık kaydedilir (snapshot). Sonradan değiştirilse bile geçmiş faturalar etkilenmez.
+</Callout>
+
+## İptal ve yeniden etkinleştirme
+
+- `POST /subscriptions/:id/cancel` — aboneliği iptal eder (yalnız ADMIN). Gövdede `immediate` (anında mı, dönem sonunda mı) ve en fazla 500 karakterlik `reason` gönderebilirsiniz.
+- `POST /subscriptions/:id/reactivate` — iptal edilmiş bir aboneliği yeniden etkinleştirir (yalnız ADMIN).
+
+```bash
+curl -X POST https://app.hummytummy.com/api/subscriptions/<SUB_ID>/cancel \
+  -H "Authorization: Bearer <ADMIN_TOKEN>" \
+  -H "Content-Type: application/json" \
+  -d '{ "immediate": false, "reason": "Sezon sonu kapanış" }'
+```

--- a/developer/pages/tr/plans/index.mdx
+++ b/developer/pages/tr/plans/index.mdx
@@ -1,7 +1,47 @@
 ---
 title: Planlar
+description: HummyTummy abonelik paketleri — fiyatlar, kapsam ve hangi paketin sizin için doğru olduğu.
 ---
+
+import { Callout, Cards } from 'nextra/components'
 
 # Planlar
 
-Bu bölüm hazırlanıyor.
+HummyTummy üç satılabilir paket sunar: **Başlangıç (BASIC)**, **Profesyonel (PRO)** ve **Kurumsal (BUSINESS)**. Her yeni işletme, kayıt anında **7 günlük tam özellikli Deneme (TRIAL)** ile başlar; deneme bittiğinde devam etmek için ücretli bir paket seçmek gerekir.
+
+Tüm fiyatlar **Türk Lirası (TRY)** cinsinden ve **KDV dahildir**.
+
+## Paketler ve fiyatlar
+
+| Paket | Aylık | Yıllık | Kime uygun |
+| --- | --- | --- | --- |
+| **Başlangıç** (BASIC) | **₺499/ay** | **₺4.490/yıl** | Kafe ve küçük restoranlar için temel POS + stok takibi |
+| **Profesyonel** (PRO) | **₺1.299/ay** | **₺12.990/yıl** | Rezervasyon + delivery + personel takibi gereken şehir merkezi restoranlar |
+| **Kurumsal** (BUSINESS) | **₺2.999/ay** | **₺29.990/yıl** | Çok şubeli zincirler — sınırsız + API erişimi + öncelikli destek |
+
+<Callout type="info">
+  Yıllık ödemede ~%17 tasarruf edersiniz: 12 aylık tutar yerine yıllık tutarı ödersiniz (ör. Başlangıç'ta 12 × ₺499 = ₺5.988 yerine ₺4.490).
+</Callout>
+
+## Her pakette ne var?
+
+Üç paketin de temel restoran işletmeciliği için ihtiyaç duyduğunuz çekirdek modülleri içerir:
+
+- **POS erişimi** (`posAccess`) — sipariş alma ve satış ekranı
+- **KDS entegrasyonu** (`kdsIntegration`) — mutfak ekranı
+- **Stok takibi** (`inventoryTracking`) — ürün ve malzeme stoğu
+
+Paketler yukarı çıktıkça gelişmiş raporlar, çok şube, rezervasyon, personel yönetimi, delivery entegrasyonu, özel marka, API erişimi gibi yetenekler açılır ve kullanım limitleri (kullanıcı, masa, şube, ürün, sipariş) yükselir.
+
+<Callout type="warning">
+  **Ücretsiz (FREE) paket kaldırılmıştır.** Eski tenant'lar için enum değeri yalnızca uyumluluk amacıyla durur; satışa açık değildir ve hiçbir yeni işletme bu pakete düşmez. Deneme süresi biten işletmeler `TRIAL_ENDED` durumuna geçer ve uygulama bir paket seçilene kadar kilitlenir — bkz. [Deneme ve faturalama](/tr/plans/deneme-ve-faturalama).
+</Callout>
+
+## Devam edin
+
+<Cards>
+  <Cards.Card title="Özellik matrisi" href="/tr/plans/ozellik-matrisi" />
+  <Cards.Card title="Plan seçimi ve yükseltme" href="/tr/plans/plan-secimi-ve-yukseltme" />
+  <Cards.Card title="Deneme ve faturalama" href="/tr/plans/deneme-ve-faturalama" />
+  <Cards.Card title="Marketplace eklentileri" href="/tr/marketplace" />
+</Cards>

--- a/developer/pages/tr/plans/index.mdx
+++ b/developer/pages/tr/plans/index.mdx
@@ -1,0 +1,7 @@
+---
+title: Planlar
+---
+
+# Planlar
+
+Bu bölüm hazırlanıyor.

--- a/developer/pages/tr/plans/ozellik-matrisi.mdx
+++ b/developer/pages/tr/plans/ozellik-matrisi.mdx
@@ -1,0 +1,63 @@
+---
+title: Özellik matrisi
+description: Başlangıç, Profesyonel ve Kurumsal paketlerinin tam özellik ve limit karşılaştırması.
+---
+
+import { Callout } from 'nextra/components'
+
+# Özellik matrisi
+
+Aşağıdaki tablolar üç satılabilir paketin (**Başlangıç / Profesyonel / Kurumsal**) tüm özellik bayraklarını ve kullanım limitlerini gösterir. Kaynak: `subscription-plans.const.ts`.
+
+## Özellikler
+
+| Özellik | Bayrak | Başlangıç | Profesyonel | Kurumsal |
+| --- | --- | :---: | :---: | :---: |
+| POS erişimi | `posAccess` | ✓ | ✓ | ✓ |
+| KDS (mutfak ekranı) entegrasyonu | `kdsIntegration` | ✓ | ✓ | ✓ |
+| Stok takibi | `inventoryTracking` | ✓ | ✓ | ✓ |
+| Gelişmiş raporlar | `advancedReports` | ✗ | ✓ | ✓ |
+| Çok şube | `multiLocation` | ✗ | ✓ | ✓ |
+| Özel marka (branding) | `customBranding` | ✗ | ✓ | ✓ |
+| Öncelikli destek | `prioritySupport` | ✗ | ✓ | ✓ |
+| Rezervasyon sistemi | `reservationSystem` | ✗ | ✓ | ✓ |
+| Personel yönetimi | `personnelManagement` | ✗ | ✓ | ✓ |
+| Delivery entegrasyonu | `deliveryIntegration` | ✗ | ✓ | ✓ |
+| API erişimi | `apiAccess` | ✗ | ✗ | ✓ |
+| Harici ekran (Partner Display) | `externalDisplay` | ✗ | ✗ | ✓ |
+
+<Callout type="info">
+  **API erişimi** ve **harici ekran (Partner Display API)** yalnızca Kurumsal pakette açıktır. Bu iki yetenek, üçüncü taraf entegrasyonlarını ve uzak/masaüstü ekran oturumlarını kapsar.
+</Callout>
+
+## Limitler
+
+`-1` değeri **sınırsız** anlamına gelir (`isUnlimited` yardımcısı `-1` ile karşılaştırır).
+
+| Limit | Alan | Başlangıç | Profesyonel | Kurumsal |
+| --- | --- | :---: | :---: | :---: |
+| Maksimum kullanıcı | `maxUsers` | 5 | 15 | ∞ |
+| Maksimum masa | `maxTables` | 20 | 50 | ∞ |
+| Maksimum şube | `maxBranches` | 1 | 3 | ∞ |
+| Maksimum ürün | `maxProducts` | 100 | 500 | ∞ |
+| Maksimum kategori | `maxCategories` | 20 | 50 | ∞ |
+| Aylık maksimum sipariş | `maxMonthlyOrders` | 500 | 2.000 | ∞ |
+
+## Deneme (TRIAL) paketi
+
+Her yeni işletmenin başladığı **Deneme** paketi 7 gün boyunca **Kurumsal'ın tüm özelliklerine ve sınırsız limitlerine** sahiptir. Satılamaz (`isPublic=false`), bu yüzden plan seçim ekranında listelenmez ve fiyatlandırma karşılaştırmasının dışındadır. Ayrıntılar için bkz. [Deneme ve faturalama](/tr/plans/deneme-ve-faturalama).
+
+<Callout type="warning">
+  Bir özellik bayrağı değiştiğinde **üç yerin de** senkron olması gerekir: Prisma şeması, projeksiyon kolonları (`FEATURE_COLUMNS`) ve `getEffectiveFeatures` fallback'i. Bu sayfadaki tablo bu kaynakların türetildiği `subscription-plans.const.ts` ile birebir eşleşir.
+</Callout>
+
+## Yetkili özelliklerin sorgulanması
+
+Bir işletmenin o an aktif (etkin) özelliklerini API üzerinden okuyabilirsiniz. Bu uç nokta paket özelliklerini, varsa marketplace eklenti yükseltmelerini ve superadmin override'larını birleştirir.
+
+```bash
+curl https://app.hummytummy.com/api/subscriptions/effective-features \
+  -H "Authorization: Bearer <ADMIN_VEYA_MANAGER_TOKEN>"
+```
+
+> Yanıt, `feature.*` ve `limit.*` projeksiyonlarına göre işletmenin gerçek erişimini döndürür — sadece paket varsayılanını değil.

--- a/developer/pages/tr/plans/plan-secimi-ve-yukseltme.mdx
+++ b/developer/pages/tr/plans/plan-secimi-ve-yukseltme.mdx
@@ -1,0 +1,152 @@
+---
+title: Plan seçimi ve yükseltme
+description: Paket seçme, yükseltme (proration), düşürme (dönem sonunda) ve ödeme akışları (PayTR / havale).
+---
+
+import { Callout, Steps, Tabs } from 'nextra/components'
+
+# Plan seçimi ve yükseltme
+
+Paket seçimi ve değişikliği iki ekran üzerinden yürür:
+
+- **Plan seçim ekranı** (`SubscriptionPlansPage`) — paketleri listeler, aylık/yıllık seçtirir.
+- **Plan değiştir ekranı** (`ChangePlanPage`) — canlı bir abonelik üzerinde yükseltme/düşürme yapar.
+
+Tüm fiyatlar **TRY** ve **KDV dahildir**. Yalnızca **ADMIN** ve **MANAGER** rolleri ödeme/checkout uçlarını çağırabilir; plan değişikliğini fiilen yazan uçlar **ADMIN**'e kısıtlıdır.
+
+## Satılabilir paketleri listeleme
+
+Plan kataloğu herkese açıktır (`@Public`) ve yalnızca **etkin + herkese açık** paketleri döndürür — yani Başlangıç / Profesyonel / Kurumsal. Deneme (`isPublic=false`) ve kaldırılan Ücretsiz (`isActive=false`) paketleri listede yer almaz.
+
+```bash
+curl https://app.hummytummy.com/api/subscriptions/plans
+```
+
+Yanıt; her paket için `id`, `name`, `displayName`, `monthlyPrice`, `yearlyPrice`, `currency`, `trialDays`, `limits`, `features` ve (varsa) aktif `discount` alanlarını içerir. İlan edilen indirimli fiyat, ücretlendirme raylarının kullandığı **aynı** `resolvePlanAmount` ile hesaplanır; yani gösterilen fiyat tahsil edilecek fiyata eşittir.
+
+## Seçim akışı: hangi yola gidilir?
+
+Plan seçim ekranı, işletmenin mevcut abonelik durumuna göre dallanır:
+
+<Steps>
+
+### Canlı abonelik (ACTIVE / TRIALING), farklı paket
+Kullanıcı **Plan değiştir** ekranına yönlendirilir. Yükseltme/düşürme proration mantığı yalnızca canlı bir faturalama döneminde anlamlıdır.
+
+```text
+/subscription/change-plan?newPlanId=<PLAN_ID>&billingCycle=MONTHLY
+```
+
+### Canlı abonelik, aynı paket
+İşlem yapılmaz (no-op).
+
+### PAST_DUE / EXPIRED / CANCELLED / abonelik yok
+Taze **checkout** akışına gidilir. Biten bir dönem üzerinde proration negatif tutar üreteceği için, bu durumlarda yeni tam dönemli bir abonelik başlatılır.
+
+```text
+/subscription/checkout?planId=<PLAN_ID>&billingCycle=MONTHLY
+```
+
+### Deneme hakkı olan işletme
+Backend, `/payments/create-intent` içinde TRIAL yanıtına kısa-devre yapar; checkout ekranı bunu özel olarak ele alır.
+
+</Steps>
+
+## Yükseltme (proration ile)
+
+Canlı bir abonelikte daha pahalı bir pakete geçiş **yükseltme** sayılır. `POST /subscriptions/:id/change-plan`, dönemin kalan günlerine göre **oransal (proration) bir teklif** döndürür — bu çağrı bir mutasyon yazmaz, sadece tahsil edilecek tutarı hesaplar.
+
+<Tabs items={['Akış', 'curl', 'Yanıt']}>
+<Tabs.Tab>
+
+1. Kullanıcı yeni (daha pahalı) paketi seçer.
+2. Backend `requiresPayment` ve `prorationAmount` ile bir `upgrade` teklifi döndürür.
+3. Ödeme PayTR (veya havale) rayından toplanır; ardından yükseltme uygulanır.
+
+</Tabs.Tab>
+<Tabs.Tab>
+
+```bash
+curl -X POST https://app.hummytummy.com/api/subscriptions/<SUB_ID>/change-plan \
+  -H "Authorization: Bearer <ADMIN_TOKEN>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "newPlanId": "<YENI_PLAN_ID>",
+    "billingCycle": "MONTHLY"
+  }'
+```
+
+</Tabs.Tab>
+<Tabs.Tab>
+
+```json
+{
+  "type": "upgrade",
+  "requiresPayment": true,
+  "paymentInfo": {
+    "subscriptionId": "sub_...",
+    "newPlanId": "plan_...",
+    "billingCycle": "MONTHLY",
+    "prorationAmount": 533.42,
+    "newAmount": 1299,
+    "currency": "TRY"
+  }
+}
+```
+
+</Tabs.Tab>
+</Tabs>
+
+<Callout type="info">
+  Proration; `currentPeriodEnd`'e kalan gün sayısı ile toplam dönem günü oranı üzerinden hesaplanır. `prorationAmount` 0'dan büyükse `requiresPayment: true` döner ve yükseltme ancak ödeme alındıktan sonra uygulanır.
+</Callout>
+
+## Düşürme (dönem sonunda uygulanır)
+
+Daha ucuz bir pakete geçiş **düşürme** sayılır ve **anında uygulanmaz** — mevcut faturalama döneminin sonuna **planlanır**. Aynı çağrı şu davranışları sergiler:
+
+- Önce mevcut kullanım, hedef paketin limitlerine karşı doğrulanır (`assertDowngradeAllowed`). Örneğin 4 şubeniz varsa 1 şubelik Başlangıç'a düşemezsiniz.
+- Geçiş, `scheduledDowngradePlanId` olarak işaretlenir; yarış koşullarına karşı bileşik `WHERE ... scheduledDowngradePlanId IS NULL` ile atomik olarak yazılır.
+- Yanıt `type: "downgrade"`, `requiresPayment: false` ve `scheduledFor` (dönem sonu tarihi) içerir.
+
+```bash
+# Planlanmış düşürmeyi sorgula
+curl https://app.hummytummy.com/api/subscriptions/<SUB_ID>/scheduled-downgrade \
+  -H "Authorization: Bearer <ADMIN_VEYA_MANAGER_TOKEN>"
+
+# Planlanmış düşürmeyi iptal et (yalnız ADMIN)
+curl -X DELETE https://app.hummytummy.com/api/subscriptions/<SUB_ID>/scheduled-downgrade \
+  -H "Authorization: Bearer <ADMIN_TOKEN>"
+```
+
+<Callout type="warning">
+  Zaten planlanmış bir plan değişikliği varken yeni bir değişiklik denerseniz istek reddedilir ("önce mevcut değişikliği iptal edin"). Para birimi değiştiren plan geçişleri de desteklenmez (sistem TRY-only çalışır).
+</Callout>
+
+## Ödeme rayları: PayTR ve havale
+
+Yeni bir abonelik veya yükseltme ödemesi iki raydan toplanabilir:
+
+- **PayTR (kart)** — varsayılan. PayTR yalnızca **TRY** tahsil eder. `POST /payments/create-intent` bir PENDING ödeme oluşturur, webhook ile onaylanınca abonelik aktifleşir. Dakikada en fazla 5 deneme (`@Throttle`).
+- **Havale / EFT (manuel banka transferi)** — alternatif yöntem. `GET /payments/bank-transfer/details` platform banka bilgilerini, `POST /payments/bank-transfer/intent` ise bir havale ödemesi rezervasyonu oluşturur. Havale ödemesini **superadmin onayı aktifleştirir** (webhook değil). Superadmin IBAN tanımlamadıysa havale ekranı kapalı gelir.
+
+```bash
+# Kart (PayTR) ile abonelik ödemesi başlat
+curl -X POST https://app.hummytummy.com/api/payments/create-intent \
+  -H "Authorization: Bearer <ADMIN_TOKEN>" \
+  -H "Content-Type: application/json" \
+  -d '{ "planId": "<PLAN_ID>", "billingCycle": "YEARLY" }'
+```
+
+<Callout type="info">
+  Marketplace eklenti satın alımları **aynı PayTR checkout rayını** (`POST /api/v1/checkout/intent` → `CK-` önekli webhook → `confirmAndProvision`) kullanır. Eklentiler ancak ödeme alındıktan sonra etkinleşir. Bkz. [Marketplace](/tr/marketplace).
+</Callout>
+
+## Sonradan özellik edinme
+
+Bir özelliğe sonradan ihtiyaç duyduğunuzda iki yol vardır:
+
+1. **Plan yükseltme** — daha üst pakete geçerek tüm özellik setini ve daha yüksek limitleri açın (bu sayfadaki yükseltme akışı).
+2. **Marketplace eklentisi** — tek bir yeteneği paket değiştirmeden ekleyin. Bkz. [Marketplace](/tr/marketplace).
+
+> Superadmin override (manuel özellik açma) yalnızca dahili bir işlemdir; müşteriye açık bir akış değildir.

--- a/developer/pages/tr/reference/_meta.ts
+++ b/developer/pages/tr/reference/_meta.ts
@@ -1,3 +1,7 @@
 export default {
-  "index": "Genel Bakış"
+  "index": "Genel Bakış",
+  "hata-kodlari": "Hata Kodları",
+  "partner-scopes": "Partner Scope'ları",
+  "plan-matrisi": "Plan Matrisi",
+  "sozluk": "Sözlük"
 }

--- a/developer/pages/tr/reference/_meta.ts
+++ b/developer/pages/tr/reference/_meta.ts
@@ -1,0 +1,3 @@
+export default {
+  "index": "Genel Bakış"
+}

--- a/developer/pages/tr/reference/hata-kodlari.mdx
+++ b/developer/pages/tr/reference/hata-kodlari.mdx
@@ -1,0 +1,198 @@
+---
+title: Hata Kodları
+description: Standart hata zarfı, makine-okunur errorCode değerleri ve Prisma veritabanı hatalarının HTTP durum kodlarına eşlenmesi.
+---
+
+import { Callout, Tabs } from 'nextra/components'
+
+# Hata Kodları
+
+HummyTummy API'sindeki tüm hatalar tek bir standart **hata zarfı** ile döner.
+İstemci tarafında metin mesajına göre değil, kararlı `errorCode` alanına göre
+dallanmanız önerilir.
+
+## Hata zarfı
+
+Her hata yanıtı aşağıdaki yapıyı izler:
+
+```json
+{
+  "statusCode": 409,
+  "message": "A record with this email already exists",
+  "error": "UniqueConstraintViolation",
+  "errorCode": "RESOURCE_ALREADY_EXISTS",
+  "timestamp": "2026-06-23T08:14:05.123Z",
+  "path": "/api/v1/auth/register",
+  "requestId": "1750665245123-a1b2c3d4e"
+}
+```
+
+| Alan | Tip | Açıklama |
+| --- | --- | --- |
+| `statusCode` | `number` | HTTP durum kodu. |
+| `message` | `string \| string[]` | Kullanıcıya gösterilebilir mesaj. Doğrulama hatalarında bir dizi olabilir. |
+| `error` | `string` | İnsan/kategori etiketi (bazen yerelleştirilmiş ya da class-validator'ın `"Bad Request"` değeri). **Buna göre dallanmayın.** |
+| `errorCode` | `string?` | Kararlı, makine-okunur kod. **İstemci yalnızca buna göre dallanmalıdır.** Yalnızca fırlatılan istisna bir kod iliştirdiğinde bulunur. |
+| `timestamp` | `string` | İstek zaman damgası (ISO 8601). |
+| `path` | `string` | İstek yolu. |
+| `requestId` | `string?` | İzleme için istek kimliği — destek talebinde paylaşın. |
+| `details` | `any?` | Yalnızca `development` ortamında bulunur. |
+| `stack` | `string?` | Yalnızca `development` ortamında bulunur. |
+
+<Callout type="info">
+  `errorCode` **PII içermez** ve bu nedenle her ortamda (production dahil)
+  döner. `details` ve `stack` ise yalnızca `development` ortamında yer alır.
+</Callout>
+
+<Callout type="warning">
+  `error` alanı yerelleştirilebilir veya çerçevenin ürettiği bir etikete
+  düşebilir. Davranışsal dallanmayı **her zaman** `errorCode` üzerinden yapın;
+  `errorCode` yoksa `statusCode`'a düşün.
+</Callout>
+
+## errorCode değerleri
+
+Aşağıdaki kodlar `ErrorCode` enum'ından gelir ve iş mantığı istisnalarıyla
+(`BusinessException`) iliştirilir.
+
+### Kimlik doğrulama
+
+| `errorCode` | Anlamı |
+| --- | --- |
+| `INVALID_CREDENTIALS` | E-posta veya parola hatalı. |
+| `TOKEN_EXPIRED` | Token'ın süresi doldu. |
+| `TOKEN_INVALID` | Token geçersiz/bozuk. |
+| `UNAUTHORIZED` | Kimlik doğrulama gerekli. |
+
+### Yetkilendirme
+
+| `errorCode` | Anlamı |
+| --- | --- |
+| `FORBIDDEN` | Erişim reddedildi. |
+| `INSUFFICIENT_PERMISSIONS` | Rol/izin bu işlem için yetersiz. |
+
+### Kaynak
+
+| `errorCode` | Anlamı |
+| --- | --- |
+| `RESOURCE_NOT_FOUND` | İstenen kayıt yok. |
+| `RESOURCE_ALREADY_EXISTS` | Aynı kayıt zaten var (ör. yinelenen e-posta). |
+| `RESOURCE_CONFLICT` | Kaynağın mevcut durumuyla çakışma. |
+
+### Doğrulama
+
+| `errorCode` | Anlamı |
+| --- | --- |
+| `VALIDATION_ERROR` | Genel girdi doğrulaması başarısız. |
+| `INVALID_INPUT` | Girdi değeri geçersiz. |
+| `MISSING_REQUIRED_FIELD` | Zorunlu alan eksik. |
+
+### İş mantığı
+
+| `errorCode` | Anlamı |
+| --- | --- |
+| `INSUFFICIENT_STOCK` | Ürün için yeterli stok yok. `details`: `{ productName, available, requested }`. |
+| `ORDER_ALREADY_PAID` | Sipariş zaten ödenmiş. |
+| `TABLE_OCCUPIED` | Masa dolu. |
+| `INVALID_ORDER_STATUS` | İşlem siparişin mevcut durumunda yapılamaz. |
+| `SUBSCRIPTION_REQUIRED` | Etkin abonelik gerekir (HTTP 402). |
+| `FEATURE_NOT_AVAILABLE` | Özellik mevcut planda yok; üst plan gerekir (HTTP 402). |
+| `QUOTA_EXCEEDED` | Plan limiti aşıldı (HTTP 402). |
+
+### Ödeme
+
+| `errorCode` | Anlamı |
+| --- | --- |
+| `PAYMENT_FAILED` | Ödeme başarısız oldu. |
+| `PAYMENT_PROCESSING_ERROR` | Ödeme işlenirken hata. |
+| `INVALID_PAYMENT_METHOD` | Geçersiz ödeme yöntemi. |
+
+### Sistem
+
+| `errorCode` | Anlamı |
+| --- | --- |
+| `INTERNAL_SERVER_ERROR` | Beklenmeyen sunucu hatası. |
+| `SERVICE_UNAVAILABLE` | Servis geçici olarak kullanılamıyor. |
+| `DATABASE_ERROR` | Veritabanı hatası. |
+| `EXTERNAL_SERVICE_ERROR` | Dış servis hatası (ör. ödeme sağlayıcı). |
+
+### Hız sınırı
+
+| `errorCode` | Anlamı |
+| --- | --- |
+| `TOO_MANY_REQUESTS` | Çok fazla istek (HTTP 429). |
+
+### Tenant
+
+| `errorCode` | Anlamı |
+| --- | --- |
+| `TENANT_NOT_FOUND` | Tenant bulunamadı. |
+| `INVALID_TENANT` | Geçersiz tenant. |
+
+## Veritabanı hatalarının HTTP eşlemesi
+
+Prisma'nın bilinen veritabanı hataları (`PrismaClientKnownRequestError`) global
+istisna filtresinde anlamlı HTTP durum kodlarına çevrilir. Bu yanıtlarda
+`error` alanı kategori etiketini taşır; `errorCode` bu durumlarda **bulunmaz**
+(bunlar `BusinessException` değildir).
+
+| Prisma kodu | HTTP | `error` | Anlamı |
+| --- | --- | --- | --- |
+| `P2002` | `409 Conflict` | `UniqueConstraintViolation` | Tekil kısıt ihlali (yinelenen kayıt). |
+| `P2025` | `404 Not Found` | `RecordNotFound` | Kayıt bulunamadı. |
+| `P2003` | `400 Bad Request` | `ForeignKeyConstraintViolation` | İlişkili kayıt yok veya bağımlılık nedeniyle silinemiyor. |
+| `P2014` | `400 Bad Request` | `RequiredRelationViolation` | Değişiklik zorunlu bir ilişkiyi ihlal ederdi. |
+| `P2016` | `400 Bad Request` | `InvalidQuery` | Geçersiz sorgu parametreleri. |
+| `P2021` | `500 Internal Server Error` | `DatabaseConfigError` | Tablo yok (yapılandırma hatası). |
+| `P2024` | `503 Service Unavailable` | `DatabaseTimeout` | Veritabanı bağlantı zaman aşımı. |
+| `P2034` | `409 Conflict` | `ConcurrentUpdate` | Serileştirilebilir işlem çakışması (Postgres `40001`). İşlem **commit olmadı**, güvenle yeniden denenebilir. |
+| `P2000`, `P2020` | `400 Bad Request` | `ValueOutOfRange` | Değer izin verilen aralık dışı veya çok uzun. |
+| (diğer) | `500 Internal Server Error` | `DatabaseError` | Eşlenmemiş veritabanı hatası. |
+
+<Callout type="info">
+  `P2034` (`ConcurrentUpdate`, 409) ödeme uzlaştırma, marketplace satın alma
+  gibi yarış durumu altındaki Serializable işlemlerin beklenen "kaybeden"
+  sonucudur ve isteğiniz hiç işlenmemiştir. Bu yanıtı alırsanız isteği aynen
+  yeniden gönderebilirsiniz.
+</Callout>
+
+## İstemci tarafında işleme
+
+<Tabs items={['Pseudo-kod', 'curl']}>
+  <Tabs.Tab>
+```ts
+const res = await fetch('/api/v1/display/orders', { method: 'POST', /* … */ });
+if (!res.ok) {
+  const err = await res.json(); // ErrorResponse
+  switch (err.errorCode) {
+    case 'QUOTA_EXCEEDED':
+    case 'FEATURE_NOT_AVAILABLE':
+    case 'SUBSCRIPTION_REQUIRED':
+      // Kullanıcıyı plan yükseltmeye yönlendir (HTTP 402)
+      break;
+    case undefined:
+      // errorCode yok → statusCode'a göre dallan (ör. 409 ConcurrentUpdate → retry)
+      break;
+    default:
+      showToast(err.message);
+  }
+}
+```
+  </Tabs.Tab>
+  <Tabs.Tab>
+```bash
+curl -i -X POST https://api.hummytummy.com/api/v1/display/orders \
+  -H "Authorization: Bearer <SCREEN_TOKEN>" \
+  -H "Content-Type: application/json" \
+  -d '{ "items": [], "type": "DINE_IN" }'
+
+# HTTP/1.1 409 Conflict
+# {
+#   "statusCode": 409,
+#   "error": "ConcurrentUpdate",
+#   "message": "Concurrent update conflict — please retry. Your request did not take effect.",
+#   ...
+# }
+```
+  </Tabs.Tab>
+</Tabs>

--- a/developer/pages/tr/reference/index.mdx
+++ b/developer/pages/tr/reference/index.mdx
@@ -1,0 +1,7 @@
+---
+title: Referans
+---
+
+# Referans
+
+Bu bölüm hazırlanıyor.

--- a/developer/pages/tr/reference/index.mdx
+++ b/developer/pages/tr/reference/index.mdx
@@ -1,7 +1,38 @@
 ---
 title: Referans
+description: HummyTummy API'sini entegre ederken sık başvuracağınız hata kodları, partner scope'ları, plan matrisi ve terim sözlüğü.
 ---
+
+import { Cards, Callout } from 'nextra/components'
 
 # Referans
 
-Bu bölüm hazırlanıyor.
+Bu bölüm, HummyTummy API'sine entegre olurken sürekli geri döneceğiniz
+sabit referans tablolarını bir araya getirir: standart hata zarfı ve
+makine-okunur hata kodları, partner ekran token'larının taşıdığı scope'lar,
+özellik × plan matrisi ve sistemde geçen terimlerin sözlüğü.
+
+<Callout type="info">
+  Tüm REST uç noktaları global `/api` ön ekiyle servis edilir
+  (örn. `POST /api/v1/display/orders`). Para birimi her zaman **TRY**'dir.
+</Callout>
+
+## Sayfalar
+
+<Cards>
+  <Cards.Card title="Hata Kodları" href="/tr/reference/hata-kodlari" arrow>
+    Standart hata zarfı, `errorCode` alanı ve Prisma → HTTP eşlemeleri
+    (P2002 → 409, P2025 → 404 …).
+  </Cards.Card>
+  <Cards.Card title="Partner Scope'ları" href="/tr/reference/partner-scopes" arrow>
+    Partner API anahtarının ve ekran token'larının taşıyabileceği 6 scope
+    ve her birinin hangi `/display` uç noktasını açtığı.
+  </Cards.Card>
+  <Cards.Card title="Plan Matrisi" href="/tr/reference/plan-matrisi" arrow>
+    Özellik × plan tablosu ve plan limitleri (kullanıcı, şube, ürün …).
+  </Cards.Card>
+  <Cards.Card title="Sözlük" href="/tr/reference/sozluk" arrow>
+    Tenant, Branch, KDS, Self-pay, Scope, Outbox, Entitlement gibi
+    terimlerin tanımları.
+  </Cards.Card>
+</Cards>

--- a/developer/pages/tr/reference/partner-scopes.mdx
+++ b/developer/pages/tr/reference/partner-scopes.mdx
@@ -1,0 +1,53 @@
+---
+title: Partner Scope'ları
+description: Partner API anahtarının ve ekran token'larının taşıyabileceği 6 scope ve her birinin açtığı /display uç noktası.
+---
+
+import { Callout } from 'nextra/components'
+
+# Partner Scope'ları
+
+Bir **Partner API anahtarı** ve onun ürettiği **ekran token'ları**
+(screen session), neyi yapabileceklerini belirleyen scope'lar taşır.
+Toplam 6 scope vardır. Her `/display` uç noktası `@RequireScope` ile tek bir
+scope ister ve `ScreenScopeGuard` bunu token'ın taşıdığı scope'lara karşı
+doğrular.
+
+<Callout type="info">
+  Bir ekran token'ının efektif scope'ları **her zaman** üst API anahtarının
+  scope'larının bir alt kümesidir. Anahtarın taşımadığı bir scope token'a
+  verilemez.
+</Callout>
+
+## Scope listesi
+
+| Scope | Ne sağlar | Uç nokta(lar) |
+| --- | --- | --- |
+| `menu:read` | Ekranın tenant'ına (ve varsa masasına) ait genel menüyü okuma. | `GET /api/v1/display/menu` |
+| `orders:read` | Ekranın sipariş oturumunun verdiği siparişleri okuma. | `GET /api/v1/display/orders` |
+| `orders:write` | Ekrandan sipariş oluşturma. | `POST /api/v1/display/orders` |
+| `requests:write` | Garson çağırma ve hesap isteme. | `POST /api/v1/display/waiter-requests`, `POST /api/v1/display/bill-requests` |
+| `payments:write` | Self-pay: ödenebilir kalemler, PayTR hosted-iframe ödeme niyeti ve durum sorgulama. | `GET /api/v1/display/payable-items`, `POST /api/v1/display/pay-intent`, `GET /api/v1/display/pay-status` |
+| `realtime:subscribe` | Gerçek zamanlı WebSocket akışına abone olma (sipariş/durum güncellemeleri). | KDS gerçek zamanlı gateway (WebSocket) |
+
+<Callout type="warning">
+  Bir uç noktayı gerekli scope olmadan çağırırsanız `ScreenScopeGuard`
+  isteği **403 Forbidden** ile reddeder. WebSocket bağlantısı için
+  `realtime:subscribe` yoksa oturum bağlanma anında reddedilir.
+</Callout>
+
+## En az ayrıcalık ilkesi
+
+Her ekran/cihaz için yalnızca ihtiyaç duyduğu scope'ları verin:
+
+- **Yalnızca menü gösteren tablet** → `menu:read`
+- **Sipariş + garson çağrısı** → `menu:read`, `orders:write`, `orders:read`, `requests:write`
+- **Masada self-pay** → yukarıdakiler + `payments:write`
+- **Canlı durum güncellemeleri** → ek olarak `realtime:subscribe`
+
+<Callout type="info">
+  `payments:write` üç uç noktayı birden açar: ödenebilir kalemlerin
+  listelenmesi, ödeme niyeti oluşturma ve niyet durumunu sorgulama. Ödeme
+  niyetinin geri dönüş origin'i istemciden değil, anahtarın
+  `allowedReturnOrigins` allowlist'inden alınır.
+</Callout>

--- a/developer/pages/tr/reference/plan-matrisi.mdx
+++ b/developer/pages/tr/reference/plan-matrisi.mdx
@@ -1,0 +1,76 @@
+---
+title: Plan Matrisi
+description: Özellik × plan tablosu, plan limitleri ve fiyatlar (TRY). Onboarding TRIAL planı ve Başlangıç / Profesyonel / Kurumsal tierleri.
+---
+
+import { Callout } from 'nextra/components'
+
+# Plan Matrisi
+
+Bu sayfa, planların hangi özellikleri ve limitleri taşıdığının kompakt bir
+özetidir. Plan ayrıntıları, fiyat değişiklikleri ve satın alma akışı için
+[Planlar](/tr/plans) bölümüne bakın.
+
+<Callout type="info">
+  Yeni tenant'lar 7 günlük tam özellikli **TRIAL** (Deneme) planında başlar.
+  Deneme bittiğinde tenant **TRIAL_ENDED** durumuna geçer ve uygulama plan
+  seçim + ödeme akışına kilitlenir — devam etmek için bir ücretli plan
+  seçilmelidir. Eski **FREE** planı kullanımdan kaldırıldı (yalnızca enum
+  tombstone'u olarak duruyor; hiçbir tenant FREE'ye düşmez).
+</Callout>
+
+## Fiyatlar
+
+Tüm fiyatlar **TRY** ve **KDV dahil** (ilan edilen brüt) tutarlardır.
+Faturalandırmada KDV ayrıştırması geriye dönük hesaplanır.
+
+| Plan | `name` | Aylık | Yıllık | Deneme |
+| --- | --- | --- | --- | --- |
+| Deneme | `TRIAL` | ₺0 | ₺0 | 7 gün |
+| Başlangıç | `BASIC` | ₺499 | ₺4.490 | 14 gün |
+| Profesyonel | `PRO` | ₺1.299 | ₺12.990 | 14 gün |
+| Kurumsal | `BUSINESS` | ₺2.999 | ₺29.990 | 14 gün |
+
+## Limitler
+
+`-1` = sınırsız.
+
+| Limit | TRIAL | BASIC | PRO | BUSINESS |
+| --- | --- | --- | --- | --- |
+| `maxUsers` | ∞ | 5 | 15 | ∞ |
+| `maxBranches` | ∞ | 1 | 3 | ∞ |
+| `maxTables` | ∞ | 20 | 50 | ∞ |
+| `maxProducts` | ∞ | 100 | 500 | ∞ |
+| `maxCategories` | ∞ | 20 | 50 | ∞ |
+| `maxMonthlyOrders` | ∞ | 500 | 2.000 | ∞ |
+
+## Özellik × plan
+
+| Özellik (`flag`) | TRIAL | BASIC | PRO | BUSINESS |
+| --- | --- | --- | --- | --- |
+| POS erişimi (`posAccess`) | ✅ | ✅ | ✅ | ✅ |
+| KDS entegrasyonu (`kdsIntegration`) | ✅ | ✅ | ✅ | ✅ |
+| Stok takibi (`inventoryTracking`) | ✅ | ✅ | ✅ | ✅ |
+| Gelişmiş raporlar (`advancedReports`) | ✅ | ❌ | ✅ | ✅ |
+| Çoklu lokasyon (`multiLocation`) | ✅ | ❌ | ✅ | ✅ |
+| Özel marka (`customBranding`) | ✅ | ❌ | ✅ | ✅ |
+| Rezervasyon sistemi (`reservationSystem`) | ✅ | ❌ | ✅ | ✅ |
+| Personel yönetimi (`personnelManagement`) | ✅ | ❌ | ✅ | ✅ |
+| Delivery entegrasyonu (`deliveryIntegration`) | ✅ | ❌ | ✅ | ✅ |
+| Öncelikli destek (`prioritySupport`) | ✅ | ❌ | ✅ | ✅ |
+| API erişimi (`apiAccess`) | ✅ | ❌ | ❌ | ✅ |
+| Harici ekran / Partner Display (`externalDisplay`) | ✅ | ❌ | ❌ | ✅ |
+
+<Callout type="warning">
+  **Partner Display API** (harici ekran, üçüncü taraf tabletler) `externalDisplay`
+  özelliğine bağlıdır ve yalnızca **BUSINESS** planda (ve onboarding TRIAL'ında)
+  açıktır. Bu özellik partner API anahtarı verilmesini ve ekran token'ı
+  üretimini kapısında tutar. Aynı şekilde `apiAccess` da yalnızca BUSINESS'ta
+  vardır.
+</Callout>
+
+<Callout type="info">
+  TRIAL planı 7 gün boyunca **tüm** premium özellikleri ve sınırsız limitleri
+  açar; amacı tenant'ın ürünü tam olarak değerlendirebilmesidir. Bu, kalıcı bir
+  tier değildir — süresi dolunca ücretli bir plan seçilmelidir.
+</Callout>

--- a/developer/pages/tr/reference/sozluk.mdx
+++ b/developer/pages/tr/reference/sozluk.mdx
@@ -1,0 +1,72 @@
+---
+title: Sözlük
+description: HummyTummy sisteminde geçen temel terimlerin tanımları — Tenant, Branch, Rol, KDS, POS, QR menü, Self-pay, Scope, Screen token, Webhook, Outbox, Entitlement, Add-on.
+---
+
+# Sözlük
+
+HummyTummy API'sinde ve dokümantasyonda sık geçen terimlerin kısa tanımları.
+
+### Tenant
+Bir restoran işletmesini (müşteri hesabı) temsil eden en üst düzey kiracı.
+Aboneliğin, planın ve tüm verinin sahibidir. Tenant çözümlemesi host adına
+göre değil, JWT içindeki `tenantId` üzerinden yapılır.
+
+### Branch (Şube)
+Bir tenant'a ait fiziksel konum/şube. Masalar, siparişler, stok ve çoğu
+operasyonel veri şubeye bağlıdır. Şubeye-özel uç noktalar `X-Branch-Id`
+başlığını gerektirir.
+
+### Rol
+Bir kullanıcının yetki düzeyi. Roller: `ADMIN`, `MANAGER`, `WAITER`,
+`KITCHEN`, `COURIER`. `WAITER`, `KITCHEN` ve `COURIER` "sert kısıtlı"
+rollerdir — tek bir şubeye sabitlenirler (`primaryBranchId` zorunludur) ve
+başka bir şubeyi hedefleyemezler.
+
+### KDS (Kitchen Display System)
+Mutfak ekran sistemi. Gelen siparişleri mutfak/hazırlık istasyonlarına gerçek
+zamanlı yansıtan ekran. `kdsIntegration` özelliğine bağlıdır.
+
+### POS (Point of Sale)
+Satış noktası — sipariş alma, ödeme ve masa yönetiminin yapıldığı kasa
+arayüzü. `posAccess` özelliğine bağlıdır.
+
+### QR menü
+Müşterinin masadaki QR kodu okutarak eriştiği genel menü ve sipariş arayüzü.
+Bir QR oturumu (ordering session) üzerinden sipariş ve self-pay akışlarını
+besler.
+
+### Self-pay
+Müşterinin garson aracılığı olmadan, kendi cihazından (veya masa ekranından)
+hesabını ödemesi. PayTR hosted-iframe ödeme niyeti oluşturularak yürütülür;
+`payments:write` scope'u gerektirir.
+
+### Scope
+Bir partner API anahtarının ve ekran token'ının taşıdığı izin birimi
+(ör. `menu:read`, `orders:write`). Her `/display` uç noktası belirli bir scope
+ister. Bkz. [Partner Scope'ları](/tr/reference/partner-scopes).
+
+### Screen token (Ekran token'ı)
+Bir partner API anahtarından üretilen, belirli bir ekran/cihaz oturumuna
+(screen session) bağlı erişim token'ı. Bir tenant'a, isteğe bağlı bir masaya
+ve bir şubeye bağlıdır; efektif scope'ları üst anahtarın bir alt kümesidir.
+
+### Webhook
+Sunucudan dışa doğru gönderilen olay bildirimi. Örneğin PayTR ödeme
+sağlayıcısının ödeme sonucunu bildirdiği geri-çağrı; ödeme yalnızca webhook
+onayından sonra provizyonlanır (`confirmAndProvision`).
+
+### Outbox
+Veritabanı işlemiyle aynı transaction içinde yazılan, ardından güvenilir
+biçimde yayımlanan olay kaydı deseni. Yan etkilerin (olay yayını) ana veriyle
+atomik olmasını ve "en az bir kez" teslimi sağlar.
+
+### Entitlement (Hak)
+Bir tenant'ın aktif planından (ve add-on'larından) türetilen efektif özellik
+ve limit kümesi. Plan değiştiğinde yeniden hesaplanır (re-projeksiyon) ve
+özellik kapıları (`PlanFeatureGuard`) bu hesaba bakar.
+
+### Add-on (Eklenti)
+Plana eklenen, ayrı satın alınan ek özellik veya kapasite. Marketplace
+üzerinden PayTR ödeme rayı ile satın alınır ve ödeme onaylandıktan sonra
+entitlement'a eklenir.

--- a/developer/public/robots.txt
+++ b/developer/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://developer.hummytummy.com/sitemap.xml

--- a/developer/styles/globals.css
+++ b/developer/styles/globals.css
@@ -1,0 +1,33 @@
+/* HummyTummy docs brand layer — warm/orange, consistent with the landing +
+   pricing pages. Applied on top of nextra-theme-docs defaults. */
+
+:root {
+  --ht-cream: #faf6f0;
+  --ht-ink: #1c1917;
+  --ht-orange: #f97316;
+}
+
+/* Display font for headings (Fraunces loaded via theme.config head link). */
+.nextra-content h1,
+.nextra-content h2,
+.nextra-content h3,
+article h1,
+article h2 {
+  font-family: 'Fraunces', Georgia, serif !important;
+  letter-spacing: -0.01em;
+}
+
+/* Warm page tint in light mode. */
+html:not(.dark) body {
+  background-color: var(--ht-cream);
+}
+
+/* Brand the hero/first heading on the landing page. */
+.nextra-content h1 {
+  color: var(--ht-ink);
+}
+
+/* Slightly warmer cards/callouts. */
+html:not(.dark) .nextra-card {
+  background-color: #fffdfa;
+}

--- a/developer/theme.config.tsx
+++ b/developer/theme.config.tsx
@@ -25,12 +25,42 @@ const Logo = () => (
   </span>
 )
 
+// "Go to app" navbar CTA — replaces nextra-theme-docs' default GitHub project
+// icon (we don't expose the private repo on a public portal). Label follows the
+// active locale.
+const AppLink = () => {
+  const { locale } = useRouter()
+  return (
+    <a
+      href="https://hummytummy.com"
+      target="_blank"
+      rel="noreferrer"
+      style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: 6,
+        padding: '6px 12px',
+        borderRadius: 8,
+        background: '#f97316',
+        color: '#fff',
+        fontWeight: 600,
+        fontSize: 14,
+        whiteSpace: 'nowrap',
+      }}
+    >
+      {locale === 'en' ? 'Go to app' : 'Uygulamaya git'}
+      <span aria-hidden style={{ fontSize: 12 }}>↗</span>
+    </a>
+  )
+}
+
 const config = {
   logo: <Logo />,
-  project: { link: 'https://hummytummy.com' },
-  docsRepositoryBase: 'https://github.com/mtarikucar/kds',
+  // No `project`/`docsRepositoryBase`: the default project icon is the GitHub
+  // logo and the repo is private — we surface a branded "Go to app" CTA instead.
   // Warm brand accent (matches the landing + pricing pages). Orange ≈ hue 24.
   color: { hue: 24, saturation: 95 },
+  navbar: { extraContent: <AppLink /> },
   i18n: [
     { locale: 'tr', name: 'Türkçe' },
     { locale: 'en', name: 'English' },
@@ -41,9 +71,12 @@ const config = {
   },
   feedback: { content: null },
   editLink: { content: null },
+  // Nextra 3 removed `useNextSeoProps`; the document <title> + meta are set here
+  // in `head` instead. `title` from useConfig() is the current page's title.
   head: () => {
     const { frontMatter, title } = useConfig()
     const { locale } = useRouter()
+    const pageTitle = title ? `${title} — HummyTummy Docs` : 'HummyTummy Docs'
     const desc =
       frontMatter.description ||
       (locale === 'en'
@@ -51,10 +84,12 @@ const config = {
         : 'HummyTummy — bulut tabanlı restoran yönetim sistemi dokümantasyonu.')
     return (
       <>
+        <title>{pageTitle}</title>
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <meta name="description" content={desc} />
-        <meta property="og:title" content={title ? `${title} — HummyTummy Docs` : 'HummyTummy Docs'} />
+        <meta property="og:title" content={pageTitle} />
         <meta property="og:description" content={desc} />
+        <meta name="og:type" content="website" />
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="" />
         <link
@@ -73,10 +108,6 @@ const config = {
         </a>
       </span>
     ),
-  },
-  // Title template per locale.
-  useNextSeoProps() {
-    return { titleTemplate: '%s — HummyTummy Docs' }
   },
 }
 

--- a/developer/theme.config.tsx
+++ b/developer/theme.config.tsx
@@ -1,0 +1,83 @@
+import React from 'react'
+import { useConfig } from 'nextra-theme-docs'
+import { useRouter } from 'next/router'
+
+const Logo = () => (
+  <span style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+    <span
+      style={{
+        display: 'grid',
+        placeItems: 'center',
+        width: 30,
+        height: 30,
+        borderRadius: 9,
+        background: '#f97316',
+        color: '#fff',
+        fontWeight: 800,
+        fontFamily: '"Fraunces", Georgia, serif',
+      }}
+    >
+      H
+    </span>
+    <span style={{ fontFamily: '"Fraunces", Georgia, serif', fontWeight: 600, fontSize: 18 }}>
+      HummyTummy <span style={{ color: '#f97316' }}>Docs</span>
+    </span>
+  </span>
+)
+
+const config = {
+  logo: <Logo />,
+  project: { link: 'https://hummytummy.com' },
+  docsRepositoryBase: 'https://github.com/mtarikucar/kds',
+  // Warm brand accent (matches the landing + pricing pages). Orange ≈ hue 24.
+  color: { hue: 24, saturation: 95 },
+  i18n: [
+    { locale: 'tr', name: 'Türkçe' },
+    { locale: 'en', name: 'English' },
+  ],
+  search: {
+    placeholder: () =>
+      useRouter().locale === 'en' ? 'Search docs…' : 'Dokümanlarda ara…',
+  },
+  feedback: { content: null },
+  editLink: { content: null },
+  head: () => {
+    const { frontMatter, title } = useConfig()
+    const { locale } = useRouter()
+    const desc =
+      frontMatter.description ||
+      (locale === 'en'
+        ? 'HummyTummy — cloud restaurant management documentation.'
+        : 'HummyTummy — bulut tabanlı restoran yönetim sistemi dokümantasyonu.')
+    return (
+      <>
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <meta name="description" content={desc} />
+        <meta property="og:title" content={title ? `${title} — HummyTummy Docs` : 'HummyTummy Docs'} />
+        <meta property="og:description" content={desc} />
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="" />
+        <link
+          href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,500;9..144,600;9..144,700&display=swap"
+          rel="stylesheet"
+        />
+      </>
+    )
+  },
+  footer: {
+    content: (
+      <span>
+        © {new Date().getFullYear()} HummyTummy ·{' '}
+        <a href="https://hummytummy.com" style={{ textDecoration: 'underline' }}>
+          hummytummy.com
+        </a>
+      </span>
+    ),
+  },
+  // Title template per locale.
+  useNextSeoProps() {
+    return { titleTemplate: '%s — HummyTummy Docs' }
+  },
+}
+
+export default config

--- a/developer/tsconfig.json
+++ b/developer/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [{ "name": "next" }]
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -201,6 +201,32 @@ services:
     networks:
       - kds_network
 
+  # Developer Docs Portal (Nextra / Next.js)
+  developer:
+    env_file:
+      - .env.production
+    image: ghcr.io/mtarikucar/kds/developer:current
+    build:
+      context: ./developer
+      dockerfile: Dockerfile
+    container_name: kds_developer_prod
+    restart: always
+    environment:
+      NODE_ENV: production
+    ports:
+      - '3200:3000'
+    healthcheck:
+      # The docs app has no /api/health route; /tr is the default-locale
+      # landing page (nextra/locales middleware redirects / → /tr) and
+      # returns 200, so it's the durable liveness probe.
+      test: ['CMD', 'wget', '--spider', '-q', 'http://0.0.0.0:3000/tr']
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 20s
+    networks:
+      - kds_network
+
 
 volumes:
   postgres_data:

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -182,6 +182,38 @@ services:
           cpus: '0.25'
           memory: 256M
 
+  # Developer Docs Portal (Nextra / Next.js) - Staging
+  developer:
+    env_file:
+      - .env.test
+    image: ghcr.io/mtarikucar/kds/developer-staging:current
+    container_name: kds_developer_staging
+    restart: always
+    environment:
+      NODE_ENV: production
+    ports:
+      # Host 3202 (distinct from prod's 3200) so staging + prod developer
+      # containers coexist on the shared VPS without a host-port collision.
+      - '3202:3000'
+    healthcheck:
+      # No /api/health route; /tr is the default-locale page (nextra/locales
+      # middleware redirects / → /tr) and returns 200 — durable liveness probe.
+      test: ['CMD', 'wget', '--spider', '-q', 'http://0.0.0.0:3000/tr']
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+    networks:
+      - kds_staging_network
+    deploy:
+      resources:
+        limits:
+          cpus: '0.5'
+          memory: 512M
+        reservations:
+          cpus: '0.25'
+          memory: 256M
+
 
 volumes:
   postgres_data_staging:

--- a/docs/superpowers/specs/2026-06-23-developer-docs-portal-design.md
+++ b/docs/superpowers/specs/2026-06-23-developer-docs-portal-design.md
@@ -1,0 +1,38 @@
+# developer.hummytummy.com — Documentation Portal — Design
+
+**Date:** 2026-06-23 · **Branch:** `feat/developer-docs-portal` · **Status:** Approved (goal-driven build)
+
+## Problem
+There is no single place documenting HummyTummy. We need a clean, professional, **bilingual (TR + EN)** documentation portal at **developer.hummytummy.com** covering the whole system: getting started, every admin page's purpose/details, plans & plan management, the marketplace add-ons, the developer/integration surface (API basics, Partner Display API, webhooks), and the desktop app.
+
+## Stack & architecture
+- New monorepo app **`developer/`** — Next.js + **Nextra** (`nextra-theme-docs`), MDX content. (Separate package; pins a Nextra-compatible Next version, independent of `landing/`'s Next 16.)
+- **Bilingual** via Nextra i18n: locales `tr` (default) + `en`; per-page `*.tr.mdx` / `*.en.mdx`, `_meta.{tr,en}.json`, `nextra/locales` middleware.
+- **Brand** = the warm landing/pricing language (cream `#faf6f0`, orange `#f97316`, ink `#1c1917`, Fraunces display) via `theme.config.tsx` (logo, primary hue, footer, head meta).
+- Content sources: existing `docs/SISTEM_TANITIMI.md`, `docs/YONETICI_REHBERI.md`, `docs/partner-display-api.md`, and the live code (backend modules) for accuracy.
+
+## Deploy (same VPS, mirrors landing/marketing)
+- `developer/Dockerfile` (Next standalone) → container `developer` (port **3200**).
+- `ops/nginx/developer.hummytummy.com.conf` → reverse-proxy to the container; versioned like the other vhosts.
+- `docker-compose.prod.yml` + `docker-compose.staging.yml` service; image `ghcr.io/.../developer`.
+- CI: build/push on tag in `release-deploy.yml`; `scripts/deploy.sh` swaps the container (staging via `test-deploy.yml`).
+- **User-side (only external step):** Cloudflare DNS `developer` A/CNAME → VPS IP (proxied). Without it the subdomain won't resolve; everything else is automated.
+
+## Information architecture (sidebar)
+1. **Başlangıç / Getting Started** — what the system is, account creation, first-run setup, concepts (tenant, branch, roles).
+2. **Yönetici Rehberi / Admin Guide** — per-page purpose + details: POS, QR Menu, KDS (kitchen), Tables, Orders, Stock/Inventory, Reports, Reservations, Personnel, Customers, Settings, Branches.
+3. **Planlar / Plans** — the 3 packages (BASIC/PRO/BUSINESS), feature×plan matrix, choosing/upgrading/managing a plan, trial + TRIAL_ENDED, billing (TRY, monthly/yearly, havale).
+4. **Marketplace** — every sellable add-on: what it grants, price, recurring/one-time, dependencies, how to purchase (checkout → PayTR → grant).
+5. **Geliştirici / Developer** — API basics (base URL, auth realms, branch scope / X-Branch-Id, rate limits, error envelope, idempotency); **Partner Display API** (key → screen-session → /display + realtime, full recipe); **Webhooks** (subscribe, HMAC signature verification, event types, retries).
+6. **Desktop Uygulaması / Desktop App** — install, auto-update (Tauri), hardware (printers, cash drawer), KDS/kiosk mode.
+7. **Referans / Reference** — error codes, partner scopes, plan feature matrix, glossary.
+
+## Phasing
+- **Faz 1 — live skeleton:** Nextra app + brand theme + i18n + sidebar + home page + deploy infra (Dockerfile/compose/nginx/CI). developer.hummytummy.com live (pending DNS).
+- **Faz 2 — core content (bilingual):** Webhooks, Developer/Integration (API + Partner Display), Marketplace, Plans & management, Desktop.
+- **Faz 3 — expand:** full Admin guide (per page), Getting started, Reference.
+
+Goal directive ("tüm sistem tamamlanana kadar durma") = build ALL three phases to completion + deploy to prod.
+
+## Non-goals
+- No auth on the docs (public). No live API console/playground (v1). No versioned docs (single current version). No search backend beyond Nextra's built-in flexsearch.

--- a/ops/nginx/README.md
+++ b/ops/nginx/README.md
@@ -16,6 +16,7 @@ silently diverge again.
 |------|----------|-------|
 | `staging.hummytummy.com.conf` | staging | Verified live (2026-06-22). Canonical. |
 | `hummytummy.com.conf` | prod | **Reconstructed** — capture the live prod vhost and reconcile before treating as authoritative (see the header in the file). |
+| `developer.hummytummy.com.conf` | prod (docs) | Developer docs portal (Nextra) → `127.0.0.1:3200`. **Needs a user-side Cloudflare DNS record (`developer` → VPS IP) + a certbot cert before it resolves** (see the header in the file). |
 | `apply.sh` | — | Safe apply: backup → copy → `nginx -t` → reload only on pass. |
 
 ## Routing model (both envs identical, only ports differ)

--- a/ops/nginx/developer.hummytummy.com.conf
+++ b/ops/nginx/developer.hummytummy.com.conf
@@ -1,0 +1,54 @@
+# ============================================================================
+# developer.hummytummy.com — PRODUCTION host nginx vhost (SOURCE OF TRUTH)
+# ============================================================================
+# Edge config for the developer documentation portal (Nextra / Next.js,
+# docker-compose.prod.yml `developer` service). Mirrors the structure of the
+# other prod vhosts (Cloudflare in front → host nginx → container).
+#
+# ⚠️  REQUIRES a user-side Cloudflare DNS record: developer → VPS IP
+#     (38.242.233.166). Until that record exists the hostname will not resolve
+#     and this server block is never reached. The TLS cert below is
+#     certbot-managed; issue it once DNS resolves:
+#         certbot certonly --webroot -w /var/www/certbot -d developer.hummytummy.com
+#
+# Apply with ops/nginx/apply.sh (backs up, `nginx -t`, then reloads):
+#         sudo /root/kds/ops/nginx/apply.sh developer.hummytummy.com.conf
+#
+# Prod container port (docker-compose.prod.yml):
+#   developer (Nextra docs, host 3200 → container 3000) → 127.0.0.1:3200
+# ============================================================================
+
+server {
+    listen 80;
+    listen [::]:80;
+    server_name developer.hummytummy.com;
+    location /.well-known/acme-challenge/ { root /var/www/certbot; }
+    location / { return 301 https://$host$request_uri; }
+}
+
+server {
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
+    server_name developer.hummytummy.com;
+
+    ssl_certificate     /etc/letsencrypt/live/developer.hummytummy.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/developer.hummytummy.com/privkey.pem;
+    include /etc/letsencrypt/options-ssl-nginx.conf;
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
+
+    client_max_body_size 25m;
+
+    proxy_set_header Host              $host;
+    proxy_set_header X-Real-IP         $remote_addr;
+    proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+
+    # Whole site is the docs portal (Next standalone server). Upgrade/Connection
+    # are forwarded so Next's HMR / RSC streaming works behind the proxy.
+    location / {
+        proxy_pass http://127.0.0.1:3200;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade    $http_upgrade;
+        proxy_set_header Connection "upgrade";
+    }
+}

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -12,7 +12,7 @@
 #   deploy.sh prod-rollback
 #
 # Notes:
-#   * Images come from GHCR (ghcr.io/mtarikucar/kds/{backend,frontend,landing}).
+#   * Images come from GHCR (ghcr.io/mtarikucar/kds/{backend,frontend,landing,developer}).
 #     The :vX.Y.Z (or :<sha>) tag is the immutable identity; :current is
 #     the production pointer that docker-compose reads. We only move
 #     :current once verify_and_promote passes.
@@ -62,13 +62,17 @@ REDIS_CONTAINER=""
 BACKEND_CONTAINER=""
 FRONTEND_CONTAINER=""
 LANDING_CONTAINER=""
+DEVELOPER_CONTAINER=""
 BACKEND_IMG=""
 FRONTEND_IMG=""
 LANDING_IMG=""
+DEVELOPER_IMG=""
 API_LOCAL_URL=""
 API_PUBLIC_URL=""
 FRONTEND_PUBLIC_URL=""
 LANDING_PUBLIC_URL=""
+DEVELOPER_LOCAL_URL=""
+DEVELOPER_PUBLIC_URL=""
 HEALTH_BUDGET_SEC=300
 BACKUP_RETENTION_DAYS=14
 STATE_FILE=""
@@ -100,13 +104,22 @@ configure_env() {
     BACKEND_CONTAINER="kds_backend_prod"
     FRONTEND_CONTAINER="kds_frontend_prod"
     LANDING_CONTAINER="kds_landing_prod"
+    DEVELOPER_CONTAINER="kds_developer_prod"
     BACKEND_IMG="$ghcr_base/backend"
     FRONTEND_IMG="$ghcr_base/frontend"
     LANDING_IMG="$ghcr_base/landing"
+    DEVELOPER_IMG="$ghcr_base/developer"
     API_LOCAL_URL="http://localhost:3000/api/health"
     API_PUBLIC_URL="https://hummytummy.com/api/health"
     FRONTEND_PUBLIC_URL="https://hummytummy.com"
     LANDING_PUBLIC_URL="https://hummytummy.com/landing"
+    # Container maps host 3200 → 3000; /tr is the docs app's default-locale
+    # page (no /api/health). The PUBLIC URL depends on a user-side Cloudflare
+    # DNS record (developer → VPS IP) that may not exist yet, so its probe is
+    # NON-FATAL (warn-only) in verify_and_promote — the local 3200 probe is
+    # the authoritative health gate.
+    DEVELOPER_LOCAL_URL="http://localhost:3200/tr"
+    DEVELOPER_PUBLIC_URL="https://developer.hummytummy.com/tr"
     HEALTH_BUDGET_SEC=300
     BACKUP_RETENTION_DAYS=14
     BACKUP_PREFIX="prod"
@@ -118,13 +131,22 @@ configure_env() {
     BACKEND_CONTAINER="kds_backend_staging"
     FRONTEND_CONTAINER="kds_frontend_staging"
     LANDING_CONTAINER="kds_landing_staging"
+    DEVELOPER_CONTAINER="kds_developer_staging"
     BACKEND_IMG="$ghcr_base/backend-staging"
     FRONTEND_IMG="$ghcr_base/frontend-staging"
     LANDING_IMG="$ghcr_base/landing-staging"
+    DEVELOPER_IMG="$ghcr_base/developer-staging"
     API_LOCAL_URL="http://localhost:3002/api/health"
     API_PUBLIC_URL="https://staging.hummytummy.com/api/health"
     FRONTEND_PUBLIC_URL="https://staging.hummytummy.com"
     LANDING_PUBLIC_URL="https://staging.hummytummy.com/landing"
+    # Staging docs container maps host 3202 → 3000 (per the compose file) — a
+    # distinct host port from prod's 3200 so both stacks can run the developer
+    # container side-by-side on the shared VPS. No public staging subdomain is
+    # wired, so DEVELOPER_PUBLIC_URL is empty and the local 3202 probe is
+    # authoritative.
+    DEVELOPER_LOCAL_URL="http://localhost:3202/tr"
+    DEVELOPER_PUBLIC_URL=""
     # Bumped from the original 180s → 300s (route-mapping past 180s on
     # cold boots) → 600s. Run 26431353670 showed the HummyTummy-sized
     # image still hadn't responded to /api/health at the 300s mark.
@@ -225,7 +247,7 @@ backup_database() {
 snapshot_image_ids() {
   : > "$STATE_FILE"
   local saved=0
-  for entry in "BACKEND $BACKEND_CONTAINER" "FRONTEND $FRONTEND_CONTAINER" "LANDING $LANDING_CONTAINER"; do
+  for entry in "BACKEND $BACKEND_CONTAINER" "FRONTEND $FRONTEND_CONTAINER" "LANDING $LANDING_CONTAINER" "DEVELOPER $DEVELOPER_CONTAINER"; do
     local role="${entry%% *}"
     local container="${entry##* }"
     local sha
@@ -238,7 +260,7 @@ snapshot_image_ids() {
       warn "$container not running — no prior SHA to snapshot"
     fi
   done
-  log "Snapshot complete: $saved/3 containers (file: $STATE_FILE)"
+  log "Snapshot complete: $saved/4 containers (file: $STATE_FILE)"
 }
 
 pull_versioned_images() {
@@ -248,7 +270,7 @@ pull_versioned_images() {
     echo "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_USER" --password-stdin >/dev/null
   fi
 
-  for img in "$BACKEND_IMG" "$FRONTEND_IMG" "$LANDING_IMG"; do
+  for img in "$BACKEND_IMG" "$FRONTEND_IMG" "$LANDING_IMG" "$DEVELOPER_IMG"; do
     log "docker pull $img:$VERSION"
     docker pull "$img:$VERSION"
   done
@@ -425,13 +447,19 @@ swap_backend() {
 swap_app_containers() {
   retag_to_current "$FRONTEND_IMG"
   retag_to_current "$LANDING_IMG"
+  retag_to_current "$DEVELOPER_IMG"
   # --remove-orphans reaps the retired in-repo marketing SPA container —
   # marketing.hummytummy.com is served by the standalone kds-marketing
   # stack (ports 3210/3211) since the v1.0.x cutover.
-  dc up -d --force-recreate --remove-orphans frontend landing
+  dc up -d --force-recreate --remove-orphans frontend landing developer
   sleep 3
-  verify_running_image "$FRONTEND_CONTAINER" "$FRONTEND_IMG"
-  verify_running_image "$LANDING_CONTAINER"  "$LANDING_IMG"
+  verify_running_image "$FRONTEND_CONTAINER"  "$FRONTEND_IMG"
+  verify_running_image "$LANDING_CONTAINER"   "$LANDING_IMG"
+  verify_running_image "$DEVELOPER_CONTAINER" "$DEVELOPER_IMG"
+  # Docs portal is loopback-probed (host 3200 → /tr). This is the
+  # authoritative health gate for the container; the public subdomain probe
+  # in verify_and_promote is non-fatal (depends on user-side Cloudflare DNS).
+  wait_until_healthy "$DEVELOPER_LOCAL_URL" 60
 }
 
 verify_and_promote() {
@@ -442,6 +470,15 @@ verify_and_promote() {
   # Landing probe is best-effort — its URL layout has changed in the
   # past and we don't want a 301 to fail the deploy.
   wait_until_healthy "$LANDING_PUBLIC_URL"  30 || warn "Landing probe non-200 (likely a redirect)"
+  # Developer docs subdomain probe is NON-FATAL: developer.hummytummy.com
+  # resolves only once a user-side Cloudflare DNS record (developer → VPS IP)
+  # exists, which may not be in place yet. The container's own health was
+  # already proven via the local 3200 probe in swap_app_containers, so a
+  # failed public probe here must NOT roll back the deploy — warn only.
+  if [ -n "$DEVELOPER_PUBLIC_URL" ]; then
+    wait_until_healthy "$DEVELOPER_PUBLIC_URL" 30 \
+      || warn "Developer docs public probe non-200 (likely Cloudflare DNS for developer.hummytummy.com not yet set — container is healthy locally)"
+  fi
   # SSL cert expiry — warn at 14d, error at 3d.
   local host="${API_PUBLIC_URL#https://}"; host="${host%%/*}"
   local exp_str exp_ts now_ts days
@@ -462,7 +499,7 @@ verify_and_promote() {
   fi
 
   # :current already moved by swap_*. Image immutability proof:
-  for img in "$BACKEND_IMG" "$FRONTEND_IMG" "$LANDING_IMG"; do
+  for img in "$BACKEND_IMG" "$FRONTEND_IMG" "$LANDING_IMG" "$DEVELOPER_IMG"; do
     local cur_sha ver_sha
     cur_sha=$(docker image inspect "$img:current" --format '{{.Id}}' 2>/dev/null || echo "")
     ver_sha=$(docker image inspect "$img:$VERSION" --format '{{.Id}}' 2>/dev/null || echo "")
@@ -537,12 +574,17 @@ restore_image_ids() {
     docker tag "$LANDING_PREV_IMAGE"  "$LANDING_IMG:current"  || warn "landing retag failed"
     restored=$((restored + 1))
   fi
+  if [ -n "${DEVELOPER_PREV_IMAGE:-}" ]; then
+    log "Pinning developer :current → ${DEVELOPER_PREV_IMAGE}"
+    docker tag "$DEVELOPER_PREV_IMAGE" "$DEVELOPER_IMG:current" || warn "developer retag failed"
+    restored=$((restored + 1))
+  fi
   if [ "$restored" -eq 0 ]; then
     err "Snapshot is empty — manual recovery required"
     return 1
   fi
 
-  dc up -d --force-recreate --remove-orphans backend frontend landing
+  dc up -d --force-recreate --remove-orphans backend frontend landing developer
   sleep 5
   wait_until_healthy "$API_LOCAL_URL" "$HEALTH_BUDGET_SEC" || warn "Post-rollback API not healthy"
 


### PR DESCRIPTION
## Developer Documentation Portal — developer.hummytummy.com

A Nextra (Next.js standalone) bilingual docs portal documenting the entire HummyTummy system, served at **developer.hummytummy.com**.

### Content — 78 pages, TR (primary) + EN (mirror), grounded in real source
- **getting-started** — concepts (tenant/branch/roles), account creation (real `/api/auth/register` contract), first setup (7-day TRIAL → TRIAL_ENDED lock)
- **admin-guide** — all 12 admin screens (POS, QR menu, KDS, tables, orders, stock, reports, reservations, personnel, customers, branches, settings) + the plan-gate matrix
- **plans** — 3-tier (BASIC ₺499 / PRO ₺1.299 / BUSINESS ₺2.999), trial + billing, feature matrix
- **marketplace** — PayTR purchase flow + add-on product details
- **developer** — API fundamentals, Partner Display API, **webhooks** (subscribe API, secret-once, `X-HummyTummy-Signature` HMAC, 12 publishable events verified against the real allowlist)
- **desktop** — install, KDS mode, hardware, auto-update
- **reference** — error codes, partner scopes, plan matrix, glossary

### Infra
- compose: prod `developer` (host 3200) + staging `developer-staging` (host **3202**, distinct so both coexist on the shared VPS)
- `deploy.sh`: pull / `:current` retag / health-probe / rollback for the developer image (public probe warn-only)
- CI: `release-deploy.yml` + `test-deploy.yml` build & push the developer image
- `ops/nginx/developer.hummytummy.com.conf`: prod vhost

### Verification
- production build green (78 pages prerendered)
- standalone `node server.js` smoke test: all routes 200, `/` → `/tr` 307
- all internal cross-links resolve; document titles correct; no GitHub icon / repo leak

### ⚠️ User-side step for the public URL (prod)
Create Cloudflare DNS `developer` → VPS IP, then issue the cert and apply the vhost:
```
certbot certonly --webroot -w /var/www/certbot -d developer.hummytummy.com
sudo /root/kds/ops/nginx/apply.sh developer.hummytummy.com.conf
```
The container deploy itself does not depend on this (localhost probe is authoritative).

🤖 Generated with [Claude Code](https://claude.com/claude-code)