### PR TITLE
Floor-plan editor P1 — backend foundation (zones, elements, table geometry, layout API)

### DIFF
--- a/backend/prisma/migrations/20260624140000_floor_plan_zones_elements/migration.sql
+++ b/backend/prisma/migrations/20260624140000_floor_plan_zones_elements/migration.sql
@@ -1,0 +1,92 @@
+-- 2D Floor-Plan: zones (kat/bahçe/teras) + decorative/structural elements,
+-- plus spatial placement fields on tables.
+--
+-- A FloorZone is a designable 2D canvas per branch; tables and FloorElements
+-- (walls/doors/bar/kitchen/decor/text) are placed on it. Tables gain
+-- posX/posY/width/height/rotation/shape and an optional zoneId (null = not
+-- yet placed). Additive + idempotent (CREATE TABLE / ADD COLUMN IF NOT
+-- EXISTS, guarded constraints) so it is safe to re-run on the live DB and
+-- under the deploy baseline pipeline. The legacy tables.section column is
+-- retained for now and dropped in a later phase.
+
+-- CreateTable: floor_zones
+CREATE TABLE IF NOT EXISTS "floor_zones" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "sortOrder" INTEGER NOT NULL DEFAULT 0,
+    "kind" TEXT NOT NULL DEFAULT 'INDOOR',
+    "canvasWidth" INTEGER NOT NULL DEFAULT 1200,
+    "canvasHeight" INTEGER NOT NULL DEFAULT 800,
+    "gridSize" INTEGER NOT NULL DEFAULT 20,
+    "backgroundImageUrl" TEXT,
+    "backgroundOpacity" DOUBLE PRECISION NOT NULL DEFAULT 1.0,
+    "tenantId" TEXT NOT NULL,
+    "branchId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "floor_zones_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable: floor_elements
+CREATE TABLE IF NOT EXISTS "floor_elements" (
+    "id" TEXT NOT NULL,
+    "type" TEXT NOT NULL,
+    "x" DOUBLE PRECISION NOT NULL DEFAULT 0,
+    "y" DOUBLE PRECISION NOT NULL DEFAULT 0,
+    "width" DOUBLE PRECISION NOT NULL DEFAULT 100,
+    "height" DOUBLE PRECISION NOT NULL DEFAULT 100,
+    "rotation" DOUBLE PRECISION NOT NULL DEFAULT 0,
+    "points" JSONB,
+    "style" JSONB,
+    "label" TEXT,
+    "zIndex" INTEGER NOT NULL DEFAULT 0,
+    "zoneId" TEXT NOT NULL,
+    "tenantId" TEXT NOT NULL,
+    "branchId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "floor_elements_pkey" PRIMARY KEY ("id")
+);
+
+-- AlterTable: tables spatial placement fields
+ALTER TABLE "tables" ADD COLUMN IF NOT EXISTS "zoneId"   TEXT;
+ALTER TABLE "tables" ADD COLUMN IF NOT EXISTS "posX"     DOUBLE PRECISION NOT NULL DEFAULT 0;
+ALTER TABLE "tables" ADD COLUMN IF NOT EXISTS "posY"     DOUBLE PRECISION NOT NULL DEFAULT 0;
+ALTER TABLE "tables" ADD COLUMN IF NOT EXISTS "width"    DOUBLE PRECISION NOT NULL DEFAULT 80;
+ALTER TABLE "tables" ADD COLUMN IF NOT EXISTS "height"   DOUBLE PRECISION NOT NULL DEFAULT 80;
+ALTER TABLE "tables" ADD COLUMN IF NOT EXISTS "rotation" DOUBLE PRECISION NOT NULL DEFAULT 0;
+ALTER TABLE "tables" ADD COLUMN IF NOT EXISTS "shape"    TEXT NOT NULL DEFAULT 'ROUND';
+
+-- CreateIndex
+CREATE UNIQUE INDEX IF NOT EXISTS "floor_zones_tenantId_branchId_name_key" ON "floor_zones"("tenantId", "branchId", "name");
+CREATE INDEX IF NOT EXISTS "floor_zones_tenantId_branchId_idx" ON "floor_zones"("tenantId", "branchId");
+CREATE INDEX IF NOT EXISTS "floor_elements_zoneId_idx" ON "floor_elements"("zoneId");
+CREATE INDEX IF NOT EXISTS "floor_elements_tenantId_branchId_idx" ON "floor_elements"("tenantId", "branchId");
+CREATE INDEX IF NOT EXISTS "tables_zoneId_idx" ON "tables"("zoneId");
+
+-- AddForeignKey (guarded — Postgres has no ADD CONSTRAINT IF NOT EXISTS)
+DO $$ BEGIN
+  ALTER TABLE "floor_zones" ADD CONSTRAINT "floor_zones_tenantId_fkey" FOREIGN KEY ("tenantId") REFERENCES "tenants"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+DO $$ BEGIN
+  ALTER TABLE "floor_zones" ADD CONSTRAINT "floor_zones_branchId_fkey" FOREIGN KEY ("branchId") REFERENCES "branches"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+DO $$ BEGIN
+  ALTER TABLE "floor_elements" ADD CONSTRAINT "floor_elements_zoneId_fkey" FOREIGN KEY ("zoneId") REFERENCES "floor_zones"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+DO $$ BEGIN
+  ALTER TABLE "floor_elements" ADD CONSTRAINT "floor_elements_tenantId_fkey" FOREIGN KEY ("tenantId") REFERENCES "tenants"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+DO $$ BEGIN
+  ALTER TABLE "floor_elements" ADD CONSTRAINT "floor_elements_branchId_fkey" FOREIGN KEY ("branchId") REFERENCES "branches"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+DO $$ BEGIN
+  ALTER TABLE "tables" ADD CONSTRAINT "tables_zoneId_fkey" FOREIGN KEY ("zoneId") REFERENCES "floor_zones"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -82,6 +82,8 @@ model Tenant {
   modifierGroups      ModifierGroup[]
   modifiers           Modifier[]
   tables              Table[]
+  floorZones          FloorZone[]
+  floorElements       FloorElement[]
   orders              Order[]
   stockMovements      StockMovement[]
   subscriptions       Subscription[]
@@ -553,6 +555,22 @@ model Table {
   // Table grouping (merge/split)
   groupId String? // Shared UUID for merged tables; null = standalone
 
+  // Floor-plan spatial placement (v3.2.45). A table belongs to at most one
+  // FloorZone (a kat / bahçe / teras); posX/posY are canvas coordinates
+  // within that zone, width/height the rendered footprint, rotation in
+  // degrees, shape the silhouette. zoneId=null ⇒ not yet placed (the editor
+  // surfaces it in an "unplaced" tray). Seats are rendered from `capacity`.
+  // The legacy free-text `section` above is retained for now and dropped in
+  // a later phase once the admin page is rebuilt around zones.
+  zoneId   String?
+  zone     FloorZone? @relation(fields: [zoneId], references: [id], onDelete: SetNull)
+  posX     Float      @default(0)
+  posY     Float      @default(0)
+  width    Float      @default(80)
+  height   Float      @default(80)
+  rotation Float      @default(0)
+  shape    String     @default("ROUND") // ROUND, SQUARE, RECT
+
   tenantId String
   tenant   Tenant @relation(fields: [tenantId], references: [id], onDelete: Cascade)
 
@@ -587,7 +605,78 @@ model Table {
   @@index([tenantId])
   @@index([tenantId, groupId])
   @@index([tenantId, branchId])
+  @@index([zoneId])
   @@map("tables")
+}
+
+// ========================================
+// FLOOR PLAN (2D restaurant map)
+// ========================================
+
+// A designable area of the restaurant — a floor, garden, terrace, etc.
+// (kat / bahçe / teras). Each zone is its own 2D canvas that holds placed
+// Tables and decorative/structural FloorElements. Branch-scoped: every
+// branch designs its own floor plan independently.
+model FloorZone {
+  id                 String  @id @default(uuid())
+  name               String
+  sortOrder          Int     @default(0)
+  kind               String  @default("INDOOR") // INDOOR, OUTDOOR
+  // Logical canvas size in design units (px-equivalent). The live view
+  // scales this to fit the viewport; the editor pans/zooms within it.
+  canvasWidth        Int     @default(1200)
+  canvasHeight       Int     @default(800)
+  gridSize           Int     @default(20)
+  // Optional blueprint image the operator can trace the plan over.
+  backgroundImageUrl String?
+  backgroundOpacity  Float   @default(1.0)
+
+  tenantId String
+  tenant   Tenant @relation(fields: [tenantId], references: [id], onDelete: Cascade)
+  branchId String
+  branch   Branch @relation(fields: [branchId], references: [id], onDelete: Cascade)
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  tables   Table[]
+  elements FloorElement[]
+
+  @@unique([tenantId, branchId, name])
+  @@index([tenantId, branchId])
+  @@map("floor_zones")
+}
+
+// A non-table item on a zone's canvas: walls, doors, the bar, the kitchen
+// block, plants/decor, or free text labels. Purely visual — gives the map
+// the feel of a real restaurant blueprint.
+model FloorElement {
+  id       String  @id @default(uuid())
+  type     String // WALL, DOOR, BAR, KITCHEN, PLANT, DECOR, TEXT, RECT
+  x        Float   @default(0)
+  y        Float   @default(0)
+  width    Float   @default(100)
+  height   Float   @default(100)
+  rotation Float   @default(0)
+  points   Json? // polyline walls: [{ x, y }, ...]
+  style    Json? // { fill, stroke, strokeWidth, fontSize, color, ... }
+  label    String?
+  zIndex   Int     @default(0)
+
+  zoneId String
+  zone   FloorZone @relation(fields: [zoneId], references: [id], onDelete: Cascade)
+
+  tenantId String
+  tenant   Tenant @relation(fields: [tenantId], references: [id], onDelete: Cascade)
+  branchId String
+  branch   Branch @relation(fields: [branchId], references: [id], onDelete: Cascade)
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@index([zoneId])
+  @@index([tenantId, branchId])
+  @@map("floor_elements")
 }
 
 // ========================================
@@ -4211,6 +4300,8 @@ model Branch {
   bridges                 LocalBridgeAgent[]
   orders                  Order[]
   tables                  Table[]
+  floorZones              FloorZone[]
+  floorElements           FloorElement[]
   deliveryPlatformConfigs DeliveryPlatformConfig[]
   // v3.0.0 — strict branch-scope inverse relations.
   deviceCommands          DeviceCommand[]

--- a/backend/src/modules/kds/kds.gateway.ts
+++ b/backend/src/modules/kds/kds.gateway.ts
@@ -704,6 +704,27 @@ export class KdsGateway implements OnGatewayConnection, OnGatewayDisconnect {
     );
   }
 
+  /**
+   * Broadcast that the floor-plan layout (zones / placed tables / decorative
+   * elements) changed for a branch, so any open live POS map or read-only
+   * Tables map re-fetches and re-renders. `zoneId` narrows the hint when a
+   * single zone changed; omitted means "the whole plan" (zone add/remove/
+   * reorder). Pairs with floor-plan editor saves.
+   */
+  emitFloorLayoutUpdated(
+    tenantId: string,
+    branchId: string,
+    payload: { zoneId?: string } = {},
+  ) {
+    this.server
+      .to(`kitchen-${tenantId}-${branchId}`)
+      .to(`pos-${tenantId}-${branchId}`)
+      .emit("floor:layout-updated", { ...payload, timestamp: new Date() });
+    this.logger.debug(
+      `floor:layout-updated zone=${payload.zoneId ?? "*"} → kitchen/pos-${tenantId}`,
+    );
+  }
+
   // ========================================
   // CUSTOMER-SPECIFIC EVENTS
   // ========================================

--- a/backend/src/modules/tables/dto/create-table.dto.ts
+++ b/backend/src/modules/tables/dto/create-table.dto.ts
@@ -9,6 +9,7 @@ import {
   Min,
   IsEnum,
 } from "class-validator";
+import { TableSpatialFieldsDto } from "./table-spatial.dto";
 
 export enum TableStatus {
   AVAILABLE = "AVAILABLE",
@@ -16,7 +17,10 @@ export enum TableStatus {
   RESERVED = "RESERVED",
 }
 
-export class CreateTableDto {
+// Extends the optional floor-plan geometry (zoneId/posX/posY/width/height/
+// rotation/shape) so a table may be created directly onto the canvas; all
+// geometry fields are optional and default in the DB when omitted.
+export class CreateTableDto extends TableSpatialFieldsDto {
   // Caps protect Table.number / Table.section (Postgres TEXT — no implicit
   // ceiling) and the @@unique(tenantId, number) constraint from accepting
   // a multi-MB blob as the canonical id of a physical table. Realistic

--- a/backend/src/modules/tables/dto/floor-element.dto.ts
+++ b/backend/src/modules/tables/dto/floor-element.dto.ts
@@ -1,0 +1,103 @@
+import { ApiProperty, PartialType } from "@nestjs/swagger";
+import {
+  IsString,
+  IsNotEmpty,
+  IsOptional,
+  IsEnum,
+  IsNumber,
+  IsInt,
+  MaxLength,
+  Min,
+  Max,
+  IsObject,
+} from "class-validator";
+
+export enum FloorElementType {
+  WALL = "WALL",
+  DOOR = "DOOR",
+  BAR = "BAR",
+  KITCHEN = "KITCHEN",
+  PLANT = "PLANT",
+  DECOR = "DECOR",
+  TEXT = "TEXT",
+  RECT = "RECT",
+}
+
+// Coordinates/size are in the zone's logical design units; the same
+// CANVAS_MAX-ish ceiling keeps a single element from being placed light-years
+// off-canvas. Negatives allowed for slight off-grid bleed.
+const COORD_MIN = -2_000;
+const COORD_MAX = 12_000;
+
+export class CreateFloorElementDto {
+  @ApiProperty()
+  @IsString()
+  @IsNotEmpty()
+  zoneId: string;
+
+  @ApiProperty({ enum: FloorElementType })
+  @IsEnum(FloorElementType)
+  type: FloorElementType;
+
+  @ApiProperty({ required: false, default: 0 })
+  @IsNumber()
+  @Min(COORD_MIN)
+  @Max(COORD_MAX)
+  @IsOptional()
+  x?: number;
+
+  @ApiProperty({ required: false, default: 0 })
+  @IsNumber()
+  @Min(COORD_MIN)
+  @Max(COORD_MAX)
+  @IsOptional()
+  y?: number;
+
+  @ApiProperty({ required: false, default: 100 })
+  @IsNumber()
+  @Min(1)
+  @Max(COORD_MAX)
+  @IsOptional()
+  width?: number;
+
+  @ApiProperty({ required: false, default: 100 })
+  @IsNumber()
+  @Min(1)
+  @Max(COORD_MAX)
+  @IsOptional()
+  height?: number;
+
+  @ApiProperty({ required: false, default: 0 })
+  @IsNumber()
+  @Min(-360)
+  @Max(360)
+  @IsOptional()
+  rotation?: number;
+
+  // points (polyline walls) and style are free-form JSON validated as
+  // objects/arrays only; the renderer owns their shape. Kept permissive so
+  // the editor can evolve element styling without a migration.
+  @ApiProperty({ required: false, type: "array", items: { type: "object" } })
+  @IsOptional()
+  points?: any;
+
+  @ApiProperty({ required: false, type: "object" })
+  @IsObject()
+  @IsOptional()
+  style?: Record<string, any>;
+
+  @ApiProperty({ required: false })
+  @IsString()
+  @MaxLength(280)
+  @IsOptional()
+  label?: string;
+
+  @ApiProperty({ required: false, default: 0 })
+  @IsInt()
+  @Min(-1000)
+  @Max(1000)
+  @IsOptional()
+  zIndex?: number;
+}
+
+export class UpdateFloorElementDto extends PartialType(CreateFloorElementDto) {}

--- a/backend/src/modules/tables/dto/floor-zone.dto.ts
+++ b/backend/src/modules/tables/dto/floor-zone.dto.ts
@@ -1,0 +1,99 @@
+import { ApiProperty, PartialType } from "@nestjs/swagger";
+import {
+  IsString,
+  IsNotEmpty,
+  IsOptional,
+  IsInt,
+  IsEnum,
+  IsNumber,
+  IsUrl,
+  Max,
+  Min,
+  MaxLength,
+  ValidateNested,
+  IsArray,
+  ArrayMaxSize,
+} from "class-validator";
+import { Type } from "class-transformer";
+
+export enum FloorZoneKind {
+  INDOOR = "INDOOR",
+  OUTDOOR = "OUTDOOR",
+}
+
+// Canvas bounds are generous but capped: a logical design surface, not a
+// pixel buffer. 10k×10k design units covers any real venue while stopping a
+// client from stamping an absurd value the editor would choke rendering.
+const CANVAS_MIN = 200;
+const CANVAS_MAX = 10_000;
+
+export class CreateFloorZoneDto {
+  @ApiProperty({ example: "Kat 1" })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(60)
+  name: string;
+
+  @ApiProperty({ enum: FloorZoneKind, required: false, default: "INDOOR" })
+  @IsEnum(FloorZoneKind)
+  @IsOptional()
+  kind?: FloorZoneKind;
+
+  @ApiProperty({ required: false, default: 1200 })
+  @IsInt()
+  @Min(CANVAS_MIN)
+  @Max(CANVAS_MAX)
+  @IsOptional()
+  canvasWidth?: number;
+
+  @ApiProperty({ required: false, default: 800 })
+  @IsInt()
+  @Min(CANVAS_MIN)
+  @Max(CANVAS_MAX)
+  @IsOptional()
+  canvasHeight?: number;
+
+  @ApiProperty({ required: false, default: 20 })
+  @IsInt()
+  @Min(2)
+  @Max(200)
+  @IsOptional()
+  gridSize?: number;
+
+  @ApiProperty({ required: false })
+  @IsUrl({ require_tld: false })
+  @MaxLength(2048)
+  @IsOptional()
+  backgroundImageUrl?: string;
+
+  @ApiProperty({ required: false, default: 1 })
+  @IsNumber()
+  @Min(0)
+  @Max(1)
+  @IsOptional()
+  backgroundOpacity?: number;
+}
+
+export class UpdateFloorZoneDto extends PartialType(CreateFloorZoneDto) {}
+
+class ReorderZoneItemDto {
+  @ApiProperty()
+  @IsString()
+  @IsNotEmpty()
+  id: string;
+
+  @ApiProperty()
+  @IsInt()
+  @Min(0)
+  @Max(10_000)
+  sortOrder: number;
+}
+
+export class ReorderZonesDto {
+  @ApiProperty({ type: [ReorderZoneItemDto] })
+  @IsArray()
+  @ArrayMaxSize(200)
+  @ValidateNested({ each: true })
+  @Type(() => ReorderZoneItemDto)
+  zones: ReorderZoneItemDto[];
+}

--- a/backend/src/modules/tables/dto/save-layout.dto.ts
+++ b/backend/src/modules/tables/dto/save-layout.dto.ts
@@ -1,0 +1,135 @@
+import { ApiProperty } from "@nestjs/swagger";
+import {
+  IsString,
+  IsNotEmpty,
+  IsOptional,
+  IsEnum,
+  IsNumber,
+  IsArray,
+  ArrayMaxSize,
+  ValidateNested,
+  Min,
+  Max,
+  IsObject,
+} from "class-validator";
+import { Type } from "class-transformer";
+import { TableShape } from "./table-spatial.dto";
+
+const COORD_MIN = -2_000;
+const COORD_MAX = 12_000;
+
+// One placed table's geometry in a bulk save. zoneId null = move back to the
+// unplaced tray. Only geometry + zone here — table number/capacity/status are
+// owned by the table CRUD endpoints, never overwritten by a layout drag.
+export class LayoutTableItemDto {
+  @ApiProperty()
+  @IsString()
+  @IsNotEmpty()
+  id: string;
+
+  @ApiProperty({ required: false, nullable: true })
+  @IsString()
+  @IsOptional()
+  zoneId?: string | null;
+
+  @ApiProperty()
+  @IsNumber()
+  @Min(COORD_MIN)
+  @Max(COORD_MAX)
+  posX: number;
+
+  @ApiProperty()
+  @IsNumber()
+  @Min(COORD_MIN)
+  @Max(COORD_MAX)
+  posY: number;
+
+  @ApiProperty()
+  @IsNumber()
+  @Min(10)
+  @Max(2000)
+  width: number;
+
+  @ApiProperty()
+  @IsNumber()
+  @Min(10)
+  @Max(2000)
+  height: number;
+
+  @ApiProperty()
+  @IsNumber()
+  @Min(-360)
+  @Max(360)
+  rotation: number;
+
+  @ApiProperty({ enum: TableShape })
+  @IsEnum(TableShape)
+  shape: TableShape;
+}
+
+// One placed element's geometry in a bulk save (existing elements only —
+// creating/deleting elements goes through the element CRUD endpoints).
+export class LayoutElementItemDto {
+  @ApiProperty()
+  @IsString()
+  @IsNotEmpty()
+  id: string;
+
+  @ApiProperty()
+  @IsNumber()
+  @Min(COORD_MIN)
+  @Max(COORD_MAX)
+  x: number;
+
+  @ApiProperty()
+  @IsNumber()
+  @Min(COORD_MIN)
+  @Max(COORD_MAX)
+  y: number;
+
+  @ApiProperty()
+  @IsNumber()
+  @Min(1)
+  @Max(COORD_MAX)
+  width: number;
+
+  @ApiProperty()
+  @IsNumber()
+  @Min(1)
+  @Max(COORD_MAX)
+  height: number;
+
+  @ApiProperty()
+  @IsNumber()
+  @Min(-360)
+  @Max(360)
+  rotation: number;
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  points?: any;
+
+  @ApiProperty({ required: false, type: "object" })
+  @IsObject()
+  @IsOptional()
+  style?: Record<string, any>;
+}
+
+// Persist a whole drag/resize session in one transactional call. Caps keep a
+// single request from rewriting an unbounded number of rows.
+export class SaveLayoutDto {
+  @ApiProperty({ type: [LayoutTableItemDto] })
+  @IsArray()
+  @ArrayMaxSize(1000)
+  @ValidateNested({ each: true })
+  @Type(() => LayoutTableItemDto)
+  tables: LayoutTableItemDto[];
+
+  @ApiProperty({ type: [LayoutElementItemDto], required: false })
+  @IsArray()
+  @ArrayMaxSize(2000)
+  @ValidateNested({ each: true })
+  @Type(() => LayoutElementItemDto)
+  @IsOptional()
+  elements?: LayoutElementItemDto[];
+}

--- a/backend/src/modules/tables/dto/table-spatial.dto.ts
+++ b/backend/src/modules/tables/dto/table-spatial.dto.ts
@@ -1,0 +1,73 @@
+import { ApiProperty } from "@nestjs/swagger";
+import {
+  IsEnum,
+  IsNumber,
+  IsOptional,
+  IsString,
+  Max,
+  Min,
+} from "class-validator";
+
+export enum TableShape {
+  ROUND = "ROUND",
+  SQUARE = "SQUARE",
+  RECT = "RECT",
+}
+
+/**
+ * Optional spatial-placement fields shared by CreateTableDto / UpdateTableDto.
+ * A table can be created/edited with no geometry (it lands in the editor's
+ * "unplaced" tray) and positioned later via the floor-plan editor. These let
+ * the table CRUD also carry geometry when the editor creates a table directly
+ * onto the canvas.
+ */
+export class TableSpatialFieldsDto {
+  @ApiProperty({
+    required: false,
+    nullable: true,
+    description: "Owning floor zone; null = unplaced",
+  })
+  @IsString()
+  @IsOptional()
+  zoneId?: string | null;
+
+  @ApiProperty({ required: false })
+  @IsNumber()
+  @Min(-2000)
+  @Max(12000)
+  @IsOptional()
+  posX?: number;
+
+  @ApiProperty({ required: false })
+  @IsNumber()
+  @Min(-2000)
+  @Max(12000)
+  @IsOptional()
+  posY?: number;
+
+  @ApiProperty({ required: false })
+  @IsNumber()
+  @Min(10)
+  @Max(2000)
+  @IsOptional()
+  width?: number;
+
+  @ApiProperty({ required: false })
+  @IsNumber()
+  @Min(10)
+  @Max(2000)
+  @IsOptional()
+  height?: number;
+
+  @ApiProperty({ required: false })
+  @IsNumber()
+  @Min(-360)
+  @Max(360)
+  @IsOptional()
+  rotation?: number;
+
+  @ApiProperty({ enum: TableShape, required: false })
+  @IsEnum(TableShape)
+  @IsOptional()
+  shape?: TableShape;
+}

--- a/backend/src/modules/tables/floor-plan.controller.ts
+++ b/backend/src/modules/tables/floor-plan.controller.ts
@@ -1,0 +1,162 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Patch,
+  Delete,
+  Body,
+  Param,
+  UseGuards,
+  ParseUUIDPipe,
+} from "@nestjs/common";
+import {
+  ApiTags,
+  ApiOperation,
+  ApiBearerAuth,
+  ApiResponse,
+} from "@nestjs/swagger";
+import { FloorPlanService } from "./floor-plan.service";
+import { JwtAuthGuard } from "../auth/guards/jwt-auth.guard";
+import { RolesGuard } from "../auth/guards/roles.guard";
+import { TenantGuard } from "../auth/guards/tenant.guard";
+import { PlanFeatureGuard } from "../subscriptions/guards/plan-feature.guard";
+import { Roles } from "../auth/decorators/roles.decorator";
+import { CurrentScope } from "../auth/decorators/current-scope.decorator";
+import { BranchScope } from "../../common/scoping/branch-scope";
+import { UserRole } from "../../common/constants/roles.enum";
+import {
+  CreateFloorZoneDto,
+  UpdateFloorZoneDto,
+  ReorderZonesDto,
+} from "./dto/floor-zone.dto";
+import {
+  CreateFloorElementDto,
+  UpdateFloorElementDto,
+} from "./dto/floor-element.dto";
+import { SaveLayoutDto } from "./dto/save-layout.dto";
+
+/**
+ * 2D floor-plan API: zones (kat/bahçe/teras), their decorative/structural
+ * elements, and bulk layout persistence. All routes are branch-scoped via
+ * @CurrentScope. Reads are open to any authenticated role (the live POS/KDS
+ * map consumes them); writes are ADMIN/MANAGER (floor-plan design).
+ */
+@ApiTags("floor-plan")
+@ApiBearerAuth()
+@Controller("floor-plan")
+@UseGuards(JwtAuthGuard, TenantGuard, RolesGuard, PlanFeatureGuard)
+export class FloorPlanController {
+  constructor(private readonly floorPlan: FloorPlanService) {}
+
+  @Get()
+  @ApiOperation({ summary: "Get the full floor plan for the current branch" })
+  @ApiResponse({
+    status: 200,
+    description: "Zones (with elements + tables) + unplaced tables",
+  })
+  getPlan(@CurrentScope() scope: BranchScope) {
+    return this.floorPlan.getPlan(scope);
+  }
+
+  // ---- Zones (static routes before :id) ----
+
+  @Post("zones")
+  @Roles(UserRole.ADMIN, UserRole.MANAGER)
+  @ApiOperation({ summary: "Create a floor zone (ADMIN, MANAGER)" })
+  @ApiResponse({ status: 201, description: "Zone created" })
+  @ApiResponse({ status: 409, description: "Zone name already exists" })
+  createZone(
+    @Body() dto: CreateFloorZoneDto,
+    @CurrentScope() scope: BranchScope,
+  ) {
+    return this.floorPlan.createZone(scope, dto);
+  }
+
+  @Post("zones/reorder")
+  @Roles(UserRole.ADMIN, UserRole.MANAGER)
+  @ApiOperation({ summary: "Reorder floor zones (ADMIN, MANAGER)" })
+  reorderZones(
+    @Body() dto: ReorderZonesDto,
+    @CurrentScope() scope: BranchScope,
+  ) {
+    return this.floorPlan.reorderZones(scope, dto);
+  }
+
+  @Patch("zones/:id")
+  @Roles(UserRole.ADMIN, UserRole.MANAGER)
+  @ApiOperation({ summary: "Update a floor zone (ADMIN, MANAGER)" })
+  @ApiResponse({ status: 404, description: "Zone not found" })
+  updateZone(
+    @Param("id", new ParseUUIDPipe()) id: string,
+    @Body() dto: UpdateFloorZoneDto,
+    @CurrentScope() scope: BranchScope,
+  ) {
+    return this.floorPlan.updateZone(scope, id, dto);
+  }
+
+  @Delete("zones/:id")
+  @Roles(UserRole.ADMIN, UserRole.MANAGER)
+  @ApiOperation({
+    summary:
+      "Delete a floor zone — its tables fall back to unplaced, its elements are removed (ADMIN, MANAGER)",
+  })
+  @ApiResponse({ status: 404, description: "Zone not found" })
+  deleteZone(
+    @Param("id", new ParseUUIDPipe()) id: string,
+    @CurrentScope() scope: BranchScope,
+  ) {
+    return this.floorPlan.deleteZone(scope, id);
+  }
+
+  // ---- Elements ----
+
+  @Post("elements")
+  @Roles(UserRole.ADMIN, UserRole.MANAGER)
+  @ApiOperation({ summary: "Create a floor element (ADMIN, MANAGER)" })
+  createElement(
+    @Body() dto: CreateFloorElementDto,
+    @CurrentScope() scope: BranchScope,
+  ) {
+    return this.floorPlan.createElement(scope, dto);
+  }
+
+  @Patch("elements/:id")
+  @Roles(UserRole.ADMIN, UserRole.MANAGER)
+  @ApiOperation({ summary: "Update a floor element (ADMIN, MANAGER)" })
+  @ApiResponse({ status: 404, description: "Element not found" })
+  updateElement(
+    @Param("id", new ParseUUIDPipe()) id: string,
+    @Body() dto: UpdateFloorElementDto,
+    @CurrentScope() scope: BranchScope,
+  ) {
+    return this.floorPlan.updateElement(scope, id, dto);
+  }
+
+  @Delete("elements/:id")
+  @Roles(UserRole.ADMIN, UserRole.MANAGER)
+  @ApiOperation({ summary: "Delete a floor element (ADMIN, MANAGER)" })
+  @ApiResponse({ status: 404, description: "Element not found" })
+  deleteElement(
+    @Param("id", new ParseUUIDPipe()) id: string,
+    @CurrentScope() scope: BranchScope,
+  ) {
+    return this.floorPlan.deleteElement(scope, id);
+  }
+
+  // ---- Bulk layout save ----
+
+  @Patch("layout")
+  @Roles(UserRole.ADMIN, UserRole.MANAGER)
+  @ApiOperation({
+    summary:
+      "Persist a full drag/resize session: table + element geometry (ADMIN, MANAGER)",
+  })
+  @ApiResponse({ status: 200, description: "Counts of rows updated" })
+  @ApiResponse({
+    status: 400,
+    description: "A target zone is not in this branch",
+  })
+  saveLayout(@Body() dto: SaveLayoutDto, @CurrentScope() scope: BranchScope) {
+    return this.floorPlan.saveLayout(scope, dto);
+  }
+}

--- a/backend/src/modules/tables/floor-plan.service.spec.ts
+++ b/backend/src/modules/tables/floor-plan.service.spec.ts
@@ -1,0 +1,195 @@
+import {
+  BadRequestException,
+  ConflictException,
+  NotFoundException,
+} from "@nestjs/common";
+import { FloorPlanService } from "./floor-plan.service";
+import {
+  mockPrismaClient,
+  MockPrismaClient,
+} from "../../common/test/prisma-mock.service";
+
+/**
+ * Unit specs for FloorPlanService — the 2D floor-plan model (zones, elements,
+ * bulk layout save). Focus: branch-scoping (every WHERE carries tenantId +
+ * branchId), the cross-branch zone IDOR guards, the delete-zone fallback
+ * (tables → unplaced, elements removed), and that layout saves validate
+ * target zones before writing. Prisma is mocked; $transaction is wired to run
+ * its callback against the same mock (callback form) or Promise.all an array
+ * (the reorder form).
+ */
+describe("FloorPlanService", () => {
+  let prisma: MockPrismaClient;
+  let gateway: { emitFloorLayoutUpdated: jest.Mock };
+  let svc: FloorPlanService;
+
+  const scope = { tenantId: "t1", branchId: "b1" };
+
+  beforeEach(() => {
+    prisma = mockPrismaClient();
+    gateway = { emitFloorLayoutUpdated: jest.fn() };
+    svc = new FloorPlanService(prisma as any, gateway as any);
+
+    (prisma.$transaction as any).mockImplementation(async (arg: any) =>
+      Array.isArray(arg) ? Promise.all(arg) : arg(prisma),
+    );
+  });
+
+  describe("getPlan", () => {
+    it("groups tables under their zone and collects unplaced tables", async () => {
+      (prisma.floorZone.findMany as any).mockResolvedValue([
+        { id: "z1", name: "Kat 1", sortOrder: 0, elements: [] },
+        { id: "z2", name: "Bahçe", sortOrder: 1, elements: [] },
+      ]);
+      (prisma.table.findMany as any).mockResolvedValue([
+        { id: "tb1", number: "1", capacity: 4, status: "AVAILABLE", groupId: null, zoneId: "z1", posX: 10, posY: 20, width: 80, height: 80, rotation: 0, shape: "ROUND", _count: { orders: 2 } },
+        { id: "tb2", number: "2", capacity: 2, status: "OCCUPIED", groupId: null, zoneId: null, posX: 0, posY: 0, width: 80, height: 80, rotation: 0, shape: "SQUARE", _count: { orders: 0 } },
+      ]);
+
+      const plan = await svc.getPlan(scope as any);
+
+      expect(plan.zones).toHaveLength(2);
+      expect(plan.zones[0].tables).toHaveLength(1);
+      expect(plan.zones[0].tables[0]).toMatchObject({ id: "tb1", activeOrderCount: 2, tableShape: "ROUND" });
+      expect(plan.zones[1].tables).toHaveLength(0);
+      expect(plan.unplacedTables).toHaveLength(1);
+      expect(plan.unplacedTables[0].id).toBe("tb2");
+    });
+
+    it("scopes both queries to the branch", async () => {
+      (prisma.floorZone.findMany as any).mockResolvedValue([]);
+      (prisma.table.findMany as any).mockResolvedValue([]);
+      await svc.getPlan(scope as any);
+      expect((prisma.floorZone.findMany as any).mock.calls[0][0].where).toMatchObject({ tenantId: "t1", branchId: "b1" });
+      expect((prisma.table.findMany as any).mock.calls[0][0].where).toMatchObject({ tenantId: "t1", branchId: "b1" });
+    });
+  });
+
+  describe("createZone", () => {
+    it("rejects a duplicate zone name", async () => {
+      (prisma.floorZone.findFirst as any).mockResolvedValue({ id: "z-existing" });
+      await expect(svc.createZone(scope as any, { name: "Kat 1" } as any)).rejects.toThrow(ConflictException);
+      expect(prisma.floorZone.create).not.toHaveBeenCalled();
+    });
+
+    it("appends after the last zone (sortOrder = last+1) and emits", async () => {
+      (prisma.floorZone.findFirst as any).mockResolvedValue(null); // name free
+      (prisma.floorZone.findFirst as any).mockResolvedValueOnce(null); // name free
+      (prisma.floorZone.findFirst as any).mockResolvedValueOnce(null);
+      // second findFirst call (last sortOrder lookup) returns sortOrder 4
+      (prisma.floorZone.findFirst as any)
+        .mockReset()
+        .mockResolvedValueOnce(null) // assertZoneNameFree
+        .mockResolvedValueOnce({ sortOrder: 4 }); // last zone
+      (prisma.floorZone.create as any).mockResolvedValue({ id: "z-new", sortOrder: 5 });
+
+      await svc.createZone(scope as any, { name: "Teras" } as any);
+
+      const createArg = (prisma.floorZone.create as any).mock.calls[0][0].data;
+      expect(createArg.sortOrder).toBe(5);
+      expect(createArg).toMatchObject({ tenantId: "t1", branchId: "b1", name: "Teras" });
+      expect(gateway.emitFloorLayoutUpdated).toHaveBeenCalled();
+    });
+  });
+
+  describe("deleteZone", () => {
+    it("unplaces tables, removes elements, deletes the zone, emits", async () => {
+      (prisma.floorZone.findFirst as any).mockResolvedValue({ id: "z1" });
+      (prisma.table.updateMany as any).mockResolvedValue({ count: 3 });
+      (prisma.floorElement.deleteMany as any).mockResolvedValue({ count: 2 });
+      (prisma.floorZone.deleteMany as any).mockResolvedValue({ count: 1 });
+
+      await svc.deleteZone(scope as any, "z1");
+
+      expect((prisma.table.updateMany as any).mock.calls[0][0]).toMatchObject({
+        where: { zoneId: "z1", tenantId: "t1", branchId: "b1" },
+        data: { zoneId: null },
+      });
+      expect(prisma.floorElement.deleteMany).toHaveBeenCalledWith({
+        where: { zoneId: "z1", tenantId: "t1", branchId: "b1" },
+      });
+      expect(gateway.emitFloorLayoutUpdated).toHaveBeenCalled();
+    });
+
+    it("404s when the zone is not in the branch", async () => {
+      (prisma.floorZone.findFirst as any).mockResolvedValue(null);
+      await expect(svc.deleteZone(scope as any, "z1")).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe("createElement", () => {
+    it("rejects an element whose zone is not in the branch", async () => {
+      (prisma.floorZone.findFirst as any).mockResolvedValue(null);
+      await expect(
+        svc.createElement(scope as any, { zoneId: "z-other", type: "WALL" } as any),
+      ).rejects.toThrow(NotFoundException);
+      expect(prisma.floorElement.create).not.toHaveBeenCalled();
+    });
+
+    it("creates with branch scope stamped and emits", async () => {
+      (prisma.floorZone.findFirst as any).mockResolvedValue({ id: "z1" });
+      (prisma.floorElement.create as any).mockResolvedValue({ id: "e1" });
+      await svc.createElement(scope as any, { zoneId: "z1", type: "BAR", x: 5, y: 6 } as any);
+      const data = (prisma.floorElement.create as any).mock.calls[0][0].data;
+      expect(data).toMatchObject({ zoneId: "z1", type: "BAR", tenantId: "t1", branchId: "b1" });
+      expect(gateway.emitFloorLayoutUpdated).toHaveBeenCalledWith("t1", "b1", { zoneId: "z1" });
+    });
+  });
+
+  describe("saveLayout", () => {
+    it("rejects when a target zone is not in the branch (before any write)", async () => {
+      (prisma.floorZone.findMany as any).mockResolvedValue([]); // none of the zoneIds resolve
+      await expect(
+        svc.saveLayout(scope as any, {
+          tables: [{ id: "tb1", zoneId: "z-bad", posX: 0, posY: 0, width: 80, height: 80, rotation: 0, shape: "ROUND" }],
+        } as any),
+      ).rejects.toThrow(BadRequestException);
+      expect(prisma.table.updateMany).not.toHaveBeenCalled();
+    });
+
+    it("persists table + element geometry scope-bound and emits", async () => {
+      (prisma.floorZone.findMany as any).mockResolvedValue([{ id: "z1" }]);
+      (prisma.table.updateMany as any).mockResolvedValue({ count: 1 });
+      (prisma.floorElement.updateMany as any).mockResolvedValue({ count: 1 });
+
+      const res = await svc.saveLayout(scope as any, {
+        tables: [{ id: "tb1", zoneId: "z1", posX: 100, posY: 200, width: 90, height: 90, rotation: 45, shape: "RECT" }],
+        elements: [{ id: "e1", x: 1, y: 2, width: 50, height: 60, rotation: 0 }],
+      } as any);
+
+      expect(res).toEqual({ tableCount: 1, elementCount: 1 });
+      const tWhere = (prisma.table.updateMany as any).mock.calls[0][0].where;
+      expect(tWhere).toMatchObject({ id: "tb1", tenantId: "t1", branchId: "b1" });
+      const tData = (prisma.table.updateMany as any).mock.calls[0][0].data;
+      expect(tData).toMatchObject({ zoneId: "z1", posX: 100, posY: 200, shape: "RECT" });
+      expect(gateway.emitFloorLayoutUpdated).toHaveBeenCalledWith("t1", "b1", {});
+    });
+
+    it("allows unplacing a table (zoneId null) with no zone validation", async () => {
+      (prisma.table.updateMany as any).mockResolvedValue({ count: 1 });
+      const res = await svc.saveLayout(scope as any, {
+        tables: [{ id: "tb1", zoneId: null, posX: 0, posY: 0, width: 80, height: 80, rotation: 0, shape: "ROUND" }],
+      } as any);
+      expect(res.tableCount).toBe(1);
+      expect(prisma.floorZone.findMany).not.toHaveBeenCalled();
+      expect((prisma.table.updateMany as any).mock.calls[0][0].data.zoneId).toBeNull();
+    });
+  });
+
+  describe("reorderZones", () => {
+    it("updates each zone's sortOrder scope-bound and emits", async () => {
+      (prisma.floorZone.updateMany as any).mockResolvedValue({ count: 1 });
+      await svc.reorderZones(scope as any, {
+        zones: [
+          { id: "z1", sortOrder: 1 },
+          { id: "z2", sortOrder: 0 },
+        ],
+      } as any);
+      expect((prisma.floorZone.updateMany as any).mock.calls[0][0]).toMatchObject({
+        where: { id: "z1", tenantId: "t1", branchId: "b1" },
+        data: { sortOrder: 1 },
+      });
+      expect(gateway.emitFloorLayoutUpdated).toHaveBeenCalled();
+    });
+  });
+});

--- a/backend/src/modules/tables/floor-plan.service.ts
+++ b/backend/src/modules/tables/floor-plan.service.ts
@@ -1,0 +1,390 @@
+import {
+  Injectable,
+  NotFoundException,
+  ConflictException,
+  BadRequestException,
+} from "@nestjs/common";
+import { PrismaService } from "../../prisma/prisma.service";
+import { KdsGateway } from "../kds/kds.gateway";
+import { BranchScope, branchScope } from "../../common/scoping/branch-scope";
+import { OrderStatus } from "../../common/constants/order-status.enum";
+import {
+  CreateFloorZoneDto,
+  UpdateFloorZoneDto,
+  ReorderZonesDto,
+} from "./dto/floor-zone.dto";
+import {
+  CreateFloorElementDto,
+  UpdateFloorElementDto,
+} from "./dto/floor-element.dto";
+import { SaveLayoutDto } from "./dto/save-layout.dto";
+
+/**
+ * Owns the 2D floor-plan model: zones (kat/bahçe/teras), the decorative /
+ * structural elements placed on them, and bulk persistence of a drag/resize
+ * session. Table identity/CRUD stays in TablesService; this service only
+ * touches a table's spatial placement (zone + geometry).
+ *
+ * Every mutation is (tenantId, branchId)-scoped via a compound WHERE — the
+ * same IDOR guard the table mutations use — so a MANAGER scoped to branch A
+ * can never read or move branch B's plan.
+ */
+@Injectable()
+export class FloorPlanService {
+  constructor(
+    private prisma: PrismaService,
+    private kdsGateway: KdsGateway,
+  ) {}
+
+  private readonly ACTIVE_ORDER_FILTER = {
+    status: { notIn: [OrderStatus.PAID, OrderStatus.CANCELLED] },
+  };
+
+  /**
+   * The whole plan for the current branch: every zone (sorted) with its
+   * elements and placed tables, plus the tables not yet placed on any zone
+   * (the editor's "unplaced" tray). Tables carry an `activeOrderCount` so the
+   * live map can badge busy tables without a second request.
+   */
+  async getPlan(scope: BranchScope) {
+    const [zones, tables] = await Promise.all([
+      this.prisma.floorZone.findMany({
+        where: { ...branchScope(scope) },
+        orderBy: [{ sortOrder: "asc" }, { createdAt: "asc" }],
+        include: {
+          elements: { orderBy: { zIndex: "asc" } },
+        },
+      }),
+      this.prisma.table.findMany({
+        where: { ...branchScope(scope) },
+        orderBy: { number: "asc" },
+        include: {
+          _count: { select: { orders: { where: this.ACTIVE_ORDER_FILTER } } },
+        },
+      }),
+    ]);
+
+    const shape = (t: (typeof tables)[number]) => ({
+      id: t.id,
+      number: t.number,
+      capacity: t.capacity,
+      status: t.status,
+      groupId: t.groupId,
+      zoneId: t.zoneId,
+      posX: t.posX,
+      posY: t.posY,
+      width: t.width,
+      height: t.height,
+      rotation: t.rotation,
+      tableShape: t.shape,
+      activeOrderCount: t._count.orders,
+    });
+
+    const placedByZone = new Map<string, ReturnType<typeof shape>[]>();
+    const unplaced: ReturnType<typeof shape>[] = [];
+    for (const t of tables) {
+      if (t.zoneId) {
+        const list = placedByZone.get(t.zoneId) ?? [];
+        list.push(shape(t));
+        placedByZone.set(t.zoneId, list);
+      } else {
+        unplaced.push(shape(t));
+      }
+    }
+
+    return {
+      zones: zones.map((z) => ({
+        ...z,
+        tables: placedByZone.get(z.id) ?? [],
+      })),
+      unplacedTables: unplaced,
+    };
+  }
+
+  async createZone(scope: BranchScope, dto: CreateFloorZoneDto) {
+    await this.assertZoneNameFree(scope, dto.name);
+
+    // Append after the current last zone so a new zone shows up at the end of
+    // the tab strip rather than fighting for sortOrder 0.
+    const last = await this.prisma.floorZone.findFirst({
+      where: { ...branchScope(scope) },
+      orderBy: { sortOrder: "desc" },
+      select: { sortOrder: true },
+    });
+
+    const zone = await this.prisma.floorZone.create({
+      data: {
+        name: dto.name,
+        kind: dto.kind ?? "INDOOR",
+        canvasWidth: dto.canvasWidth ?? 1200,
+        canvasHeight: dto.canvasHeight ?? 800,
+        gridSize: dto.gridSize ?? 20,
+        backgroundImageUrl: dto.backgroundImageUrl,
+        backgroundOpacity: dto.backgroundOpacity ?? 1,
+        sortOrder: (last?.sortOrder ?? -1) + 1,
+        tenantId: scope.tenantId,
+        branchId: scope.branchId,
+      },
+    });
+    this.kdsGateway.emitFloorLayoutUpdated(scope.tenantId, scope.branchId, {});
+    return zone;
+  }
+
+  async updateZone(scope: BranchScope, id: string, dto: UpdateFloorZoneDto) {
+    const existing = await this.prisma.floorZone.findFirst({
+      where: { id, ...branchScope(scope) },
+    });
+    if (!existing) throw new NotFoundException("Floor zone not found");
+
+    if (dto.name && dto.name !== existing.name) {
+      await this.assertZoneNameFree(scope, dto.name);
+    }
+
+    const claim = await this.prisma.floorZone.updateMany({
+      where: { id, ...branchScope(scope) },
+      data: {
+        ...(dto.name !== undefined ? { name: dto.name } : {}),
+        ...(dto.kind !== undefined ? { kind: dto.kind } : {}),
+        ...(dto.canvasWidth !== undefined
+          ? { canvasWidth: dto.canvasWidth }
+          : {}),
+        ...(dto.canvasHeight !== undefined
+          ? { canvasHeight: dto.canvasHeight }
+          : {}),
+        ...(dto.gridSize !== undefined ? { gridSize: dto.gridSize } : {}),
+        ...(dto.backgroundImageUrl !== undefined
+          ? { backgroundImageUrl: dto.backgroundImageUrl }
+          : {}),
+        ...(dto.backgroundOpacity !== undefined
+          ? { backgroundOpacity: dto.backgroundOpacity }
+          : {}),
+      },
+    });
+    if (claim.count === 0) throw new NotFoundException("Floor zone not found");
+    this.kdsGateway.emitFloorLayoutUpdated(scope.tenantId, scope.branchId, {
+      zoneId: id,
+    });
+    return this.prisma.floorZone.findFirst({
+      where: { id, ...branchScope(scope) },
+    });
+  }
+
+  /**
+   * Delete a zone. Its tables are NOT deleted — they fall back to the
+   * unplaced tray (zoneId → null via the FK's ON DELETE SET NULL, mirrored
+   * here explicitly so it's scope-bound and obvious). Its elements are
+   * removed (FK cascade). Runs in one transaction.
+   */
+  async deleteZone(scope: BranchScope, id: string) {
+    await this.prisma.$transaction(async (tx) => {
+      const zone = await tx.floorZone.findFirst({
+        where: { id, ...branchScope(scope) },
+      });
+      if (!zone) throw new NotFoundException("Floor zone not found");
+
+      await tx.table.updateMany({
+        where: { zoneId: id, ...branchScope(scope) },
+        data: { zoneId: null },
+      });
+      await tx.floorElement.deleteMany({
+        where: { zoneId: id, ...branchScope(scope) },
+      });
+      const claim = await tx.floorZone.deleteMany({
+        where: { id, ...branchScope(scope) },
+      });
+      if (claim.count === 0)
+        throw new NotFoundException("Floor zone not found");
+    });
+    this.kdsGateway.emitFloorLayoutUpdated(scope.tenantId, scope.branchId, {});
+    return { id };
+  }
+
+  async reorderZones(scope: BranchScope, dto: ReorderZonesDto) {
+    await this.prisma.$transaction(
+      dto.zones.map((z) =>
+        this.prisma.floorZone.updateMany({
+          where: { id: z.id, ...branchScope(scope) },
+          data: { sortOrder: z.sortOrder },
+        }),
+      ),
+    );
+    this.kdsGateway.emitFloorLayoutUpdated(scope.tenantId, scope.branchId, {});
+    return { reordered: dto.zones.length };
+  }
+
+  async createElement(scope: BranchScope, dto: CreateFloorElementDto) {
+    await this.assertZoneInScope(scope, dto.zoneId);
+    const element = await this.prisma.floorElement.create({
+      data: {
+        zoneId: dto.zoneId,
+        type: dto.type,
+        x: dto.x ?? 0,
+        y: dto.y ?? 0,
+        width: dto.width ?? 100,
+        height: dto.height ?? 100,
+        rotation: dto.rotation ?? 0,
+        points: dto.points ?? undefined,
+        style: dto.style ?? undefined,
+        label: dto.label,
+        zIndex: dto.zIndex ?? 0,
+        tenantId: scope.tenantId,
+        branchId: scope.branchId,
+      },
+    });
+    this.kdsGateway.emitFloorLayoutUpdated(scope.tenantId, scope.branchId, {
+      zoneId: dto.zoneId,
+    });
+    return element;
+  }
+
+  async updateElement(
+    scope: BranchScope,
+    id: string,
+    dto: UpdateFloorElementDto,
+  ) {
+    const existing = await this.prisma.floorElement.findFirst({
+      where: { id, ...branchScope(scope) },
+    });
+    if (!existing) throw new NotFoundException("Floor element not found");
+
+    // Moving an element to another zone must stay within the branch.
+    if (dto.zoneId && dto.zoneId !== existing.zoneId) {
+      await this.assertZoneInScope(scope, dto.zoneId);
+    }
+
+    const claim = await this.prisma.floorElement.updateMany({
+      where: { id, ...branchScope(scope) },
+      data: {
+        ...(dto.zoneId !== undefined ? { zoneId: dto.zoneId } : {}),
+        ...(dto.type !== undefined ? { type: dto.type } : {}),
+        ...(dto.x !== undefined ? { x: dto.x } : {}),
+        ...(dto.y !== undefined ? { y: dto.y } : {}),
+        ...(dto.width !== undefined ? { width: dto.width } : {}),
+        ...(dto.height !== undefined ? { height: dto.height } : {}),
+        ...(dto.rotation !== undefined ? { rotation: dto.rotation } : {}),
+        ...(dto.points !== undefined ? { points: dto.points } : {}),
+        ...(dto.style !== undefined ? { style: dto.style } : {}),
+        ...(dto.label !== undefined ? { label: dto.label } : {}),
+        ...(dto.zIndex !== undefined ? { zIndex: dto.zIndex } : {}),
+      },
+    });
+    if (claim.count === 0)
+      throw new NotFoundException("Floor element not found");
+    this.kdsGateway.emitFloorLayoutUpdated(scope.tenantId, scope.branchId, {
+      zoneId: dto.zoneId ?? existing.zoneId,
+    });
+    return this.prisma.floorElement.findFirst({
+      where: { id, ...branchScope(scope) },
+    });
+  }
+
+  async deleteElement(scope: BranchScope, id: string) {
+    const existing = await this.prisma.floorElement.findFirst({
+      where: { id, ...branchScope(scope) },
+      select: { zoneId: true },
+    });
+    if (!existing) throw new NotFoundException("Floor element not found");
+    await this.prisma.floorElement.deleteMany({
+      where: { id, ...branchScope(scope) },
+    });
+    this.kdsGateway.emitFloorLayoutUpdated(scope.tenantId, scope.branchId, {
+      zoneId: existing.zoneId,
+    });
+    return { id };
+  }
+
+  /**
+   * Persist a full editor drag/resize session in one transaction: each
+   * table's zone + geometry and each touched element's geometry. Only rows
+   * that belong to this branch are written (compound WHERE), and any target
+   * zoneId is validated to be in-branch first so a layout payload can't
+   * reparent a table into another branch's zone.
+   */
+  async saveLayout(scope: BranchScope, dto: SaveLayoutDto) {
+    // Validate every distinct target zone up front (one query), so a bad
+    // zoneId fails the whole save rather than silently dropping a table into
+    // limbo mid-transaction.
+    const zoneIds = [
+      ...new Set(
+        dto.tables
+          .map((t) => t.zoneId)
+          .filter((z): z is string => typeof z === "string" && z.length > 0),
+      ),
+    ];
+    if (zoneIds.length > 0) {
+      const found = await this.prisma.floorZone.findMany({
+        where: { id: { in: zoneIds }, ...branchScope(scope) },
+        select: { id: true },
+      });
+      if (found.length !== zoneIds.length) {
+        throw new BadRequestException(
+          "One or more target zones do not exist in this branch",
+        );
+      }
+    }
+
+    const result = await this.prisma.$transaction(async (tx) => {
+      let tableCount = 0;
+      for (const t of dto.tables) {
+        const claim = await tx.table.updateMany({
+          where: { id: t.id, ...branchScope(scope) },
+          data: {
+            zoneId: t.zoneId ?? null,
+            posX: t.posX,
+            posY: t.posY,
+            width: t.width,
+            height: t.height,
+            rotation: t.rotation,
+            shape: t.shape,
+          },
+        });
+        tableCount += claim.count;
+      }
+
+      let elementCount = 0;
+      for (const e of dto.elements ?? []) {
+        const claim = await tx.floorElement.updateMany({
+          where: { id: e.id, ...branchScope(scope) },
+          data: {
+            x: e.x,
+            y: e.y,
+            width: e.width,
+            height: e.height,
+            rotation: e.rotation,
+            ...(e.points !== undefined ? { points: e.points } : {}),
+            ...(e.style !== undefined ? { style: e.style } : {}),
+          },
+        });
+        elementCount += claim.count;
+      }
+      return { tableCount, elementCount };
+    });
+
+    this.kdsGateway.emitFloorLayoutUpdated(scope.tenantId, scope.branchId, {});
+    return result;
+  }
+
+  // ------------------------------------------------------------------
+  // helpers
+  // ------------------------------------------------------------------
+
+  private async assertZoneNameFree(scope: BranchScope, name: string) {
+    const clash = await this.prisma.floorZone.findFirst({
+      where: { ...branchScope(scope), name },
+      select: { id: true },
+    });
+    if (clash) {
+      throw new ConflictException(`A zone named "${name}" already exists`);
+    }
+  }
+
+  private async assertZoneInScope(scope: BranchScope, zoneId: string) {
+    const zone = await this.prisma.floorZone.findFirst({
+      where: { id: zoneId, ...branchScope(scope) },
+      select: { id: true },
+    });
+    if (!zone) {
+      throw new NotFoundException("Floor zone not found in this branch");
+    }
+  }
+}

--- a/backend/src/modules/tables/tables.module.ts
+++ b/backend/src/modules/tables/tables.module.ts
@@ -1,6 +1,8 @@
 import { Module } from "@nestjs/common";
 import { TablesService } from "./tables.service";
 import { TablesController } from "./tables.controller";
+import { FloorPlanService } from "./floor-plan.service";
+import { FloorPlanController } from "./floor-plan.controller";
 import { PrismaModule } from "../../prisma/prisma.module";
 import { KdsModule } from "../kds/kds.module";
 import { ReservationsModule } from "../reservations/reservations.module";
@@ -11,8 +13,8 @@ import { ReservationsModule } from "../reservations/reservations.module";
   // customer table listing routes through it so the branch a guest sees
   // matches the public reservation flow.
   imports: [PrismaModule, KdsModule, ReservationsModule],
-  controllers: [TablesController],
-  providers: [TablesService],
-  exports: [TablesService],
+  controllers: [TablesController, FloorPlanController],
+  providers: [TablesService, FloorPlanService],
+  exports: [TablesService, FloorPlanService],
 })
 export class TablesModule {}

--- a/backend/src/modules/tables/tables.service.ts
+++ b/backend/src/modules/tables/tables.service.ts
@@ -76,6 +76,13 @@ export class TablesService {
       );
     }
 
+    // If the table is being created directly onto a zone (e.g. the editor
+    // drops a new table on the canvas), the zone must belong to this branch
+    // — otherwise the table would be placed on another branch's plan.
+    if (createTableDto.zoneId) {
+      await this.assertZoneInScope(scope, createTableDto.zoneId);
+    }
+
     // v3.0.0 strict: every Table now requires a branchId (Restrict on
     // delete). Sourced from @CurrentScope() in the controller — the
     // table physically belongs to one branch and OrdersService.create
@@ -86,10 +93,47 @@ export class TablesService {
         capacity: createTableDto.capacity,
         section: createTableDto.section,
         status: createTableDto.status || TableStatus.AVAILABLE,
+        // Optional floor-plan geometry; DB defaults apply when omitted.
+        ...(createTableDto.zoneId !== undefined
+          ? { zoneId: createTableDto.zoneId }
+          : {}),
+        ...(createTableDto.posX !== undefined
+          ? { posX: createTableDto.posX }
+          : {}),
+        ...(createTableDto.posY !== undefined
+          ? { posY: createTableDto.posY }
+          : {}),
+        ...(createTableDto.width !== undefined
+          ? { width: createTableDto.width }
+          : {}),
+        ...(createTableDto.height !== undefined
+          ? { height: createTableDto.height }
+          : {}),
+        ...(createTableDto.rotation !== undefined
+          ? { rotation: createTableDto.rotation }
+          : {}),
+        ...(createTableDto.shape !== undefined
+          ? { shape: createTableDto.shape }
+          : {}),
         tenantId: scope.tenantId,
         branchId: scope.branchId,
       },
     });
+  }
+
+  /**
+   * Guard: a zoneId supplied via table create/update must reference a
+   * FloorZone in the caller's branch. Stops a table being parented into
+   * another branch's (or tenant's) floor plan.
+   */
+  private async assertZoneInScope(scope: BranchScope, zoneId: string) {
+    const zone = await this.prisma.floorZone.findFirst({
+      where: { id: zoneId, ...branchScope(scope) },
+      select: { id: true },
+    });
+    if (!zone) {
+      throw new NotFoundException("Floor zone not found in this branch");
+    }
   }
 
   async findAll(scope: BranchScope, section?: string) {
@@ -323,6 +367,12 @@ export class TablesService {
           `Table number ${updateTableDto.number} already exists`,
         );
       }
+    }
+
+    // A zoneId in the update payload must reference an in-branch zone (IDOR
+    // guard, mirrors create()). zoneId=null (unplace) is always allowed.
+    if (updateTableDto.zoneId) {
+      await this.assertZoneInScope(scope, updateTableDto.zoneId);
     }
 
     // Active-order guard parity with updateStatus(). UpdateTableDto =

--- a/docs/superpowers/specs/2026-06-24-floor-plan-editor-design.md
+++ b/docs/superpowers/specs/2026-06-24-floor-plan-editor-design.md
@@ -1,0 +1,71 @@
+# Restaurant 2D Floor-Plan Editor — Design Spec
+
+**Date:** 2026-06-24
+**Goal:** Turn the Tables ("masalar") page into a dynamic 2D map of the restaurant: an admin designs the floor (multiple **zones** — kat/bahçe/teras — each its own canvas, with tables + structural/decor elements), and the **same map runs live** in POS (real-time status, click-to-act) and a read-only Tables view. Rich table rendering (shape + auto seats + rotation + status/notification badges).
+
+**Scope approved by user:** full live-integrated map · tables + structural/decor elements (+ optional per-zone background blueprint image) · rich table shapes. Backward-compat not required (no active users). Directive: `/goal` — build the most professional/comprehensive version and don't stop until shipped to prod.
+
+**Engine:** `react-konva` (already installed). Purpose-built: `Stage`/`Layer`/`Transformer` (resize+rotate handles), drag, zoom/pan, hit-testing, snapping, perf.
+
+---
+
+## Data model (Prisma — branch-scoped)
+
+### New `FloorZone` (a kat / bahçe / teras)
+`id, name, sortOrder, kind(INDOOR|OUTDOOR), canvasWidth, canvasHeight, gridSize, backgroundImageUrl?, backgroundOpacity, tenantId, branchId, timestamps`.
+Unique `(tenantId, branchId, name)`. `tables: Table[]`, `elements: FloorElement[]`. Branch onDelete Cascade (branch can't be deleted while tables exist anyway — Table.branch is Restrict).
+
+### New `FloorElement` (non-table structure/decor)
+`id, type(WALL|DOOR|BAR|KITCHEN|PLANT|DECOR|TEXT|RECT), x, y, width, height, rotation, points(Json — polyline walls), style(Json — fill/stroke/fontSize…), label?, zIndex, zoneId(FK Cascade), tenantId, branchId, timestamps`.
+
+### `Table` additions (spatial)
+`zoneId(FK SetNull, nullable) + zone`, `posX, posY (Float, default 0)`, `width(80) height(80)`, `rotation(0)`, `shape String default "ROUND" (ROUND|SQUARE|RECT)`.
+- `zoneId = null` ⇒ table not yet placed → shown in the editor's "unplaced tray".
+- **`section` String stays through P1–P2** (additive, harmless) and is **dropped in P3** when the admin page is rewritten — avoids throwaway edits to a page that gets replaced.
+- Statuses unchanged: `AVAILABLE | OCCUPIED | RESERVED`. Seats render from existing `capacity`.
+
+Strings (shape/type/kind) validated at the DTO layer via `@IsEnum`, matching the existing `Table.status` String convention (no Prisma enum churn).
+
+---
+
+## Backend (module `modules/tables`, new `FloorPlanService` + `FloorPlanController`)
+
+Branch-scoped (`@CurrentScope`), ADMIN/MANAGER to edit, any authenticated role to read. New routes under `/floor-plan`:
+
+| Method | Route | Notes |
+|---|---|---|
+| GET | `/floor-plan/zones` | zones (sorted) each with `elements` + `tables` (+ live order/request counts + `upcomingReservation`) + an `unplacedTables` list |
+| POST | `/floor-plan/zones` | create zone |
+| PATCH | `/floor-plan/zones/:id` | rename/resize/grid/background |
+| DELETE | `/floor-plan/zones/:id` | SetNull its tables (→ unplaced), cascade-delete its elements |
+| POST | `/floor-plan/zones/reorder` | `[{id, sortOrder}]` |
+| POST | `/floor-plan/elements` / PATCH `:id` / DELETE `:id` | element CRUD |
+| PATCH | `/floor-plan/layout` | **bulk** `{ tables:[{id,zoneId,posX,posY,width,height,rotation,shape}], elements?:[{id,x,y,width,height,rotation,points,style}] }` — one call to persist a drag session |
+
+- Table create/update DTOs extended with optional spatial fields.
+- Gateway: `emitFloorLayoutUpdated(tenantId, branchId, {zoneId?})` → `floor:layout-updated` to `pos-`/`kitchen-` rooms so open live maps refresh after a republish.
+- Every write IDOR-guarded with compound `(tenantId, branchId)` WHERE (matches existing table mutations); bulk layout runs in one transaction.
+
+---
+
+## Frontend
+
+Shared **`FloorMap`** Konva core (`features/floor-plan/`), two modes:
+
+- **Edit mode** (`FloorPlanEditorPage`, admin): element palette (table ROUND/SQUARE/RECT, wall, door, bar, kitchen, plant, decor, text), drag + `Transformer` resize/rotate, snap-to-grid + grid overlay, marquee + shift multi-select, duplicate/copy-paste/delete, **undo/redo**, zoom/pan + fit-to-screen, per-table inspector, per-zone settings (rename, reorder via tabs, canvas size, upload background + opacity), "unplaced tables" tray, explicit Save + dirty indicator (debounced bulk `PATCH /floor-plan/layout`).
+- **Live mode** (POS floor + read-only Tables map): same coords, tables colored by real-time status, badges (pending orders / waiter / bill — reuse `TableGrid` logic), reservation-hold badge, merged-group link, click → action sheet (open order / change status / transfer / merge). Zoom/pan + zone tabs + list fallback. Live via existing sockets + `floor:layout-updated`.
+
+State: a `floorEditorStore` (zustand: selection, active tool, undo stack, dirty) for edit mode; react-query for persistence; live mode reuses the POS socket store.
+
+Touch-points updated: `types/index.ts`, `tablesApi.ts` (+ `floorPlanApi.ts`), `tableStatus.ts`, POS `TableGrid`→live map, admin `TableManagementPage`→editor (+ keep a plain list for quick CRUD), reservations assign-on-map, QR `TableSelectionModal` (can show zone name), i18n (ar/en/ru/tr/uz). KDS unchanged (uses `number`).
+
+---
+
+## Phasing (each ships branch→PR→staging→prod)
+
+- **P1 — Foundation (additive, safe):** schema (FloorZone, FloorElement, Table spatial fields) + idempotent migration + `FloorPlanService`/`Controller` + DTOs + bulk layout API + `floor:layout-updated` gateway event + backend tests. Nothing in the UI changes yet; `section` retained.
+- **P2 — Editor:** the Konva edit-mode editor (zones, tables, structural/decor, background, undo/redo, snap, inspector) at a new admin route + `floorPlanApi.ts` + types + i18n + vitest.
+- **P3 — Live integration:** live `FloorMap` in POS + read-only Tables map; wire real-time status/badges/click-actions; reservations assign-on-map; rewrite/replace `TableManagementPage`; **drop `section`** (migration + consumer cleanup); QR picker zone label.
+- **P4 — Polish:** touch/mobile, animations, empty/loading states, full i18n sweep, accessibility, perf pass, completeness review.
+
+Quality bar each phase: backend tsc+jest, frontend tsc+vitest+eslint, i18n parity+value-drift, contract-drift, cargo (if touched); adversarial-review workflow over the diff; fix blockers; then ship.


### PR DESCRIPTION
Phase 1 of 4 of the 2D restaurant floor-plan editor (design spec: `docs/superpowers/specs/2026-06-24-floor-plan-editor-design.md`).

**Additive + safe** — no UI change yet, legacy `tables.section` retained; everything nullable/defaulted.

## What's in P1
- **Schema**: `FloorZone` (a kat/bahçe/teras — its own 2D canvas, branch-scoped) + `FloorElement` (walls/doors/bar/kitchen/decor/text) + spatial fields on `Table` (`zoneId?`, `posX/posY/width/height/rotation/shape`).
- **Migration**: idempotent (`CREATE TABLE`/`ADD COLUMN IF NOT EXISTS`, guarded FKs). **Validated on a throwaway Postgres**: applies + re-applies clean; zone-delete SET-NULLs its tables (→ unplaced) and cascade-deletes its elements.
- **`FloorPlanService`/`Controller`** under `/floor-plan`: `getPlan` (zones+elements+placed tables + unplaced tray), zone CRUD + reorder, element CRUD, transactional **bulk `PATCH /floor-plan/layout`** for drag-save. Every mutation `(tenantId, branchId)`-scoped; target zones validated in-branch (cross-branch reparent IDOR guard).
- **`emitFloorLayoutUpdated`** → `floor:layout-updated` socket event so live POS/KDS maps refresh on republish.
- Table create/update accept optional geometry (zone-scope guarded).

## Verification
Backend tsc 0 · jest **454 suites / 4215 tests** (12 new `FloorPlanService` specs) · eslint clean · migration replayed on scratch DB.

Next: P2 (Konva editor), P3 (live POS/Tables integration + drop `section`), P4 (polish).