### PR TITLE
fix(migration): branch_is_headquarters wrong table name (Branch → branches) — prod migration recovery

### DIFF
--- a/backend/prisma/migrations/20260625180000_branch_is_headquarters/migration.sql
+++ b/backend/prisma/migrations/20260625180000_branch_is_headquarters/migration.sql
@@ -1,31 +1,32 @@
+-- @doctor:idempotent verified=ADD COLUMN IF NOT EXISTS; both UPDATEs guarded by NOT EXISTS(... isHeadquarters) so a re-run is a no-op once one HQ is set per tenant
 -- Branch-centric device hub: designate each tenant's "Merkez/HQ" branch — the
 -- home for central (şubesiz) devices. Additive + idempotent (safe to re-run on
 -- the deploy baseline pipeline). Pure label/bucket; does NOT affect branch
--- capacity counting.
-ALTER TABLE "Branch"
+-- capacity counting. NB: the Branch model is @@map("branches").
+ALTER TABLE "branches"
   ADD COLUMN IF NOT EXISTS "isHeadquarters" BOOLEAN NOT NULL DEFAULT false;
 
 -- Backfill: the seeded MAIN branch is the HQ. Run only if no HQ exists yet for
 -- the tenant (idempotent — re-runs are no-ops once one is set).
-UPDATE "Branch" b
+UPDATE "branches" b
    SET "isHeadquarters" = true
  WHERE b."code" = 'MAIN'
    AND NOT EXISTS (
-     SELECT 1 FROM "Branch" h
+     SELECT 1 FROM "branches" h
       WHERE h."tenantId" = b."tenantId" AND h."isHeadquarters" = true
    );
 
 -- Fallback for tenants without a MAIN-coded branch: the earliest branch becomes
 -- HQ (one per tenant, only when none is flagged yet).
-UPDATE "Branch" b
+UPDATE "branches" b
    SET "isHeadquarters" = true
  WHERE b."id" = (
-         SELECT b2."id" FROM "Branch" b2
+         SELECT b2."id" FROM "branches" b2
           WHERE b2."tenantId" = b."tenantId"
           ORDER BY b2."createdAt" ASC, b2."id" ASC
           LIMIT 1
        )
    AND NOT EXISTS (
-     SELECT 1 FROM "Branch" h
+     SELECT 1 FROM "branches" h
       WHERE h."tenantId" = b."tenantId" AND h."isHeadquarters" = true
    );


### PR DESCRIPTION
**Incident:** the v3.2.56 migration `20260625180000_branch_is_headquarters` used `ALTER TABLE "Branch"`, but the Branch model is `@@map("branches")`. It failed in prod (`42P01 relation "Branch" does not exist`), leaving the migration in a **failed state** and the `isHeadquarters` column **not created** — so the v3.2.56 backend's Prisma client (which expects the column) errors on Branch-touching queries.

**Root cause:** my throwaway-Postgres validation created a literal `"Branch"` table instead of the real `@@map`'d `"branches"`, so it passed locally but failed prod.

**Fix:** corrected the table name to `"branches"` + added the `-- @doctor:idempotent` marker (`ADD COLUMN IF NOT EXISTS` + `NOT EXISTS`-guarded backfills) so the deploy migration-doctor can auto-recover it. Re-validated against `"branches"`: clean apply, idempotent, exactly 1 HQ per tenant.

Merge + tag **after** the prod DB recovery (a failed-migration row blocks `migrate deploy` until resolved; see the recovery runbook in the deploy notes).