### PR TITLE
Fix 6 POS money-correctness bugs (deep business-logic audit)

### DIFF
--- a/backend/src/modules/customer-orders/services/self-pay-intent.service.ts
+++ b/backend/src/modules/customer-orders/services/self-pay-intent.service.ts
@@ -258,6 +258,24 @@ export class SelfPayIntentService {
       session.tenantId,
     );
 
+    // Reject duplicate orderItemIds BEFORE pricing. Each iteration below
+    // derives `remaining` from the same alreadyPaid/reserved snapshot, so two
+    // entries for the same item both pass the remaining check and DOUBLE the
+    // PayTR charge. Worse, the settlement webhook calls payByItems whose
+    // resolveItemsById rejects duplicate orderItemIds — so PayTR would charge
+    // the customer and then book ZERO payments (intent → FAILED, manual
+    // refund). Apply payByItems' dedup semantics here so the intent never
+    // mints a token for a payload settlement will reject.
+    const seenItemIds = new Set<string>();
+    for (const entry of dto.items) {
+      if (seenItemIds.has(entry.orderItemId)) {
+        throw new BadRequestException(
+          `Duplicate orderItemId ${entry.orderItemId} — combine the units into a single entry`,
+        );
+      }
+      seenItemIds.add(entry.orderItemId);
+    }
+
     // Compute total + per-order groupings (server-derived; client can't override).
     let totalAmount = new Prisma.Decimal(0);
     const itemsByOrder = new Map<string, ItemsByOrderShape>();

--- a/backend/src/modules/orders/services/orders.service.ts
+++ b/backend/src/modules/orders/services/orders.service.ts
@@ -926,7 +926,23 @@ export class OrdersService {
         ? totalAmountDec
         : rawDiscount;
       updateData.discount = cappedDiscount;
-      updateData.finalAmount = totalAmountDec.sub(cappedDiscount);
+      const newFinalAmount = totalAmountDec.sub(cappedDiscount);
+      updateData.finalAmount = newFinalAmount;
+      // Re-derive the (KDV-inclusive) tax proportionally — the other three
+      // money paths (createInner, items-rewrite at 905-908, removeItem) all
+      // recompute taxAmount after a discount; the discount-only branch used to
+      // leave order.taxAmount stale, so the printed fiş showed KDV for the
+      // pre-discount total. taxAmount scales linearly with the discounted
+      // total (taxAmount/finalAmount = grossTax/totalAmount is constant), so
+      // newTax = currentTax × newFinal/oldFinal — exact even when a discount
+      // already existed (a flat (1−ratio) on the stored tax would double-count).
+      const oldFinalAmount = new Prisma.Decimal(order.finalAmount);
+      updateData.taxAmount = oldFinalAmount.gt(0)
+        ? new Prisma.Decimal(order.taxAmount)
+            .mul(newFinalAmount)
+            .div(oldFinalAmount)
+            .toDecimalPlaces(2)
+        : new Prisma.Decimal(0);
     }
 
     // Atomic replace of the item set: a crash between the deleteMany
