### PR TITLE
fix(ci): unblock production deploys — secrets gate crashed on unmapped observability env

### DIFF
--- a/.github/workflows/release-deploy.yml
+++ b/.github/workflows/release-deploy.yml
@@ -102,6 +102,11 @@ jobs:
           GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
           GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET }}
           DESKTOP_RELEASE_API_KEY: ${{ secrets.DESKTOP_RELEASE_API_KEY }}
+          # Observability pair: listed in `recommended` below — every name the
+          # loops dereference MUST be mapped here, or `${!name}` trips nounset
+          # and kills the gate (exactly what blocked v3.2.94).
+          METRICS_TOKEN: ${{ secrets.METRICS_TOKEN }}
+          GRAFANA_ADMIN_PASSWORD: ${{ secrets.GRAFANA_ADMIN_PASSWORD }}
         run: |
           set -euo pipefail
           # backend env-validation.ts aborts boot on missing/short
@@ -131,7 +136,9 @@ jobs:
 
           missing=()
           for name in "${required[@]}"; do
-            [ -z "${!name}" ] && missing+=("$name")
+            # ${!name:-} (not ${!name}) — an env-mapping gap must read as
+            # "missing secret", not crash the whole gate under set -u.
+            [ -z "${!name:-}" ] && missing+=("$name")
           done
           if [ ${#missing[@]} -gt 0 ]; then
             echo "::error::Refusing to deploy — required secrets unset or empty:"
@@ -141,7 +148,7 @@ jobs:
 
           degraded=()
           for name in "${recommended[@]}"; do
-            [ -z "${!name}" ] && degraded+=("$name")
+            [ -z "${!name:-}" ] && degraded+=("$name")
           done
           if [ ${#degraded[@]} -gt 0 ]; then
             echo "::warning::Deploying with degraded functionality:"


### PR DESCRIPTION
## Incident

Repeated **"BackendDown critical"** alert emails from prod while the API is fully healthy (`/api/health` 200, DB+Redis healthy, 39h uptime).

## Root cause chain

1. PR #272 added `METRICS_TOKEN GRAFANA_ADMIN_PASSWORD` to the pre-flight gate's `recommended` list **without mapping them into the step's `env:` block**.
2. Under `set -euo pipefail`, `${!name}` on an unmapped name aborts: `line 39: !name: unbound variable` → the gate exits 1 → **v3.2.94 failed to deploy** (run 28768769573), and every future tag would too.
3. Because the release never landed, `/root/kds/.env.production` has no `METRICS_TOKEN`; the backend booted without it and fails `/api/metrics` **closed** (401, audit-H6 posture).
4. Prometheus scrape fails → `up{job="kds-backend"} == 0` → `BackendDown` (severity=critical) fires and re-mails **every hour** (`repeat_interval: 1h`).

## Fix

- Map `METRICS_TOKEN` + `GRAFANA_ADMIN_PASSWORD` into the verify step's env.
- Harden both verification loops with `${!name:-}` so a future env-mapping gap degrades to a "missing secret" report instead of crashing the gate.

## Verification

Extracted the step's `run` block and exercised all three paths locally:

| scenario | result |
|---|---|
| all secrets set | `All required secrets present (0 recommended secrets missing).` exit 0 |
| observability pair unset | `::warning::Deploying with degraded functionality` exit 0 |
| required (JWT_SECRET) missing | `::error::Refusing to deploy` + clean listing, exit 1 |

Also reproduced the original failure verbatim (`!name: unbound variable`, exit 1) with the pre-fix expansion.

## After merge

Tag `v3.2.95` → deploy renders `METRICS_TOKEN`/`GRAFANA_ADMIN_PASSWORD` into `.env.production` (both secrets exist in the repo since 2026-07-05), backend restarts with the token, `ops/monitoring/up.sh` reconciles the monitoring stack → scrape succeeds → `BackendDown` resolves (resolved email will arrive).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DrvuteKh6F7YXV3GhD78p3