### PR TITLE
fix(frontend): recover from stale code-split chunks after a deploy

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,10 @@
-import { useState, useEffect, useMemo, lazy, Suspense } from 'react';
+import { useState, useEffect, useMemo, Suspense } from 'react';
 import { Routes, Route, Navigate } from 'react-router-dom';
+// Code-split routes use lazyWithReload (not React.lazy) so an open tab
+// recovers from a deploy that replaced the hashed chunk files: a stale-chunk
+// import 404 triggers a one-shot reload onto the fresh index.html instead of
+// a white screen. See utils/lazyWithReload.ts.
+import { lazyWithReload } from './utils/lazyWithReload';
 import LoginPage from './pages/auth/LoginPage';
 import RegisterPage from './pages/auth/RegisterPage';
 import ForgotPasswordPage from './pages/auth/ForgotPasswordPage';
@@ -7,18 +12,18 @@ import ResetPasswordPage from './pages/auth/ResetPasswordPage';
 import VerifyEmailPage from './pages/auth/VerifyEmailPage';
 
 // SuperAdmin Pages (lazy-loaded)
-const SuperAdminLoginPage = lazy(() => import('./pages/superadmin/SuperAdminLoginPage'));
-const SuperAdmin2FAPage = lazy(() => import('./pages/superadmin/SuperAdmin2FAPage'));
-const SuperAdminDashboardPage = lazy(() => import('./pages/superadmin/SuperAdminDashboardPage'));
-const TenantsPage = lazy(() => import('./pages/superadmin/TenantsPage'));
-const TenantDetailPage = lazy(() => import('./pages/superadmin/TenantDetailPage'));
-const AllUsersPage = lazy(() => import('./pages/superadmin/AllUsersPage'));
-const PlansPage = lazy(() => import('./pages/superadmin/PlansPage'));
-const SubscriptionsPage = lazy(() => import('./pages/superadmin/SubscriptionsPage'));
-const BankTransferPage = lazy(() => import('./pages/superadmin/BankTransferPage'));
-const AuditLogsPage = lazy(() => import('./pages/superadmin/AuditLogsPage'));
-const SuperAdminSettingsPage = lazy(() => import('./pages/superadmin/SuperAdminSettingsPage'));
-const MarketplaceAdminPage = lazy(() => import('./pages/superadmin/MarketplaceAdminPage'));
+const SuperAdminLoginPage = lazyWithReload(() => import('./pages/superadmin/SuperAdminLoginPage'));
+const SuperAdmin2FAPage = lazyWithReload(() => import('./pages/superadmin/SuperAdmin2FAPage'));
+const SuperAdminDashboardPage = lazyWithReload(() => import('./pages/superadmin/SuperAdminDashboardPage'));
+const TenantsPage = lazyWithReload(() => import('./pages/superadmin/TenantsPage'));
+const TenantDetailPage = lazyWithReload(() => import('./pages/superadmin/TenantDetailPage'));
+const AllUsersPage = lazyWithReload(() => import('./pages/superadmin/AllUsersPage'));
+const PlansPage = lazyWithReload(() => import('./pages/superadmin/PlansPage'));
+const SubscriptionsPage = lazyWithReload(() => import('./pages/superadmin/SubscriptionsPage'));
+const BankTransferPage = lazyWithReload(() => import('./pages/superadmin/BankTransferPage'));
+const AuditLogsPage = lazyWithReload(() => import('./pages/superadmin/AuditLogsPage'));
+const SuperAdminSettingsPage = lazyWithReload(() => import('./pages/superadmin/SuperAdminSettingsPage'));
+const MarketplaceAdminPage = lazyWithReload(() => import('./pages/superadmin/MarketplaceAdminPage'));
 import { SuperAdminLayout, SuperAdminProtectedRoute } from './features/superadmin/components';
 
 // (The marketing panel moved to the separate kds-marketing project.)
@@ -28,63 +33,63 @@ import CustomersPage from './pages/customers/CustomersPage';
 import CustomerDetailPage from './pages/customers/CustomerDetailPage';
 
 // QR Menu Pages (lazy-loaded - customer-facing)
