### PR TITLE
Floor-plan editor P3b — live floor map in POS table selection

### DIFF
--- a/backend/src/modules/reservations/reservations.module.ts
+++ b/backend/src/modules/reservations/reservations.module.ts
@@ -3,6 +3,9 @@ import { PrismaModule } from "../../prisma/prisma.module";
 import { NotificationsModule } from "../notifications/notifications.module";
 import { SubscriptionsModule } from "../subscriptions/subscriptions.module";
 import { SmsSettingsModule } from "../sms-settings/sms-settings.module";
+// KdsGateway: reservation status flips (seat/cancel/no-show + the auto-hold /
+// release crons) emit floor:layout-updated so live POS/Tables maps recolor.
+import { KdsModule } from "../kds/kds.module";
 import { ReservationsController } from "./controllers/reservations.controller";
 import { PublicReservationsController } from "./controllers/public-reservations.controller";
 import { ReservationsService } from "./services/reservations.service";
@@ -17,6 +20,7 @@ import { ReservationNotificationService } from "./services/reservation-notificat
     NotificationsModule,
     SubscriptionsModule,
     SmsSettingsModule,
+    KdsModule,
   ],
   controllers: [ReservationsController, PublicReservationsController],
   providers: [

--- a/backend/src/modules/reservations/services/reservation-scheduler.service.spec.ts
+++ b/backend/src/modules/reservations/services/reservation-scheduler.service.spec.ts
@@ -91,6 +91,19 @@ describe('ReservationSchedulerService.autoHoldUpcomingInner', () => {
     const res = await (svc as any).autoHoldUpcomingInner();
     expect(res.held).toBe(0);
   });
+
+  it('emits floor:layout-updated once per branch for held tables (live-map recolor)', async () => {
+    const prisma = makePrisma();
+    const { date, time } = hhmmFromNow(10);
+    prisma.reservation.findMany.mockResolvedValue([
+      { id: 'r1', tenantId: 't1', branchId: 'b1', date, startTime: time, tableId: 'tbl1' },
+    ]);
+    prisma.table.updateMany.mockResolvedValue({ count: 1 });
+    const gateway = { emitFloorLayoutUpdated: jest.fn() };
+    const svc = new ReservationSchedulerService(prisma as any, gateway as any);
+    await (svc as any).autoHoldUpcomingInner();
+    expect(gateway.emitFloorLayoutUpdated).toHaveBeenCalledWith('t1', 'b1', {});
+  });
 });
 
 describe('ReservationSchedulerService.releaseExpiredHoldsInner', () => {
@@ -129,6 +142,18 @@ describe('ReservationSchedulerService.releaseExpiredHoldsInner', () => {
     prisma.table.updateMany.mockResolvedValue({ count: 1 });
     const svc = new ReservationSchedulerService(prisma as any);
     expect((await (svc as any).releaseExpiredHoldsInner()).released).toBe(1);
+  });
+
+  it('emits floor:layout-updated once per branch for released tables (live-map recolor)', async () => {
+    const prisma = makePrisma();
+    prisma.table.findMany.mockResolvedValue([
+      { id: 'tbl1', tenantId: 't1', branchId: 'b1', reservationHoldId: 'r1', reservationHold: { id: 'r1', status: ReservationStatus.CANCELLED } },
+    ]);
+    prisma.table.updateMany.mockResolvedValue({ count: 1 });
+    const gateway = { emitFloorLayoutUpdated: jest.fn() };
+    const svc = new ReservationSchedulerService(prisma as any, gateway as any);
+    await (svc as any).releaseExpiredHoldsInner();
+    expect(gateway.emitFloorLayoutUpdated).toHaveBeenCalledWith('t1', 'b1', {});
   });
 
   // These two cases use fake timers pinned to local noon so the HH:mm ↔

--- a/backend/src/modules/reservations/services/reservation-scheduler.service.ts
+++ b/backend/src/modules/reservations/services/reservation-scheduler.service.ts
@@ -1,8 +1,9 @@
-import { Injectable, Logger } from "@nestjs/common";
+import { Injectable, Logger, Optional } from "@nestjs/common";
 import { Cron, CronExpression } from "@nestjs/schedule";
 import { PrismaService } from "../../../prisma/prisma.service";
 import { ReservationStatus } from "../constants/reservation-status.enum";
 import { TableStatus } from "../../tables/dto/create-table.dto";
+import { KdsGateway } from "../../kds/kds.gateway";
 // v2.8.95 — both autoHoldUpcoming and releaseExpiredHolds mutate
 // shared table state on a 5-minute tick. Without a per-replica lock
 // every replica double-flips tables and double-emits NO_SHOW events.
@@ -51,7 +52,25 @@ const GRACE_AFTER_START_MINUTES = 30;
 export class ReservationSchedulerService {
   private readonly logger = new Logger(ReservationSchedulerService.name);
 
-  constructor(private readonly prisma: PrismaService) {}
+  constructor(
+    private readonly prisma: PrismaService,
+    // Live floor-map refresh when the crons flip table status (auto-hold
+    // AVAILABLE→RESERVED / release RESERVED→AVAILABLE). @Optional() so the
+    // bare-constructed scheduler unit tests keep working (emit no-ops there).
+    @Optional() private readonly kdsGateway?: KdsGateway,
+  ) {}
+
+  /**
+   * Emit one floor:layout-updated per affected (tenant, branch) after a cron
+   * batch so every open live map recolors. `touched` holds "tenantId|branchId"
+   * keys. Null-safe + best-effort — an emit must never fail the cron.
+   */
+  private emitTouchedBranches(touched: Set<string>) {
+    for (const key of touched) {
+      const [tenantId, branchId] = key.split("|");
+      this.kdsGateway?.emitFloorLayoutUpdated(tenantId, branchId, {});
+    }
+  }
 
   @Cron(CronExpression.EVERY_5_MINUTES, { name: "reservation-auto-hold" })
   async autoHoldUpcoming(): Promise<{ held: number }> {
@@ -87,6 +106,7 @@ export class ReservationSchedulerService {
       select: {
         id: true,
         tenantId: true,
+        branchId: true,
         date: true,
         startTime: true,
         tableId: true,
@@ -101,6 +121,7 @@ export class ReservationSchedulerService {
     );
 
     let held = 0;
+    const touched = new Set<string>();
     for (const r of candidates) {
       const offsetMin =
         offsetByTenant.get(r.tenantId) ?? DEFAULT_HOLD_OFFSET_MINUTES;
@@ -127,7 +148,10 @@ export class ReservationSchedulerService {
           reservationHoldId: r.id,
         },
       });
-      if (updated.count > 0) held += 1;
+      if (updated.count > 0) {
+        held += 1;
+        touched.add(`${r.tenantId}|${r.branchId}`);
+      }
     }
 
     if (held > 0) {
@@ -135,6 +159,7 @@ export class ReservationSchedulerService {
         `auto-hold: marked ${held} table(s) RESERVED for upcoming reservations`,
       );
     }
+    this.emitTouchedBranches(touched);
     return { held };
   }
 
@@ -164,6 +189,7 @@ export class ReservationSchedulerService {
 
     const now = new Date();
     let released = 0;
+    const touched = new Set<string>();
 
     for (const table of heldTables) {
       const r = table.reservationHold;
@@ -240,7 +266,10 @@ export class ReservationSchedulerService {
           reservationHoldId: null,
         },
       });
-      if (updated.count > 0) released += 1;
+      if (updated.count > 0) {
+        released += 1;
+        touched.add(`${table.tenantId}|${table.branchId}`);
+      }
     }
 
     if (released > 0) {
@@ -248,6 +277,7 @@ export class ReservationSchedulerService {
         `release-holds: cleared ${released} stale RESERVED hold(s)`,
       );
     }
+    this.emitTouchedBranches(touched);
     return { released };
   }
 

--- a/backend/src/modules/reservations/services/reservations.service.ts
+++ b/backend/src/modules/reservations/services/reservations.service.ts
@@ -19,6 +19,7 @@ import { ReservationQueryDto } from "../dto/reservation-query.dto";
 import { ReservationSettingsService } from "./reservation-settings.service";
 import { ReservationStatus } from "../constants/reservation-status.enum";
 import { ReservationNotificationService } from "./reservation-notification.service";
+import { KdsGateway } from "../../kds/kds.gateway";
 import {
   ReservationAvailabilityService,
   timeToMinutes,
@@ -49,7 +50,21 @@ export class ReservationsService {
     // @Optional() so bare-constructed test instances keep working; production
     // DI always provides the global EntitlementService.
     @Optional() private readonly entitlements?: EntitlementService,
+    // Live floor-plan map refresh on reservation-driven table status flips.
+    // @Optional() so bare-constructed unit tests keep working (the emit is then
+    // a no-op); production DI provides it via KdsModule.
+    @Optional() private readonly kdsGateway?: KdsGateway,
   ) {}
+
+  /**
+   * Recolor every open live floor map after a reservation changed a table's
+   * status (seat → OCCUPIED, complete/cancel/no-show/reject → AVAILABLE).
+   * Best-effort + null-safe: a socket hiccup or a bare-constructed test
+   * instance must never fail the reservation write.
+   */
+  private emitFloorRefresh(tenantId: string, branchId: string) {
+    this.kdsGateway?.emitFloorLayoutUpdated(tenantId, branchId, {});
+  }
 
   private countReservation(status: string): void {
     this.metrics?.incCounter(
@@ -767,6 +782,9 @@ export class ReservationsService {
     // (CONFIRMED rejections within the 30-min window), release it now
     // so a walk-in can use the table immediately.
     await this.releaseHoldIfOwned(reservation.id, reservation.tableId);
+    if (reservation.tableId) {
+      this.emitFloorRefresh(scope.tenantId, scope.branchId);
+    }
 
     const updated = await this.prisma.reservation.update({
       where: { id: reservation.id },
@@ -834,6 +852,7 @@ export class ReservationsService {
         where: { id: reservation.tableId, ...branchScope(scope) },
         data: { status: "OCCUPIED", reservationHoldId: null },
       });
+      this.emitFloorRefresh(scope.tenantId, scope.branchId);
     }
 
     return this.prisma.reservation.update({
@@ -890,6 +909,7 @@ export class ReservationsService {
         where: { id: reservation.tableId, ...branchScope(scope) },
         data: { status: "AVAILABLE", reservationHoldId: null },
       });
+      this.emitFloorRefresh(scope.tenantId, scope.branchId);
     }
 
     return this.prisma.reservation.update({
@@ -920,6 +940,9 @@ export class ReservationsService {
     // but doing it inline keeps the staff-visible state in sync with
     // the action they just took.
     await this.releaseHoldIfOwned(reservation.id, reservation.tableId);
+    if (reservation.tableId) {
+      this.emitFloorRefresh(scope.tenantId, scope.branchId);
+    }
 
     return this.prisma.reservation.update({
       where: { id: reservation.id },
@@ -958,6 +981,9 @@ export class ReservationsService {
       });
     } else {
       await this.releaseHoldIfOwned(reservation.id, reservation.tableId);
+    }
+    if (reservation.tableId) {
+      this.emitFloorRefresh(scope.tenantId, scope.branchId);
     }
 
     const cancelled = await this.prisma.reservation.update({
@@ -1047,6 +1073,9 @@ export class ReservationsService {
     // this row's assigned table — staff/customers shouldn't have to
     // wait for the next cron tick for the table to free up.
     await this.releaseHoldIfOwned(reservation.id, reservation.tableId);
+    if (reservation.tableId) {
+      this.emitFloorRefresh(tenantId, reservation.branchId);
+    }
 
     const updated = await this.prisma.reservation.update({
       where: { id: reservation.id },

--- a/backend/src/modules/tables/tables.service.spec.ts
+++ b/backend/src/modules/tables/tables.service.spec.ts
@@ -26,6 +26,7 @@ describe('TablesService (iter-9 defense-in-depth + v3 branch scope)', () => {
   let prisma: MockPrismaClient;
   let svc: TablesService;
   let availability: { resolvePublicBranchId: jest.Mock };
+  let kdsGateway: { emitFloorLayoutUpdated: jest.Mock } & Record<string, jest.Mock>;
 
   const scope: BranchScope = {
     tenantId: 't1',
@@ -38,7 +39,7 @@ describe('TablesService (iter-9 defense-in-depth + v3 branch scope)', () => {
     prisma = mockPrismaClient();
     // The service emits realtime updates via KdsGateway after writes;
     // a no-op mock keeps the tests focused on the DB-layer invariants.
-    const kdsGateway = {
+    kdsGateway = {
       emitTableUpdate: jest.fn(),
       emitTableUnmerge: jest.fn(),
       emitTableMerge: jest.fn(),
@@ -102,6 +103,26 @@ describe('TablesService (iter-9 defense-in-depth + v3 branch scope)', () => {
       await expect(
         svc.updateStatus(scope, 'tab-other', { status: TableStatus.OCCUPIED }),
       ).rejects.toThrow(NotFoundException);
+    });
+
+    it('emits floor:layout-updated when the status actually changes (live map recolor)', async () => {
+      prisma.table.findFirst.mockResolvedValue({ id: 'tab-1', tenantId: 't1', branchId: 'b1', zoneId: 'z1', status: TableStatus.AVAILABLE } as any);
+      (prisma.table.updateMany as any).mockResolvedValue({ count: 1 });
+      (prisma.table.findFirstOrThrow as any).mockResolvedValue({ id: 'tab-1', tenantId: 't1', branchId: 'b1', zoneId: 'z1', status: TableStatus.OCCUPIED } as any);
+
+      await svc.updateStatus(scope, 'tab-1', { status: TableStatus.OCCUPIED });
+
+      expect(kdsGateway.emitFloorLayoutUpdated).toHaveBeenCalledWith('t1', 'b1', { zoneId: 'z1' });
+    });
+
+    it('skips the emit when the status is unchanged (no-op confirm tap)', async () => {
+      prisma.table.findFirst.mockResolvedValue({ id: 'tab-1', tenantId: 't1', branchId: 'b1', zoneId: null, status: TableStatus.OCCUPIED } as any);
+      (prisma.table.updateMany as any).mockResolvedValue({ count: 1 });
+      (prisma.table.findFirstOrThrow as any).mockResolvedValue({ id: 'tab-1', tenantId: 't1', branchId: 'b1', zoneId: null, status: TableStatus.OCCUPIED } as any);
+
+      await svc.updateStatus(scope, 'tab-1', { status: TableStatus.OCCUPIED });
+
+      expect(kdsGateway.emitFloorLayoutUpdated).not.toHaveBeenCalled();
     });
   });
 
@@ -429,6 +450,26 @@ describe('TablesService (iter-9 defense-in-depth + v3 branch scope)', () => {
       await svc.update(scope, 'tab-1', { capacity: 6 } as any);
 
       expect((prisma.order.count as any).mock.calls.length).toBe(0);
+    });
+
+    it('emits floor:layout-updated when the edit modal changes status (live-map parity)', async () => {
+      prisma.table.findFirst.mockResolvedValue({ id: 'tab-1', tenantId: 't1', branchId: 'b1', zoneId: 'z1', status: TableStatus.OCCUPIED } as any);
+      (prisma.order.count as any).mockResolvedValue(0);
+      (prisma.table.updateMany as any).mockResolvedValue({ count: 1 });
+
+      await svc.update(scope, 'tab-1', { status: TableStatus.AVAILABLE } as any);
+
+      expect(kdsGateway.emitFloorLayoutUpdated).toHaveBeenCalledWith('t1', 'b1', { zoneId: 'z1' });
+    });
+
+    it('does NOT emit floor:layout-updated on a pure capacity edit (no status/geometry change)', async () => {
+      prisma.table.findFirst.mockResolvedValue({ id: 'tab-1', tenantId: 't1', branchId: 'b1', zoneId: 'z1', status: TableStatus.OCCUPIED } as any);
+      (prisma.table.findUnique as any).mockResolvedValue(null);
+      (prisma.table.updateMany as any).mockResolvedValue({ count: 1 });
+
+      await svc.update(scope, 'tab-1', { capacity: 6 } as any);
+
+      expect(kdsGateway.emitFloorLayoutUpdated).not.toHaveBeenCalled();
     });
   });
 });

--- a/backend/src/modules/tables/tables.service.ts
+++ b/backend/src/modules/tables/tables.service.ts
@@ -381,8 +381,9 @@ export class TablesService {
   }
 
   async update(scope: BranchScope, id: string, updateTableDto: UpdateTableDto) {
-    // Check if table exists and belongs to scope
-    await this.findOne(scope, id);
+    // Check if table exists and belongs to scope. Keep the prior row so we can
+    // tell whether a status change actually happened (live-map emit below).
+    const prior = await this.findOne(scope, id);
 
     // If table number is being updated, check for conflicts
     if (updateTableDto.number) {
@@ -450,13 +451,17 @@ export class TablesService {
       });
     });
 
-    // Refresh open floor-plan/live maps only when the table's geometry or zone
-    // actually changed — a pure status/number/capacity edit isn't a layout
-    // change (those propagate via their own table/order events).
+    // Refresh open floor-plan/live maps when the table's geometry/zone OR its
+    // status changed. A status edit via the admin Edit modal fires no order
+    // event, so without this the live map would keep the old color on every
+    // terminal until an unrelated refetch (parity with updateStatus()).
     const spatialTouched = TablesService.SPATIAL_KEYS.some(
       (k) => (updateTableDto as Record<string, unknown>)[k] !== undefined,
     );
-    if (spatialTouched) {
+    const statusChanged =
+      updateTableDto.status !== undefined &&
+      updateTableDto.status !== prior.status;
+    if (spatialTouched || statusChanged) {
       this.kdsGateway.emitFloorLayoutUpdated(
         scope.tenantId,
         scope.branchId,
@@ -476,11 +481,13 @@ export class TablesService {
     // moments apart can both succeed even if a new order was just
     // created — leaving the table free to be seated again while an
     // unpaid bill is still open.
+    let priorStatus: string | undefined;
     const updated = await this.prisma.$transaction(async (tx) => {
       const table = await tx.table.findFirst({
         where: { id, ...branchScope(scope) },
       });
       if (!table) throw new NotFoundException("Table not found");
+      priorStatus = table.status;
 
       // Marking AVAILABLE must not happen while active orders are open.
       // The frontend already filters for this, but two concurrent waiters
@@ -515,12 +522,16 @@ export class TablesService {
       });
     });
 
-    // A status change recolors the live floor map. Emit the same event the
+    // A real status change recolors the live floor map. Emit the same event the
     // map listens for so every open POS/Tables map (incl. other terminals)
-    // refreshes — parity with update()/remove()/merge which already emit.
-    this.kdsGateway.emitFloorLayoutUpdated(scope.tenantId, updated.branchId, {
-      zoneId: updated.zoneId ?? undefined,
-    });
+    // refreshes — parity with update()/remove()/merge. Skip the broadcast when
+    // the status didn't actually change (a "confirm" tap on the current status)
+    // so we don't invalidate every terminal's plan query for a no-op.
+    if (priorStatus !== updated.status) {
+      this.kdsGateway.emitFloorLayoutUpdated(scope.tenantId, updated.branchId, {
+        zoneId: updated.zoneId ?? undefined,
+      });
+    }
     return updated;
   }
 

--- a/frontend/src/features/floor-plan/components/LiveFloorMap.tsx
+++ b/frontend/src/features/floor-plan/components/LiveFloorMap.tsx
@@ -53,7 +53,10 @@ export default function LiveFloorMap({ onTableClick, emptyAction }: Props) {
   const [activeZoneId, setActiveZoneId] = useState<string | null>(null);
   const { ref: wrapRef, size } = useElementSize();
 
-  if (isLoading) {
+  // `!plan` covers the branch-unresolved case: useFloorPlan is enabled:!!branchId,
+  // so while branchId is null the query is idle (isLoading false) with no data —
+  // show the loader, not the misleading "no zones designed yet" empty state.
+  if (isLoading || !plan) {
     return (
       <div className="flex items-center justify-center h-full text-slate-400">
         <Loader2 className="w-5 h-5 animate-spin mr-2" /> {t('floorPlan:loading')}

--- a/frontend/src/features/tables/tablesApi.ts
+++ b/frontend/src/features/tables/tablesApi.ts
@@ -62,6 +62,10 @@ export const useUpdateTable = () => {
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['tables'] });
+      // A table edit (status/geometry/zone) also shows on the live floor map —
+      // recolor/refresh it on this client (the backend emits for other
+      // terminals when status or geometry changed).
+      queryClient.invalidateQueries({ queryKey: ['floorPlan'] });
       toast.success(i18n.t('common:notifications.tableUpdatedSuccessfully'));
     },
     onError: (error: any) => {

--- a/frontend/src/i18n/locales/ar/pos.json
+++ b/frontend/src/i18n/locales/ar/pos.json
@@ -167,6 +167,8 @@
   },
   "tableSelection": {
     "title": "اختر طاولة",
+    "viewGrid": "شبكة",
+    "viewMap": "خريطة",
     "description": "اختر طاولة لبدء استلام الطلبات",
     "takeawayOrder": "طلب للاستلام",
     "takeawayDescription": "طلب بدون طاولة",

--- a/frontend/src/i18n/locales/en/pos.json
+++ b/frontend/src/i18n/locales/en/pos.json
@@ -167,6 +167,8 @@
   },
   "tableSelection": {
     "title": "Select a Table",
+    "viewGrid": "Grid",
+    "viewMap": "Map",
     "description": "Choose a table to start taking orders",
     "takeawayOrder": "Takeaway Order",
     "takeawayDescription": "Order without a table",

--- a/frontend/src/i18n/locales/ru/pos.json
+++ b/frontend/src/i18n/locales/ru/pos.json
@@ -167,6 +167,8 @@
   },
   "tableSelection": {
     "title": "Выберите стол",
+    "viewGrid": "Сетка",
+    "viewMap": "Карта",
     "description": "Выберите стол чтобы начать принимать заказы",
     "takeawayOrder": "Заказ на вынос",
     "takeawayDescription": "Заказ без стола",

--- a/frontend/src/i18n/locales/tr/pos.json
+++ b/frontend/src/i18n/locales/tr/pos.json
@@ -167,6 +167,8 @@
   },
   "tableSelection": {
     "title": "Masa Seçin",
+    "viewGrid": "Izgara",
+    "viewMap": "Plan",
     "description": "Sipariş almaya başlamak için bir masa seçin",
     "takeawayOrder": "Paket Sipariş",
     "takeawayDescription": "Masa olmadan sipariş",

--- a/frontend/src/i18n/locales/uz/pos.json
+++ b/frontend/src/i18n/locales/uz/pos.json
@@ -167,6 +167,8 @@
   },
   "tableSelection": {
     "title": "Stol tanlang",
+    "viewGrid": "Katak",
+    "viewMap": "Xarita",
     "description": "Buyurtma olishni boshlash uchun stol tanlang",
     "takeawayOrder": "Olib ketish buyurtmasi",
     "takeawayDescription": "Stolsiz buyurtma",

--- a/frontend/src/pages/admin/TableManagementPage.tsx
+++ b/frontend/src/pages/admin/TableManagementPage.tsx
@@ -24,7 +24,8 @@ import {
   useUpdateTableStatus,
 } from '../../features/tables/tablesApi';
 import LiveFloorMap from '../../features/floor-plan/components/LiveFloorMap';
-import { Table, TableStatus, FloorPlanTable } from '../../types';
+import { useFloorPlan } from '../../features/floor-plan/floorPlanApi';
+import { Table, TableStatus } from '../../types';
 import Button from '../../components/ui/Button';
 import Modal from '../../components/ui/Modal';
 import Input from '../../components/ui/Input';
@@ -50,8 +51,17 @@ const TableManagementPage = () => {
   const navigate = useNavigate();
   // 'list' = the classic card grid; 'plan' = the live 2D floor map.
   const [view, setView] = useState<'list' | 'plan'>('list');
-  // Table tapped on the live plan → opens the quick status action sheet.
-  const [statusTarget, setStatusTarget] = useState<FloorPlanTable | null>(null);
+  // Table tapped on the live plan → opens the quick status action sheet. We hold
+  // only the id and re-derive the live row from the (socket-refreshed) plan, so
+  // the sheet's status/active-state can't go stale while it's open.
+  const [statusTargetId, setStatusTargetId] = useState<string | null>(null);
+  const { data: livePlan } = useFloorPlan();
+  const statusTarget = statusTargetId
+    ? (livePlan?.zones
+        .flatMap((z) => z.tables)
+        .concat(livePlan?.unplacedTables ?? [])
+        .find((tbl) => tbl.id === statusTargetId) ?? null)
+    : null;
   const [modalOpen, setModalOpen] = useState(false);
   const [editingTable, setEditingTable] = useState<Table | null>(null);
   // Styled delete confirmation replaces the native confirm(); holds the
@@ -315,16 +325,13 @@ const TableManagementPage = () => {
       )}
 
       {/* Main Content */}
-      {isLoading ? (
-        <div className="flex justify-center py-16">
-          <Spinner />
-        </div>
-      ) : view === 'plan' ? (
+      {view === 'plan' ? (
         /* Live 2D floor map — same plan as the editor, with real-time status.
-           Tapping a table opens the quick status action sheet. */
+           Tapping a table opens the quick status action sheet. The map drives
+           its OWN useFloorPlan loading; don't gate it on the tables-list query. */
         <div className="bg-white rounded-2xl border border-slate-200/60 overflow-hidden h-[72vh]">
           <LiveFloorMap
-            onTableClick={(tbl) => setStatusTarget(tbl)}
+            onTableClick={(tbl) => setStatusTargetId(tbl.id)}
             emptyAction={
               <Button onClick={() => navigate('/admin/floor-plan')}>
                 <MapIcon className="h-4 w-4 mr-2" />
@@ -332,6 +339,10 @@ const TableManagementPage = () => {
               </Button>
             }
           />
+        </div>
+      ) : isLoading ? (
+        <div className="flex justify-center py-16">
+          <Spinner />
         </div>
       ) : !tables || tables.length === 0 ? (
         /* Empty State */
@@ -596,7 +607,7 @@ const TableManagementPage = () => {
           plan. Sets the table status (the map recolors via socket/invalidate). */}
       <Modal
         isOpen={!!statusTarget}
-        onClose={() => setStatusTarget(null)}
+        onClose={() => setStatusTargetId(null)}
         title={
           statusTarget
             ? t('admin.tableNumberLabel', { number: statusTarget.number })
@@ -616,13 +627,17 @@ const TableManagementPage = () => {
                   <button
                     key={s}
                     type="button"
-                    disabled={isUpdatingStatus}
-                    onClick={() =>
+                    // Already-active status is a no-op — disable it (mirrors the
+                    // list-card segments) so a "confirm" tap doesn't fire a
+                    // redundant write + cross-terminal invalidation.
+                    disabled={isUpdatingStatus || active}
+                    onClick={() => {
+                      if (active) return;
                       updateTableStatus(
                         { id: statusTarget.id, status: s },
-                        { onSuccess: () => setStatusTarget(null) },
-                      )
-                    }
+                        { onSuccess: () => setStatusTargetId(null) },
+                      );
+                    }}
                     className={`flex items-center gap-2.5 h-11 px-4 rounded-xl border text-sm transition-colors ${
                       active
                         ? `${cfg.chip} font-medium`

--- a/frontend/src/pages/pos/POSPage.test.tsx
+++ b/frontend/src/pages/pos/POSPage.test.tsx
@@ -31,6 +31,9 @@ vi.mock('../../components/pos/ProgressiveSplitModal', () => ({ default: () => nu
 vi.mock('../../components/pos/ReservationActionDialog', () => ({ default: () => null }));
 vi.mock('../../components/pos/ManualLockDialog', () => ({ default: () => null }));
 vi.mock('../../components/ui/Spinner', () => ({ default: () => <div data-testid="spinner" /> }));
+// Heavy Konva live map — stub it (jsdom has no canvas, and its import chain
+// pulls i18n/config which this test's react-i18next mock doesn't initialize).
+vi.mock('../../features/floor-plan/components/LiveFloorMap', () => ({ default: () => <div data-testid="live-floor-map" /> }));
 
 // --- i18n ----------------------------------------------------------------
 vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (k: string) => k }) }));

--- a/frontend/src/pages/pos/POSPage.tsx
+++ b/frontend/src/pages/pos/POSPage.tsx
@@ -1,7 +1,8 @@
 import { useState, useEffect, useCallback, useMemo } from 'react';
 import { toast } from 'sonner';
 import { useTranslation } from 'react-i18next';
-import { ArrowLeft, ShoppingBag, ArrowRight, Users, Clock, User, Receipt } from 'lucide-react';
+import { ArrowLeft, ShoppingBag, ArrowRight, Users, Clock, User, Receipt, LayoutGrid, Map as MapIcon } from 'lucide-react';
+import LiveFloorMap from '../../features/floor-plan/components/LiveFloorMap';
 import MenuPanel from '../../components/pos/MenuPanel';
 import OrderCart from '../../components/pos/OrderCart';
 import PaymentModal from '../../components/pos/PaymentModal';
@@ -51,6 +52,8 @@ const POSPage = () => {
 
   // View state: table-selection or order
   const [currentView, setCurrentView] = useState<POSView>('table-selection');
+  // Table-selection layout: classic grid, or the live 2D floor map.
+  const [tableViewMode, setTableViewMode] = useState<'grid' | 'map'>('grid');
 
   const [selectedTable, setSelectedTable] = useState<Table | null>(null);
   // Cart persisted in localStorage so an accidental tab close / refresh
@@ -714,13 +717,36 @@ const POSPage = () => {
       {currentView === 'table-selection' && !isTablelessMode && (
         <div className="h-[calc(100vh-12rem)] flex flex-col">
           {/* Header */}
-          <div className="mb-6">
-            <h1 className="text-2xl md:text-3xl font-heading font-bold text-slate-900">
-              {t('tableSelection.title')}
-            </h1>
-            <p className="text-sm md:text-base text-slate-500 mt-1">
-              {t('tableSelection.description')}
-            </p>
+          <div className="mb-6 flex items-start justify-between gap-3">
+            <div>
+              <h1 className="text-2xl md:text-3xl font-heading font-bold text-slate-900">
+                {t('tableSelection.title')}
+              </h1>
+              <p className="text-sm md:text-base text-slate-500 mt-1">
+                {t('tableSelection.description')}
+              </p>
+            </div>
+            {/* Grid / live-map view toggle */}
+            <div className="inline-flex rounded-lg border border-slate-200 bg-white p-0.5 shrink-0">
+              <button
+                type="button"
+                onClick={() => setTableViewMode('grid')}
+                aria-pressed={tableViewMode === 'grid'}
+                aria-label={t('tableSelection.viewGrid', 'Izgara')}
+                className={`flex items-center justify-center w-10 h-9 rounded-md transition-colors ${tableViewMode === 'grid' ? 'bg-primary-50 text-primary-700' : 'text-slate-500 hover:text-slate-700'}`}
+              >
+                <LayoutGrid className="w-4 h-4" />
+              </button>
+              <button
+                type="button"
+                onClick={() => setTableViewMode('map')}
+                aria-pressed={tableViewMode === 'map'}
+                aria-label={t('tableSelection.viewMap', 'Plan')}
+                className={`flex items-center justify-center w-10 h-9 rounded-md transition-colors ${tableViewMode === 'map' ? 'bg-primary-50 text-primary-700' : 'text-slate-500 hover:text-slate-700'}`}
+              >
+                <MapIcon className="w-4 h-4" />
+              </button>
+            </div>
           </div>
 
           {/* Takeaway Hero Card (if tableless mode enabled) */}
@@ -755,7 +781,7 @@ const POSPage = () => {
           )}
 
           {/* Tables Grid */}
-          {!isLoadingTables && tables && (
+          {!isLoadingTables && tables && tableViewMode === 'grid' && (
             <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 2xl:grid-cols-6 gap-3 md:gap-4 auto-rows-max overflow-auto pb-4" data-tour="table-grid">
               {tables.map((table) => {
                 const notifications = getTableNotifications(table.id);
@@ -830,6 +856,20 @@ const POSPage = () => {
                   </button>
                 );
               })}
+            </div>
+          )}
+
+          {/* Live 2D floor map — tap a table to start/resume its order. Looks
+              up the full Table by id so handleSelectTable keeps every branch
+              (reservation dialog, manual-lock, load-existing-order). */}
+          {!isLoadingTables && tableViewMode === 'map' && (
+            <div className="flex-1 min-h-0 rounded-2xl border border-slate-200 overflow-hidden bg-white">
+              <LiveFloorMap
+                onTableClick={(fpt) => {
+                  const full = tables?.find((tb) => tb.id === fpt.id);
+                  if (full) handleSelectTable(full);
+                }}
+              />
             </div>
           )}
         </div>


### PR DESCRIPTION
P3b — extends the live floor map to the POS floor (where staff actually work).

- POS table-selection gets a **Grid / Map** toggle (Grid stays the default → no behavior change unless switched).
- Map view renders the same `LiveFloorMap` (read-only, real-time status). Tapping a table **looks up the full `Table` by id** from the POS tables query and calls the existing `handleSelectTable`, so every path is preserved: fresh order on AVAILABLE, resume existing order on OCCUPIED, reservation dialog / manual-lock on RESERVED.
- i18n `pos:tableSelection.viewGrid/viewMap` in all 5 locales; POSPage test stubs the Konva map.

Integration was mapped against the real POS flow (handler signature, table identity, data source) before wiring. **Verification:** frontend tsc 0 · vitest 251/1828 · eslint 0 · i18n parity + value-drift green.

Note: a separate increment (reservation-on-map) is in progress on the same feature area and will ship independently.