### PR TITLE
feat(paygo): Paygo SP630PRO ECR (GMP-3 ÖKC) integration — Phase 0 (INERT)

### DIFF
--- a/apps/local-bridge-agent/README.md
+++ b/apps/local-bridge-agent/README.md
@@ -30,12 +30,29 @@ The bridge is HummyTummy's only authorised speaker on that LAN. It:
 
 ```
 agent ── command_queue ──┬── escpos.rs       (Epson TM/Star TSP)
+                         ├── gmp3/            (Turkish YN ÖKC over GMP-3 — Paygo SP630, …)
                          ├── yazarkasa_*.rs  (Hugin, Beko, Profilo, …)
                          ├── ingenico_iwl.rs (card-present terminal)
                          └── (...)
 ```
 
 Each driver implements a tiny trait `LocalDriver { execute(&self, cmd) -> Result<Outcome> }` so the rest of the agent never branches on brand. Adding a new driver is one file + one entry in the registry.
+
+### GMP-3 ÖKC driver (`drivers/gmp3/`)
+
+One vendor-neutral driver serves every certified Turkish *Yeni Nesil ÖKC* (they
+all speak the GİB GMP-3 message family); per-vendor quirks live in
+`gmp3/profiles.rs` (Paygo `paygo.sp630` is the first). It handles BOTH command
+families a single ECR box exposes — coupled card sale (`charge_card`/`void_card`)
+and standalone fiş (`fiscal_receipt`/`fiscal_cancel`/`fiscal_report`) — plus
+`capability_probe`. Commands route here by `protocol == "GMP3"` (no `target`).
+
+Transport is configured on-prem in `gmp3.toml` in the data dir (see
+`gmp3.toml.example`), keyed by device serial (== the command's `fiscalSerial`).
+`mode = "simulator"` exercises the whole rail without hardware; `mode = "real"`
+**fails closed** until a vendor profile's certified GMP-3 handshake ships
+(`VendorProfile::real_impl_ready`, Phase 1) — the driver never fabricates an
+approval or a fiş.
 
 ## Build
 

--- a/apps/local-bridge-agent/gmp3.toml.example
+++ b/apps/local-bridge-agent/gmp3.toml.example
@@ -1,0 +1,29 @@
+# GMP-3 ÖKC transport config for the local bridge agent.
+#
+# Copy to `gmp3.toml` in the bridge data dir (the same `data_dir` that holds
+# `printers.toml` and `command_queue.db`). One `[[device]]` per Turkish
+# Yeni Nesil ÖKC (Paygo SP630, …) on the LAN. The cloud never learns these LAN
+# addresses (they sit behind NAT), so the transport is resolved here on-prem.
+#
+# Each entry is matched to a command by `serial` (== the command's fiscalSerial,
+# which is the terminal/fiscal-device record's serial in the cloud).
+
+# --- Test / bring-up: a fully-simulated device (moves NO real money) ----------
+[[device]]
+serial      = "5B0024050735"   # the SP630 serial (see the sticker on the back)
+mode        = "simulator"      # "simulator" | "real"
+sim_outcome = "approve"        # simulator only: approve (default) | decline | error
+# host/port are ignored in simulator mode.
+
+# --- Production (Phase 1, once the certified handshake ships) ------------------
+# A device with mode = "real" FAILS CLOSED until the vendor's GMP-3 handshake is
+# implemented and its profile flips `real_impl_ready` — the bridge refuses to
+# move money on an uncertified handshake. Uncomment + fill in for Phase 1:
+#
+# [[device]]
+# serial = "5B0024050736"
+# mode   = "real"
+# host   = "192.168.1.60"      # the ÖKC's LAN IP (its GMP-3 server)
+# port   = 59000               # optional; the vendor profile default otherwise
+# # Phase 1 also needs the PÖKC cert material (paths added when the real
+# # handshake lands) — see docs/integrations/paygo-token-gmp3-onboarding.md.

--- a/apps/local-bridge-agent/src/cloud_ws.rs
+++ b/apps/local-bridge-agent/src/cloud_ws.rs
@@ -281,8 +281,9 @@ impl CloudTransport for ReqwestTransport {
         // Bridge command fan-in: the backend claims the next queued command
         // across all devices attached to this bridge (Device.bridgeId), scoping
         // by the bridge bearer token — so the bridge id is NOT in the path. The
-        // route returns a JSON array (0 or 1 command) so the Vec decode below is
-        // satisfied; a 204 means nothing queued.
+        // route returns HTTP 200 with a JSON array (0 or 1 command); an empty
+        // batch is `[]` (decodes to zero commands), not 204. The 204 branch below
+        // is retained defensively for other/legacy endpoints.
         let url = format!("{}/v1/bridges/commands/next", self.cfg.cloud_url);
         let token = crate::config::resolve_bearer_token().unwrap_or_default();
         let resp = self

--- a/apps/local-bridge-agent/src/cloud_ws.rs
+++ b/apps/local-bridge-agent/src/cloud_ws.rs
@@ -1,10 +1,13 @@
 //! Cloud transport for the bridge.
 //!
 //! Primary channel is WSS to `/ws/bridge`. The cloud pushes commands; the
-//! bridge sends acks back on the same socket. REST fallback at
-//! `/v1/bridges/:id/commands/next` is used when the WSS is down — slower,
-//! but resilient against captive portals or weird LAN proxies that drop
-//! upgrade headers.
+//! bridge sends acks back on the same socket. REST fallback via the
+//! bridge-scoped fan-in loop (`GET /v1/bridges/commands/next` +
+//! `POST /v1/bridges/commands/:id/ack`, `Authorization: Bridge`) is used when
+//! the WSS is down — slower, but resilient against captive portals or weird LAN
+//! proxies that drop upgrade headers. The backend claims/acks across the devices
+//! attached to this bridge (Device.bridgeId); the pre-existing per-device loop
+//! (`/v1/devices/*`, `Authorization: Device`) is unaffected.
 //!
 //! ## The transport seam
 //!
@@ -115,11 +118,12 @@ pub trait CloudTransport: Send + Sync {
     /// GET `/healthz`. Returns the HTTP status code.
     async fn get_healthz(&self) -> Result<u16>;
 
-    /// GET `/v1/bridges/:id/commands/next`, decoded into a [`FetchResponse`].
+    /// GET `/v1/bridges/commands/next` (bridge-scoped fan-in), decoded into a
+    /// [`FetchResponse`].
     async fn get_next_commands(&self) -> Result<FetchResponse>;
 
-    /// POST an outcome to `/v1/devices/commands/:id/ack`. Errors on a
-    /// non-success HTTP status so the caller can retry/fail uniformly.
+    /// POST an outcome to `/v1/bridges/commands/:id/ack` (bridge-scoped). Errors
+    /// on a non-success HTTP status so the caller can retry/fail uniformly.
     async fn post_ack(&self, cmd_id: &str, outcome: &CommandOutcome) -> Result<()>;
 
     /// POST `/v1/bridges/heartbeat` with the bridge bearer token + identity.
@@ -274,10 +278,12 @@ impl CloudTransport for ReqwestTransport {
     }
 
     async fn get_next_commands(&self) -> Result<FetchResponse> {
-        let url = format!(
-            "{}/v1/bridges/{}/commands/next",
-            self.cfg.cloud_url, self.cfg.bridge_id
-        );
+        // Bridge command fan-in: the backend claims the next queued command
+        // across all devices attached to this bridge (Device.bridgeId), scoping
+        // by the bridge bearer token — so the bridge id is NOT in the path. The
+        // route returns a JSON array (0 or 1 command) so the Vec decode below is
+        // satisfied; a 204 means nothing queued.
+        let url = format!("{}/v1/bridges/commands/next", self.cfg.cloud_url);
         let token = crate::config::resolve_bearer_token().unwrap_or_default();
         let resp = self
             .http
@@ -308,7 +314,9 @@ impl CloudTransport for ReqwestTransport {
     }
 
     async fn post_ack(&self, cmd_id: &str, outcome: &CommandOutcome) -> Result<()> {
-        let url = format!("{}/v1/devices/commands/{}/ack", self.cfg.cloud_url, cmd_id);
+        // Ack via the bridge-scoped route (Authorization: Bridge). The backend
+        // verifies the command's device belongs to THIS bridge before acking.
+        let url = format!("{}/v1/bridges/commands/{}/ack", self.cfg.cloud_url, cmd_id);
         let token = crate::config::resolve_bearer_token().unwrap_or_default();
         self.http
             .post(url)

--- a/apps/local-bridge-agent/src/drivers/gmp3/mod.rs
+++ b/apps/local-bridge-agent/src/drivers/gmp3/mod.rs
@@ -1,0 +1,463 @@
+//! Vendor-neutral GMP-3 driver for Turkish *Yeni Nesil ÖKC* devices.
+//!
+//! One driver (`kind = "gmp3"`) serves the whole family of GİB GMP-3 ÖKCs; the
+//! per-vendor bits live in [`profiles`]. It handles BOTH command families a
+//! single physical device exposes:
+//!   - coupled card sale (`charge_card` / `void_card`) — the payment-terminal
+//!     rail, `paygo_ecr` provider;
+//!   - standalone fiş (`fiscal_receipt` / `fiscal_cancel` / `fiscal_report`) —
+//!     the fiscal-core rail, `fiscal_paygo` provider;
+//!   - plus `capability_probe`.
+//!
+//! ## Routing
+//! The cloud GMP-3 adapters emit `protocol: "GMP3"` + `vendorProfile` (no
+//! `target`), so the driver registry routes GMP-3-protocol commands here (see
+//! `drivers::Registry::dispatch`).
+//!
+//! ## Transport config (resolved LOCALLY, like `printers.toml`)
+//! The cloud never learns the device's LAN address (NAT); it lives on-prem in
+//! `gmp3.toml` in the bridge data dir, keyed by the device serial (== the
+//! command's `fiscalSerial`):
+//!
+//! ```toml
+//! [[device]]
+//! serial = "5B0024050735"   # matches the command's fiscalSerial
+//! mode = "simulator"        # "simulator" (test) | "real" (Phase 1, cert'd)
+//! sim_outcome = "approve"   # simulator only: approve | decline | error
+//! host = "192.168.1.60"     # required for real mode
+//! port = 59000              # optional; profile default otherwise
+//! ```
+//!
+//! ## Honest failure (no fake success)
+//! `mode = "real"` fails closed until the vendor's certified handshake ships
+//! (`VendorProfile::real_impl_ready`) — we never fabricate an approval or a fiş.
+//! A device not present in `gmp3.toml`, an unknown vendor profile, or an
+//! unhandled kind all surface as `Err` (→ a `failed` ack), never a silent no-op.
+
+pub mod profiles;
+pub mod protocol;
+pub mod transport;
+
+use crate::{
+    command_queue::{CommandOutcome, PendingCommand},
+    drivers::LocalDriver,
+};
+use anyhow::{anyhow, Context, Result};
+use async_trait::async_trait;
+use serde::Deserialize;
+use std::path::{Path, PathBuf};
+
+use profiles::VendorProfile;
+use protocol::{CommandFamily, SimOutcome, SimResult};
+
+/// One device's on-prem transport config from `gmp3.toml`.
+#[derive(Debug, Clone, Deserialize)]
+struct Gmp3DeviceEntry {
+    /// Device serial — matched against the command's `fiscalSerial`.
+    serial: String,
+    /// "simulator" (opt-in test mode) | anything else → real (fail-closed in
+    /// Phase 0). Defaulting the UNSET/unknown value to real is deliberate: a
+    /// misconfigured device must fail closed, never silently simulate a sale.
+    #[serde(default)]
+    mode: Option<String>,
+    /// Simulator only: approve (default) | decline | error.
+    #[serde(default)]
+    sim_outcome: Option<String>,
+    /// LAN host (required for real mode; unused by the simulator).
+    #[serde(default)]
+    #[allow(dead_code)] // consumed by the real path (Phase 1); kept honest here.
+    host: Option<String>,
+    /// LAN port (optional; the vendor profile's default applies otherwise).
+    #[serde(default)]
+    #[allow(dead_code)]
+    port: Option<u16>,
+}
+
+impl Gmp3DeviceEntry {
+    fn is_simulator(&self) -> bool {
+        matches!(
+            self.mode.as_deref().map(|m| m.trim().to_ascii_lowercase()),
+            Some(ref m) if m == "simulator" || m == "sim"
+        )
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+struct Gmp3Config {
+    #[serde(default)]
+    device: Vec<Gmp3DeviceEntry>,
+}
+
+/// The GMP-3 driver. Holds the locally-configured device transports (loaded once
+/// at boot from `gmp3.toml`). Like the ESC/POS driver, it registers even when
+/// the config is absent (so the agent boots) and fails honestly at command time.
+pub struct Gmp3Driver {
+    devices: Vec<Gmp3DeviceEntry>,
+    /// Where `gmp3.toml` was looked for — named in errors so an operator knows
+    /// exactly which file to create/fix.
+    config_path: PathBuf,
+}
+
+impl Gmp3Driver {
+    /// Production init: read `gmp3.toml` from the bridge data dir. Always
+    /// registers the driver (returns `Some`) so a missing config doesn't drop
+    /// the `gmp3` kind — the failure surfaces honestly at command time.
+    pub async fn try_init(data_dir: &Path) -> Result<Option<Self>> {
+        let config_path = data_dir.join("gmp3.toml");
+        let devices = match load_config(&config_path) {
+            Ok(d) => {
+                tracing::info!(
+                    count = d.len(),
+                    path = %config_path.display(),
+                    "gmp3: loaded device transports"
+                );
+                d
+            }
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    path = %config_path.display(),
+                    "gmp3: no usable device config; GMP-3 commands will FAIL until gmp3.toml is set"
+                );
+                Vec::new()
+            }
+        };
+        Ok(Some(Gmp3Driver {
+            devices,
+            config_path,
+        }))
+    }
+
+    #[cfg(test)]
+    fn with_devices(devices: Vec<Gmp3DeviceEntry>) -> Self {
+        Gmp3Driver {
+            devices,
+            config_path: PathBuf::from("<test>/gmp3.toml"),
+        }
+    }
+
+    fn find(&self, serial: &str) -> Option<&Gmp3DeviceEntry> {
+        self.devices.iter().find(|d| d.serial == serial)
+    }
+
+    fn payload_str<'a>(&self, cmd: &'a PendingCommand, key: &str) -> Option<&'a str> {
+        cmd.payload.get(key).and_then(|v| v.as_str())
+    }
+}
+
+#[async_trait]
+impl LocalDriver for Gmp3Driver {
+    fn kind(&self) -> &str {
+        "gmp3"
+    }
+
+    async fn execute(&self, cmd: &PendingCommand) -> Result<CommandOutcome> {
+        // 1. Defensive protocol check (dispatch already routed us GMP-3 traffic).
+        let protocol = self.payload_str(cmd, "protocol").unwrap_or("");
+        if protocol != "GMP3" {
+            return Err(anyhow!(
+                "gmp3: command {} has protocol '{}', expected 'GMP3'",
+                cmd.id,
+                protocol
+            ));
+        }
+
+        // 2. Resolve the vendor profile from the command.
+        let vendor_profile = self.payload_str(cmd, "vendorProfile").unwrap_or("");
+        let profile: &VendorProfile = profiles::resolve(vendor_profile).ok_or_else(|| {
+            anyhow!(
+                "gmp3: unknown vendorProfile '{}' for command {} (known: {})",
+                vendor_profile,
+                cmd.id,
+                profiles::known_ids().join(", ")
+            )
+        })?;
+
+        // 3. Classify the command kind into a GMP-3 family.
+        let family: CommandFamily = protocol::classify(&cmd.kind).ok_or_else(|| {
+            anyhow!(
+                "gmp3: driver does not handle command kind '{}' (command {})",
+                cmd.kind,
+                cmd.id
+            )
+        })?;
+
+        // 4. Resolve the on-prem device config by serial. No entry ⇒ fail closed
+        //    (never fabricate a device), naming the config file to fix.
+        let fiscal_serial = self.payload_str(cmd, "fiscalSerial").unwrap_or("");
+        let device = self.find(fiscal_serial).ok_or_else(|| {
+            if self.devices.is_empty() {
+                anyhow!(
+                    "gmp3: no devices configured (looked in {}). Cannot run {} for serial '{}' — create gmp3.toml",
+                    self.config_path.display(),
+                    cmd.kind,
+                    fiscal_serial
+                )
+            } else {
+                anyhow!(
+                    "gmp3: no device with serial '{}' in {} (have: {})",
+                    fiscal_serial,
+                    self.config_path.display(),
+                    self.devices
+                        .iter()
+                        .map(|d| d.serial.as_str())
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                )
+            }
+        })?;
+
+        // 5. Simulator vs. real.
+        if device.is_simulator() {
+            let outcome = SimOutcome::parse(device.sim_outcome.as_deref().unwrap_or("approve"));
+            tracing::info!(
+                serial = %fiscal_serial,
+                vendor = %profile.id,
+                kind = %cmd.kind,
+                outcome = ?outcome,
+                "gmp3: SIMULATOR — no hardware touched"
+            );
+            return match protocol::simulate(family, &cmd.id, outcome) {
+                SimResult::Done(result) => Ok(CommandOutcome {
+                    status: "done".to_string(),
+                    result,
+                    error: None,
+                }),
+                // A simulated error/decline-as-error drives the SAME honest
+                // failure path a real device error/timeout would (kind-aware
+                // parking + failed ack), so the recovery rail is exercised too.
+                SimResult::Failed(err) => Err(anyhow!(err)),
+            };
+        }
+
+        // Real mode: fail closed until the vendor's certified handshake ships.
+        // We do NOT open a socket we cannot complete a transaction over —
+        // partial contact with a fiscal/card device is worse than none.
+        if !profile.real_impl_ready {
+            return Err(anyhow!(protocol::real_mode_unavailable(
+                profile.display_name,
+                profile.id
+            )));
+        }
+
+        // Phase 1: the certified handshake/TLV/crypto over transport::TcpEndpoint
+        // lands here (build request → request_reply → parse → outcome). Until a
+        // profile flips real_impl_ready true, this is unreachable.
+        Err(anyhow!(
+            "gmp3: real transport for {} is marked ready but not wired — build error",
+            profile.id
+        ))
+    }
+}
+
+/// Load + validate `gmp3.toml`. Errors if the file is missing or unparseable, or
+/// declares zero devices, so the caller logs it and registers the driver in a
+/// "will fail honestly" state (parity with the ESC/POS printer config).
+fn load_config(path: &Path) -> Result<Vec<Gmp3DeviceEntry>> {
+    let raw = std::fs::read_to_string(path)
+        .with_context(|| format!("reading gmp3 config {}", path.display()))?;
+    let cfg: Gmp3Config =
+        toml::from_str(&raw).with_context(|| format!("parsing gmp3 config {}", path.display()))?;
+    if cfg.device.is_empty() {
+        return Err(anyhow!(
+            "gmp3 config {} has no [[device]] entries",
+            path.display()
+        ));
+    }
+    Ok(cfg.device)
+}
+
+/// The un-decorated result shape helper for tests / callers that want to assert
+/// the JSON without matching on `CommandOutcome`.
+#[cfg(test)]
+fn cmd(id: &str, kind: &str, payload: serde_json::Value) -> PendingCommand {
+    PendingCommand {
+        id: id.to_string(),
+        kind: kind.to_string(),
+        payload,
+        priority: 10,
+        attempts: 0,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn sim_device(serial: &str, outcome: &str) -> Gmp3DeviceEntry {
+        Gmp3DeviceEntry {
+            serial: serial.to_string(),
+            mode: Some("simulator".to_string()),
+            sim_outcome: Some(outcome.to_string()),
+            host: None,
+            port: None,
+        }
+    }
+
+    fn charge_payload(serial: &str) -> serde_json::Value {
+        json!({
+            "protocol": "GMP3",
+            "vendorProfile": "paygo.sp630",
+            "fiscalSerial": serial,
+            "amountCents": 12345,
+            "currency": "TRY",
+            "orderId": "o1",
+        })
+    }
+
+    #[tokio::test]
+    async fn kind_is_gmp3() {
+        let d = Gmp3Driver::with_devices(vec![]);
+        assert_eq!(d.kind(), "gmp3");
+    }
+
+    #[tokio::test]
+    async fn simulator_charge_approves_with_coupled_fiscal_no() {
+        let d = Gmp3Driver::with_devices(vec![sim_device("SER-1", "approve")]);
+        let out = d
+            .execute(&cmd("c-1", "charge_card", charge_payload("SER-1")))
+            .await
+            .expect("simulator charge succeeds");
+        assert_eq!(out.status, "done");
+        assert_eq!(out.result["approved"], true);
+        assert!(out.result["fiscalNo"]
+            .as_str()
+            .unwrap()
+            .starts_with("SIMFIS-"));
+    }
+
+    #[tokio::test]
+    async fn simulator_decline_is_done_not_approved() {
+        let d = Gmp3Driver::with_devices(vec![sim_device("SER-1", "decline")]);
+        let out = d
+            .execute(&cmd("c-2", "charge_card", charge_payload("SER-1")))
+            .await
+            .expect("decline is a done ack");
+        assert_eq!(out.status, "done");
+        assert_eq!(out.result["approved"], false);
+    }
+
+    #[tokio::test]
+    async fn simulator_error_is_a_failed_dispatch() {
+        let d = Gmp3Driver::with_devices(vec![sim_device("SER-1", "error")]);
+        assert!(
+            d.execute(&cmd("c-3", "charge_card", charge_payload("SER-1")))
+                .await
+                .is_err(),
+            "a simulated error must drive the honest failure path"
+        );
+    }
+
+    #[tokio::test]
+    async fn simulator_fiscal_receipt_returns_fiscal_no() {
+        let d = Gmp3Driver::with_devices(vec![sim_device("SER-1", "approve")]);
+        let payload = json!({
+            "protocol": "GMP3", "vendorProfile": "paygo.sp630",
+            "fiscalSerial": "SER-1", "kind": "cash_receipt",
+        });
+        let out = d
+            .execute(&cmd("c-4", "fiscal_receipt", payload))
+            .await
+            .expect("simulator fiş succeeds");
+        assert_eq!(out.status, "done");
+        assert!(out.result["fiscalNo"]
+            .as_str()
+            .unwrap()
+            .starts_with("SIMFIS-"));
+    }
+
+    #[tokio::test]
+    async fn real_mode_fails_closed_for_uncertified_vendor() {
+        let d = Gmp3Driver::with_devices(vec![Gmp3DeviceEntry {
+            serial: "SER-1".to_string(),
+            mode: Some("real".to_string()),
+            sim_outcome: None,
+            host: Some("192.168.1.60".to_string()),
+            port: Some(59000),
+        }]);
+        let err = d
+            .execute(&cmd("c-5", "charge_card", charge_payload("SER-1")))
+            .await
+            .expect_err("real mode must fail closed in Phase 0");
+        assert!(err.to_string().contains("not certified"), "got: {err}");
+    }
+
+    #[tokio::test]
+    async fn unconfigured_serial_fails_honestly() {
+        let d = Gmp3Driver::with_devices(vec![sim_device("SER-1", "approve")]);
+        let err = d
+            .execute(&cmd("c-6", "charge_card", charge_payload("UNKNOWN")))
+            .await
+            .expect_err("a serial not in gmp3.toml must fail, not fake success");
+        assert!(err.to_string().contains("UNKNOWN"), "got: {err}");
+    }
+
+    #[tokio::test]
+    async fn unknown_vendor_profile_fails() {
+        let d = Gmp3Driver::with_devices(vec![sim_device("SER-1", "approve")]);
+        let payload = json!({
+            "protocol": "GMP3", "vendorProfile": "acme.9000", "fiscalSerial": "SER-1",
+        });
+        let err = d
+            .execute(&cmd("c-7", "charge_card", payload))
+            .await
+            .expect_err("unknown vendor profile must fail");
+        assert!(err.to_string().contains("acme.9000"), "got: {err}");
+    }
+
+    #[tokio::test]
+    async fn no_devices_configured_fails_with_config_hint() {
+        let d = Gmp3Driver::with_devices(vec![]);
+        let err = d
+            .execute(&cmd("c-8", "charge_card", charge_payload("SER-1")))
+            .await
+            .expect_err("no gmp3.toml → honest failure");
+        assert!(
+            err.to_string().contains("no devices configured"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn loads_devices_from_toml() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("gmp3.toml");
+        std::fs::write(
+            &path,
+            r#"
+                [[device]]
+                serial = "5B0024050735"
+                mode = "simulator"
+                sim_outcome = "approve"
+                host = "192.168.1.60"
+                port = 59000
+            "#,
+        )
+        .unwrap();
+        let devices = load_config(&path).unwrap();
+        assert_eq!(devices.len(), 1);
+        assert_eq!(devices[0].serial, "5B0024050735");
+        assert!(devices[0].is_simulator());
+    }
+
+    #[test]
+    fn missing_config_is_an_error() {
+        let dir = tempfile::TempDir::new().unwrap();
+        assert!(load_config(&dir.path().join("nope.toml")).is_err());
+    }
+
+    #[test]
+    fn unset_mode_is_not_simulator() {
+        // An entry with no `mode` must NOT be treated as a simulator — that
+        // would silently fake sales on a device meant to be real.
+        let entry = Gmp3DeviceEntry {
+            serial: "S".to_string(),
+            mode: None,
+            sim_outcome: None,
+            host: None,
+            port: None,
+        };
+        assert!(!entry.is_simulator());
+    }
+}

--- a/apps/local-bridge-agent/src/drivers/gmp3/profiles.rs
+++ b/apps/local-bridge-agent/src/drivers/gmp3/profiles.rs
@@ -1,0 +1,71 @@
+//! GMP-3 vendor profiles.
+//!
+//! Every certified Turkish *Yeni Nesil ÖKC* speaks the same GİB GMP-3 message
+//! family, so the driver is protocol-first, not vendor-first: one `gmp3` driver
+//! plus one small profile per brand. A profile carries only the bits that
+//! actually differ between vendors: the default TCP port, and whether that
+//! brand's real (certified) handshake is implemented yet. Adding a new POS/ÖKC
+//! brand later is a single entry here (plus its cert/handshake specifics in
+//! `protocol.rs` when the real driver lands) — no new driver, no schema change.
+
+/// One vendor's GMP-3 profile.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct VendorProfile {
+    /// The `vendorProfile` string the cloud sends in the command payload
+    /// (e.g. "paygo.sp630"). Matched verbatim.
+    pub id: &'static str,
+    /// Human-readable name, for logs/errors.
+    pub display_name: &'static str,
+    /// TCP port the device's GMP-3 server listens on when the on-prem
+    /// `gmp3.toml` entry omits an explicit `port`.
+    pub default_port: u16,
+    /// Whether this brand's REAL (certified) GMP-3 handshake is implemented.
+    /// While false, a device configured `mode = "real"` fails closed regardless
+    /// of config — the honest boundary until Phase-1 vendor onboarding lands.
+    pub real_impl_ready: bool,
+}
+
+/// All known GMP-3 vendor profiles. Paygo is the first concrete binding; other
+/// Turkish ÖKC brands (Beko, Hugin, Profilo, Ingenico, Verifone, Pavo, …) each
+/// become one more entry here as they are onboarded.
+static PROFILES: &[VendorProfile] = &[VendorProfile {
+    id: "paygo.sp630",
+    display_name: "Paygo SP630PRO ECR",
+    // GMP-3 devices expose their integration server around :59000 on the LAN.
+    default_port: 59000,
+    // Phase 0: the real cert-handshake driver is not implemented yet. Flip to
+    // true only when the certified Paygo/Token GMP-3 handshake ships (Phase 1).
+    real_impl_ready: false,
+}];
+
+/// Resolve a vendor profile by its `vendorProfile` id, or `None` if unknown.
+pub fn resolve(vendor_profile: &str) -> Option<&'static VendorProfile> {
+    PROFILES.iter().find(|p| p.id == vendor_profile)
+}
+
+/// The ids of every registered profile — surfaced in the "unknown profile"
+/// error so an operator sees what IS supported.
+pub fn known_ids() -> Vec<&'static str> {
+    PROFILES.iter().map(|p| p.id).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolves_paygo_sp630() {
+        let p = resolve("paygo.sp630").expect("paygo profile registered");
+        assert_eq!(p.default_port, 59000);
+        assert!(
+            !p.real_impl_ready,
+            "Phase 0 ships the Paygo real handshake as not-ready (fail-closed)"
+        );
+    }
+
+    #[test]
+    fn unknown_profile_resolves_to_none() {
+        assert!(resolve("nope.unknown").is_none());
+        assert!(known_ids().contains(&"paygo.sp630"));
+    }
+}

--- a/apps/local-bridge-agent/src/drivers/gmp3/protocol.rs
+++ b/apps/local-bridge-agent/src/drivers/gmp3/protocol.rs
@@ -1,0 +1,258 @@
+//! GMP-3 protocol layer — vendor-neutral.
+//!
+//! Two responsibilities in Phase 0:
+//!   1. Classify the cloud command kind into a GMP-3 command family.
+//!   2. Produce deterministic SIMULATOR outcomes whose JSON shape EXACTLY
+//!      matches what the cloud reads back (payment-terminal `mapAck` and
+//!      fiscal-core `mapReceiptOutcome`/`runReport`), so the whole rail is
+//!      testable end-to-end without certified hardware.
+//!
+//! The real (certified) path — the DH + PÖKC cert handshake, AES-CBC + HMAC
+//! framing, and the İşlem Sıra No (transaction sequence number) that Turkish GİB
+//! GMP-3 mandates — is Phase 1. It builds on `transport::TcpEndpoint`; nothing
+//! here fabricates a device reply. Until a vendor profile's `real_impl_ready`
+//! flips true, `mode = "real"` fails closed via [`real_mode_unavailable`].
+
+use serde_json::{json, Value};
+
+/// A GMP-3 command family, derived from the cloud command `kind`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CommandFamily {
+    /// Coupled card sale — charges the card AND prints the mali fiş in one op.
+    ChargeCard,
+    /// Void/reverse a previously-approved card charge.
+    VoidCard,
+    /// Standalone mali fiş (cash / meal-card / non-card sale).
+    FiscalReceipt,
+    /// Void a previously-issued fiscal receipt.
+    FiscalCancel,
+    /// GMP-3 X/Z report (day-close for Z).
+    FiscalReport,
+    /// Read-only device status probe.
+    CapabilityProbe,
+}
+
+/// Map a cloud command `kind` to its GMP-3 family, or `None` if this driver
+/// doesn't handle it (the caller then errors — never a silent no-op).
+pub fn classify(kind: &str) -> Option<CommandFamily> {
+    match kind {
+        "charge_card" => Some(CommandFamily::ChargeCard),
+        "void_card" => Some(CommandFamily::VoidCard),
+        "fiscal_receipt" => Some(CommandFamily::FiscalReceipt),
+        "fiscal_cancel" => Some(CommandFamily::FiscalCancel),
+        "fiscal_report" => Some(CommandFamily::FiscalReport),
+        "capability_probe" => Some(CommandFamily::CapabilityProbe),
+        _ => None,
+    }
+}
+
+/// The configured simulator outcome for a device (from `gmp3.toml`
+/// `sim_outcome`). Defaults to approve.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SimOutcome {
+    Approve,
+    Decline,
+    Error,
+}
+
+impl SimOutcome {
+    pub fn parse(s: &str) -> SimOutcome {
+        match s.trim().to_ascii_lowercase().as_str() {
+            "decline" | "declined" => SimOutcome::Decline,
+            "error" | "fail" | "failed" => SimOutcome::Error,
+            _ => SimOutcome::Approve,
+        }
+    }
+}
+
+/// A simulated command result: either a `done` ack with a result blob, or a
+/// `failed` ack with an error string — mapped to a `CommandOutcome` by the
+/// driver.
+#[derive(Debug, Clone)]
+pub enum SimResult {
+    Done(Value),
+    Failed(String),
+}
+
+/// Deterministic reference derived from the command id (no RNG — same command
+/// id → same reference, so tests and recovery are reproducible). Clearly
+/// `SIM-`/`SIMFIS-` prefixed so a simulated value can NEVER be mistaken for a
+/// real bank RRN or fiscal number.
+fn short(cmd_id: &str) -> String {
+    cmd_id.chars().take(12).collect()
+}
+
+/// Build the deterministic simulator outcome for a command family. The JSON keys
+/// mirror the real device contract the cloud reads:
+///   - card: `{approved, approvalCode, rrn, cardBrand, maskedPan, fiscalNo}`
+///   - fiscal receipt: `{fiscalNo, fiscalZNo}`
+///   - fiscal report: `{zNo, openedAt, closedAt, totals}`
+///   - probe: `{deviceStatus}`
+pub fn simulate(family: CommandFamily, cmd_id: &str, outcome: SimOutcome) -> SimResult {
+    let s = short(cmd_id);
+    match family {
+        CommandFamily::ChargeCard => match outcome {
+            SimOutcome::Approve => SimResult::Done(json!({
+                "approved": true,
+                "approvalCode": format!("SIM-{s}"),
+                "rrn": format!("SIM-{s}"),
+                "cardBrand": "SIMULATOR",
+                "maskedPan": "**** **** **** 0000",
+                // Coupled: the SP630 prints the fiş atomically with the charge.
+                "fiscalNo": format!("SIMFIS-{s}"),
+                "simulator": true,
+            })),
+            SimOutcome::Decline => SimResult::Done(json!({
+                "approved": false,
+                "error": "Simulated card decline",
+                "simulator": true,
+            })),
+            SimOutcome::Error => SimResult::Failed("Simulated terminal error".into()),
+        },
+        CommandFamily::VoidCard => match outcome {
+            SimOutcome::Approve => SimResult::Done(json!({
+                "approved": true,
+                "approvalCode": format!("SIM-VOID-{s}"),
+                "simulator": true,
+            })),
+            _ => SimResult::Failed("Simulated void failure".into()),
+        },
+        CommandFamily::FiscalReceipt => match outcome {
+            SimOutcome::Approve => SimResult::Done(json!({
+                "fiscalNo": format!("SIMFIS-{s}"),
+                "fiscalZNo": "1",
+                "simulator": true,
+            })),
+            _ => SimResult::Failed("Simulated fiscal error".into()),
+        },
+        CommandFamily::FiscalCancel => match outcome {
+            SimOutcome::Approve => SimResult::Done(json!({ "simulator": true })),
+            _ => SimResult::Failed("Simulated fiscal cancel failure".into()),
+        },
+        CommandFamily::FiscalReport => match outcome {
+            SimOutcome::Approve => SimResult::Done(json!({
+                "zNo": format!("SIMZ-{s}"),
+                // Clearly-synthetic epoch timestamps so a simulated Z can never
+                // be mistaken for a real day-close.
+                "openedAt": "1970-01-01T00:00:00.000Z",
+                "closedAt": "1970-01-01T00:00:00.000Z",
+                "totals": {},
+                "simulator": true,
+            })),
+            _ => SimResult::Failed("Simulated report failure".into()),
+        },
+        CommandFamily::CapabilityProbe => match outcome {
+            SimOutcome::Error => {
+                SimResult::Done(json!({ "deviceStatus": "error", "simulator": true }))
+            }
+            _ => SimResult::Done(json!({ "deviceStatus": "online", "simulator": true })),
+        },
+    }
+}
+
+/// The honest fail-closed error for a device configured `mode = "real"` on a
+/// vendor whose certified GMP-3 handshake is not implemented yet (Phase 0). We
+/// do NOT touch the hardware we cannot finish a transaction with.
+pub fn real_mode_unavailable(display_name: &str, profile_id: &str) -> String {
+    format!(
+        "GMP-3 real mode is not certified for {display_name} ({profile_id}) yet — \
+         complete Phase-1 vendor onboarding (Token SDK + cert + test device), or set \
+         `mode = \"simulator\"` in gmp3.toml for testing. Refusing to move money on an \
+         uncertified handshake."
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classifies_all_gmp3_kinds() {
+        assert_eq!(classify("charge_card"), Some(CommandFamily::ChargeCard));
+        assert_eq!(classify("void_card"), Some(CommandFamily::VoidCard));
+        assert_eq!(
+            classify("fiscal_receipt"),
+            Some(CommandFamily::FiscalReceipt)
+        );
+        assert_eq!(classify("fiscal_cancel"), Some(CommandFamily::FiscalCancel));
+        assert_eq!(classify("fiscal_report"), Some(CommandFamily::FiscalReport));
+        assert_eq!(
+            classify("capability_probe"),
+            Some(CommandFamily::CapabilityProbe)
+        );
+        assert_eq!(classify("print_receipt"), None);
+    }
+
+    #[test]
+    fn sim_outcome_parses_forgivingly() {
+        assert_eq!(SimOutcome::parse("APPROVE"), SimOutcome::Approve);
+        assert_eq!(SimOutcome::parse(" decline "), SimOutcome::Decline);
+        assert_eq!(SimOutcome::parse("error"), SimOutcome::Error);
+        assert_eq!(SimOutcome::parse("weird"), SimOutcome::Approve);
+    }
+
+    #[test]
+    fn simulated_card_approval_carries_the_full_ack_contract() {
+        match simulate(
+            CommandFamily::ChargeCard,
+            "cmd-abcdef123456",
+            SimOutcome::Approve,
+        ) {
+            SimResult::Done(v) => {
+                assert_eq!(v["approved"], true);
+                assert_eq!(v["cardBrand"], "SIMULATOR");
+                // Coupled fiş present so the finalizer skips the standalone rail.
+                assert!(v["fiscalNo"].as_str().unwrap().starts_with("SIMFIS-"));
+                assert!(v["approvalCode"].as_str().unwrap().starts_with("SIM-"));
+            }
+            other => panic!("expected Done, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn simulated_card_decline_is_done_but_not_approved() {
+        match simulate(CommandFamily::ChargeCard, "c1", SimOutcome::Decline) {
+            SimResult::Done(v) => {
+                assert_eq!(v["approved"], false);
+                assert!(v.get("fiscalNo").is_none(), "no fiş on a decline");
+            }
+            other => panic!("expected Done(declined), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn simulated_card_error_is_a_failed_ack() {
+        match simulate(CommandFamily::ChargeCard, "c1", SimOutcome::Error) {
+            SimResult::Failed(_) => {}
+            other => panic!("expected Failed, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn simulated_fiscal_receipt_returns_a_fiscal_no() {
+        match simulate(CommandFamily::FiscalReceipt, "cmd-xyz", SimOutcome::Approve) {
+            SimResult::Done(v) => {
+                assert!(v["fiscalNo"].as_str().unwrap().starts_with("SIMFIS-"))
+            }
+            other => panic!("expected Done, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn deterministic_reference_from_command_id() {
+        let a = simulate(
+            CommandFamily::ChargeCard,
+            "same-id-000",
+            SimOutcome::Approve,
+        );
+        let b = simulate(
+            CommandFamily::ChargeCard,
+            "same-id-000",
+            SimOutcome::Approve,
+        );
+        match (a, b) {
+            (SimResult::Done(va), SimResult::Done(vb)) => assert_eq!(va, vb),
+            _ => panic!("same command id must yield the same simulated result"),
+        }
+    }
+}

--- a/apps/local-bridge-agent/src/drivers/gmp3/transport.rs
+++ b/apps/local-bridge-agent/src/drivers/gmp3/transport.rs
@@ -1,0 +1,139 @@
+//! Bidirectional TCP transport for GMP-3 devices.
+//!
+//! Unlike the ESC/POS printer path (`escpos::write_tcp`, which is write-only),
+//! a GMP-3 ÖKC is a request/response peer: we send a sale/receipt frame and
+//! read back a sequence-numbered result. This module provides that missing read
+//! half as a small, dependency-free, real primitive — the on-prem bridge is the
+//! TCP CLIENT and the device (Paygo SP630) is the server on the LAN.
+//!
+//! Phase 0 exposes a half-close request/response exchange (`request_reply`):
+//! connect → write the whole request → `shutdown(Write)` to signal end-of-request
+//! → read the reply to EOF. It is real and unit-tested against a loopback server.
+//! The certified GMP-3 wire framing (length-prefixed / STX-ETX over a persistent,
+//! encrypted socket with the İşlem Sıra No handshake) lands in Phase 1 and builds
+//! on this primitive; nothing here fakes a device.
+
+use anyhow::{anyhow, Context, Result};
+use std::io::{Read, Write};
+use std::net::{Shutdown, TcpStream, ToSocketAddrs};
+use std::time::Duration;
+
+/// A GMP-3 device endpoint on the LAN.
+#[derive(Debug, Clone)]
+pub struct TcpEndpoint {
+    pub host: String,
+    pub port: u16,
+    /// Bounded connect timeout so a powered-off device fails fast instead of
+    /// wedging the dispatch loop.
+    pub connect_timeout: Duration,
+    /// Read/write timeout for the exchange itself.
+    pub io_timeout: Duration,
+}
+
+impl TcpEndpoint {
+    /// Endpoint with conservative default timeouts (10s connect, 20s I/O — a
+    /// card sale involves a cardholder tapping/inserting + an acquirer round
+    /// trip, so the I/O timeout is generous).
+    pub fn new(host: impl Into<String>, port: u16) -> Self {
+        Self {
+            host: host.into(),
+            port,
+            connect_timeout: Duration::from_secs(10),
+            io_timeout: Duration::from_secs(20),
+        }
+    }
+
+    /// Half-close request/response. Connects (bounded), writes the whole
+    /// request, half-closes the write side to signal "request complete", then
+    /// reads the device's reply to EOF. Any connect/write/read error surfaces as
+    /// `Err` — the caller turns that into a `failed` ack; we NEVER synthesise a
+    /// reply.
+    pub fn request_reply(&self, request: &[u8]) -> Result<Vec<u8>> {
+        let addr_str = format!("{}:{}", self.host, self.port);
+        let addr = addr_str
+            .to_socket_addrs()
+            .with_context(|| format!("resolving GMP-3 device address {addr_str}"))?
+            .next()
+            .ok_or_else(|| {
+                anyhow!("GMP-3 device address {addr_str} resolved to no socket address")
+            })?;
+
+        let mut stream = TcpStream::connect_timeout(&addr, self.connect_timeout)
+            .with_context(|| format!("connecting to GMP-3 device {addr_str}"))?;
+        stream
+            .set_read_timeout(Some(self.io_timeout))
+            .context("setting GMP-3 read timeout")?;
+        stream
+            .set_write_timeout(Some(self.io_timeout))
+            .context("setting GMP-3 write timeout")?;
+        // A GMP-3 frame is one short burst; send promptly rather than waiting
+        // for Nagle to coalesce.
+        let _ = stream.set_nodelay(true);
+
+        stream
+            .write_all(request)
+            .with_context(|| format!("writing GMP-3 request to {addr_str}"))?;
+        stream.flush().ok();
+        // Signal end-of-request so the device can reply and we can read to EOF.
+        stream
+            .shutdown(Shutdown::Write)
+            .with_context(|| format!("half-closing write to {addr_str}"))?;
+
+        let mut reply = Vec::new();
+        stream
+            .read_to_end(&mut reply)
+            .with_context(|| format!("reading GMP-3 reply from {addr_str}"))?;
+        Ok(reply)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::TcpListener;
+    use std::sync::mpsc;
+
+    #[test]
+    fn request_reply_round_trips_over_loopback() {
+        // Stand up a loopback "device": read the request, echo a canned reply.
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind loopback");
+        let addr = listener.local_addr().unwrap();
+        let (tx, rx) = mpsc::channel::<Vec<u8>>();
+
+        let server = std::thread::spawn(move || {
+            let (mut sock, _) = listener.accept().expect("device accepts connection");
+            let mut got = Vec::new();
+            sock.read_to_end(&mut got)
+                .expect("device reads request to EOF");
+            tx.send(got).unwrap();
+            sock.write_all(b"GMP3-OK:fiscalNo=42")
+                .expect("device writes reply");
+        });
+
+        let ep = TcpEndpoint::new(addr.ip().to_string(), addr.port());
+        let reply = ep
+            .request_reply(b"SALE:amount=12345")
+            .expect("request/response succeeds");
+
+        assert_eq!(reply, b"GMP3-OK:fiscalNo=42");
+        let received = rx.recv_timeout(Duration::from_secs(5)).unwrap();
+        server.join().unwrap();
+        assert_eq!(
+            received, b"SALE:amount=12345",
+            "the device must receive the exact request bytes"
+        );
+    }
+
+    #[test]
+    fn unreachable_device_fails_not_hangs() {
+        // Port 1 on loopback: nothing listens → connect error → Err (never a
+        // fabricated reply).
+        let ep = TcpEndpoint {
+            host: "127.0.0.1".to_string(),
+            port: 1,
+            connect_timeout: Duration::from_millis(500),
+            io_timeout: Duration::from_millis(500),
+        };
+        assert!(ep.request_reply(b"x").is_err());
+    }
+}

--- a/apps/local-bridge-agent/src/drivers/mod.rs
+++ b/apps/local-bridge-agent/src/drivers/mod.rs
@@ -12,6 +12,7 @@ use std::collections::HashMap;
 use std::path::Path;
 
 pub mod escpos;
+pub mod gmp3;
 pub mod ingenico_iwl;
 pub mod yazarkasa_hugin;
 
@@ -42,6 +43,12 @@ impl Registry {
         if let Some(d) = escpos::EscPosDriver::try_init(data_dir).await? {
             drivers.insert(d.kind().to_string(), Box::new(d));
         }
+        // Vendor-neutral GMP-3 ÖKC driver (Paygo SP630 + future Turkish ÖKC
+        // brands). Registers even without gmp3.toml (fails honestly at command
+        // time), mirroring the ESC/POS driver.
+        if let Some(d) = gmp3::Gmp3Driver::try_init(data_dir).await? {
+            drivers.insert(d.kind().to_string(), Box::new(d));
+        }
         if let Some(d) = yazarkasa_hugin::HuginDriver::try_init().await? {
             drivers.insert(d.kind().to_string(), Box::new(d));
         }
@@ -56,18 +63,33 @@ impl Registry {
     }
 
     pub async fn dispatch(&self, cmd: &PendingCommand) -> Result<CommandOutcome> {
-        // Convention: commands carry `target` in the payload root to identify
-        // the driver class ("escpos", "hugin", "ingenico-iwl").
+        // Routing precedence:
+        //   1. An explicit `target` in the payload root wins — ESC/POS (and any
+        //      command the mesh tags) identify their driver class this way
+        //      ("escpos", "hugin", "ingenico-iwl").
+        //   2. Otherwise a GMP-3 command (`protocol == "GMP3"`) routes to the
+        //      vendor-neutral `gmp3` driver. The payment-terminal / fiscal-core
+        //      GMP-3 adapters emit `protocol`+`vendorProfile` and NO `target`;
+        //      the `gmp3` driver then selects the vendor by `vendorProfile`.
         let target = cmd
             .payload
             .get("target")
             .and_then(|v| v.as_str())
             .unwrap_or("");
-        match self.drivers.get(target) {
+        let protocol = cmd.payload.get("protocol").and_then(|v| v.as_str());
+        let driver_kind: &str = if !target.is_empty() {
+            target
+        } else if protocol == Some("GMP3") {
+            "gmp3"
+        } else {
+            ""
+        };
+        match self.drivers.get(driver_kind) {
             Some(driver) => driver.execute(cmd).await,
             None => anyhow::bail!(
-                "no driver installed for target='{}' (kind={})",
+                "no driver installed for target='{}' protocol='{}' (kind={})",
                 target,
+                protocol.unwrap_or(""),
                 cmd.kind
             ),
         }
@@ -199,6 +221,61 @@ mod tests {
         })]);
         let res = reg.dispatch(&cmd_with_target("c-4", None)).await;
         assert!(res.is_err(), "no target -> no driver -> error");
+    }
+
+    fn cmd_with_payload(id: &str, payload: serde_json::Value) -> PendingCommand {
+        PendingCommand {
+            id: id.to_string(),
+            kind: "charge_card".to_string(),
+            payload,
+            priority: 0,
+            attempts: 0,
+        }
+    }
+
+    #[tokio::test]
+    async fn dispatch_routes_gmp3_protocol_without_target_to_gmp3_driver() {
+        // The payment-terminal / fiscal-core GMP-3 adapters emit protocol+
+        // vendorProfile and NO target; those must reach the `gmp3` driver.
+        let calls = StdArc::new(AtomicUsize::new(0));
+        let reg = registry_with(vec![Box::new(FakeDriver {
+            kind: "gmp3",
+            calls: calls.clone(),
+        })]);
+        let outcome = reg
+            .dispatch(&cmd_with_payload(
+                "c-g1",
+                json!({ "protocol": "GMP3", "vendorProfile": "paygo.sp630" }),
+            ))
+            .await
+            .expect("GMP3 protocol routes to the gmp3 driver");
+        assert_eq!(outcome.result["handled_by"], "gmp3");
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn explicit_target_wins_over_protocol() {
+        let escpos_calls = StdArc::new(AtomicUsize::new(0));
+        let gmp3_calls = StdArc::new(AtomicUsize::new(0));
+        let reg = registry_with(vec![
+            Box::new(FakeDriver {
+                kind: "escpos",
+                calls: escpos_calls.clone(),
+            }),
+            Box::new(FakeDriver {
+                kind: "gmp3",
+                calls: gmp3_calls.clone(),
+            }),
+        ]);
+        // Both an explicit target AND protocol=GMP3 → target wins.
+        reg.dispatch(&cmd_with_payload(
+            "c-g2",
+            json!({ "target": "escpos", "protocol": "GMP3" }),
+        ))
+        .await
+        .unwrap();
+        assert_eq!(escpos_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(gmp3_calls.load(Ordering::SeqCst), 0);
     }
 
     #[test]

--- a/backend/src/app.module.boot.spec.ts
+++ b/backend/src/app.module.boot.spec.ts
@@ -1,0 +1,26 @@
+import { Test } from "@nestjs/testing";
+import { AppModule } from "./app.module";
+
+/**
+ * Boot smoke-test: build the FULL AppModule DI graph.
+ *
+ * Isolated per-module TestingModules (the norm elsewhere) never assemble the
+ * whole graph, so a circular / undefined module import — e.g. two modules that
+ * import each other without forwardRef — sails through the unit suite and only
+ * explodes at `NestFactory.create(AppModule)` in production
+ * (UndefinedModuleException → process exit). This test compiles the real graph
+ * so that class of bug fails CI, not prod.
+ *
+ * `.compile()` performs module scanning + provider instantiation (which is where
+ * the cycle is detected) but does NOT run onModuleInit hooks, so no DB/network
+ * connection is opened.
+ */
+describe("AppModule bootstrap (module graph)", () => {
+  it("assembles the whole module graph without a circular/undefined import", async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+    expect(moduleRef).toBeDefined();
+    await moduleRef.close();
+  });
+});

--- a/backend/src/modules/device-mesh/command-queue.module.ts
+++ b/backend/src/modules/device-mesh/command-queue.module.ts
@@ -1,0 +1,21 @@
+import { Module } from "@nestjs/common";
+import { CommandQueueService } from "./command-queue.service";
+
+/**
+ * The per-device command queue as a standalone, leaf module.
+ *
+ * Extracted from DeviceMeshModule so BOTH the device-mesh (device-facing:
+ * next-command/ack for self-polling devices) AND the local-bridge (bridge-facing:
+ * the fan-in commands/next/ack) can consume the queue WITHOUT a circular module
+ * dependency — DeviceMeshModule imports LocalBridgeModule (for the scheduler's
+ * bridge-staleness sweep), so LocalBridgeModule importing DeviceMeshModule back
+ * would form a cycle that crashes Nest bootstrap. Both now import THIS leaf.
+ *
+ * CommandQueueService's only dependencies (PrismaService, OutboxService,
+ * ConfigService) are all @Global, so this module needs no imports.
+ */
+@Module({
+  providers: [CommandQueueService],
+  exports: [CommandQueueService],
+})
+export class CommandQueueModule {}

--- a/backend/src/modules/device-mesh/command-queue.service.spec.ts
+++ b/backend/src/modules/device-mesh/command-queue.service.spec.ts
@@ -544,4 +544,50 @@ describe("CommandQueueService", () => {
       });
     });
   });
+
+  describe("bridge command fan-in", () => {
+    it("claimNextForBridge returns the single claimed row or null", async () => {
+      (prisma.$queryRaw as any).mockResolvedValueOnce([
+        { id: "c-1", deviceId: "d-1", kind: "charge_card", payload: {} },
+      ]);
+      const claimed = await svc.claimNextForBridge("bridge-1");
+      expect(claimed).toMatchObject({ id: "c-1", deviceId: "d-1" });
+
+      (prisma.$queryRaw as any).mockResolvedValueOnce([]);
+      expect(await svc.claimNextForBridge("bridge-1")).toBeNull();
+    });
+
+    it("ackForBridge only acks a command whose device the bridge fronts", async () => {
+      // The command belongs to a device on this bridge → delegates to the
+      // device-scoped ack with the resolved deviceId.
+      (prisma.deviceCommand.findFirst as any).mockResolvedValue({
+        deviceId: "d-1",
+      });
+      const ackSpy = jest
+        .spyOn(svc, "ack")
+        .mockResolvedValue({ id: "c-1" } as any);
+
+      await svc.ackForBridge("bridge-1", "c-1", { status: "done" });
+
+      // The scope predicate must constrain by the bridge relation, not trust
+      // the caller — a bridge can't ack another bridge's / a cloud-direct
+      // device's command.
+      const where = (prisma.deviceCommand.findFirst as any).mock.calls[0][0]
+        .where;
+      expect(where).toMatchObject({
+        id: "c-1",
+        device: { bridgeId: "bridge-1" },
+      });
+      expect(ackSpy).toHaveBeenCalledWith("d-1", "c-1", { status: "done" });
+    });
+
+    it("ackForBridge rejects a command not fronted by the bridge", async () => {
+      (prisma.deviceCommand.findFirst as any).mockResolvedValue(null);
+      const ackSpy = jest.spyOn(svc, "ack");
+      await expect(
+        svc.ackForBridge("bridge-1", "c-x", { status: "done" }),
+      ).rejects.toThrow("Command not found for this bridge");
+      expect(ackSpy).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/backend/src/modules/device-mesh/command-queue.service.ts
+++ b/backend/src/modules/device-mesh/command-queue.service.ts
@@ -199,6 +199,77 @@ export class CommandQueueService {
     return rows[0] ?? null;
   }
 
+  /**
+   * Atomically claim the next queued command across ALL devices fronted by a
+   * given bridge (`Device.bridgeId = bridgeId`). Used by the on-prem
+   * `local_bridge` agent, which — unlike a self-polling KDS tablet — cannot
+   * authenticate as an individual Device: a closed fiscal box (Paygo SP630) or a
+   * dumb ESC/POS printer has no agent of its own, so the bridge pulls and
+   * dispatches on their behalf.
+   *
+   * Same `FOR UPDATE SKIP LOCKED` claim shape as {@link claimNext}, so it is
+   * safe under a bridge that opens two connections, and it interleaves fairly
+   * with any per-device claimers on the same rows. Returns null when the bridge
+   * has no queued work.
+   */
+  async claimNextForBridge(bridgeId: string) {
+    const rows = await this.prisma.$queryRaw<
+      Array<{
+        id: string;
+        tenantId: string;
+        deviceId: string;
+        kind: string;
+        payload: any;
+        priority: number;
+        attempts: number;
+        idempotencyKey: string;
+      }>
+    >`
+      UPDATE "device_commands"
+         SET "status" = 'inflight', "attempts" = "attempts" + 1
+       WHERE "id" IN (
+         SELECT "id" FROM "device_commands"
+          WHERE "deviceId" IN (
+                  SELECT "id" FROM "devices" WHERE "bridgeId" = ${bridgeId}
+                )
+            AND "status" = 'queued'
+            AND ("expiresAt" IS NULL OR "expiresAt" > NOW())
+          ORDER BY "priority" DESC, "createdAt" ASC
+          FOR UPDATE SKIP LOCKED
+          LIMIT 1
+       )
+       RETURNING "id", "tenantId", "deviceId", "kind", "payload", "priority", "attempts", "idempotencyKey";
+    `;
+    return rows[0] ?? null;
+  }
+
+  /**
+   * Ack a command on behalf of a bridge. The bridge principal may only ack a
+   * command whose device it fronts — the relation filter (`device: { bridgeId }`)
+   * enforces that at the query layer, so a compromised/buggy bridge cannot ack
+   * (or clobber) another bridge's — or a cloud-direct device's — command. Once
+   * ownership is proven we defer to the device-scoped {@link ack}, reusing its
+   * NON_RETRYABLE / TOCTOU guards unchanged.
+   */
+  async ackForBridge(
+    bridgeId: string,
+    commandId: string,
+    input: {
+      status: "done" | "failed";
+      result?: Record<string, unknown>;
+      error?: string;
+    },
+  ) {
+    const cmd = await this.prisma.deviceCommand.findFirst({
+      where: { id: commandId, device: { bridgeId } },
+      select: { deviceId: true },
+    });
+    if (!cmd) {
+      throw new NotFoundException("Command not found for this bridge");
+    }
+    return this.ack(cmd.deviceId, commandId, input);
+  }
+
   async ack(
     deviceId: string,
     commandId: string,

--- a/backend/src/modules/device-mesh/device-mesh.module.ts
+++ b/backend/src/modules/device-mesh/device-mesh.module.ts
@@ -2,7 +2,7 @@ import { Module } from "@nestjs/common";
 import { PrismaModule } from "../../prisma/prisma.module";
 import { LocalBridgeModule } from "../local-bridge/local-bridge.module";
 import { DeviceService } from "./device.service";
-import { CommandQueueService } from "./command-queue.service";
+import { CommandQueueModule } from "./command-queue.module";
 import { BranchesService } from "./branches.service";
 import { DevicesController } from "./devices.controller";
 import { BranchesController } from "./branches.controller";
@@ -23,11 +23,19 @@ import { SubscriptionsModule } from "../subscriptions/subscriptions.module";
  * fiscal/payment modules' adapter routing (Phase 6/7).
  */
 @Module({
-  imports: [PrismaModule, LocalBridgeModule, SubscriptionsModule],
+  // CommandQueueModule is a leaf providing CommandQueueService; importing +
+  // re-exporting it (instead of declaring the service here) lets LocalBridgeModule
+  // consume the queue without importing DeviceMeshModule back (which would form a
+  // bootstrap-crashing cycle, since we import LocalBridgeModule for the scheduler).
+  imports: [
+    PrismaModule,
+    CommandQueueModule,
+    LocalBridgeModule,
+    SubscriptionsModule,
+  ],
   controllers: [DevicesController, BranchesController],
   providers: [
     DeviceService,
-    CommandQueueService,
     BranchesService,
     DeviceTokenGuard,
     DeviceMeshScheduler,
@@ -36,7 +44,9 @@ import { SubscriptionsModule } from "../subscriptions/subscriptions.module";
   ],
   exports: [
     DeviceService,
-    CommandQueueService,
+    // Re-export the queue module so the 6 existing consumers that import
+    // DeviceMeshModule for CommandQueueService keep resolving it unchanged.
+    CommandQueueModule,
     BranchesService,
     DeviceTokenGuard,
     EscPosBuilderRegistry,

--- a/backend/src/modules/fiscal-core/adapters/paygo-fiscal-provider.spec.ts
+++ b/backend/src/modules/fiscal-core/adapters/paygo-fiscal-provider.spec.ts
@@ -1,0 +1,94 @@
+import { PaygoFiscalProvider } from "./paygo-fiscal-provider";
+import { Gmp3FiscalReceiptCommand } from "./gmp3-fiscal-provider.base";
+import { FiscalProviderRegistry } from "../fiscal-provider.registry";
+import { PrismaService } from "../../../prisma/prisma.service";
+import { CommandQueueService } from "../../device-mesh/command-queue.service";
+import { FiscalReceiptRequest } from "../fiscal-provider.interface";
+
+/**
+ * Spec for the Paygo SP630 GMP-3 ÖKC adapter (the cash/non-card fiş rail). The
+ * shared GMP-3 flow is exercised in depth by the Hugin spec; here we pin the
+ * Paygo vendor specifics (id + vendorProfile dispatched to the gmp3 driver's
+ * Paygo profile on the bridge) and confirm the thin subclass self-registers and
+ * routes through the same command-queue transport.
+ */
+describe("PaygoFiscalProvider", () => {
+  function makeMocks() {
+    const registry = {
+      register: jest.fn(),
+    } as unknown as FiscalProviderRegistry;
+    const prisma = {
+      fiscalDeviceRecord: {
+        findFirst: jest.fn(),
+        count: jest.fn().mockResolvedValue(0),
+      },
+      deviceCommand: { findUnique: jest.fn() },
+    } as unknown as PrismaService;
+    const commandQueue = {
+      enqueue: jest.fn().mockResolvedValue({ id: "cmd-1" }),
+    } as unknown as CommandQueueService;
+    return {
+      registry,
+      prisma,
+      commandQueue,
+      provider: new PaygoFiscalProvider(registry, prisma, commandQueue),
+    };
+  }
+
+  const req: FiscalReceiptRequest = {
+    tenantId: "t1",
+    fiscalDeviceId: "fd-paygo",
+    idempotencyKey: "idem-paygo-1",
+    lines: [
+      {
+        productCode: "P1",
+        name: "Çay",
+        qty: 2,
+        unitPriceCents: 1500,
+        vatRate: 20,
+      },
+    ],
+    payments: [{ method: "cash", amountCents: 3000 }],
+  };
+
+  it("exposes the fiscal_paygo id and the GMP-3 capability set", () => {
+    const { provider } = makeMocks();
+    expect(provider.id).toBe("fiscal_paygo");
+    expect(provider.capabilities.sort()).toEqual(
+      ["cancel", "receipt", "x_report", "z_report"].sort(),
+    );
+  });
+
+  it("self-registers on module init", () => {
+    const { provider, registry } = makeMocks();
+    provider.onModuleInit();
+    expect(registry.register).toHaveBeenCalledWith(provider);
+  });
+
+  it("dispatches the paygo.sp630 vendor profile in the GMP-3 command and maps KDV 20 → dept F", async () => {
+    const { provider, prisma, commandQueue } = makeMocks();
+    (prisma.fiscalDeviceRecord.findFirst as jest.Mock).mockResolvedValue({
+      deviceId: "mesh-paygo-1",
+      serial: "5B0024050735",
+      branchId: "b1",
+    });
+    (prisma.deviceCommand.findUnique as jest.Mock).mockResolvedValue({
+      status: "done",
+      result: { fiscalNo: "0042" },
+      error: null,
+    });
+
+    const res = await provider.issueReceipt(req);
+    expect(res.status).toBe("issued");
+    expect(res.fiscalNo).toBe("0042");
+
+    const payload = (commandQueue.enqueue as jest.Mock).mock.calls[0][2]
+      .payload as unknown as Gmp3FiscalReceiptCommand;
+    expect(payload.protocol).toBe("GMP3");
+    expect(payload.vendorProfile).toBe("paygo.sp630");
+    expect(payload.fiscalSerial).toBe("5B0024050735");
+    expect(payload.lines[0].department).toBe("F"); // KDV 20 → F
+    expect(payload.lines[0].quantityMilli).toBe(2000);
+    expect(payload.payments[0].tender).toBe("NAKIT");
+  });
+});

--- a/backend/src/modules/fiscal-core/adapters/paygo-fiscal-provider.ts
+++ b/backend/src/modules/fiscal-core/adapters/paygo-fiscal-provider.ts
@@ -1,0 +1,50 @@
+import { Injectable, Logger, OnModuleInit } from "@nestjs/common";
+import { Gmp3FiscalProviderBase } from "./gmp3-fiscal-provider.base";
+import { FiscalProviderRegistry } from "../fiscal-provider.registry";
+import { PrismaService } from "../../../prisma/prisma.service";
+import { CommandQueueService } from "../../device-mesh/command-queue.service";
+
+/**
+ * Paygo SP630PRO ECR (Token/Paygo *Yeni Nesil ÖKC*) — standalone fiscal rail.
+ *
+ * The SP630 also charges cards (see the payment-terminal `paygo_ecr` provider,
+ * which prints the fiş atomically in the same op as a card charge). THIS adapter
+ * covers the other half: sales settled by **cash / meal-card / non-card** tenders
+ * still legally require a mali fiş, and those are issued here — the device prints
+ * the fiş with no card leg.
+ *
+ * Thin subclass over {@link Gmp3FiscalProviderBase}: the GMP-3 receipt/void/report
+ * framing and the local_bridge command-queue transport live in the base. Here we
+ * only declare the vendor profile the bridge's vendor-neutral `gmp3` driver
+ * dispatches on to load the Paygo SP630 profile, and the minimum GMP-3 revision.
+ *
+ * Ships INERT: it only issues once an operator registers a `fiscal_paygo` device
+ * AND links a mesh device; absent that, resolveMeshDevice throws. No tenant has
+ * one, and the on-prem `gmp3` driver fails closed until Phase 1 certifies the real
+ * handshake — so no fiş is ever fabricated. Self-registers on boot like siblings.
+ */
+@Injectable()
+export class PaygoFiscalProvider
+  extends Gmp3FiscalProviderBase
+  implements OnModuleInit
+{
+  readonly id = "fiscal_paygo";
+  protected readonly logger = new Logger(PaygoFiscalProvider.name);
+
+  /** Bridge dispatches `paygo.sp630` to the Paygo profile of the gmp3 driver. */
+  protected readonly vendorProfile = "paygo.sp630";
+  /** Paygo SP630 ECR firmware family speaks GMP-3.x; require >= 3.2.0. */
+  protected readonly sdkVersion = "3.2.0";
+
+  constructor(
+    registry: FiscalProviderRegistry,
+    prisma: PrismaService,
+    commandQueue: CommandQueueService,
+  ) {
+    super(registry, prisma, commandQueue);
+  }
+
+  onModuleInit(): void {
+    this.registry.register(this);
+  }
+}

--- a/backend/src/modules/fiscal-core/fiscal-core.module.ts
+++ b/backend/src/modules/fiscal-core/fiscal-core.module.ts
@@ -6,6 +6,7 @@ import { MockFiscalProvider } from "./adapters/mock-fiscal-provider";
 import { EfaturaFiscalProvider } from "./adapters/efatura-fiscal-provider";
 import { HuginFiscalProvider } from "./adapters/hugin-fiscal-provider";
 import { BekoFiscalProvider } from "./adapters/beko-fiscal-provider";
+import { PaygoFiscalProvider } from "./adapters/paygo-fiscal-provider";
 import { FiscalController } from "./fiscal.controller";
 // v2.8.88: FiscalController gates on `@RequiresIntegration('fiscal')`
 // via PlanFeatureGuard.
@@ -30,6 +31,7 @@ import { DeviceMeshModule } from "../device-mesh/device-mesh.module";
     EfaturaFiscalProvider,
     HuginFiscalProvider,
     BekoFiscalProvider,
+    PaygoFiscalProvider,
   ],
   exports: [FiscalProviderRegistry, FiscalService],
 })

--- a/backend/src/modules/local-bridge/local-bridge.controller.ts
+++ b/backend/src/modules/local-bridge/local-bridge.controller.ts
@@ -145,7 +145,9 @@ export class LocalBridgeController {
   // fails fast.
 
   @UseGuards(BridgeTokenGuard)
-  @Throttle({ default: { limit: 120, ttl: 60_000 } })
+  // Override the registered `long` throttler (100/60s → 120/60s); a bare
+  // `default` key matches no registered throttler and would be silently inert.
+  @Throttle({ long: { limit: 120, ttl: 60_000 } })
   @Get("commands/next")
   @ApiOperation({
     summary:
@@ -159,7 +161,7 @@ export class LocalBridgeController {
   }
 
   @UseGuards(BridgeTokenGuard)
-  @Throttle({ default: { limit: 120, ttl: 60_000 } })
+  @Throttle({ long: { limit: 120, ttl: 60_000 } })
   @Post("commands/:commandId/ack")
   @ApiOperation({
     summary: "Bridge acks a command outcome for one of its devices",

--- a/backend/src/modules/local-bridge/local-bridge.controller.ts
+++ b/backend/src/modules/local-bridge/local-bridge.controller.ts
@@ -23,6 +23,8 @@ import { BridgeTokenGuard } from "./bridge-token.guard";
 import { PlanFeatureGuard } from "../subscriptions/guards/plan-feature.guard";
 import { RequiresFeature } from "../subscriptions/decorators/requires-feature.decorator";
 import { PlanFeature } from "../../common/constants/subscription.enum";
+import { CommandQueueService } from "../device-mesh/command-queue.service";
+import { AckCommandDto } from "../device-mesh/dto/device.dto";
 import {
   BridgeHeartbeatDto,
   ClaimBridgeDto,
@@ -32,7 +34,10 @@ import {
 @ApiTags("Local Bridge")
 @Controller("v1/bridges")
 export class LocalBridgeController {
-  constructor(private readonly bridges: LocalBridgeService) {}
+  constructor(
+    private readonly bridges: LocalBridgeService,
+    private readonly queue: CommandQueueService,
+  ) {}
 
   // -- Admin (user-auth) endpoints -----------------------------------------
   //
@@ -123,5 +128,47 @@ export class LocalBridgeController {
   })
   heartbeat(@Req() req: any, @Body() body: BridgeHeartbeatDto) {
     return this.bridges.heartbeat(req.bridge.id, body);
+  }
+
+  // -- Bridge command fan-in loop -----------------------------------------
+  //
+  // A bridge fronts multiple LAN devices that cannot self-poll (a closed Paygo
+  // SP630 fiscal box, a dumb ESC/POS printer), so it pulls + acks commands on
+  // their behalf. The queue is per-device; these two routes fan in across the
+  // devices attached to THIS bridge (Device.bridgeId), scoped by the bridge
+  // token so a bridge can only touch its own devices' commands. The pre-existing
+  // per-device loop (/v1/devices/next-command + ack, DeviceTokenGuard) is
+  // untouched — self-polling devices keep working exactly as before.
+  //
+  // Throttles mirror the device-mesh next-command/ack budget (~6× the agent's
+  // 5s poll cadence) so a legitimate bridge sees daylight and a runaway agent
+  // fails fast.
+
+  @UseGuards(BridgeTokenGuard)
+  @Throttle({ default: { limit: 120, ttl: 60_000 } })
+  @Get("commands/next")
+  @ApiOperation({
+    summary:
+      "Bridge claims the next queued command across its devices (returns [] if none). Auth: Authorization: Bridge <token>",
+  })
+  async nextCommand(@Req() req: any) {
+    // Return an array (0 or 1 element) so the Rust agent's Vec<PendingCommand>
+    // decoder is satisfied — a bare null would fail its decode and back off.
+    const cmd = await this.queue.claimNextForBridge(req.bridge.id);
+    return cmd ? [cmd] : [];
+  }
+
+  @UseGuards(BridgeTokenGuard)
+  @Throttle({ default: { limit: 120, ttl: 60_000 } })
+  @Post("commands/:commandId/ack")
+  @ApiOperation({
+    summary: "Bridge acks a command outcome for one of its devices",
+  })
+  ackCommand(
+    @Req() req: any,
+    @Param("commandId") commandId: string,
+    @Body() dto: AckCommandDto,
+  ) {
+    return this.queue.ackForBridge(req.bridge.id, commandId, dto);
   }
 }

--- a/backend/src/modules/local-bridge/local-bridge.module.ts
+++ b/backend/src/modules/local-bridge/local-bridge.module.ts
@@ -4,9 +4,12 @@ import { LocalBridgeService } from "./local-bridge.service";
 import { LocalBridgeController } from "./local-bridge.controller";
 import { BridgeTokenGuard } from "./bridge-token.guard";
 import { SubscriptionsModule } from "../subscriptions/subscriptions.module";
+// The bridge fan-in command loop (commands/next + ack) reuses the device-mesh
+// command queue; CommandQueueService is exported by DeviceMeshModule.
+import { DeviceMeshModule } from "../device-mesh/device-mesh.module";
 
 @Module({
-  imports: [PrismaModule, SubscriptionsModule],
+  imports: [PrismaModule, SubscriptionsModule, DeviceMeshModule],
   controllers: [LocalBridgeController],
   providers: [LocalBridgeService, BridgeTokenGuard],
   exports: [LocalBridgeService, BridgeTokenGuard],

--- a/backend/src/modules/local-bridge/local-bridge.module.ts
+++ b/backend/src/modules/local-bridge/local-bridge.module.ts
@@ -4,12 +4,14 @@ import { LocalBridgeService } from "./local-bridge.service";
 import { LocalBridgeController } from "./local-bridge.controller";
 import { BridgeTokenGuard } from "./bridge-token.guard";
 import { SubscriptionsModule } from "../subscriptions/subscriptions.module";
-// The bridge fan-in command loop (commands/next + ack) reuses the device-mesh
-// command queue; CommandQueueService is exported by DeviceMeshModule.
-import { DeviceMeshModule } from "../device-mesh/device-mesh.module";
+// The bridge fan-in command loop (commands/next + ack) reuses the command queue.
+// We import the leaf CommandQueueModule directly — NOT DeviceMeshModule — because
+// DeviceMeshModule imports LocalBridgeModule (for the scheduler), so importing it
+// back here would form a circular module dependency that crashes Nest bootstrap.
+import { CommandQueueModule } from "../device-mesh/command-queue.module";
 
 @Module({
-  imports: [PrismaModule, SubscriptionsModule, DeviceMeshModule],
+  imports: [PrismaModule, SubscriptionsModule, CommandQueueModule],
   controllers: [LocalBridgeController],
   providers: [LocalBridgeService, BridgeTokenGuard],
   exports: [LocalBridgeService, BridgeTokenGuard],

--- a/backend/src/modules/payment-terminal/payment-terminal.module.ts
+++ b/backend/src/modules/payment-terminal/payment-terminal.module.ts
@@ -7,6 +7,7 @@ import { PaymentTerminalService } from "./payment-terminal.service";
 import { PaymentTerminalController } from "./payment-terminal.controller";
 import { SimulatorTerminalProvider } from "./providers/simulator-terminal.provider";
 import { Gmp3CardTerminalProvider } from "./providers/gmp3-card-terminal.provider";
+import { PaygoEcrTerminalProvider } from "./providers/paygo-ecr-terminal.provider";
 import { BankEcrTerminalProvider } from "./providers/bank-ecr-terminal.provider";
 import { SoftPosTerminalProvider } from "./providers/softpos-terminal.provider";
 
@@ -21,6 +22,7 @@ import { SoftPosTerminalProvider } from "./providers/softpos-terminal.provider";
     // them is activated (CONFIGURED_NOT_ACTIVE by default; SoftPOS can't be
     // activated at all yet — activatable=false).
     Gmp3CardTerminalProvider, // bridge, fiscal_coupled (charge + fiş atomic)
+    PaygoEcrTerminalProvider, // bridge, fiscal_coupled — Paygo SP630 (activatable=false)
     BankEcrTerminalProvider, // bridge, charge-only (fiş via the existing rail)
     SoftPosTerminalProvider, // in_process PSP, fail-closed (not yet wired)
   ],

--- a/backend/src/modules/payment-terminal/providers/paygo-ecr-terminal.provider.spec.ts
+++ b/backend/src/modules/payment-terminal/providers/paygo-ecr-terminal.provider.spec.ts
@@ -1,0 +1,146 @@
+import { PaygoEcrTerminalProvider } from "./paygo-ecr-terminal.provider";
+import { PaymentTerminalProviderRegistry } from "../payment-terminal-provider.registry";
+import { TerminalChargeRequest } from "../payment-terminal-provider.interface";
+
+describe("PaygoEcrTerminalProvider", () => {
+  let provider: PaygoEcrTerminalProvider;
+
+  const baseReq: TerminalChargeRequest = {
+    tenantId: "t1",
+    branchId: "b1",
+    orderId: "o1",
+    amountCents: 12345,
+    terminal: {
+      id: "term-1",
+      providerId: "paygo_ecr",
+      deviceId: "dev-1",
+      serial: "5B0024050735", // SP630 serial style
+      config: null,
+    },
+    idempotencyKey: "idem-1",
+    fiscalContext: {
+      kind: "cash_receipt",
+      lines: [
+        {
+          productCode: "p1",
+          name: "Burger",
+          qty: 1,
+          unitPriceCents: 12345,
+          vatRate: 20,
+          discountCents: 0,
+        },
+      ],
+      payments: [{ method: "card", amountCents: 12345 }],
+      customer: null,
+    },
+  };
+
+  beforeEach(() => {
+    provider = new PaygoEcrTerminalProvider(
+      new PaymentTerminalProviderRegistry(),
+    );
+  });
+
+  it("is a fiscal_coupled bridge provider", () => {
+    expect(provider.id).toBe("paygo_ecr");
+    expect(provider.kind).toBe("bridge");
+    expect(provider.capabilities).toContain("fiscal_coupled");
+    expect(provider.capabilities).toContain("sale");
+  });
+
+  it("is NOT activatable — ships INERT until the Paygo GMP-3 handshake is certified", () => {
+    // The activation gate (payment-terminal.service.setActivation) refuses ACTIVE
+    // when activatable === false, so a paygo_ecr record can never move real money
+    // in Phase 0. This is the honest CONFIGURED_NOT_ACTIVE boundary at the
+    // provider level; do not flip it without the certified Phase-1 driver.
+    expect(provider.activatable).toBe(false);
+  });
+
+  it("self-registers on module init", () => {
+    const registry = new PaymentTerminalProviderRegistry();
+    const p = new PaygoEcrTerminalProvider(registry);
+    p.onModuleInit();
+    expect(registry.has("paygo_ecr")).toBe(true);
+  });
+
+  it("buildSaleCommand emits a GMP3 charge_card pinned to the paygo.sp630 profile", () => {
+    const cmd = provider.buildSaleCommand(baseReq);
+    expect(cmd.kind).toBe("charge_card");
+    expect(cmd.idempotencyKey).toBe("idem-1");
+    expect(cmd.payload).toMatchObject({
+      protocol: "GMP3",
+      vendorProfile: "paygo.sp630",
+      fiscalSerial: "5B0024050735",
+      orderId: "o1",
+      amountCents: 12345,
+      currency: "TRY",
+    });
+    // The coupled fiş context rides along so the SP630 prints the fiş atomically.
+    expect((cmd.payload as any).fiscal.lines).toHaveLength(1);
+    // No `target` — the bridge routes GMP3-protocol commands to the gmp3 driver.
+    expect((cmd.payload as any).target).toBeUndefined();
+  });
+
+  it("honours per-device vendorProfile/sdkVersion overrides from config", () => {
+    const cmd = provider.buildSaleCommand({
+      ...baseReq,
+      terminal: {
+        ...baseReq.terminal,
+        config: { vendorProfile: "paygo.sp730", sdkVersion: "4.0.0" },
+      },
+    });
+    expect((cmd.payload as any).vendorProfile).toBe("paygo.sp730");
+    expect((cmd.payload as any).sdkVersion).toBe("4.0.0");
+  });
+
+  it("maps a done ack with approval + fiscalNo to APPROVED (coupled fiş printed)", () => {
+    const r = provider.mapAck({
+      status: "done",
+      result: {
+        approved: true,
+        approvalCode: "APP123",
+        rrn: "RRN9",
+        cardBrand: "VISA",
+        maskedPan: "**** 1234",
+        fiscalNo: "FN-77",
+      },
+      error: null,
+    });
+    expect(r.status).toBe("APPROVED");
+    expect(r.approvalCode).toBe("APP123");
+    expect(r.fiscalNo).toBe("FN-77");
+    expect(r.cardBrand).toBe("VISA");
+  });
+
+  it("maps a done-but-refused ack to DECLINED (no Payment, no fiş)", () => {
+    const r = provider.mapAck({
+      status: "done",
+      result: { approved: false, error: "Yetersiz bakiye" },
+      error: null,
+    });
+    expect(r.status).toBe("DECLINED");
+    expect(r.fiscalNo).toBeUndefined();
+    expect(r.error).toBe("Yetersiz bakiye");
+  });
+
+  it("treats a done ack with no explicit approval as ERROR (never books money)", () => {
+    const r = provider.mapAck({
+      status: "done",
+      result: { rrn: "X" },
+      error: null,
+    });
+    expect(r.status).toBe("ERROR");
+    expect(r.approvalCode).toBeUndefined();
+  });
+
+  it("maps expired → TIMEOUT and failed → ERROR", () => {
+    expect(
+      provider.mapAck({ status: "expired", result: null, error: "no ack" })
+        .status,
+    ).toBe("TIMEOUT");
+    expect(
+      provider.mapAck({ status: "failed", result: null, error: "serial down" })
+        .status,
+    ).toBe("ERROR");
+  });
+});

--- a/backend/src/modules/payment-terminal/providers/paygo-ecr-terminal.provider.ts
+++ b/backend/src/modules/payment-terminal/providers/paygo-ecr-terminal.provider.ts
@@ -1,0 +1,132 @@
+import { Injectable, Logger, OnModuleInit } from "@nestjs/common";
+import { PaymentTerminalProviderRegistry } from "../payment-terminal-provider.registry";
+import {
+  PaymentTerminalProvider,
+  TerminalCapability,
+  TerminalChargeRequest,
+  TerminalChargeResult,
+  TerminalSaleCommand,
+} from "../payment-terminal-provider.interface";
+
+/**
+ * Paygo SP630PRO ECR — a Token/Paygo *Yeni Nesil ÖKC* that charges the card AND
+ * prints the mali fiş atomically in one device op (`fiscal_coupled`). This is the
+ * FIRST concrete GMP-3 vendor binding on the payment-terminal rail; it mirrors the
+ * generic `gmp3_card` scaffold but pins the vendor profile the on-prem bridge
+ * dispatches on (`paygo.sp630`) so the bridge's vendor-neutral `gmp3` driver loads
+ * the Paygo profile.
+ *
+ * A bridge provider: the charge runs through the on-prem agent's `charge_card`
+ * queue (NON_RETRYABLE — a lost ack never auto-redelivers, so no double-charge),
+ * and `mapAck` maps the agent's outcome once it lands. Because the SP630 prints
+ * the fiş in the same op, an APPROVED ack carries `fiscalNo`; the
+ * PaymentFinalizer coupled-fiş guard then skips the standalone yazarkasa rail so
+ * there is no double-fiş.
+ *
+ * INERT until Phase 1: `activatable=false` — the real GMP-3 cert-handshake driver
+ * is hardware-side and needs the Token SDK + a certified device + written pairing
+ * authorization. Until that lands the activation gate REFUSES `ACTIVE`
+ * (payment-terminal.service `setActivation`), so a record using this provider can
+ * only sit `CONFIGURED_NOT_ACTIVE` and `resolveTerminal` never selects it — this
+ * provider cannot move real money in its current state. The whole POS
+ * charge→record→fiş→recovery rail is instead exercised end-to-end through the
+ * dedicated `simulator` provider and the bridge's own simulator mode.
+ */
+@Injectable()
+export class PaygoEcrTerminalProvider
+  implements PaymentTerminalProvider, OnModuleInit
+{
+  private readonly logger = new Logger(PaygoEcrTerminalProvider.name);
+  readonly id = "paygo_ecr";
+  readonly capabilities: TerminalCapability[] = [
+    "sale",
+    "void",
+    "fiscal_coupled",
+    "query_last",
+  ];
+  readonly kind = "bridge" as const;
+  // Not activatable yet — the real Paygo/Token GMP-3 handshake is not certified.
+  // Flip to remove this line (default = activatable) once Phase 1 lands.
+  readonly activatable = false;
+
+  // The protocol profile the bridge's `gmp3` driver dispatches on to load the
+  // Paygo SP630 vendor profile, and the GMP-3 revision the device reports.
+  // Both overridable per device via terminal.config.
+  private readonly vendorProfile = "paygo.sp630";
+  private readonly sdkVersion = "3.2.1";
+
+  constructor(private readonly registry: PaymentTerminalProviderRegistry) {}
+
+  onModuleInit(): void {
+    this.registry.register(this);
+  }
+
+  buildSaleCommand(req: TerminalChargeRequest): TerminalSaleCommand {
+    const cfg = req.terminal.config ?? {};
+    return {
+      kind: "charge_card",
+      payload: {
+        protocol: "GMP3",
+        vendorProfile: (cfg.vendorProfile as string) ?? this.vendorProfile,
+        sdkVersion: (cfg.sdkVersion as string) ?? this.sdkVersion,
+        fiscalSerial: req.terminal.serial,
+        tenantId: req.tenantId,
+        branchId: req.branchId ?? null,
+        orderId: req.orderId,
+        amountCents: req.amountCents,
+        currency: "TRY",
+        // GMP-3 charges the card AND prints the fiş in one op — the fiscal
+        // context (lines/KDV/tender/customer) rides along so the SP630 prints
+        // the same fiş the standalone yazarkasa rail would.
+        fiscal: req.fiscalContext ?? null,
+      },
+      idempotencyKey: req.idempotencyKey,
+      priority: 10,
+    };
+  }
+
+  mapAck(ack: {
+    status: string;
+    result: Record<string, unknown> | null;
+    error: string | null;
+  }): TerminalChargeResult {
+    if (ack.status === "done") {
+      const r = ack.result ?? {};
+      // Approve ONLY on an explicit positive signal — a Payment is recorded on
+      // APPROVED, so a malformed/ambiguous ack (approved missing) must never
+      // book money. Explicit refusal → DECLINED (card leg ran, bank declined;
+      // no fiş printed). Anything else → ERROR (order stays open, no Payment).
+      if (r.approved === true) {
+        return {
+          status: "APPROVED",
+          approvalCode: (r.approvalCode as string) ?? undefined,
+          rrn: (r.rrn as string) ?? undefined,
+          cardBrand: (r.cardBrand as string) ?? undefined,
+          maskedPan: (r.maskedPan as string) ?? undefined,
+          // fiscalNo present ⇒ the SP630 printed the fiş atomically; the
+          // standalone yazarkasa rail then skips (coupled-fiş guard).
+          fiscalNo: (r.fiscalNo as string) ?? undefined,
+          raw: r,
+        };
+      }
+      if (r.approved === false) {
+        return {
+          status: "DECLINED",
+          error: (r.error as string) ?? ack.error ?? "Card declined",
+          raw: r,
+        };
+      }
+      return {
+        status: "ERROR",
+        error:
+          (r.error as string) ?? ack.error ?? "Terminal ack missing approval",
+        raw: r,
+      };
+    }
+    if (ack.status === "expired") {
+      return { status: "TIMEOUT", error: ack.error ?? "Terminal timed out" };
+    }
+    // failed (NON_RETRYABLE — terminal, never auto-redelivered)
+    return { status: "ERROR", error: ack.error ?? "Terminal error" };
+  }
+}

--- a/docs/integrations/paygo-token-gmp3-onboarding.md
+++ b/docs/integrations/paygo-token-gmp3-onboarding.md
@@ -1,0 +1,120 @@
+# Paygo SP630PRO ECR (GMP-3 ÖKC) — onboarding & go-live runbook
+
+This is the operator/integrator checklist for taking the Paygo **SP630PRO ECR**
+(and any other Turkish *Yeni Nesil ÖKC*) from the shipped INERT skeleton to a
+certified, money-moving integration.
+
+The engineering is built and tested (Phase 0, ships INERT). What remains before a
+real device can charge a card or print a fiş is a **vendor dependency** on
+Token/Paygo — the certificate-based GMP-3 pairing is a hard gate that public GİB
+docs alone cannot bypass. This document lists exactly what to obtain and the
+order to do it in.
+
+## What the device is
+
+Token/Paygo SP630PRO ECR — one box that is a **bank-card EFT-POS + fiscal engine
++ mali-fiş thermal printer**, on **Ethernet / USB / 4G**. Driven over **GMP-3**
+(GİB Mesajlaşma Protokolü): our software is the TCP client, the ÖKC is the fiscal
+master. Every financial message is behind a **certificate-based secure pairing**
+(Diffie-Hellman + PÖKC cert validation → AES-CBC + HMAC, sequence-numbered).
+
+## What is already built (Phase 0 — INERT, tested)
+
+- **Backend** — `paygo_ecr` payment-terminal provider (coupled card + fiş,
+  `activatable=false`) and `fiscal_paygo` fiscal-core provider (cash/non-card
+  fiş). No DB migration; provider ids are free strings.
+- **Bridge** — vendor-neutral `gmp3` driver (`apps/local-bridge-agent/src/drivers/gmp3/`)
+  with the Paygo profile, a real bidirectional TCP transport, and a simulator
+  mode; protocol-based command routing; the cloud↔bridge command fan-in loop.
+- **Operator UI** — Paygo appears in Settings→Card Terminals and the Fiscal
+  Devices panel.
+- **Safety** — `paygo_ecr` cannot be activated (`activatable=false`) and the
+  bridge's real mode fails closed, so nothing moves real money until Phase 1.
+
+You can exercise the ENTIRE flow today with the simulator (see "Testing now").
+
+## What to obtain from Token/Paygo (the hard dependency)
+
+Request these from Token/Paygo (Koç fintech / Token Finansal Teknolojiler),
+ideally via your acquiring bank or the Token integration/partner desk:
+
+1. **GMP-3 SDK + integration/message-mapping document for the SP630
+   specifically.** Confirm the delivery: the public Token developer-portal SDK
+   (`IntegrationHub`, C#/.NET + a C++ lib) targets the newer **Android** devices;
+   the Linux **SP-generation** SP630 may need the older SP-family library. Ask
+   which one applies and in what language. *(Why: this defines the wire framing,
+   the handshake, and the crypto we must implement in the Rust bridge.)*
+2. **A test / development SP630 unit** (or a vendor simulator, if offered). The
+   certificate pairing needs real hardware to validate. *(Why: we cannot certify
+   a handshake we cannot run.)*
+3. **GMP-3 value-added service activation + TSM firma kodu** (merchant/firm
+   provisioning on the device and the TSM). *(Why: the device won't accept a
+   pairing until the GMP-3 service is enabled and the merchant is provisioned.)*
+4. **Written pairing authorization ("uyumlu hale getirme").** Token must formally
+   authorize our application to pair with their devices. *(Why: the cert
+   handshake is a closed gate; authorization is prerequisite, not optional.)*
+5. **PÖKC certificate chain + handshake parameters** — the DH group, the AES/HMAC
+   scheme, the İşlem Sıra No (transaction sequence number) rules, and the TCP
+   port the device's GMP-3 server listens on. *(Why: these are the exact inputs
+   the Rust handshake needs; without them the transport stays fail-closed.)*
+
+Architectural note: Token's SDK is C#/.NET or C++, which does **not** drop into
+our Rust bridge. Two options once #1–#5 land:
+- **C1 (chosen):** reimplement the GMP-3 handshake/TLV/crypto natively in Rust
+  from the GİB spec + Token's message doc. Max control, no extra runtime, fits
+  our Rust-first stack; needs the PÖKC cert chain and a real device to validate.
+- **C2 (fallback):** FFI-wrap Token's C++ lib or run a thin sidecar in the SDK's
+  language on the bridge box. Faster to a certified handshake, but adds a non-Rust
+  runtime dependency to the bridge.
+
+## Phase 1 — implementation checklist (once #1–#5 are in hand)
+
+1. In `drivers/gmp3/protocol.rs`, implement the real GMP-3 framing (TLV / STX-ETX),
+   the DH + PÖKC cert handshake, and AES-CBC + HMAC with the İşlem Sıra No, on top
+   of the existing `transport::TcpEndpoint`.
+2. Wire the real path in `drivers/gmp3/mod.rs` (`execute` → build request →
+   `request_reply` → parse → outcome) and flip `paygo.sp630`'s
+   `real_impl_ready = true` in `profiles.rs`.
+3. Thread the acquirer `idempotencyKey` end-to-end so a retry is safe (the queue
+   parks-not-retries money kinds until this is proven).
+4. Certify on the test SP630: run charge / void / cash-fiş / Z-report against the
+   real device; verify the mali fiş prints and the `fiscalNo`/RRN come back.
+5. Flip `paygo_ecr`'s `activatable` (remove the `= false`) once certified.
+
+## Go-live runbook (per branch, on certified hardware)
+
+1. **Pair the box** in the Branch Device Hub (`/admin/branches/:id` → Cihazlar),
+   creating a device slot of kind `yazarkasa` / `pos_terminal`.
+2. **Register the terminal** in Settings→Card Terminals with provider
+   `paygo_ecr`, the device serial, and link the paired device. It starts
+   `CONFIGURED_NOT_ACTIVE`.
+3. **Register the fiscal device** in the Fiscal Devices panel with provider
+   `fiscal_paygo` (for cash/non-card fiş), linked to the same mesh device.
+4. **Configure the bridge** — add a `[[device]]` to `gmp3.toml` on the on-prem
+   bridge with `mode = "real"`, the ÖKC's LAN `host`/`port`, and the cert paths.
+5. **Activate** — once the Phase-1 handshake is certified and `activatable` is
+   flipped, set the terminal `ACTIVE` in Settings→Card Terminals. `resolveTerminal`
+   now selects it and POS "Ödemeye geç → KART" drives the real device.
+6. **Verify** — run one live card sale (card charged + fiş printed) and one cash
+   sale (fiş printed), and confirm a Z report.
+
+## Testing now (no vendor dependency)
+
+- **End-to-end POS flow:** use the existing `simulator` payment-terminal provider
+  (register + set `SIMULATOR`) to exercise charge → record → recovery.
+- **Bridge GMP-3 rail:** add a `gmp3.toml` `[[device]]` with `mode = "simulator"`
+  (see `gmp3.toml.example`). The `gmp3` driver returns deterministic, clearly
+  `SIM-`/`SIMFIS-`-prefixed approvals and fiş numbers — no hardware, no real money.
+- **Unit tests:** `cargo test` in `apps/local-bridge-agent` and the backend
+  `paygo-ecr-terminal.provider.spec.ts` / `paygo-fiscal-provider.spec.ts` cover
+  the adapters, routing, simulator outcomes, and fail-closed real mode.
+
+## Adding another ÖKC brand later
+
+Because every certified Turkish ÖKC speaks GMP-3, a new brand (Beko, Hugin,
+Profilo, Ingenico, Verifone, Pavo, …) is a small delta: one `VendorProfile` entry
+in `profiles.rs` (+ its cert/handshake quirks in `protocol.rs`), a thin backend
+adapter (clone `paygo_ecr` / `fiscal_paygo`), and one FE label. The GMP-3 core is
+reused. **Certification is not reusable, though** — each brand needs its own
+vendor SDK, cert chain, test device, and written authorization, exactly like the
+list above.

--- a/docs/integrations/paygo-token-request-email.md
+++ b/docs/integrations/paygo-token-request-email.md
@@ -1,0 +1,40 @@
+# Token/Paygo GMP-3 entegrasyon talep e-postası (taslak)
+
+> Doldur: `[…]` alanlarını kendi bilgilerinle değiştir. Alıcı: Token/Paygo
+> entegrasyon-partner masası **veya** bu POS'u aldığın banka/entegratör yetkilisi.
+
+---
+
+**Kime:** [Token/Paygo entegrasyon ekibi / banka POS yetkilisi]
+**Konu:** Paygo SP630PRO ECR — GMP-3 harici yazılım entegrasyonu ve geliştirici erişim talebi
+
+Merhaba,
+
+[Firma adı] olarak işletmemizde **Paygo SP630PRO ECR** cihazı kullanıyoruz
+(SERİ NO: **5B0024050735**, ONAY BELGE NO: **Z-1243646Z-195.07(47)-2580**).
+Kendi restoran POS/adisyon yazılımımızı bu cihazla **GMP-3 (GİB Mesajlaşma
+Protokolü)** üzerinden entegre edip, satışları yazılımımızdan başlatıp cihazın
+kartı çekmesini ve mali fişi basmasını sağlamak istiyoruz.
+
+Yazılım tarafımız hazır; entegrasyonu tamamlayıp sertifikalayabilmek için sizden
+aşağıdakileri rica ediyoruz:
+
+1. **SP630PRO ECR için GMP-3 SDK ve entegrasyon/mesaj-eşleme dokümanı.**
+   Lütfen belirtin: bu cihaz için hangi kütüphaneyi ve hangi dili sağlıyorsunuz
+   (Linux SP-nesli GMP-3 kütüphanesi mi, yoksa yeni portal SDK'sı — .NET/C++ — mi)?
+2. **Bir test/geliştirme SP630 cihazı** (veya varsa bir vendor simülatörü).
+   Canlı cihazımızı test için kullanmak istemiyoruz.
+3. **GMP-3 katma-değerli servis aktivasyonu + TSM firma kodu** (merchant/firma
+   provizyonu) — hangi başvuru/formlar gerekiyorsa iletebilir misiniz?
+4. **Yazılımımız için yazılı eşleşme yetkisi** ("uyumlu hale getirme") — sertifikalı
+   eşleşmenin (pairing) önünü açacak onay.
+5. **PÖKC sertifika zinciri ve handshake parametreleri:** kullanılan port,
+   Diffie-Hellman grubu, AES/HMAC şeması ve İşlem Sıra No (transaction sequence)
+   kuralları.
+
+Ayrıca entegrasyon ve sertifikasyon süreci için tipik adımları, süreleri ve
+varsa maliyetleri de paylaşırsanız memnun oluruz.
+
+Teşekkürler,
+[Ad Soyad] — [Firma]
+[Telefon] · [E-posta] · [VKN/Merchant ID]

--- a/docs/superpowers/specs/2026-07-05-paygo-ecr-integration-design.md
+++ b/docs/superpowers/specs/2026-07-05-paygo-ecr-integration-design.md
@@ -1,0 +1,191 @@
+# Paygo SP630PRO ECR integration — design spec
+
+**Date:** 2026-07-05
+**Status:** Approved (design), Phase 0 in implementation
+**Device:** Paygo SP630PRO ECR — a Turkish *Yeni Nesil ÖKC* (next-gen fiscal cash
+register) by Token/Paygo that bundles a bank-card EFT-POS **+** a fiscal engine **+**
+a thermal *mali fiş* printer in one box, reachable over **Ethernet (LAN) / USB / 4G**.
+Driven over **GMP-3** (GİB Mesajlaşma Protokolü): the ÖKC is the fiscal master and
+our POS software is the TCP client. Every financial message sits behind a
+**mandatory certificate-based secure pairing** (DH + PÖKC cert → AES-CBC + HMAC),
+so a socket cannot just send a sale.
+
+## Goal
+
+Integrate this specific device — and, by construction, the whole family of Turkish
+GMP-3 ÖKCs (Beko, Hugin, Profilo, Ingenico, Verifone, Pavo, …) — into the existing
+platform, doing the **most comprehensive, production-grade** engineering. Ship
+**INERT / simulator-first**: everything is built and tested but cannot move real
+money until certified hardware + the Token vendor artifacts land (Phase 1).
+
+Two rails, because "every sale needs a fiş":
+- **Card sale** → the SP630 charges the card **and** prints the fiş in one atomic
+  op (`fiscal_coupled`) via the **payment-terminal** rail.
+- **Cash / meal-card / non-card sale** → the SP630 prints the mali fiş via the
+  **fiscal-core** rail.
+Both command families land on the **same** on-prem Rust driver, because it is one
+physical device.
+
+## What already exists (grounding — verified against source)
+
+- **payment-terminal module** (`backend/src/modules/payment-terminal/`) —
+  `PaymentTerminalProvider` contract (`kind: bridge|in_process`, `buildSaleCommand`/
+  `mapAck`, `activatable` gate, `TerminalCapability` incl. `fiscal_coupled`).
+  Adapters: `simulator` (real, fake money), `gmp3_card` (scaffold, our template),
+  `bank_ecr`, `softpos`. Full money-safety in `payment-terminal.service.ts`
+  (charge-before-record, `recoverApprovedUnrecorded` cron, `NEEDS_REVIEW`, guarded
+  `updateMany`, `void_card`). `resolveTerminal` matches only `ACTIVE|SIMULATOR`
+  (`ACTIVE_STATES`) → registered rows default `CONFIGURED_NOT_ACTIVE` → **inert**.
+- **fiscal-core module** (`backend/src/modules/fiscal-core/`) — `FiscalProvider`
+  contract + `Gmp3FiscalProviderBase` that frames the full GMP-3 payload (dept A–H
+  by KDV, tender codes, integer-kuruş lines) and **enqueues** `fiscal_receipt`/
+  `fiscal_cancel`/`fiscal_report` onto the device-mesh queue. Thin brand subclasses:
+  `fiscal_hugin`, `fiscal_beko` (our template), `mock`, `efatura`.
+- **device-mesh + Rust local-bridge** — cloud→hardware via idempotent
+  `DeviceCommand` rows; money/fiscal kinds are `NON_RETRYABLE` on both sides
+  (`CommandQueueService.NON_RETRYABLE_KINDS`, Rust `MONEY_TOKENS`). Real TCP write
+  exists for ESC/POS (`drivers/escpos.rs::write_tcp`, write-only). `LocalDriver`
+  trait + `Registry` dispatch by `payload.target`. `Device.bridgeId →
+  LocalBridgeAgent` relation already models "device behind a bridge".
+- **Operator UI** — Branch Device Hub (pair the box), Settings→Card Terminals
+  (`PaymentTerminalsSettingsPage.tsx`, register + `CONFIGURED_NOT_ACTIVE→ACTIVE`),
+  Fiscal Devices (`FiscalRecoveryPage.tsx`). Adding a provider = module registration
+  + one FE label. **No schema migration** (`PaymentTerminalRecord.providerId` is a
+  free string, config rides in `config Json?`).
+
+## The gaps this spec closes
+
+1. **No real GMP-3 transport driver** in the bridge (card + fiscal paths dead-end).
+2. **Dispatch routes by `payload.target`**, but the GMP-3 backend adapters emit
+   `protocol:"GMP3"`+`vendorProfile` with **no `target`** → nothing routes.
+3. **cloud↔bridge command loop is unwired**: the Rust bridge polls
+   `GET /v1/bridges/:id/commands/next` (**404 — route absent**) and acks with
+   `Authorization: Bridge` to a `Device`-guarded route (**401**). The `LocalBridge`
+   controller serves only `claim` + `heartbeat`. A closed fiscal box can't
+   self-poll, so the bridge must front it → this loop is required for real operation.
+4. **No Paygo backend adapters, no vendor procurement artifact.**
+
+## Architecture — vendor-neutral `gmp3` core + per-vendor profiles
+
+Because GMP-3 is a GİB standard shared by every certified ÖKC, the Rust bridge is
+built **protocol-first, not vendor-first**: one `gmp3` driver + a profile registry
+keyed on `vendorProfile`. Paygo (`paygo.sp630`) is profile #1; Beko/Hugin/… are a
+profile file each later. Engineering reuse is high; **certification is not** —
+every brand still needs its own vendor SDK/cert/test-device/authorization.
+
+## Contracts (pinned — do not drift)
+
+### Command payloads (cloud → bridge)
+
+**Coupled card** (`PaygoEcrTerminalProvider.buildSaleCommand`, `kind:"charge_card"`):
+```jsonc
+{
+  "protocol": "GMP3",
+  "vendorProfile": "paygo.sp630",   // overridable via terminal.config.vendorProfile
+  "sdkVersion": "3.2.1",
+  "fiscalSerial": "<terminal.serial>",
+  "tenantId": "...", "branchId": "...|null", "orderId": "...",
+  "amountCents": 12345, "currency": "TRY",
+  "fiscal": { /* TerminalFiscalContext: lines/KDV/payments/customer */ } | null
+}
+```
+**Fiscal** (`PaygoFiscalProvider` via base, kinds `fiscal_receipt|fiscal_cancel|fiscal_report`):
+same `{protocol:"GMP3", vendorProfile:"paygo.sp630", fiscalSerial, …}` shape the base
+already builds. Neither payload carries `target`.
+
+### Ack result keys (bridge → cloud) — read by `mapAck` / `mapReceiptOutcome`
+- Card: `{ approved: bool, approvalCode, rrn, cardBrand, maskedPan, fiscalNo }`
+  (approve ONLY on `approved === true`; `fiscalNo` present ⇒ coupled fiş printed).
+- Fiscal: `{ fiscalNo, fiscalZNo, zNo, openedAt, closedAt, totals, deviceStatus, error, raw }`.
+
+### Bridge dispatch routing (`drivers/mod.rs`)
+`payload.target` wins (existing: `escpos`). Else if `payload.protocol == "GMP3"` →
+driver kind `"gmp3"`. Backward compatible; escpos unaffected.
+
+### GMP-3 driver (Rust, `kind = "gmp3"`)
+- Selects a `VendorProfile` from the profile registry by `vendorProfile`
+  (`paygo.sp630` registered; unknown → honest error).
+- Reads on-prem `gmp3.toml` (bridge `data_dir`): `fiscalSerial → { host, port,
+  mode: "simulator"|"real", cert paths… }`. Absent/misconfigured → fail closed.
+- `mode="simulator"` → deterministic outcome (APPROVED + `SIM-…` approval + fake
+  `fiscalNo`), **no hardware** — mirrors the backend simulator so the whole rail is
+  testable on the bridge without a device.
+- `mode="real"` → **Phase 1** real handshake/TLV/AES-HMAC. **Phase 0: fail closed**
+  with a clear "not certified — configure mode=simulator" error. NEVER a fake `done`.
+- Handles `charge_card | void_card | fiscal_receipt | fiscal_cancel | fiscal_report
+  | capability_probe`.
+- Transport: a real bidirectional TCP client (connect-timeout + write + read-reply
+  with timeout), loopback-tested — generalizes `escpos::write_tcp` with a read half.
+
+### Bridge command fan-in loop (additive)
+- **Backend** `LocalBridgeController` (BridgeTokenGuard):
+  - `GET /v1/bridges/commands/next` → claim next queued command across the bridge's
+    own devices (`Device.bridgeId = req.bridge.id`), return `[cmd]` or `[]`.
+  - `POST /v1/bridges/commands/:commandId/ack` → resolve the command's device via
+    the bridge, then the existing scoped `CommandQueueService.ack`.
+  - `CommandQueueService.claimNextForBridge(bridgeId)` — same `FOR UPDATE SKIP
+    LOCKED` claim, scoped `deviceId IN (SELECT id FROM devices WHERE bridgeId=$1)`.
+- **Rust** `cloud_ws.rs`: `get_next_commands` → `GET /v1/bridges/commands/next`
+  (bridge id from token, drop the path id); `post_ack` → `POST
+  /v1/bridges/commands/{id}/ack`. Both keep `Authorization: Bridge`. Existing
+  per-device `/v1/devices/*` loop is untouched (self-polling devices unaffected).
+
+## Deliverables (Phase 0 — all INERT, all tested)
+
+**Backend (TS)**
+- `payment-terminal/providers/paygo-ecr-terminal.provider.ts` — `id="paygo_ecr"`,
+  `vendorProfile="paygo.sp630"`, `activatable=false`, caps `[sale,void,
+  fiscal_coupled,query_last]`; `buildSaleCommand`/`mapAck` (gmp3_card shape) + spec.
+- `fiscal-core/adapters/paygo-fiscal-provider.ts` — extends `Gmp3FiscalProviderBase`,
+  `id="fiscal_paygo"`, `vendorProfile="paygo.sp630"` + spec.
+- Register both in their modules.
+- `device-mesh/command-queue.service.ts` — `claimNextForBridge` + specs.
+- `local-bridge/local-bridge.controller.ts` + `.service.ts` — fan-in routes + specs.
+
+**Rust bridge (`apps/local-bridge-agent`)**
+- `src/drivers/gmp3/mod.rs` (driver), `protocol.rs` (framing/TLV/seq + crypto trait,
+  fail-closed default), `profiles.rs` (`VendorProfile` + registry + paygo), and a
+  bidirectional `transport.rs` (or reuse) — plus a `gmp3.toml` loader. Registered in
+  `drivers/mod.rs::Registry::init`.
+- Dispatch protocol-routing in `drivers/mod.rs`.
+- `cloud_ws.rs` URL swap to the bridge fan-in routes.
+- Unit tests for: profile selection, simulator outcomes, fail-closed real mode,
+  transport loopback round-trip, protocol routing.
+
+**Frontend**
+- `PaymentTerminalsSettingsPage.tsx` — `paygo_ecr` label.
+- `FiscalRecoveryPage.tsx` — `fiscal_paygo` (Paygo) option.
+
+**Docs**
+- `docs/integrations/paygo-token-gmp3-onboarding.md` — the vendor procurement
+  checklist (what to obtain from Token/Paygo) + the Phase-1 go-live runbook.
+
+## The hard dependency (Phase 1 — from Token/Paygo)
+1. SP630-correct **GMP-3 SDK + message-mapping doc** (confirm the language — the
+   public portal SDK is C#/.NET+C++ for Android devices; the Linux SP630 may use the
+   older SP-generation lib). We are Rust-first → either reimplement the handshake in
+   Rust from the GİB spec (C1, chosen) or FFI/sidecar the vendor lib (C2).
+2. **Test/dev SP630** (or vendor simulator) — cert pairing needs real hardware.
+3. **GMP3 value-added service activation + TSM firma kodu** (merchant provisioning).
+4. **Written pairing authorization** ("uyumlu hale getirme").
+5. **PÖKC cert chain + handshake params** (DH group, AES/HMAC scheme, İşlem Sıra No,
+   port).
+
+## Non-goals (this pass)
+- Real GMP-3 handshake/crypto (Phase 1). 4G/USB transport (LAN first). Android portal
+  SDK FFI/sidecar (chose Rust-native). Real acquirer/PSP certification.
+
+## Safety / INERT proof
+- `paygo_ecr.activatable === false` → `setActivation("ACTIVE")` throws; `SIMULATOR`
+  is simulator-provider-only → paygo_ecr can only sit `CONFIGURED_NOT_ACTIVE` →
+  `resolveTerminal` never selects it. Real POS card flow unchanged.
+- `fiscal_paygo` only issues when an operator registers a `fiscal_paygo` device AND
+  links a mesh device; absent that, `resolveMeshDevice` throws. No tenant has one.
+- Rust `gmp3` driver `mode="real"` fails closed (never fake `done`); money/fiscal
+  kinds stay `NON_RETRYABLE` (no double-charge/double-fiş on a lost ack).
+- Bridge fan-in routes are additive; the per-device loop is untouched.
+
+## Reversibility
+No DB migration is introduced (free-string providerId + existing `Device.bridgeId`).
+If a migration becomes necessary during implementation it ships as a reversible
+up/down pair per the repo rule. All new code is removable without data effects.

--- a/frontend/src/features/fiscal/FiscalRecoveryPage.tsx
+++ b/frontend/src/features/fiscal/FiscalRecoveryPage.tsx
@@ -150,6 +150,7 @@ function FiscalDevicesPanel() {
           >
             <option value="fiscal_hugin">Hugin</option>
             <option value="fiscal_beko">Beko</option>
+            <option value="fiscal_paygo">Paygo (SP630)</option>
           </select>
         </label>
         <label className="flex flex-col text-xs">

--- a/frontend/src/pages/settings/PaymentTerminalsSettingsPage.tsx
+++ b/frontend/src/pages/settings/PaymentTerminalsSettingsPage.tsx
@@ -34,6 +34,7 @@ const STATE_VARIANT: Record<TerminalActivationState, 'default' | 'success' | 'wa
 const PROVIDER_LABELS: Record<string, string> = {
   simulator: 'Simulator',
   gmp3_card: 'GMP-3 Yazarkasa-POS',
+  paygo_ecr: 'Paygo Yazarkasa-POS (SP630)',
   bank_ecr: 'Bank POS (ECR)',
   softpos: 'SoftPOS / PSP',
 };


### PR DESCRIPTION
## Paygo SP630PRO ECR (GMP-3 ÖKC) integration — Phase 0 (ships INERT)

Integrates the **Paygo SP630PRO ECR** — a Turkish *Yeni Nesil ÖKC* (card EFT-POS
+ fiscal engine + mali-fiş printer in one box, driven over **GMP-3**) — into the
platform. Built **protocol-first / vendor-neutral**: one `gmp3` bridge driver +
per-vendor profiles, so the whole Turkish ÖKC family (Beko, Hugin, Profilo,
Ingenico, …) is a small delta later. Paygo (`paygo.sp630`) is profile #1.

**Ships completely INERT** — it cannot move real money or print a fiş until the
Token/Paygo certified GMP-3 handshake lands (Phase 1). Zero regression to the
current manual card flow.

### Two rails, one physical device
- **Card sale** → coupled: the SP630 charges the card **and** prints the fiş
  atomically (payment-terminal `paygo_ecr`, `fiscal_coupled`).
- **Cash / meal-card / non-card sale** → the SP630 prints the mali fiş
  (fiscal-core `fiscal_paygo`).
Both command families land on the same on-prem Rust driver.

### What's in this PR
**Backend**
- `PaygoEcrTerminalProvider` (coupled card+fiş, `activatable=false`) and
  `PaygoFiscalProvider` (cash/non-card fiş). No DB migration (free-string
  providerId).
- Bridge command **fan-in loop**: `GET /v1/bridges/commands/next` +
  `POST /v1/bridges/commands/:id/ack` under `BridgeTokenGuard`, scoped to the
  bridge's own devices (`Device.bridgeId`). A closed fiscal box can't self-poll,
  so the bridge fronts it. The pre-existing per-device loop is untouched.
- `CommandQueueService` extracted into a leaf `CommandQueueModule` (both
  device-mesh and local-bridge consume it without a circular module dependency;
  re-exported so existing consumers are unchanged).
- `app.module.boot.spec.ts` — compiles the full AppModule graph so a module
  cycle fails the unit gate, not production.

**Rust bridge (`apps/local-bridge-agent`)**
- Vendor-neutral `gmp3` driver: profiles, protocol classify + deterministic
  simulator, a real bidirectional TCP transport, and a **fail-closed** real mode.
- Protocol-aware dispatch routing (GMP-3 commands carry `protocol`/`vendorProfile`
  and no `target`).
- `cloud_ws` points at the bridge fan-in routes.

**Frontend + docs**
- Paygo labels in Settings→Card Terminals and Fiscal Devices.
- `gmp3.toml.example`; `docs/integrations/paygo-token-gmp3-onboarding.md` (what to
  obtain from Token/Paygo + Phase-1 checklist + go-live runbook); design spec.

### Safety / INERT proof
- `paygo_ecr.activatable === false` → activation gate refuses `ACTIVE`; SIMULATOR
  is simulator-provider-only → the record can only sit `CONFIGURED_NOT_ACTIVE`,
  and `resolveTerminal` never selects it.
- `fiscal_paygo` only issues once an operator registers + links a device.
- Rust `gmp3` `mode="real"` fails closed (never a fake `done`); money/fiscal
  kinds stay `NON_RETRYABLE` (no double-charge/double-fiş on a lost ack).

### Verification
- Backend: `tsc` clean; **4400 tests / 469 suites** pass (incl. the new boot
  guard).
- Rust bridge: `fmt` + `clippy -D warnings` clean; **83 tests** pass.
- Frontend: `tsc` clean; fiscal tests pass.
- A 4-dimension adversarial review (money-safety / cross-language contract /
  security-scope / Rust) with per-finding verification caught the module-cycle
  blocker (fixed) + 2 nits (fixed); 3 findings refuted.

### Go-live (Phase 1) — needs Token/Paygo
GMP-3 SDK for the SP630, a test device, GMP3 service activation + TSM firma kodu,
written pairing authorization, and the PÖKC cert chain. See
`docs/integrations/paygo-token-gmp3-onboarding.md`.
