### PR TITLE
feat(pos): polish the order-screen layout (most-used page)

### DIFF
--- a/frontend/src/components/pos/MenuPanel.tsx
+++ b/frontend/src/components/pos/MenuPanel.tsx
@@ -184,7 +184,7 @@ const MenuPanel = ({
           </div>
         ) : viewMode === 'grid' ? (
           /* Grid View */
-          <div className="grid grid-cols-2 md:grid-cols-3 xl:grid-cols-4 gap-2.5 sm:gap-4">
+          <div className="grid grid-cols-2 md:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5 gap-2.5 sm:gap-4">
             {filteredProducts.map((product) => {
               const inCartQty = cartQuantities[product.id] ?? 0;
               const requiresModifiers = hasRequiredModifiers(product);

--- a/frontend/src/components/pos/OrderCart.tsx
+++ b/frontend/src/components/pos/OrderCart.tsx
@@ -299,9 +299,13 @@ const OrderCart = ({
                 </div>
               )}
 
-              <div className="flex justify-between text-lg font-bold">
-                <span className="text-slate-900">{t('total')}:</span>
-                <span className="text-primary-600">{formatPrice(total)}</span>
+              {/* TOTAL — the single most important number on the screen, so
+                  it's the largest/boldest element in the footer. */}
+              <div className="flex items-end justify-between">
+                <span className="text-sm font-medium text-slate-500">{t('total')}</span>
+                <span className="text-3xl font-extrabold text-primary-600 tabular-nums leading-none">
+                  {formatPrice(total)}
+                </span>
               </div>
 
               {/* Conditional button rendering based on checkout mode */}
@@ -321,10 +325,11 @@ const OrderCart = ({
 
                   {/* Payment button - uses canProceedToPayment for eligibility.
                       deep-review FH2: also blocked while the cart diverged from
-                      the saved order, so we never charge the stale amount. */}
+                      the saved order, so we never charge the stale amount.
+                      Tall (h-14) primary tap target — the page's main action. */}
                   <Button
                     variant="primary"
-                    className="w-full"
+                    className="w-full h-14 text-base font-semibold"
                     size="lg"
                     onClick={onCheckout}
                     disabled={!hasActiveOrder || !canProceedToPayment || cartDirty}
@@ -347,10 +352,10 @@ const OrderCart = ({
                   )}
                 </div>
               ) : (
-                /* Single-step checkout button */
+                /* Single-step checkout button — tall primary tap target. */
                 <Button
                   variant="primary"
-                  className="w-full"
+                  className="w-full h-14 text-base font-semibold"
                   size="lg"
                   onClick={onCheckout}
                   isLoading={isCheckingOut}

--- a/frontend/src/pages/pos/POSPage.test.tsx
+++ b/frontend/src/pages/pos/POSPage.test.tsx
@@ -86,6 +86,10 @@ vi.mock('./useTableSelection', () => ({
 }));
 
 vi.mock('../../hooks/useResponsive', () => ({ useResponsive: () => ({ isDesktop: true }) }));
+// POSPage now calls useFormatCurrency at top level (header total pill). The
+// real hook reads i18n.language via useLocale, which the bare react-i18next
+// mock above doesn't provide — stub it to a simple formatter.
+vi.mock('../../hooks/useFormatCurrency', () => ({ useFormatCurrency: () => (n: number) => `₺${n}` }));
 vi.mock('../../lib/tauri', () => ({ isTauri: () => false, HardwareService: {} }));
 vi.mock('../../store/uiStore', () => ({ useUiStore: { getState: () => ({}) } }));
 

--- a/frontend/src/pages/pos/POSPage.tsx
+++ b/frontend/src/pages/pos/POSPage.tsx
@@ -25,8 +25,8 @@ import { useTables, useUpdateTableStatus, useMergeTables, useUnmergeTable, useUn
 import { useGetPosSettings } from '../../features/pos/posApi';
 import { usePosSocket } from '../../features/pos/usePosSocket';
 import { Product, Table, TableStatus, OrderType, OrderStatus, SplitType, SplitPaymentEntry, Payment } from '../../types';
-import { Card, CardHeader, CardTitle, CardContent } from '../../components/ui/Card';
 import { useResponsive, BREAKPOINTS } from '../../hooks/useResponsive';
+import { useFormatCurrency } from '../../hooks/useFormatCurrency';
 import Spinner from '../../components/ui/Spinner';
 import { HardwareService, isTauri } from '../../lib/tauri';
 import { useUiStore } from '../../store/uiStore';
@@ -47,6 +47,7 @@ import type { POSView, CartItem } from './posTypes';
 
 const POSPage = () => {
   const { t } = useTranslation('pos');
+  const formatPrice = useFormatCurrency();
 
   // View state: table-selection or order
   const [currentView, setCurrentView] = useState<POSView>('table-selection');
@@ -869,17 +870,22 @@ const POSPage = () => {
                 )}
               </p>
             </div>
-            {/* Cart indicator for mobile (only when the side cart is hidden) */}
+            {/* Cart pill for mobile (only when the side cart is hidden). Now
+                surfaces the running TOTAL alongside the count so the cashier
+                can glance the bill without opening the drawer. */}
             {!useSideBySideLayout && hasCartItems && (
               <button
                 onClick={() => setIsCartDrawerOpen(true)}
-                className="relative p-2 bg-primary-50 text-primary-700 rounded-lg"
+                className="flex items-center gap-2 pl-3 pr-4 py-2.5 bg-primary-600 text-white rounded-xl shadow-sm active:scale-95 transition-transform"
                 aria-label={t('cart.yourOrder')}
               >
-                <ShoppingBag className="h-5 w-5" />
-                <span className="absolute -top-1 -right-1 bg-primary-600 text-white text-xs rounded-full h-5 w-5 flex items-center justify-center">
-                  {cartItems.length}
+                <span className="relative">
+                  <ShoppingBag className="h-5 w-5" />
+                  <span className="absolute -top-2 -right-2 bg-white text-primary-700 text-[10px] font-bold rounded-full h-4 min-w-[1rem] px-1 flex items-center justify-center">
+                    {cartItems.length}
+                  </span>
                 </span>
+                <span className="font-bold tabular-nums">{formatPrice(total)}</span>
               </button>
             )}
           </div>
@@ -895,21 +901,17 @@ const POSPage = () => {
           {/* DESKTOP + LANDSCAPE TABLET (>=768): 2/3 Menu + 1/3 Cart Layout */}
           {useSideBySideLayout && (
             <div className="flex-1 grid grid-cols-3 gap-4 lg:gap-6 min-h-0">
-              {/* Menu Panel - 2/3 width */}
-              <div className="col-span-2" data-tour="menu-panel">
-                <Card className="h-full">
-                  <CardHeader className="pb-3">
-                    <CardTitle className="text-lg">{t('common:navigation.menu')}</CardTitle>
-                  </CardHeader>
-                  <CardContent className="h-[calc(100%-70px)] overflow-y-auto">
-                    <MenuPanel
-                      onAddItem={handleAddItem}
-                      cartQuantities={cartQuantities}
-                      onIncrement={handleMenuIncrement}
-                      onDecrement={handleMenuDecrement}
-                    />
-                  </CardContent>
-                </Card>
+              {/* Menu Panel - 2/3 width. Rendered chrome-free (no redundant
+                  "Menu" Card header) so the product grid uses the FULL column
+                  height — MenuPanel has its own header (search + categories)
+                  and internal scroll. */}
+              <div className="col-span-2 min-h-0" data-tour="menu-panel">
+                <MenuPanel
+                  onAddItem={handleAddItem}
+                  cartQuantities={cartQuantities}
+                  onIncrement={handleMenuIncrement}
+                  onDecrement={handleMenuDecrement}
+                />
               </div>
 
               {/* Order Cart - 1/3 width */}
@@ -945,22 +947,17 @@ const POSPage = () => {
             </div>
           )}
 
-          {/* PHONE: Full-screen Menu (cart lives in the drawer) */}
+          {/* PHONE: Full-screen Menu (cart lives in the drawer). Chrome-free
+              for the same reason as the side-by-side branch — MenuPanel owns
+              its header + scroll and fills the full height. */}
           {!useSideBySideLayout && (
             <div className="flex-1 min-h-0">
-              <Card className="h-full">
-                <CardHeader className="pb-3">
-                  <CardTitle className="text-lg">{t('common:navigation.menu')}</CardTitle>
-                </CardHeader>
-                <CardContent className="h-[calc(100%-70px)] overflow-y-auto">
-                  <MenuPanel
-                    onAddItem={handleAddItem}
-                    cartQuantities={cartQuantities}
-                    onIncrement={handleMenuIncrement}
-                    onDecrement={handleMenuDecrement}
-                  />
-                </CardContent>
-              </Card>
+              <MenuPanel
+                onAddItem={handleAddItem}
+                cartQuantities={cartQuantities}
+                onIncrement={handleMenuIncrement}
+                onDecrement={handleMenuDecrement}
+              />
             </div>
           )}
         </div>


### PR DESCRIPTION
POS order-screen refinements (user-chosen 'polish, keep chips' direction):
- Removed the redundant Card + 'Menu' title bar wrapping MenuPanel (tablet/desktop 2/3 column + phone full-screen) → product grid uses the FULL height; dropped the unused Card import + fragile nested height calc.
- Mobile order header: cart button is now a prominent pill showing the running TOTAL (count · ₺total), not just an item count.
- Cart footer: TOTAL is the largest element (text-3xl extra-bold tabular); Pay/Checkout is a taller h-14 tap target.
- Menu grid: +1 product column on very wide terminals (2xl:grid-cols-5).
- POSPage.test: stub useFormatCurrency (POSPage now calls it at top level; the bare i18n mock lacks i18n.language which useLocale reads).

Local gates: frontend tsc 0 · POSPage vitest 4/4 · eslint 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)