-const QRMenuPage = lazy(() => import('./pages/qr-menu/QRMenuPage'));
-const CartPage = lazy(() => import('./pages/qr-menu/CartPage'));
-const OrderTrackingPage = lazy(() => import('./pages/qr-menu/OrderTrackingPage'));
-const QrPaymentResultPage = lazy(() => import('./pages/qr-menu/QrPaymentResultPage'));
-const LoyaltyPage = lazy(() => import('./pages/qr-menu/LoyaltyPage'));
-const SubdomainQRMenuPage = lazy(() => import('./pages/qr-menu/SubdomainQRMenuPage'));
-const SubdomainCartPage = lazy(() => import('./pages/qr-menu/SubdomainCartPage'));
-const SubdomainOrdersPage = lazy(() => import('./pages/qr-menu/SubdomainOrdersPage'));
-const SubdomainLoyaltyPage = lazy(() => import('./pages/qr-menu/SubdomainLoyaltyPage'));
+const QRMenuPage = lazyWithReload(() => import('./pages/qr-menu/QRMenuPage'));
+const CartPage = lazyWithReload(() => import('./pages/qr-menu/CartPage'));
+const OrderTrackingPage = lazyWithReload(() => import('./pages/qr-menu/OrderTrackingPage'));
+const QrPaymentResultPage = lazyWithReload(() => import('./pages/qr-menu/QrPaymentResultPage'));
+const LoyaltyPage = lazyWithReload(() => import('./pages/qr-menu/LoyaltyPage'));
+const SubdomainQRMenuPage = lazyWithReload(() => import('./pages/qr-menu/SubdomainQRMenuPage'));
+const SubdomainCartPage = lazyWithReload(() => import('./pages/qr-menu/SubdomainCartPage'));
+const SubdomainOrdersPage = lazyWithReload(() => import('./pages/qr-menu/SubdomainOrdersPage'));
+const SubdomainLoyaltyPage = lazyWithReload(() => import('./pages/qr-menu/SubdomainLoyaltyPage'));
 
-const LandingPage = lazy(() => import('./pages/LandingPage'));
-const PublicReservationPage = lazy(() => import('./pages/reservations/PublicReservationPage'));
-const ReservationLookupPage = lazy(() => import('./pages/reservations/ReservationLookupPage'));
-const TermsOfServicePage = lazy(() => import('./pages/legal/TermsOfServicePage'));
-const PrivacyPolicyPage = lazy(() => import('./pages/legal/PrivacyPolicyPage'));
+const LandingPage = lazyWithReload(() => import('./pages/LandingPage'));
+const PublicReservationPage = lazyWithReload(() => import('./pages/reservations/PublicReservationPage'));
+const ReservationLookupPage = lazyWithReload(() => import('./pages/reservations/ReservationLookupPage'));
+const TermsOfServicePage = lazyWithReload(() => import('./pages/legal/TermsOfServicePage'));
+const PrivacyPolicyPage = lazyWithReload(() => import('./pages/legal/PrivacyPolicyPage'));
 // Subscription checkout consent links to these three; without
 // matching routes the new-tab open lands on the Next.js landing
 // app, gets a locale prefix from next-intl, and 404s.
-const KvkkPage = lazy(() => import('./pages/legal/KvkkPage'));
-const DistanceSalesPage = lazy(() => import('./pages/legal/DistanceSalesPage'));
-const RefundPolicyPage = lazy(() => import('./pages/legal/RefundPolicyPage'));
+const KvkkPage = lazyWithReload(() => import('./pages/legal/KvkkPage'));
+const DistanceSalesPage = lazyWithReload(() => import('./pages/legal/DistanceSalesPage'));
+const RefundPolicyPage = lazyWithReload(() => import('./pages/legal/RefundPolicyPage'));
 import DashboardPage from './pages/DashboardPage';
 import POSPage from './pages/pos/POSPage';
 import KitchenDisplayPage from './pages/kitchen/KitchenDisplayPage';
 // Admin Pages (lazy-loaded)