@@ -976,6 +992,27 @@ export class OrdersService {
         if (allocCount > 0) {
           throw new ConflictException(
             "Cannot change the order discount once any per-item payment has been collected. " +
+              "Refund the existing payment(s) first, then re-apply the discount.",
+          );
+        }
+        // A plain (non-per-item) Payment — e.g. a partial cash payment via
+        // create() — writes no OrderItemPayment row, so the allocCount guard
+        // above misses it. Without this, a discount that drops finalAmount
+        // below the amount already collected silently over-charges the
+        // customer (order.finalAmount < Σ COMPLETED payments) with no refund.
+        const paidAgg = await tx.payment.aggregate({
+          where: {
+            orderId: id,
+            tenantId: scope.tenantId,
+            status: "COMPLETED",
+          },
+          _sum: { amount: true },
+        });
+        const alreadyPaid = new Prisma.Decimal(paidAgg._sum.amount ?? 0);
+        const newFinal = new Prisma.Decimal(updateData.finalAmount as any);
+        if (alreadyPaid.gt(0) && newFinal.lt(alreadyPaid)) {
+          throw new ConflictException(
+            "Cannot lower the order total below the amount already paid. " +
               "Refund the existing payment(s) first, then re-apply the discount.",
           );
         }

--- a/backend/src/modules/orders/services/payments.service.spec.ts
+++ b/backend/src/modules/orders/services/payments.service.spec.ts
@@ -946,7 +946,21 @@ describe("PaymentsService — progressive per-item payments", () => {
             orderItemPayments: [],
           },
         ],
-        payments: [],
+        // Reflect the prior COMPLETED payments so the closing call's
+        // order-level reconciliation (finalAmount − priorPaid) matches the
+        // per-item residual exactly (production loads these fresh each call).
+        payments: priorSum.gt(0)
+          ? [
+              {
+                amount: priorSum,
+                status: PaymentStatus.COMPLETED,
+                method: "CASH",
+                notes: null,
+                paidAt: new Date(),
+                orderItemPayments: [],
+              },
+            ]
+          : [],
       });
       (prisma.order.findFirst as unknown as jest.Mock).mockImplementation(
         async () => stubPayableRead(),

--- a/backend/src/modules/orders/services/payments.service.ts
+++ b/backend/src/modules/orders/services/payments.service.ts
@@ -540,7 +540,13 @@ export class PaymentsService {
             );
             const orderAmount = new Prisma.Decimal(order.finalAmount);
 
-            if (totalPaidAmount.gte(orderAmount)) {
+            // Close the order on a within-tolerance total. The overpayment
+            // guard above accepts a payment up to remaining+PAYMENT_TOLERANCE,
+            // so the PAID transition must grant the SAME ±tolerance — else a
+            // kuruş-short full payment (float-legacy caller) is booked yet the
+            // order is stranded SERVED forever (no invoice/loyalty/fiş, table
+            // never releases). Mirrors splitBill + payByItems (M13).
+            if (totalPaidAmount.gte(orderAmount.sub(PAYMENT_TOLERANCE))) {
               await this.finalizeFullyPaid(
                 tx,
                 order,
@@ -1019,7 +1025,14 @@ export class PaymentsService {
       // sibling check must also stay in Decimal or the >= will be on
       // mixed types and throw at runtime / typecheck.
       const totalPaidAmount = new Prisma.Decimal(totalPaid._sum.amount ?? 0);
-      const isFullyPaid = totalPaidAmount.gte(orderAmount);
+      // Use the SAME ±PAYMENT_TOLERANCE validateSplitTotal already grants when
+      // accepting the split: it tolerates a total a kuruş short of `remaining`,
+      // so the PAID transition must too — otherwise an accepted split takes the
+      // money but leaves the order stranded SERVED with ~0.01 "outstanding"
+      // (table held, no invoice/fiş/loyalty). Mirrors payByItems (M13).
+      const isFullyPaid = totalPaidAmount.gte(
+        orderAmount.sub(PAYMENT_TOLERANCE),
+      );
 
       if (isFullyPaid) {
         // Preserve pre-refactor splitBill semantics: customer stats
@@ -1215,7 +1228,13 @@ export class PaymentsService {
 
             const order = await tx.order.findFirst({
               where: { id: orderId, tenantId },
-              include: { orderItems: true },
+              include: {
+                orderItems: true,
+                // Prior COMPLETED payments — used to reconcile the closing
+                // payment to the exact order residual (loaded under the
+                // advisory lock acquired above, so it reflects current state).
+                payments: { where: { status: PaymentStatus.COMPLETED } },
+              },
             });
 
             if (!order) {
@@ -1347,6 +1366,45 @@ export class PaymentsService {
                 amount: entryAmount,
               });
               derivedTotal = derivedTotal.add(entryAmount);
+            }
+
+            // ORDER-LEVEL RECONCILIATION (audit fix). The per-item amounts
+            // above round the pro-rata discount INDEPENDENTLY, so when every
+            // item is paid in its own call the sum of those rounded item
+            // totals drifts from order.finalAmount (e.g. 60×round2(1.49×0.9954)
+            // = 88.80 vs finalAmount 88.99 → 0.19 lost; or the mirror case
+            // overcharges). When THIS call allocates the last outstanding
+            // unit(s) of the whole order, force the closing payment to the
+            // exact order residual (finalAmount − already-collected) so
+            // Σ(all completed payments) === finalAmount to the kuruş, and push
+            // the drift onto the closing allocation row so the per-item ledger
+            // stays consistent with the Payment row.
+            const postAllocated = new Map<string, number>(paidByItem);
+            for (const entry of dto.items) {
+              postAllocated.set(
+                entry.orderItemId,
+                (postAllocated.get(entry.orderItemId) ?? 0) + entry.quantity,
+              );
+            }
+            const closesOrder = order.orderItems.every(
+              (oi) => (postAllocated.get(oi.id) ?? 0) >= oi.quantity,
+            );
+            if (closesOrder) {
+              const priorPaid = (order.payments ?? []).reduce(
+                (s, p) => s.add(new Prisma.Decimal(p.amount)),
+                new Prisma.Decimal(0),
+              );
+              let target = new Prisma.Decimal(order.finalAmount).sub(priorPaid);
+              if (target.lt(0)) target = new Prisma.Decimal(0);
+              target = target.toDecimalPlaces(2);
+              const drift = target.sub(derivedTotal);
+              if (!drift.isZero() && allocationRows.length > 0) {
+                const last = allocationRows[allocationRows.length - 1];
+                let adjusted = last.amount.add(drift);
+                if (adjusted.lt(0)) adjusted = new Prisma.Decimal(0);
+                last.amount = adjusted;
+              }
+              derivedTotal = target;
             }
 
             // Build the per-payment receipt snapshot so this Payment


### PR DESCRIPTION
A deep adversarial audit of the POS money paths (8 business-logic clusters, every finding double-verified by two independent skeptics, + a cross-cutting completeness critic) surfaced **6 real money bugs**. All fixed; then the fixes themselves were adversarially re-reviewed (arithmetic re-derived) and came back clean.

## Fixed
1. **`create()` + `splitBill()` stranded orders** — finalize used a strict `gte`, but the overpayment/split guards accept ±`PAYMENT_TOLERANCE` (1 kuruş). A kuruş-short full/split payment was booked yet the order never flipped PAID → table held forever, no invoice/fiş/loyalty, revenue lost. Both now close within ±tolerance (matching `payByItems` M13). `payments.service.ts`
2. **`payByItems` discount drift** — each item's pro-rata discount was rounded independently, so paying every item in its own call drifted Σ(payments) off `finalAmount` (under/over-collected while flipping PAID). The closing call now reconciles to the exact order residual (`finalAmount − Σ prior COMPLETED`, loaded under the advisory lock), absorbing drift onto the closing allocation. `payments.service.ts`
3. **Discount-only PATCH stale KDV** — never recomputed `taxAmount` → fiş printed KDV for the pre-discount total. Now scales tax with the discounted total (exact even when a discount already existed). `orders.service.ts`
4. **Discount-below-paid overcharge** — the guard only checked `OrderItemPayment`; a plain partial `create()` payment let a later discount drop `finalAmount` below the amount already collected (overcharge, no refund). Now also rejects below Σ COMPLETED payments. `orders.service.ts`
5. **Self-pay PayTR double-charge** — the intent lacked `payByItems`' duplicate-`orderItemId` guard, so a duplicated item overcharged on PayTR then settlement failed booking zero (money taken, nothing recorded → manual refund). Intent now rejects duplicates up front. `self-pay-intent.service.ts`

## Verification
Backend tsc 0 · jest **454 suites / 4226 tests** (incl. updated `payByItems` reconciliation spec) · eslint clean · audit findings double-verified · fixes adversarially re-reviewed (0 issues).

## Noted follow-ups (real, non-blocking — no money loss)
- Order-create idempotency returns 409 instead of the existing order under a concurrent same-key double-submit (unique constraint already prevents the dup; only the loser's response is wrong).
- Per-payment receipt prints the full order total instead of the diner's paid share on split/pay-items (charged amount is correct; display only — needs a snapshot-schema + Rust-template change).