### PR TITLE
Redesign the QR codes admin page

### DIFF
--- a/frontend/src/components/qr/DesignEditor.tsx
+++ b/frontend/src/components/qr/DesignEditor.tsx
@@ -181,7 +181,7 @@ const DesignEditor = ({ settings, onUpdate, isUpdating, tenant }: DesignEditorPr
               className={`
                 py-3 px-4 border-b-2 font-medium text-sm flex items-center gap-2 transition-colors
                 ${activeTab === tab.id
-                  ? 'border-blue-500 text-blue-600'
+                  ? 'border-primary-500 text-primary-600'
                   : 'border-transparent text-slate-500 hover:text-slate-700 hover:border-slate-300'
                 }
               `}
@@ -327,7 +327,7 @@ const DesignEditor = ({ settings, onUpdate, isUpdating, tenant }: DesignEditorPr
                         onClick={() => setPreviewMode('mobile')}
                         className={`flex-1 px-3 py-1.5 rounded-lg text-xs font-medium transition-all ${
                           previewMode === 'mobile'
-                            ? 'bg-blue-600 text-white'
+                            ? 'bg-primary-600 text-white'
                             : 'bg-slate-100 text-slate-700 hover:bg-slate-200'
                         }`}
                       >
@@ -338,7 +338,7 @@ const DesignEditor = ({ settings, onUpdate, isUpdating, tenant }: DesignEditorPr
                         onClick={() => setPreviewMode('tablet')}
                         className={`flex-1 px-3 py-1.5 rounded-lg text-xs font-medium transition-all ${
                           previewMode === 'tablet'
-                            ? 'bg-blue-600 text-white'
+                            ? 'bg-primary-600 text-white'
                             : 'bg-slate-100 text-slate-700 hover:bg-slate-200'
                         }`}
                       >

--- a/frontend/src/components/qr/QrCodeDisplay.tsx
+++ b/frontend/src/components/qr/QrCodeDisplay.tsx
@@ -150,11 +150,11 @@ const QrCodeDisplay = ({ qrCode, tenant, compact = false, settings, caption }: Q
         <head>
           <title>${tenant?.name} - ${qrCode.label}</title>
           <style>
-            body { 
-              display: flex; 
-              justify-content: center; 
-              align-items: center; 
-              min-height: 100vh; 
+            body {
+              display: flex;
+              justify-content: center;
+              align-items: center;
+              min-height: 100vh;
               margin: 0;
               text-align: center;
             }
@@ -188,10 +188,30 @@ const QrCodeDisplay = ({ qrCode, tenant, compact = false, settings, caption }: Q
     window.open(qrCode.url, '_blank');
   };
 
+  // A single compact action button (icon + accessible label).
+  const IconAction = ({
+    onClick,
+    label,
+    children,
+  }: {
+    onClick: () => void;
+    label: string;
+    children: React.ReactNode;
+  }) => (
+    <button
+      onClick={onClick}
+      title={label}
+      aria-label={label}
+      className="flex-1 h-9 inline-flex items-center justify-center rounded-lg border border-slate-200 bg-white text-slate-600 hover:bg-primary-50 hover:text-primary-600 hover:border-primary-200 transition-colors"
+    >
+      {children}
+    </button>
+  );
+
   if (compact) {
     return (
-      <div className="bg-white border border-slate-200 rounded-xl shadow-sm hover:shadow-md transition-shadow p-5 flex flex-col items-center">
-        <div className="bg-gradient-to-br from-gray-50 to-white p-3 rounded-lg border border-slate-100 mb-3">
+      <div className="group bg-white border border-slate-200/70 rounded-2xl shadow-sm hover:shadow-md hover:border-primary-200 transition-all p-4 flex flex-col items-center">
+        <div className="relative bg-white p-3 rounded-xl border border-slate-100 ring-1 ring-slate-100 mb-3">
           <QRCode
             id={`qr-${qrCode.id}-small`}
             value={qrCode.url}
@@ -201,189 +221,162 @@ const QrCodeDisplay = ({ qrCode, tenant, compact = false, settings, caption }: Q
             bgColor={settings?.backgroundColor || '#FFFFFF'}
           />
         </div>
-        <p className="font-semibold text-sm text-slate-900 mb-1">{qrCode.label}</p>
-        <p className="text-xs text-slate-500 mb-3">{t('admin.clickToViewOptions')}</p>
+        <p className="font-semibold text-sm text-slate-900 text-center">{qrCode.label}</p>
+        <p className="text-xs text-slate-400 mb-3">{t('admin.tableQRCodes')}</p>
         <div className="flex gap-2 w-full">
-          <button
-            onClick={() => downloadQR('small')}
-            className="flex-1 px-3 py-2 text-sm border border-slate-200 bg-white hover:bg-slate-50 rounded-lg flex items-center justify-center gap-1 transition-colors"
-            title={t('qr.downloadQrCode')}
-          >
-            <Download className="h-3.5 w-3.5" />
-          </button>
-          <button
-            onClick={openPreview}
-            className="flex-1 px-3 py-2 text-sm border border-slate-200 bg-white hover:bg-slate-50 rounded-lg flex items-center justify-center gap-1 transition-colors"
-            title={t('qr.previewMenu')}
-          >
-            <Search className="h-3.5 w-3.5" />
-          </button>
-          <button
-            onClick={() => printQR('small')}
-            className="flex-1 px-3 py-2 text-sm border border-slate-200 bg-white hover:bg-slate-50 rounded-lg flex items-center justify-center gap-1 transition-colors"
-            title={t('qr.printQrCode')}
-          >
-            <Printer className="h-3.5 w-3.5" />
-          </button>
+          <IconAction onClick={() => downloadQR('small')} label={t('qr.downloadQrCode')}>
+            <Download className="h-4 w-4" />
+          </IconAction>
+          <IconAction onClick={openPreview} label={t('qr.previewMenu')}>
+            <Search className="h-4 w-4" />
+          </IconAction>
+          <IconAction onClick={() => printQR('small')} label={t('qr.printQrCode')}>
+            <Printer className="h-4 w-4" />
+          </IconAction>
         </div>
       </div>
     );
   }
 
   return (
-    <div className="bg-white rounded-xl shadow-sm border border-slate-100 p-6">
-      <div className="grid md:grid-cols-2 gap-8">
-        {/* QR Code Display Section */}
-        <div className="space-y-4">
-          <div className="text-center">
-            <h3 className="text-xl font-bold text-slate-900 mb-2">{qrCode.label}</h3>
-            <p className="text-sm text-slate-600">{resolvedCaption}</p>
-          </div>
+    <div className="grid md:grid-cols-2 gap-6 lg:gap-8">
+      {/* QR Code Display Section */}
+      <div className="space-y-4">
+        <div className="text-center">
+          <h3 className="text-lg font-bold text-slate-900">{qrCode.label}</h3>
+          <p className="text-sm text-slate-500 mt-0.5">{resolvedCaption}</p>
+        </div>
 
-          {/* Size Selector */}
-          <div className="bg-slate-50 rounded-lg p-3">
-            <p className="text-xs font-medium text-slate-700 mb-2 uppercase tracking-wide">{t('qr.previewSize')}</p>
-            <div className="grid grid-cols-3 gap-2">
-              {Object.entries(sizePresets).map(([key, preset]) => (
-                <button
-                  key={key}
-                  onClick={() => setSelectedSize(key as any)}
-                  className={`px-3 py-2 rounded-lg text-sm font-medium transition-all ${selectedSize === key
-                    ? 'bg-blue-600 text-white shadow-sm'
-                    : 'bg-white text-slate-700 border border-slate-200 hover:border-blue-300'
-                    }`}
-                >
-                  <div className="text-xs">{preset.label}</div>
-                  <div className="text-xs opacity-75">{preset.description}</div>
-                </button>
-              ))}
-            </div>
-          </div>
-
-          {/* QR Code Preview */}
-          <div className="flex justify-center">
-            <div className="bg-gradient-to-br from-gray-50 to-white p-4 rounded-xl border-2 border-slate-200 shadow-inner">
-              <QRCode
-                id={`qr-${qrCode.id}-${selectedSize}`}
-                value={qrCode.url}
-                size={currentSize.size}
-                level="H"
-                fgColor={settings?.primaryColor || '#000000'}
-                bgColor={settings?.backgroundColor || '#FFFFFF'}
-              />
-            </div>
+        {/* QR Code Preview */}
+        <div className="flex justify-center">
+          <div className="bg-white p-5 rounded-2xl border border-slate-200 ring-1 ring-slate-100 shadow-sm">
+            <QRCode
+              id={`qr-${qrCode.id}-${selectedSize}`}
+              value={qrCode.url}
+              size={currentSize.size}
+              level="H"
+              fgColor={settings?.primaryColor || '#000000'}
+              bgColor={settings?.backgroundColor || '#FFFFFF'}
+            />
           </div>
         </div>
 
-        {/* Actions Section */}
-        <div className="space-y-4">
-          {/* URL Display */}
-          <div className="bg-slate-50 rounded-lg p-4">
-            <div className="flex items-center justify-between mb-2">
-              <p className="text-xs font-medium text-slate-700 uppercase tracking-wide">{t('qr.menuUrl')}</p>
+        {/* Size Selector */}
+        <div>
+          <p className="text-xs font-medium text-slate-500 mb-2 uppercase tracking-wide">{t('qr.previewSize')}</p>
+          <div className="grid grid-cols-3 gap-2">
+            {Object.entries(sizePresets).map(([key, preset]) => (
               <button
-                onClick={copyToClipboard}
-                className="text-xs text-blue-600 hover:text-blue-700 flex items-center gap-1"
+                key={key}
+                onClick={() => setSelectedSize(key as any)}
+                className={`px-3 py-2 rounded-lg text-sm font-medium transition-all border ${selectedSize === key
+                  ? 'bg-primary-600 text-white border-primary-600 shadow-sm'
+                  : 'bg-white text-slate-700 border-slate-200 hover:border-primary-300'
+                  }`}
               >
-                {copied ? (
-                  <><Check className="h-3 w-3" /> {t('qr.copied')}</>
-                ) : (
-                  <><Copy className="h-3 w-3" /> {t('buttons.copy')}</>)}
+                <div className="text-xs">{preset.label}</div>
+                <div className={`text-[11px] ${selectedSize === key ? 'opacity-80' : 'text-slate-400'}`}>{preset.description}</div>
               </button>
-            </div>
-            <p className="text-sm text-slate-900 font-mono break-all bg-white rounded p-2 border border-slate-200">
-              {qrCode.url}
-            </p>
+            ))}
           </div>
+        </div>
+      </div>
 
-          {/* Download Options */}
-          <div className="space-y-3">
-            <p className="text-xs font-medium text-slate-700 uppercase tracking-wide">{t('qr.downloadFormat')}</p>
-            <div className="grid grid-cols-3 gap-2">
-              <button
-                onClick={() => setDownloadFormat('png')}
-                className={`px-3 py-2 rounded-lg text-sm font-medium flex items-center justify-center gap-2 transition-all ${downloadFormat === 'png'
-                  ? 'bg-blue-100 text-blue-700 border-2 border-blue-300'
-                  : 'bg-white text-slate-700 border border-slate-200 hover:border-slate-300'
-                  }`}
-              >
-                <FileImage className="h-4 w-4" />
-                {t('qr.png')}
-              </button>
-              <button
-                onClick={() => setDownloadFormat('svg')}
-                className={`px-3 py-2 rounded-lg text-sm font-medium flex items-center justify-center gap-2 transition-all ${downloadFormat === 'svg'
-                  ? 'bg-blue-100 text-blue-700 border-2 border-blue-300'
-                  : 'bg-white text-slate-700 border border-slate-200 hover:border-slate-300'
-                  }`}
-              >
-                <FileImage className="h-4 w-4" />
-                {t('qr.svg')}
-              </button>
-              <button
-                onClick={() => setDownloadFormat('pdf')}
-                className={`px-3 py-2 rounded-lg text-sm font-medium flex items-center justify-center gap-2 transition-all ${downloadFormat === 'pdf'
-                  ? 'bg-blue-100 text-blue-700 border-2 border-blue-300'
-                  : 'bg-white text-slate-700 border border-slate-200 hover:border-slate-300'
-                  }`}
-              >
-                <FileText className="h-4 w-4" />
-                {t('qr.pdf')}
-              </button>
-            </div>
+      {/* Actions Section */}
+      <div className="space-y-5">
+        {/* URL Display */}
+        <div className="bg-slate-50 rounded-xl p-4 border border-slate-100">
+          <div className="flex items-center justify-between mb-2">
+            <p className="text-xs font-medium text-slate-500 uppercase tracking-wide">{t('qr.menuUrl')}</p>
+            <button
+              onClick={copyToClipboard}
+              className="text-xs font-medium text-primary-600 hover:text-primary-700 flex items-center gap-1"
+            >
+              {copied ? (
+                <><Check className="h-3 w-3" /> {t('qr.copied')}</>
+              ) : (
+                <><Copy className="h-3 w-3" /> {t('buttons.copy')}</>)}
+            </button>
           </div>
+          <p className="text-sm text-slate-900 font-mono break-all bg-white rounded-lg p-2.5 border border-slate-200">
+            {qrCode.url}
+          </p>
+        </div>
 
-          {/* Action Buttons */}
-          <div className="space-y-3 pt-4">
+        {/* Download Options */}
+        <div className="space-y-2.5">
+          <p className="text-xs font-medium text-slate-500 uppercase tracking-wide">{t('qr.downloadFormat')}</p>
+          <div className="grid grid-cols-3 gap-2">
+            {([
+              { fmt: 'png' as const, icon: FileImage, label: t('qr.png') },
+              { fmt: 'svg' as const, icon: FileImage, label: t('qr.svg') },
+              { fmt: 'pdf' as const, icon: FileText, label: t('qr.pdf') },
+            ]).map(({ fmt, icon: Icon, label }) => (
+              <button
+                key={fmt}
+                onClick={() => setDownloadFormat(fmt)}
+                className={`px-3 py-2 rounded-lg text-sm font-medium flex items-center justify-center gap-2 transition-all border ${downloadFormat === fmt
+                  ? 'bg-primary-50 text-primary-700 border-primary-300'
+                  : 'bg-white text-slate-700 border-slate-200 hover:border-slate-300'
+                  }`}
+              >
+                <Icon className="h-4 w-4" />
+                {label}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* Action Buttons */}
+        <div className="space-y-3">
+          <Button
+            onClick={() => downloadQR()}
+            variant="primary"
+            className="w-full flex items-center justify-center gap-2"
+          >
+            <Download className="h-5 w-5" />
+            {t('qr.downloadFile', { format: downloadFormat.toUpperCase(), size: currentSize.label })}
+          </Button>
+
+          <div className="grid grid-cols-2 gap-3">
             <Button
-              onClick={() => downloadQR()}
-              variant="primary"
+              onClick={() => printQR()}
+              variant="outline"
+              className="flex items-center justify-center gap-2"
+            >
+              <Printer className="h-4 w-4" />
+              {t('buttons.print')}
+            </Button>
+            <Button
+              onClick={openPreview}
+              variant="outline"
+              className="flex items-center justify-center gap-2"
+            >
+              <Search className="h-4 w-4" />
+              {t('buttons.preview')}
+            </Button>
+          </div>
+
+          {typeof (navigator as any).share === 'function' && (
+            <Button
+              onClick={shareQR}
+              variant="outline"
               className="w-full flex items-center justify-center gap-2"
             >
-              <Download className="h-5 w-5" />
-              {t('qr.downloadFile', { format: downloadFormat.toUpperCase(), size: currentSize.label })}
+              <Share2 className="h-4 w-4" />
+              {t('qr.shareQrCode')}
             </Button>
+          )}
+        </div>
 
-            <div className="grid grid-cols-2 gap-3">
-              <Button
-                onClick={() => printQR()}
-                variant="outline"
-                className="flex items-center justify-center gap-2"
-              >
-                <Printer className="h-4 w-4" />
-                {t('buttons.print')}
-              </Button>
-              <Button
-                onClick={openPreview}
-                variant="outline"
-                className="flex items-center justify-center gap-2"
-              >
-                <Search className="h-4 w-4" />
-                {t('buttons.preview')}
-              </Button>
-            </div>
-
-            {typeof (navigator as any).share === 'function' && (
-              <Button
-                onClick={shareQR}
-                variant="outline"
-                className="w-full flex items-center justify-center gap-2"
-              >
-                <Share2 className="h-4 w-4" />
-                {t('qr.shareQrCode')}
-              </Button>
-            )}
-          </div>
-
-          {/* Usage Tips */}
-          <div className="bg-blue-50 border border-blue-200 rounded-lg p-3 mt-4">
-            <p className="text-xs font-medium text-blue-900 mb-1">{t('qr.proTipsTitle')}</p>
-            <ul className="text-xs text-blue-800 space-y-1">
-              <li>• {t('qr.proTip1')}</li>
-              <li>• {t('qr.proTip2')}</li>
-              <li>• {t('qr.proTip3')}</li>
-            </ul>
-          </div>
+        {/* Usage Tips */}
+        <div className="bg-primary-50/60 border border-primary-100 rounded-xl p-3.5">
+          <p className="text-xs font-semibold text-primary-900 mb-1">{t('qr.proTipsTitle')}</p>
+          <ul className="text-xs text-primary-800/90 space-y-1">
+            <li>• {t('qr.proTip1')}</li>
+            <li>• {t('qr.proTip2')}</li>
+            <li>• {t('qr.proTip3')}</li>
+          </ul>
         </div>
       </div>
     </div>

--- a/frontend/src/pages/admin/QRManagementPage.tsx
+++ b/frontend/src/pages/admin/QRManagementPage.tsx
@@ -1,10 +1,9 @@
 import { useState, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useQrSettings, useUpdateQrSettings, useQrCodes } from '../../features/qr/qrApi';
-import { Card, CardHeader, CardTitle, CardContent } from '../../components/ui/Card';
 import Button from '../../components/ui/Button';
 import Spinner from '../../components/ui/Spinner';
-import { QrCode, Download, Palette, Eye, DownloadCloud, FileArchive, LayoutGrid, Store } from 'lucide-react';
+import { QrCode, Download, Palette, Printer, LayoutGrid, Store, Lightbulb } from 'lucide-react';
 import DesignEditor from '../../components/qr/DesignEditor';
 import QrCodeDisplay from '../../components/qr/QrCodeDisplay';
 import type { UpdateQrSettingsDto } from '../../types';
@@ -288,15 +287,31 @@ const QRManagementPage = () => {
 
   return (
     <div className="space-y-6" data-tour="qr-management">
-      {/* Page Header */}
-      <div className="flex items-center gap-4">
-        <div className="w-14 h-14 rounded-2xl bg-gradient-to-br from-primary-500 to-primary-600 flex items-center justify-center shadow-lg shadow-primary-500/20">
-          <QrCode className="w-7 h-7 text-white" />
+      {/* Page Header + global batch actions */}
+      <div className="flex flex-wrap items-center justify-between gap-3 md:gap-4">
+        <div className="flex items-center gap-4">
+          <div className="w-14 h-14 rounded-2xl bg-gradient-to-br from-primary-500 to-primary-600 flex items-center justify-center shadow-lg shadow-primary-500/20">
+            <QrCode className="w-7 h-7 text-white" />
+          </div>
+          <div>
+            <h1 className="text-2xl font-heading font-bold text-slate-900">{t('admin.qrCodeManagement')}</h1>
+            <p className="text-slate-500 mt-0.5">{t('admin.generateCustomizeQR')}</p>
+          </div>
         </div>
-        <div>
-          <h1 className="text-2xl font-heading font-bold text-slate-900">{t('admin.qrCodeManagement')}</h1>
-          <p className="text-slate-500 mt-0.5">{t('admin.generateCustomizeQR')}</p>
-        </div>
+        {activeTab === 'codes' && qrCodes.length > 0 && (
+          <div className="flex flex-wrap items-center gap-2">
+            {settings?.enableTableQR && stats.tableQRs > 0 && (
+              <Button onClick={printAllTableQRs} variant="primary" className="flex items-center gap-2">
+                <Printer className="h-4 w-4" />
+                {t('admin.printTableQRSheet')}
+              </Button>
+            )}
+            <Button onClick={downloadAllQRs} variant="outline" className="flex items-center gap-2">
+              <Download className="h-4 w-4" />
+              {t('admin.downloadAllQR')}
+            </Button>
+          </div>
+        )}
       </div>
 
       {/* Statistics Overview */}
@@ -372,57 +387,21 @@ const QRManagementPage = () => {
       {/* Tab Content */}
       {activeTab === 'codes' && (
         <div className="space-y-6" data-tour="qr-codes-list">
-          {/* Batch Operations */}
-          <Card data-tour="qr-download">
-            <CardHeader>
-              <CardTitle className="flex items-center gap-2">
-                <FileArchive className="h-5 w-5" />
-                {t('admin.batchOperations')}
-              </CardTitle>
-            </CardHeader>
-            <CardContent>
-              <p className="text-sm text-slate-500 mb-4">
-                {t('admin.batchOperationsDesc')}
-              </p>
-              <div className="flex flex-wrap gap-3">
-                <Button
-                  onClick={downloadAllQRs}
-                  variant="outline"
-                  className="flex items-center gap-2"
-                >
-                  <DownloadCloud className="h-4 w-4" />
-                  {t('admin.downloadAllQR')}
-                </Button>
-                {settings?.enableTableQR && qrCodes.filter(qr => qr.type === 'TABLE').length > 0 && (
-                  <Button
-                    onClick={printAllTableQRs}
-                    variant="outline"
-                    className="flex items-center gap-2"
-                  >
-                    <Eye className="h-4 w-4" />
-                    {t('admin.printTableQRSheet')}
-                  </Button>
-                )}
+          {/* Restaurant-wide QR — the hero code */}
+          <section
+            className="bg-white rounded-2xl border border-slate-200/60 overflow-hidden"
+            data-tour="qr-download"
+          >
+            <div className="px-5 md:px-6 pt-5 pb-4 border-b border-slate-100 flex items-center gap-3">
+              <div className="w-10 h-10 rounded-xl bg-primary-50 flex items-center justify-center shrink-0">
+                <Store className="h-5 w-5 text-primary-600" />
               </div>
-              <div className="mt-4 px-6 py-5 bg-primary-50 border border-primary-200 rounded-xl">
-                <p className="text-xs font-medium text-primary-900 mb-1">{t('admin.batchTips')}:</p>
-                <ul className="text-xs text-primary-800 space-y-1">
-                  <li>• {t('admin.batchTip1')}</li>
-                  <li>• {t('admin.batchTip2')}</li>
-                  <li>• {t('admin.batchTip3')}</li>
-                </ul>
+              <div>
+                <h2 className="font-semibold text-slate-900">{t('admin.restaurantQRCode')}</h2>
+                <p className="text-sm text-slate-500">{t('admin.restaurantQRDesc')}</p>
               </div>
-            </CardContent>
-          </Card>
-
-          <Card>
-            <CardHeader>
-              <CardTitle>{t('admin.restaurantQRCode')}</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <p className="text-sm text-slate-500 mb-4">
-                {t('admin.restaurantQRDesc')}
-              </p>
+            </div>
+            <div className="p-5 md:p-6">
               {qrCodes.filter(qr => qr.type === 'TENANT').map(qr => (
                 <QrCodeDisplay
                   key={qr.id}
@@ -435,57 +414,60 @@ const QRManagementPage = () => {
                   }}
                 />
               ))}
-            </CardContent>
-          </Card>
+            </div>
+          </section>
 
+          {/* Per-table QR codes */}
           {settings?.enableTableQR && (
-            <Card>
-              <CardHeader className="flex flex-row items-center justify-between">
-                <CardTitle>{t('admin.tableSpecificQRCodes')}</CardTitle>
-                {qrCodes.filter(qr => qr.type === 'TABLE').length > 0 && (
-                  <div className="flex gap-2">
-                    <Button
-                      onClick={downloadTableQRs}
-                      variant="outline"
-                      size="sm"
-                      className="flex items-center gap-1"
-                    >
-                      <Download className="h-4 w-4" />
-                      {t('admin.downloadAllQR')}
-                    </Button>
-                    <Button
-                      onClick={printAllTableQRs}
-                      variant="outline"
-                      size="sm"
-                      className="flex items-center gap-1"
-                    >
-                      <Eye className="h-4 w-4" />
-                      {t('admin.printTableQRSheet')}
-                    </Button>
+            <section className="bg-white rounded-2xl border border-slate-200/60 overflow-hidden">
+              <div className="px-5 md:px-6 pt-5 pb-4 border-b border-slate-100 flex flex-wrap items-center justify-between gap-3">
+                <div className="flex items-center gap-3">
+                  <div className="w-10 h-10 rounded-xl bg-emerald-50 flex items-center justify-center shrink-0">
+                    <LayoutGrid className="h-5 w-5 text-emerald-600" />
                   </div>
-                )}
-              </CardHeader>
-              <CardContent>
-                <p className="text-sm text-slate-500 mb-4">
-                  {t('admin.tableSpecificQRDesc')}
-                </p>
-                <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-                  {qrCodes.filter(qr => qr.type === 'TABLE').map(qr => (
-                    <QrCodeDisplay
-                      key={qr.id}
-                      qrCode={qr}
-                      tenant={tenant}
-                      compact
-                      caption={settings?.tableQRMessage}
-                      settings={{
-                        primaryColor: settings?.primaryColor,
-                        backgroundColor: settings?.backgroundColor
-                      }}
-                    />
-                  ))}
+                  <div>
+                    <h2 className="font-semibold text-slate-900 flex items-center gap-2">
+                      {t('admin.tableSpecificQRCodes')}
+                      {stats.tableQRs > 0 && (
+                        <span className="text-xs font-semibold px-2 py-0.5 rounded-full bg-slate-100 text-slate-500">
+                          {stats.tableQRs}
+                        </span>
+                      )}
+                    </h2>
+                    <p className="text-sm text-slate-500">{t('admin.tableSpecificQRDesc')}</p>
+                  </div>
                 </div>
-                {qrCodes.filter(qr => qr.type === 'TABLE').length === 0 && (
-                  <div className="col-span-full py-12 text-center">
+                {stats.tableQRs > 0 && (
+                  <Button
+                    onClick={downloadTableQRs}
+                    variant="outline"
+                    size="sm"
+                    className="flex items-center gap-1.5"
+                  >
+                    <Download className="h-4 w-4" />
+                    {t('admin.downloadAllQR')}
+                  </Button>
+                )}
+              </div>
+              <div className="p-5 md:p-6">
+                {stats.tableQRs > 0 ? (
+                  <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-3 md:gap-4">
+                    {qrCodes.filter(qr => qr.type === 'TABLE').map(qr => (
+                      <QrCodeDisplay
+                        key={qr.id}
+                        qrCode={qr}
+                        tenant={tenant}
+                        compact
+                        caption={settings?.tableQRMessage}
+                        settings={{
+                          primaryColor: settings?.primaryColor,
+                          backgroundColor: settings?.backgroundColor
+                        }}
+                      />
+                    ))}
+                  </div>
+                ) : (
+                  <div className="py-12 text-center">
                     <div className="mx-auto w-16 h-16 rounded-2xl bg-slate-100 flex items-center justify-center mb-4">
                       <LayoutGrid className="w-8 h-8 text-slate-400" />
                     </div>
@@ -495,8 +477,20 @@ const QRManagementPage = () => {
                     </p>
                   </div>
                 )}
-              </CardContent>
-            </Card>
+              </div>
+            </section>
+          )}
+
+          {/* Subtle batch tips (was a heavy card) */}
+          {qrCodes.length > 0 && (
+            <div className="flex items-start gap-2.5 px-4 py-3 rounded-xl bg-slate-50 border border-slate-100">
+              <Lightbulb className="h-4 w-4 text-amber-500 shrink-0 mt-0.5" />
+              <div className="flex flex-col sm:flex-row sm:flex-wrap gap-x-5 gap-y-1 text-xs text-slate-500">
+                <span>{t('admin.batchTip1')}</span>
+                <span>{t('admin.batchTip2')}</span>
+                <span>{t('admin.batchTip3')}</span>
+              </div>
+            </div>
           )}
         </div>
       )}


### PR DESCRIPTION
Cleaner, brand-consistent `/admin/qr-codes` (design polish; behavior unchanged).

- **Brand color fix** — `QrCodeDisplay` + `DesignEditor` used hardcoded `blue-*` (off the app's `primary` palette). Now `primary-*` everywhere (size/format selectors, copy-link, tips, preview-mode + tab accents).
- **Page layout** — global batch actions (Print table sheet / Download all) moved into the page header; the redundant "Batch Operations" card removed and its heavy tips box replaced by one subtle helper line. The two QR blocks are now clean white sections (icon + title + description) instead of generic Card chrome — a restaurant-wide "hero" QR + a denser 2/3/4-col table grid with a count badge.
- **`QrCodeDisplay` polish** — compact card reframed (crisp QR frame, type label, labeled icon actions); full view regrouped with primary accents. All download/print/share logic, QR element ids, and the caption are unchanged. The full view's outer card was removed (its only caller — the restaurant-QR section — now provides the container; `DesignEditor` + table grid use `compact`, which keeps its own card).

**Verification:** frontend tsc 0 · QR specs 11/11 · vitest 251/1828 · eslint 0 errors · i18n parity + value-drift + contract-drift green.