-const MenuManagementPage = lazy(() => import('./pages/admin/MenuManagementPage'));
-const TableManagementPage = lazy(() => import('./pages/admin/TableManagementPage'));
-const FloorPlanEditorPage = lazy(() => import('./pages/admin/FloorPlanEditorPage'));
-const UserManagementPage = lazy(() => import('./pages/admin/UserManagementPage'));
-const QRManagementPage = lazy(() => import('./pages/admin/QRManagementPage'));
-const ReportsPage = lazy(() => import('./pages/admin/ReportsPage'));
-const AnalyticsPage = lazy(() => import('./pages/admin/AnalyticsPage'));
-const ReservationsPage = lazy(() => import('./pages/admin/ReservationsPage'));
-const PersonnelManagementPage = lazy(() => import('./pages/admin/PersonnelManagementPage'));
-const StockManagementPage = lazy(() => import('./pages/admin/StockManagementPage'));
-const InvoicesPage = lazy(() => import('./pages/admin/invoices/InvoicesPage'));
-const DeliveryOrdersPage = lazy(() => import('./pages/admin/DeliveryOrdersPage'));
+const MenuManagementPage = lazyWithReload(() => import('./pages/admin/MenuManagementPage'));
+const TableManagementPage = lazyWithReload(() => import('./pages/admin/TableManagementPage'));
+const FloorPlanEditorPage = lazyWithReload(() => import('./pages/admin/FloorPlanEditorPage'));
+const UserManagementPage = lazyWithReload(() => import('./pages/admin/UserManagementPage'));
+const QRManagementPage = lazyWithReload(() => import('./pages/admin/QRManagementPage'));
+const ReportsPage = lazyWithReload(() => import('./pages/admin/ReportsPage'));
+const AnalyticsPage = lazyWithReload(() => import('./pages/admin/AnalyticsPage'));
+const ReservationsPage = lazyWithReload(() => import('./pages/admin/ReservationsPage'));
+const PersonnelManagementPage = lazyWithReload(() => import('./pages/admin/PersonnelManagementPage'));
+const StockManagementPage = lazyWithReload(() => import('./pages/admin/StockManagementPage'));
+const InvoicesPage = lazyWithReload(() => import('./pages/admin/invoices/InvoicesPage'));
+const DeliveryOrdersPage = lazyWithReload(() => import('./pages/admin/DeliveryOrdersPage'));
 
 // Onboarding (lazy-loaded)
-const WelcomePage = lazy(() => import('./pages/onboarding/WelcomePage'));
+const WelcomePage = lazyWithReload(() => import('./pages/onboarding/WelcomePage'));
 
 // Subscription & Settings Pages (lazy-loaded)
-const SubscriptionPlansPage = lazy(() => import('./pages/subscription/SubscriptionPlansPage'));
-const ChangePlanPage = lazy(() => import('./pages/subscription/ChangePlanPage'));
-const CheckoutPage = lazy(() => import('./pages/subscription/CheckoutPage'));
-const PaymentResultPage = lazy(() => import('./pages/subscription/PaymentResultPage'));
-const SettingsLayout = lazy(() => import('./pages/settings/SettingsLayout'));
-const POSSettingsPage = lazy(() => import('./pages/settings/POSSettingsPage'));
-const QRMenuSettingsPage = lazy(() => import('./pages/settings/QRMenuSettingsPage'));
-const ReportsSettingsPage = lazy(() => import('./pages/settings/ReportsSettingsPage'));
-const BrandingSettingsPage = lazy(() => import('./pages/settings/BrandingSettingsPage'));
-const IntegrationsSettingsPage = lazy(() => import('./pages/settings/IntegrationsSettingsPage'));
-const DesktopAppSettingsPage = lazy(() => import('./pages/settings/DesktopAppSettingsPage'));
-const ReservationSettingsPage = lazy(() => import('./pages/settings/ReservationSettingsPage'));
-const DeliveryPlatformsSettingsPage = lazy(() => import('./pages/settings/DeliveryPlatformsSettingsPage'));
-const SmsSettingsPage = lazy(() => import('./pages/settings/SmsSettingsPage'));
-const AccountingSettingsPage = lazy(() => import('./pages/settings/AccountingSettingsPage'));
+const SubscriptionPlansPage = lazyWithReload(() => import('./pages/subscription/SubscriptionPlansPage'));
+const ChangePlanPage = lazyWithReload(() => import('./pages/subscription/ChangePlanPage'));
+const CheckoutPage = lazyWithReload(() => import('./pages/subscription/CheckoutPage'));
+const PaymentResultPage = lazyWithReload(() => import('./pages/subscription/PaymentResultPage'));
+const SettingsLayout = lazyWithReload(() => import('./pages/settings/SettingsLayout'));
+const POSSettingsPage = lazyWithReload(() => import('./pages/settings/POSSettingsPage'));
+const QRMenuSettingsPage = lazyWithReload(() => import('./pages/settings/QRMenuSettingsPage'));
+const ReportsSettingsPage = lazyWithReload(() => import('./pages/settings/ReportsSettingsPage'));
+const BrandingSettingsPage = lazyWithReload(() => import('./pages/settings/BrandingSettingsPage'));
+const IntegrationsSettingsPage = lazyWithReload(() => import('./pages/settings/IntegrationsSettingsPage'));
+const DesktopAppSettingsPage = lazyWithReload(() => import('./pages/settings/DesktopAppSettingsPage'));
+const ReservationSettingsPage = lazyWithReload(() => import('./pages/settings/ReservationSettingsPage'));
+const DeliveryPlatformsSettingsPage = lazyWithReload(() => import('./pages/settings/DeliveryPlatformsSettingsPage'));
+const SmsSettingsPage = lazyWithReload(() => import('./pages/settings/SmsSettingsPage'));
+const AccountingSettingsPage = lazyWithReload(() => import('./pages/settings/AccountingSettingsPage'));
 import Layout from './components/layout/Layout';
 import ProtectedRoute from './components/ProtectedRoute';
 // HummyTummy Phase 3–12 admin screens.

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -12,10 +12,18 @@ import App from './App';
 import i18n from './i18n/config';
 import { initSentry } from './sentry.config';
 import { detectSubdomain } from './utils/subdomain';
+import { installChunkErrorReload } from './utils/lazyWithReload';
 import './index.css';
 
 // Initialize Sentry as early as possible
 initSentry();
+
+// Recover from stale code-split chunks after a deploy: if Vite's module-preload
+// helper fails to fetch a route chunk (old hash 404s because the deploy replaced
+// the bundle), hard-reload once onto the fresh index.html instead of throwing.
+// The lazyWithReload route wrappers handle the import() rejection path; this
+// catches the preload-helper path. See utils/lazyWithReload.ts.
+installChunkErrorReload();
 
 // React's <ErrorBoundary> only catches errors thrown during render. Promise
 // rejections and async listener exceptions slip past it entirely. Forward

--- a/frontend/src/utils/lazyWithReload.test.tsx
+++ b/frontend/src/utils/lazyWithReload.test.tsx
@@ -1,0 +1,153 @@
+import { describe, it, expect, vi } from 'vitest';
+import { Suspense } from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import {
+  isChunkLoadError,
+  withinReloadCooldown,
+  loadWithReload,
+  installChunkErrorReload,
+  lazyWithReload,
+  RELOAD_WINDOW_MS,
+  type ReloadDeps,
+} from './lazyWithReload';
+
+/**
+ * After a deploy replaces the hashed bundle files, an already-open tab's
+ * entry chunk still references the OLD hashes, which now 404. These helpers
+ * turn that white-screen into a one-shot hard reload that pulls the fresh
+ * index.html → new hashes. The loop guard (reload at most once per window)
+ * is the load-bearing bit: without it a chunk that's genuinely gone would
+ * reload forever.
+ */
+
+const CHUNK_MESSAGES = [
+  'Failed to fetch dynamically imported module: https://x/assets/ChangePlanPage-DNXSg6RE.js',
+  'error loading dynamically imported module: /assets/PlanCard-BwuQbe4a.js',
+  'Importing a module script failed.',
+];
+
+describe('isChunkLoadError', () => {
+  it.each(CHUNK_MESSAGES)('matches the stale-chunk message %#', (message) => {
+    expect(isChunkLoadError(new Error(message))).toBe(true);
+  });
+
+  it('matches a ChunkLoadError by name even with an unrelated message', () => {
+    const err = Object.assign(new Error('boom'), { name: 'ChunkLoadError' });
+    expect(isChunkLoadError(err)).toBe(true);
+  });
+
+  it('does NOT match an ordinary application error', () => {
+    expect(isChunkLoadError(new Error('Cannot read properties of undefined'))).toBe(false);
+  });
+
+  it('is safe on null / undefined / non-error values', () => {
+    expect(isChunkLoadError(null)).toBe(false);
+    expect(isChunkLoadError(undefined)).toBe(false);
+    expect(isChunkLoadError(42)).toBe(false);
+  });
+});
+
+describe('withinReloadCooldown', () => {
+  it('allows a reload when there is no prior reload (returns false)', () => {
+    expect(withinReloadCooldown(1_000, null)).toBe(false);
+  });
+
+  it('suppresses a reload within the window of the last reload (returns true)', () => {
+    const lastTs = 5_000 - (RELOAD_WINDOW_MS - 1);
+    expect(withinReloadCooldown(5_000, lastTs)).toBe(true);
+  });
+
+  it('allows a reload once the window has fully elapsed', () => {
+    expect(withinReloadCooldown(50_000, 50_000 - RELOAD_WINDOW_MS)).toBe(false);
+  });
+});
+
+function makeDeps(overrides: Partial<ReloadDeps> = {}): ReloadDeps {
+  let stored: number | null = null;
+  return {
+    reload: vi.fn(),
+    now: () => 1_000_000,
+    getLastReloadTs: () => stored,
+    setLastReloadTs: (ts: number) => {
+      stored = ts;
+    },
+    ...overrides,
+  };
+}
+
+describe('loadWithReload', () => {
+  it('returns the imported module on success, without reloading', async () => {
+    const deps = makeDeps();
+    const mod = { default: () => null };
+    await expect(loadWithReload(() => Promise.resolve(mod), deps)).resolves.toBe(mod);
+    expect(deps.reload).not.toHaveBeenCalled();
+  });
+
+  it('reloads once on a stale-chunk failure and leaves the promise pending', async () => {
+    const deps = makeDeps();
+    const chunkErr = new Error(CHUNK_MESSAGES[0]);
+
+    let settled = false;
+    void loadWithReload(() => Promise.reject(chunkErr), deps).then(
+      () => {
+        settled = true;
+      },
+      () => {
+        settled = true;
+      },
+    );
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(deps.reload).toHaveBeenCalledTimes(1);
+    // Hangs until the reload swaps the document — settling would flash the
+    // Suspense fallback or surface the error to the boundary.
+    expect(settled).toBe(false);
+  });
+
+  it('does NOT reload again when one already happened within the cooldown', async () => {
+    const deps = makeDeps({ getLastReloadTs: () => 1_000_000 - 1 });
+    const chunkErr = new Error(CHUNK_MESSAGES[0]);
+    await expect(loadWithReload(() => Promise.reject(chunkErr), deps)).rejects.toBe(chunkErr);
+    expect(deps.reload).not.toHaveBeenCalled();
+  });
+
+  it('rethrows a non-chunk error without reloading', async () => {
+    const deps = makeDeps();
+    const appErr = new Error('boom');
+    await expect(loadWithReload(() => Promise.reject(appErr), deps)).rejects.toBe(appErr);
+    expect(deps.reload).not.toHaveBeenCalled();
+  });
+});
+
+describe('installChunkErrorReload', () => {
+  it('reloads once when Vite emits vite:preloadError', () => {
+    const deps = makeDeps();
+    installChunkErrorReload(deps);
+
+    window.dispatchEvent(new Event('vite:preloadError'));
+    expect(deps.reload).toHaveBeenCalledTimes(1);
+
+    // A second preload error within the cooldown must not reload again.
+    window.dispatchEvent(new Event('vite:preloadError'));
+    expect(deps.reload).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('lazyWithReload (React integration)', () => {
+  it('recovers from a stale chunk by reloading instead of crashing to the boundary', async () => {
+    const deps = makeDeps();
+    const chunkErr = new Error(CHUNK_MESSAGES[0]);
+    const Lazy = lazyWithReload(() => Promise.reject(chunkErr), deps);
+
+    render(
+      <Suspense fallback={<div>loading</div>}>
+        <Lazy />
+      </Suspense>,
+    );
+
+    await waitFor(() => expect(deps.reload).toHaveBeenCalledTimes(1));
+    // Still showing the fallback — no crash, no error fallback rendered.
+    expect(screen.getByText('loading')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/utils/lazyWithReload.ts
+++ b/frontend/src/utils/lazyWithReload.ts
@@ -1,0 +1,137 @@
+import { lazy, type ComponentType } from 'react';
+
+/**
+ * Stale-chunk recovery for the code-split SPA.
+ *
+ * Vite fingerprints every route chunk (`ChangePlanPage-DNXSg6RE.js`). A deploy
+ * ships a fresh container with NEW hashes and DELETES the old files. A tab that
+ * loaded the app *before* the deploy is still running an entry bundle whose
+ * chunk map points at the now-deleted hashes, so the first navigation to a
+ * lazy route does `import('/assets/ChangePlanPage-<oldhash>.js')` → 404 →
+ * "Failed to fetch dynamically imported module" → white screen until the user
+ * manually hard-refreshes.
+ *
+ * The fix: when a dynamic import fails with a chunk-load error, hard-reload the
+ * page ONCE. The reload re-fetches index.html (served `no-cache`), which points
+ * at the current hashes, and the navigation succeeds transparently. A
+ * session-scoped cooldown guards against an infinite reload loop if the chunk
+ * is genuinely missing even after the reload (e.g. mid-deploy).
+ */
+
+/** Reload at most once per this window (ms) to avoid a reload loop. */
+export const RELOAD_WINDOW_MS = 10_000;
+
+/** Session-storage key holding the timestamp of the last recovery reload. */
+const RELOAD_TS_KEY = 'spa-chunk-reload-ts';
+
+// Rollup/Vite and webpack-style dynamic-import failure messages. Matching on
+// the message keeps us resilient to the error being a plain Error (no useful
+// `name`) which is what browsers throw for a failed module fetch.
+const CHUNK_ERROR_RE =
+  /Failed to fetch dynamically imported module|error loading dynamically imported module|Importing a module script failed|dynamically imported module/i;
+
+/** True when `error` looks like a failed code-split chunk fetch. */
+export function isChunkLoadError(error: unknown): boolean {
+  if (error == null) return false;
+  const name = (error as { name?: unknown }).name;
+  if (name === 'ChunkLoadError') return true;
+  const message =
+    typeof (error as { message?: unknown }).message === 'string'
+      ? (error as { message: string }).message
+      : '';
+  return CHUNK_ERROR_RE.test(message);
+}
+
+/**
+ * True when a recovery reload happened too recently to reload again — i.e. the
+ * reload didn't fix it, so suppress further reloads and let the error surface.
+ */
+export function withinReloadCooldown(now: number, lastReloadTs: number | null): boolean {
+  if (lastReloadTs == null) return false;
+  return now - lastReloadTs < RELOAD_WINDOW_MS;
+}
+
+/** Injectable side-effect seam — overridden in tests, defaulted in production. */
+export interface ReloadDeps {
+  reload: () => void;
+  now: () => number;
+  getLastReloadTs: () => number | null;
+  setLastReloadTs: (ts: number) => void;
+}
+
+const defaultDeps: ReloadDeps = {
+  reload: () => window.location.reload(),
+  now: () => Date.now(),
+  getLastReloadTs: () => {
+    try {
+      const raw = sessionStorage.getItem(RELOAD_TS_KEY);
+      return raw == null ? null : Number(raw);
+    } catch {
+      return null; // storage disabled (private mode) — treat as "no prior reload"
+    }
+  },
+  setLastReloadTs: (ts: number) => {
+    try {
+      sessionStorage.setItem(RELOAD_TS_KEY, String(ts));
+    } catch {
+      /* storage disabled — the worst case is we allow one more reload later */
+    }
+  },
+};
+
+/** Reload once if the cooldown allows. Returns whether a reload was triggered. */
+function reloadOnce(deps: ReloadDeps): boolean {
+  const now = deps.now();
+  if (withinReloadCooldown(now, deps.getLastReloadTs())) return false;
+  deps.setLastReloadTs(now);
+  deps.reload();
+  return true;
+}
+
+/**
+ * Run a dynamic-import factory, recovering from a stale-chunk failure with a
+ * one-shot reload. On a successful reload trigger the returned promise stays
+ * pending forever — the document is about to be replaced, so resolving or
+ * rejecting would only flash the Suspense fallback or the error boundary.
+ */
+export function loadWithReload<T>(
+  factory: () => Promise<T>,
+  deps: ReloadDeps = defaultDeps,
+): Promise<T> {
+  return factory().catch((error: unknown) => {
+    if (isChunkLoadError(error) && reloadOnce(deps)) {
+      return new Promise<T>(() => {}); // never settles; navigation takes over
+    }
+    throw error;
+  });
+}
+
+/**
+ * Drop-in replacement for `React.lazy` that auto-recovers from stale-chunk
+ * import failures. Use for every code-split route so an open tab survives a
+ * deploy instead of white-screening on the next navigation.
+ */
+// Mirrors React.lazy's `ComponentType<any>` constraint (not `unknown`) so the
+// route components' own prop types flow through to the returned lazy component
+// — pages like PaymentResultPage (outcome) / SubdomainQRMenuPage (subdomain)
+// must keep accepting their props.
+export function lazyWithReload<T extends ComponentType<any>>(
+  factory: () => Promise<{ default: T }>,
+  deps: ReloadDeps = defaultDeps,
+) {
+  return lazy(() => loadWithReload(factory, deps));
+}
+
+/**
+ * Register a global listener for Vite's `vite:preloadError`, fired when its
+ * module-preload helper (used for route chunks) fails to fetch. This is the
+ * second safety net alongside `lazyWithReload` — some preload failures surface
+ * here rather than as a rejected `import()`. Call once at app startup.
+ */
+export function installChunkErrorReload(deps: ReloadDeps = defaultDeps): void {
+  window.addEventListener('vite:preloadError', (event) => {
+    // We own the recovery; stop Vite from rethrowing the error to the console.
+    event.preventDefault?.();
+    reloadOnce(deps);
+  });
+}


### PR DESCRIPTION
## Problem

After a deploy, users hit a **white screen** on certain routes until they manually hard-refresh (Ctrl+Shift+R). The page requests old hashed files (e.g. `ChangePlanPage-BwuQbe4a.js`) that no longer exist on the server.

Measured live: this is **not** a cache problem — `index.html` is served `no-cache, no-store` (Cloudflare `cf-cache-status: DYNAMIC`) and assets are `immutable`. The cache layer is correct.

The real cause is **stale code-split chunks**: a tab opened *before* a deploy is still running an entry bundle whose chunk map points at hashes that the deploy deleted. The first `import()` of a lazy route 404s → `Failed to fetch dynamically imported module` → Suspense never resolves → white screen.

## Fix

- **`utils/lazyWithReload.ts`** — drop-in replacement for `React.lazy`. On a chunk-load failure it hard-reloads the page **once**, pulling the fresh `index.html` (current hashes); the navigation then succeeds transparently. A session-scoped 10s cooldown prevents a reload loop if the chunk is genuinely missing (mid-deploy).
- **`installChunkErrorReload()`** — global listener for Vite's `vite:preloadError` (the module-preload path), wired in `main.tsx` as a second safety net.
- **`App.tsx`** — all 57 code-split routes switched from `lazy(...)` to `lazyWithReload(...)`. Code-splitting is preserved (verified: each route still emits its own hashed chunk).

The existing `ErrorBoundary` (with its reload button) remains the terminal fallback if the cooldown is exhausted.

## Verification

- New unit + React-integration tests: `isChunkLoadError`, cooldown guard, reload-once, non-chunk passthrough, `vite:preloadError` listener, Suspense recovery path (15 tests).
- Full frontend suite: **1842 passed**, 1 skipped, 252 files.
- `tsc --noEmit`: 0 errors. ESLint: 0 errors. `vite build`: success, route chunks intact.