### PR TITLE
fix: audit remediation — security + correctness bugs + safe perf/scale-out hardening

### DIFF
--- a/backend/src/common/adapters/redis-io.adapter.spec.ts
+++ b/backend/src/common/adapters/redis-io.adapter.spec.ts
@@ -44,6 +44,7 @@ describe("RedisIoAdapter", () => {
     delete process.env.REDIS_URL;
     delete process.env.REDIS_HOST;
     delete process.env.REDIS_PORT;
+    delete process.env.SOCKET_ADAPTER_REQUIRE_REDIS;
     server = { adapter: jest.fn() };
     // Stub the parent IoAdapter.createIOServer so we don't spin a real
     // socket.io server; we only assert whether the Redis adapter gets wired.
@@ -107,5 +108,36 @@ describe("RedisIoAdapter", () => {
     expect(server.adapter).not.toHaveBeenCalled();
     // both pub + sub clients get torn down on failure
     expect(client.disconnect).toHaveBeenCalled();
+  });
+
+  // Multi-replica opt-in (audit 2026-07): when an operator runs >1 replica they
+  // set SOCKET_ADAPTER_REQUIRE_REDIS=true so a missing/broken Redis adapter
+  // FAILS BOOT (crash-loop → restart retries) instead of silently latching to
+  // the in-memory adapter, which would drop cross-replica events for half the
+  // clients. Default (flag unset) keeps the degrade-only single-node behaviour.
+  it("refuses to boot when SOCKET_ADAPTER_REQUIRE_REDIS=true but no Redis is configured", async () => {
+    process.env.SOCKET_ADAPTER_REQUIRE_REDIS = "true";
+
+    const adapter = new RedisIoAdapter(app);
+
+    await expect(adapter.connectToRedis()).rejects.toThrow(
+      /SOCKET_ADAPTER_REQUIRE_REDIS/,
+    );
+  });
+
+  it("refuses to boot when SOCKET_ADAPTER_REQUIRE_REDIS=true and Redis connection fails (after cleanup)", async () => {
+    process.env.SOCKET_ADAPTER_REQUIRE_REDIS = "true";
+    process.env.REDIS_URL = "redis://localhost:6379";
+    const client = fakeRedisClient(
+      jest.fn().mockRejectedValue(new Error("ECONNREFUSED")),
+    );
+    createClientMock.mockReturnValue(client);
+
+    const adapter = new RedisIoAdapter(app);
+
+    await expect(adapter.connectToRedis()).rejects.toThrow(/ECONNREFUSED/);
+    // clients are still torn down before the throw
+    expect(client.disconnect).toHaveBeenCalled();
+    expect(createAdapterMock).not.toHaveBeenCalled();
   });
 });

--- a/backend/src/common/adapters/redis-io.adapter.ts
+++ b/backend/src/common/adapters/redis-io.adapter.ts
@@ -35,10 +35,19 @@ export class RedisIoAdapter extends IoAdapter {
         : undefined);
 
     if (!url) {
-      this.logger.warn(
+      const msg =
         "REDIS_URL not set — Socket.IO will use the in-memory adapter. " +
-          "Multi-replica deployments will LOSE realtime events across replicas.",
-      );
+        "Multi-replica deployments will LOSE realtime events across replicas.";
+      // Fail-closed opt-in: an operator running >1 replica sets
+      // SOCKET_ADAPTER_REQUIRE_REDIS=true so the app refuses to boot without a
+      // working cross-replica adapter, rather than silently serving a broken
+      // broadcast path. Default keeps single-node degrade-only behaviour.
+      if (this.requireRedis()) {
+        throw new Error(
+          `${msg} SOCKET_ADAPTER_REQUIRE_REDIS=true refuses to boot without a Redis adapter.`,
+        );
+      }
+      this.logger.warn(msg);
       return;
     }
 
@@ -81,16 +90,33 @@ export class RedisIoAdapter extends IoAdapter {
       this.subClient = subClient;
       this.logger.log("Socket.IO Redis adapter connected");
     } catch (err: any) {
-      this.logger.error(
-        `Redis connection failed (${err.message}). Falling back to in-memory Socket.IO adapter — multi-replica broadcasts will be silently broken until Redis is reachable.`,
-      );
+      // Tear the clients down first so a fail-closed throw doesn't leak them.
       try {
         await pubClient.disconnect();
       } catch {}
       try {
         await subClient.disconnect();
       } catch {}
+      if (this.requireRedis()) {
+        throw new Error(
+          `Socket.IO Redis adapter connection failed and SOCKET_ADAPTER_REQUIRE_REDIS=true — refusing to boot with a broken multi-replica broadcast path: ${err.message}`,
+        );
+      }
+      this.logger.error(
+        `Redis connection failed (${err.message}). Falling back to in-memory Socket.IO adapter — multi-replica broadcasts will be silently broken until Redis is reachable.`,
+      );
     }
+  }
+
+  /**
+   * Opt-in fail-closed flag. Operators running more than one backend replica
+   * set SOCKET_ADAPTER_REQUIRE_REDIS=true so a missing/unreachable Redis adapter
+   * crashes boot (restart: unless-stopped retries) instead of degrading to the
+   * in-memory adapter — which would drop cross-replica realtime events for
+   * every client not pinned to the emitting replica.
+   */
+  private requireRedis(): boolean {
+    return process.env.SOCKET_ADAPTER_REQUIRE_REDIS === "true";
   }
 
   async disconnectRedis(): Promise<void> {

--- a/backend/src/modules/analytics/services/heatmap.service.spec.ts
+++ b/backend/src/modules/analytics/services/heatmap.service.spec.ts
@@ -282,42 +282,33 @@ describe('HeatmapService', () => {
   });
 
   describe('getTrafficFlowPaths', () => {
-    it('builds a path with duration in seconds and skips singleton tracks', async () => {
+    it('fetches all path points in ONE batched query — no N+1 per tracking id (perf audit 2026-07)', async () => {
       (prisma.occupancyRecord.findMany as any)
-        // distinct tracking ids
+        // 1) distinct tracking ids
         .mockResolvedValueOnce([{ trackingId: 'tk-1' }, { trackingId: 'tk-2' }])
-        // points for tk-1 (2 points, 120s apart)
+        // 2) a SINGLE batched points query for every tracking id, ordered by
+        //    trackingId then timestamp (each row carries its trackingId)
         .mockResolvedValueOnce([
-          {
-            positionX: 0,
-            positionZ: 0,
-            timestamp: new Date('2026-01-01T00:00:00Z'),
-          },
-          {
-            positionX: 5,
-            positionZ: 5,
-            timestamp: new Date('2026-01-01T00:02:00Z'),
-          },
-        ])
-        // points for tk-2 (1 point -> skipped, needs >= 2)
-        .mockResolvedValueOnce([
-          {
-            positionX: 1,
-            positionZ: 1,
-            timestamp: new Date('2026-01-01T00:00:00Z'),
-          },
+          { trackingId: 'tk-1', positionX: 0, positionZ: 0, timestamp: new Date('2026-01-01T00:00:00Z') },
+          { trackingId: 'tk-1', positionX: 5, positionZ: 5, timestamp: new Date('2026-01-01T00:02:00Z') },
+          { trackingId: 'tk-2', positionX: 1, positionZ: 1, timestamp: new Date('2026-01-01T00:00:00Z') },
         ]);
 
       const res = await svc.getTrafficFlowPaths(t, b, start, end);
 
-      // totalVisitors counts distinct tracking ids, not surviving paths
+      // The load-bearing assertion: exactly TWO queries total (ids + points),
+      // regardless of how many tracking ids there are — not 1 + N.
+      expect((prisma.occupancyRecord.findMany as any).mock.calls).toHaveLength(2);
+      // The batched query filters by trackingId IN the selected ids.
+      const pointsWhere = (prisma.occupancyRecord.findMany as any).mock.calls[1][0].where;
+      expect(pointsWhere.trackingId).toEqual({ in: ['tk-1', 'tk-2'] });
+
+      // Grouping is correct: tk-1 (2 points) → a path; tk-2 (1 point) → skipped.
       expect(res.totalVisitors).toBe(2);
-      // only tk-1 yielded a path
       expect(res.paths).toHaveLength(1);
       expect(res.paths[0].trackingId).toBe('tk-1');
       expect(res.paths[0].duration).toBe(120);
       expect(res.paths[0].points).toHaveLength(2);
-      // avg dwell over surviving paths
       expect(res.avgDwellTime).toBe(120);
     });
 
@@ -325,11 +316,7 @@ describe('HeatmapService', () => {
       (prisma.occupancyRecord.findMany as any)
         .mockResolvedValueOnce([{ trackingId: 'tk-1' }])
         .mockResolvedValueOnce([
-          {
-            positionX: 0,
-            positionZ: 0,
-            timestamp: new Date('2026-01-01T00:00:00Z'),
-          },
+          { trackingId: 'tk-1', positionX: 0, positionZ: 0, timestamp: new Date('2026-01-01T00:00:00Z') },
         ]);
 
       const res = await svc.getTrafficFlowPaths(t, b, start, end);
@@ -337,6 +324,17 @@ describe('HeatmapService', () => {
       expect(res.paths).toHaveLength(0);
       expect(res.totalVisitors).toBe(1);
       expect(res.avgDwellTime).toBe(0);
+    });
+
+    it('skips the batched points query entirely when there are no tracking ids', async () => {
+      (prisma.occupancyRecord.findMany as any).mockResolvedValueOnce([]);
+
+      const res = await svc.getTrafficFlowPaths(t, b, start, end);
+
+      // Only the distinct-ids query ran; no second query on an empty id set.
+      expect((prisma.occupancyRecord.findMany as any).mock.calls).toHaveLength(1);
+      expect(res.paths).toHaveLength(0);
+      expect(res.totalVisitors).toBe(0);
     });
   });
 

--- a/backend/src/modules/analytics/services/heatmap.service.ts
+++ b/backend/src/modules/analytics/services/heatmap.service.ts
@@ -349,30 +349,47 @@ export class HeatmapService {
       take: limit,
     });
 
-    const paths: TrafficFlowPathDto[] = [];
+    const ids = trackingIds.map((t) => t.trackingId);
 
-    // Get path points for each tracking ID
-    for (const { trackingId } of trackingIds) {
-      const points = await this.prisma.occupancyRecord.findMany({
-        where: {
-          tenantId,
-          branchId,
-          trackingId,
-          timestamp: {
-            gte: startDate,
-            lte: endDate,
+    // Fetch every path point for the selected tracks in ONE batched query.
+    // Previously this looped and issued one findMany PER tracking id (up to
+    // `limit` = 50 sequential round-trips for a single endpoint call). Ordered
+    // by trackingId then timestamp so a single in-memory pass groups the rows
+    // while preserving chronological order within each track. (No `state`
+    // filter here — same as before: the MOVING filter only selects which
+    // tracks to draw, the path itself uses all of that track's points.)
+    const allPoints = ids.length
+      ? await this.prisma.occupancyRecord.findMany({
+          where: {
+            tenantId,
+            branchId,
+            trackingId: { in: ids },
+            timestamp: {
+              gte: startDate,
+              lte: endDate,
+            },
           },
-        },
-        select: {
-          positionX: true,
-          positionZ: true,
-          timestamp: true,
-        },
-        orderBy: {
-          timestamp: "asc",
-        },
-      });
+          select: {
+            trackingId: true,
+            positionX: true,
+            positionZ: true,
+            timestamp: true,
+          },
+          orderBy: [{ trackingId: "asc" }, { timestamp: "asc" }],
+        })
+      : [];
 
+    const pointsByTrack = new Map<string, typeof allPoints>();
+    for (const point of allPoints) {
+      const existing = pointsByTrack.get(point.trackingId);
+      if (existing) existing.push(point);
+      else pointsByTrack.set(point.trackingId, [point]);
+    }
+
+    const paths: TrafficFlowPathDto[] = [];
+    // Iterate the distinct-id order so path ordering is stable.
+    for (const trackingId of ids) {
+      const points = pointsByTrack.get(trackingId) ?? [];
       if (points.length >= 2) {
         const firstPoint = points[0];
         const lastPoint = points[points.length - 1];

--- a/backend/src/modules/demo/demo.service.spec.ts
+++ b/backend/src/modules/demo/demo.service.spec.ts
@@ -25,6 +25,11 @@ describe('DemoService', () => {
     }).compile();
     service = module.get(DemoService);
     jest.spyOn(service['logger'], 'log').mockImplementation(() => undefined);
+    jest.spyOn(service['logger'], 'debug').mockImplementation(() => undefined);
+    // resetDemoData now runs under a Postgres advisory lock (multi-replica
+    // guard). Grant it by default so the body runs; a dedicated test overrides
+    // this to assert the lock actually gates the destructive wipe.
+    (prisma.$queryRawUnsafe as jest.Mock).mockResolvedValue([{ locked: true }]);
   });
 
   it('short-circuits to the existing demo admin without re-seeding', async () => {
@@ -142,5 +147,14 @@ describe('DemoService', () => {
     await service.resetDemoData();
     expect(prisma.$transaction).not.toHaveBeenCalled();
     expect(prisma.order.deleteMany).not.toHaveBeenCalled();
+  });
+
+  it('resetDemoData skips the destructive wipe when the advisory lock is held by another replica', async () => {
+    // Another replica already holds the lock this tick.
+    (prisma.$queryRawUnsafe as jest.Mock).mockResolvedValue([{ locked: false }]);
+    await service.resetDemoData();
+    // The body never ran: no tenant lookup, no wipe.
+    expect(prisma.tenant.findFirst).not.toHaveBeenCalled();
+    expect(prisma.$transaction).not.toHaveBeenCalled();
   });
 });

--- a/backend/src/modules/demo/demo.service.ts
+++ b/backend/src/modules/demo/demo.service.ts
@@ -3,6 +3,7 @@ import { Cron, CronExpression } from "@nestjs/schedule";
 import * as bcrypt from "bcryptjs";
 import { Prisma } from "@prisma/client";
 import { PrismaService } from "../../prisma/prisma.service";
+import { withAdvisoryLock } from "../../common/scheduling/advisory-lock";
 import { UserRole } from "../../common/constants/roles.enum";
 import {
   OrderStatus,
@@ -342,6 +343,18 @@ export class DemoService {
    */
   @Cron(CronExpression.EVERY_DAY_AT_4AM)
   async resetDemoData(): Promise<void> {
+    // Multi-replica guard: only one replica runs the destructive wipe + reseed
+    // per tick. Without it every replica deletes and re-seeds the demo tenant,
+    // double-seeding the sample orders.
+    await withAdvisoryLock(
+      this.prisma,
+      "demo.resetDemoData",
+      () => this.resetDemoDataInner(),
+      this.logger,
+    );
+  }
+
+  private async resetDemoDataInner(): Promise<void> {
     const tenant = await this.prisma.tenant.findFirst({
       where: { subdomain: DemoService.SUBDOMAIN },
       select: { id: true },

--- a/backend/src/modules/menu/menu.module.ts
+++ b/backend/src/modules/menu/menu.module.ts
@@ -2,6 +2,7 @@ import { Module } from "@nestjs/common";
 import { CategoriesService } from "./services/categories.service";
 import { ProductsService } from "./services/products.service";
 import { MenuQueryService } from "./services/menu-query.service";
+import { MenuCacheService } from "./services/menu-cache.service";
 import { MenuImportService } from "./services/menu-import.service";
 import { Product3dService } from "./services/product-3d.service";
 import { ProductMediaService } from "./services/product-media.service";
@@ -33,6 +34,7 @@ import { UploadModule } from "../upload/upload.module";
     CategoriesService,
     ProductsService,
     MenuQueryService,
+    MenuCacheService,
     MenuImportService,
     Product3dService,
     ProductMediaService,

--- a/backend/src/modules/menu/services/menu-cache.service.ts
+++ b/backend/src/modules/menu/services/menu-cache.service.ts
@@ -1,0 +1,109 @@
+import {
+  Injectable,
+  Logger,
+  OnModuleDestroy,
+  OnModuleInit,
+} from "@nestjs/common";
+import Redis from "ioredis";
+
+/**
+ * Redis cache for the public QR menu (MenuQueryService.getPublicMenu) — the
+ * single hottest anonymous read in the system. Every table scan / menu refresh
+ * re-runs a deep nested categories→products→modifiers query plus tenant, QR
+ * settings and POS settings lookups; menu content changes rarely relative to
+ * that read volume, so it is the textbook cache target.
+ *
+ * Design:
+ *   - Short TTL (MENU_CACHE_TTL_SECONDS): collapses the per-scan query storm to
+ *     ~one DB read per tenant per TTL window while bounding staleness — a
+ *     price/availability edit is visible within the TTL even if an explicit
+ *     invalidate() is never wired for that write path.
+ *   - invalidate(tenantId) drops the entry immediately for known menu edits.
+ *   - Best-effort + graceful: with no REDIS_URL (dev / small single-box deploy)
+ *     or on any Redis error the cache silently no-ops and the caller falls back
+ *     to the DB — exactly today's behaviour, never a failed request. Mirrors the
+ *     degrade-only posture of EntitlementInvalidationBus / RedisIoAdapter.
+ */
+const KEY_PREFIX = "menu:v1:";
+const MENU_CACHE_TTL_SECONDS = 30;
+
+@Injectable()
+export class MenuCacheService implements OnModuleInit, OnModuleDestroy {
+  private readonly logger = new Logger(MenuCacheService.name);
+  private redis: Redis | null = null;
+
+  onModuleInit(): void {
+    const url = process.env.REDIS_URL;
+    if (!url) {
+      this.logger.warn(
+        "REDIS_URL not set — public menu cache disabled (DB read on every scan)",
+      );
+      return;
+    }
+    try {
+      this.redis = new Redis(url, {
+        maxRetriesPerRequest: 2,
+        lazyConnect: false,
+      });
+      // Swallow connection errors: get/set/invalidate are all best-effort and
+      // fall back to the DB. Without a handler ioredis would emit unhandled
+      // 'error' events during a Redis blip.
+      this.redis.on("error", () => {
+        /* best-effort cache; handled per-call */
+      });
+    } catch (e) {
+      this.logger.warn(
+        `Redis connect failed; menu cache disabled: ${(e as Error).message}`,
+      );
+      this.redis = null;
+    }
+  }
+
+  async onModuleDestroy(): Promise<void> {
+    try {
+      await this.redis?.quit();
+    } catch {
+      /* ignore */
+    }
+  }
+
+  private key(tenantId: string): string {
+    return KEY_PREFIX + tenantId;
+  }
+
+  /** Cached tenant-level menu payload, or null on miss / no-cache / any error. */
+  async getMenu<T = unknown>(tenantId: string): Promise<T | null> {
+    if (!this.redis) return null;
+    try {
+      const raw = await this.redis.get(this.key(tenantId));
+      return raw ? (JSON.parse(raw) as T) : null;
+    } catch {
+      return null; // best-effort: fall through to the DB
+    }
+  }
+
+  /** Populate the cache with a short TTL. Never throws. */
+  async setMenu(tenantId: string, payload: unknown): Promise<void> {
+    if (!this.redis) return;
+    try {
+      await this.redis.set(
+        this.key(tenantId),
+        JSON.stringify(payload),
+        "EX",
+        MENU_CACHE_TTL_SECONDS,
+      );
+    } catch {
+      /* best-effort */
+    }
+  }
+
+  /** Drop a tenant's cached menu immediately (call after a menu edit). */
+  async invalidate(tenantId: string): Promise<void> {
+    if (!this.redis) return;
+    try {
+      await this.redis.del(this.key(tenantId));
+    } catch {
+      /* best-effort */
+    }
+  }
+}

--- a/backend/src/modules/menu/services/menu-query.service.spec.ts
+++ b/backend/src/modules/menu/services/menu-query.service.spec.ts
@@ -28,13 +28,22 @@ const posSettings = {
   }),
 };
 
+// Cache stub — miss by default (getMenu → null) so tests exercise the DB path.
+function makeCache(cached: unknown = null) {
+  return {
+    getMenu: jest.fn().mockResolvedValue(cached),
+    setMenu: jest.fn().mockResolvedValue(undefined),
+    invalidate: jest.fn().mockResolvedValue(undefined),
+  };
+}
+
 describe("MenuQueryService", () => {
   beforeEach(() => jest.clearAllMocks());
 
   it("404s when the tenant is missing/inactive", async () => {
     const prisma = makePrisma();
     prisma.tenant.findFirst.mockResolvedValueOnce(null);
-    const svc = new MenuQueryService(prisma as any, posSettings as any);
+    const svc = new MenuQueryService(prisma as any, posSettings as any, makeCache());
     await expect(svc.getPublicMenu("nope")).rejects.toBeInstanceOf(
       NotFoundException,
     );
@@ -43,7 +52,7 @@ describe("MenuQueryService", () => {
   it("null-coalesces missing QR settings to defaults", async () => {
     const prisma = makePrisma();
     prisma.tenant.findFirst.mockResolvedValueOnce({ id: "t1", name: "Acme" });
-    const svc = new MenuQueryService(prisma as any, posSettings as any);
+    const svc = new MenuQueryService(prisma as any, posSettings as any, makeCache());
     const res = await svc.getPublicMenu("t1");
     expect(res.settings.primaryColor).toBe("#3B82F6");
     expect(res.settings.layoutStyle).toBe("GRID");
@@ -54,7 +63,7 @@ describe("MenuQueryService", () => {
   it("coerces enableCustomerSelfPay (truthy number) to a boolean", async () => {
     const prisma = makePrisma();
     prisma.tenant.findFirst.mockResolvedValueOnce({ id: "t1", name: "Acme" });
-    const svc = new MenuQueryService(prisma as any, posSettings as any);
+    const svc = new MenuQueryService(prisma as any, posSettings as any, makeCache());
     const res = await svc.getPublicMenu("t1");
     expect(res.enableCustomerSelfPay).toBe(true);
   });
@@ -89,7 +98,7 @@ describe("MenuQueryService", () => {
         ],
       },
     ]);
-    const svc = new MenuQueryService(prisma as any, posSettings as any);
+    const svc = new MenuQueryService(prisma as any, posSettings as any, makeCache());
     const res = await svc.getPublicMenu("t1");
     const product = res.categories[0].products[0];
     expect(typeof product.price).toBe("number");
@@ -103,7 +112,7 @@ describe("MenuQueryService", () => {
   it("looks up the table only when a tableId is supplied", async () => {
     const prisma = makePrisma();
     prisma.tenant.findFirst.mockResolvedValue({ id: "t1", name: "Acme" });
-    const svc = new MenuQueryService(prisma as any, posSettings as any);
+    const svc = new MenuQueryService(prisma as any, posSettings as any, makeCache());
 
     await svc.getPublicMenu("t1");
     expect(prisma.table.findFirst).not.toHaveBeenCalled();
@@ -112,5 +121,63 @@ describe("MenuQueryService", () => {
     expect(prisma.table.findFirst).toHaveBeenCalledWith({
       where: { id: "table-7", tenantId: "t1" },
     });
+  });
+
+  it("populates the cache on a miss (writes the tenant-level base, no table)", async () => {
+    const prisma = makePrisma();
+    prisma.tenant.findFirst.mockResolvedValueOnce({ id: "t1", name: "Acme" });
+    const cache = makeCache(null); // miss
+    const svc = new MenuQueryService(prisma as any, posSettings as any, cache as any);
+
+    await svc.getPublicMenu("t1");
+
+    // The heavy category query ran, and the base was written to the cache.
+    expect(prisma.category.findMany).toHaveBeenCalledTimes(1);
+    expect(cache.setMenu).toHaveBeenCalledTimes(1);
+    const [tid, base] = cache.setMenu.mock.calls[0];
+    expect(tid).toBe("t1");
+    // The cached unit is table-agnostic — `table` is merged per request, not stored.
+    expect(base).not.toHaveProperty("table");
+    expect(base).toHaveProperty("categories");
+  });
+
+  it("serves the cached base and SKIPS the deep category query on a hit", async () => {
+    const prisma = makePrisma();
+    const cachedBase = {
+      tenant: { id: "t1", name: "Acme", wifi: null, socialMedia: {} },
+      settings: { primaryColor: "#000" },
+      enableCustomerOrdering: true,
+      enableTablelessMode: false,
+      enableCustomerSelfPay: true,
+      categories: [{ id: "c-cached", products: [] }],
+    };
+    const cache = makeCache(cachedBase); // hit
+    const svc = new MenuQueryService(prisma as any, posSettings as any, cache as any);
+
+    const res = await svc.getPublicMenu("t1");
+
+    // Cache hit short-circuits BEFORE the tenant / category / posSettings reads.
+    expect(prisma.category.findMany).not.toHaveBeenCalled();
+    expect(prisma.tenant.findFirst).not.toHaveBeenCalled();
+    expect(posSettings.findByTenant).not.toHaveBeenCalled();
+    expect(cache.setMenu).not.toHaveBeenCalled();
+    // The cached payload is returned, with a freshly-merged (null) table.
+    expect(res.categories).toEqual([{ id: "c-cached", products: [] }]);
+    expect(res.table).toBeNull();
+  });
+
+  it("merges the fresh table onto a cache hit (table stays per-request)", async () => {
+    const prisma = makePrisma();
+    prisma.table.findFirst.mockResolvedValueOnce({ id: "table-7", number: 7 });
+    const cache = makeCache({ categories: [], settings: {} });
+    const svc = new MenuQueryService(prisma as any, posSettings as any, cache as any);
+
+    const res = await svc.getPublicMenu("t1", { tableId: "table-7" });
+
+    // Table looked up live even on a cache hit, and merged onto the cached base.
+    expect(prisma.table.findFirst).toHaveBeenCalledWith({
+      where: { id: "table-7", tenantId: "t1" },
+    });
+    expect(res.table).toEqual({ id: "table-7", number: 7 });
   });
 });

--- a/backend/src/modules/menu/services/menu-query.service.ts
+++ b/backend/src/modules/menu/services/menu-query.service.ts
@@ -36,15 +36,12 @@ export class MenuQueryService {
         where: { id: tableId, tenantId },
       });
     }
-    const tablePayload = table
-      ? { id: table.id, number: table.number }
-      : null;
+    const tablePayload = table ? { id: table.id, number: table.number } : null;
 
     // Serve the cached tenant-level menu when present; only the table changes
     // per request, so one cache entry serves every table + the no-table scan.
-    const cached = await this.menuCache.getMenu<Record<string, unknown>>(
-      tenantId,
-    );
+    const cached =
+      await this.menuCache.getMenu<Record<string, unknown>>(tenantId);
     if (cached) {
       return { ...cached, table: tablePayload };
     }

--- a/backend/src/modules/menu/services/menu-query.service.ts
+++ b/backend/src/modules/menu/services/menu-query.service.ts
@@ -1,24 +1,65 @@
 import { Injectable, NotFoundException } from "@nestjs/common";
 import { PrismaService } from "../../../prisma/prisma.service";
 import { PosSettingsService } from "../../pos-settings/pos-settings.service";
+import { MenuCacheService } from "./menu-cache.service";
 
 /**
  * Public-menu query, extracted VERBATIM from QrMenuController.getPublicMenu so
  * the @Public QR menu and the partner /display surface share one source of
  * truth. Menu content is tenant-level (no per-branch availability columns), so
  * the only filter besides tenant is the optional tableId for table-specific
- * QR codes. No behaviour change from the inline controller version.
+ * QR codes.
+ *
+ * Caching: the tenant-level payload (tenant info + QR settings + the deep
+ * category→product→modifier tree + POS flags) is identical across every table
+ * and re-read on every scan — the hottest anonymous query. It is cached in
+ * Redis (MenuCacheService, short TTL, degrade-only). The per-request table
+ * lookup is table-specific and stays uncached, merged on top of the cached base.
  */
 @Injectable()
 export class MenuQueryService {
   constructor(
     private prisma: PrismaService,
     private posSettingsService: PosSettingsService,
+    private menuCache: MenuCacheService,
   ) {}
 
   async getPublicMenu(tenantId: string, opts?: { tableId?: string }) {
     const tableId = opts?.tableId;
 
+    // Table info is table-specific (cannot be shared across a tenant's QR
+    // codes), a single cheap indexed lookup, so it stays per-request and
+    // uncached. Merged onto the cached tenant-level base below.
+    let table = null;
+    if (tableId) {
+      table = await this.prisma.table.findFirst({
+        where: { id: tableId, tenantId },
+      });
+    }
+    const tablePayload = table
+      ? { id: table.id, number: table.number }
+      : null;
+
+    // Serve the cached tenant-level menu when present; only the table changes
+    // per request, so one cache entry serves every table + the no-table scan.
+    const cached = await this.menuCache.getMenu<Record<string, unknown>>(
+      tenantId,
+    );
+    if (cached) {
+      return { ...cached, table: tablePayload };
+    }
+
+    const base = await this.buildTenantMenu(tenantId);
+    // Best-effort populate — a cache write must never fail the request.
+    await this.menuCache.setMenu(tenantId, base);
+    return { ...base, table: tablePayload };
+  }
+
+  /**
+   * Build the tenant-level menu payload (everything except the per-request
+   * `table`). This is the cacheable unit; getPublicMenu adds `table` on top.
+   */
+  private async buildTenantMenu(tenantId: string) {
     const tenant = await this.prisma.tenant.findFirst({
       where: { id: tenantId, status: "ACTIVE" },
       select: {
@@ -46,14 +87,6 @@ export class MenuQueryService {
     const settings = await this.prisma.qrMenuSettings.findFirst({
       where: { tenantId, branchId: null },
     });
-
-    // Get table information if tableId provided
-    let table = null;
-    if (tableId) {
-      table = await this.prisma.table.findFirst({
-        where: { id: tableId, tenantId },
-      });
-    }
 
     const categories = await this.prisma.category.findMany({
       where: {
@@ -191,12 +224,6 @@ export class MenuQueryService {
           whatsapp: tenant.socialWhatsapp,
         },
       },
-      table: table
-        ? {
-            id: table.id,
-            number: table.number,
-          }
-        : null,
       settings: {
         primaryColor: settings?.primaryColor ?? "#3B82F6",
         secondaryColor: settings?.secondaryColor ?? "#F3F4F6",

--- a/backend/src/modules/menu/services/product-3d.service.spec.ts
+++ b/backend/src/modules/menu/services/product-3d.service.spec.ts
@@ -36,6 +36,9 @@ describe("Product3dService", () => {
     prisma = mockPrismaClient();
     config = makeConfig();
     svc = new Product3dService(prisma as any, config as any);
+    // pollPendingModels now runs under a Postgres advisory lock (multi-replica
+    // guard). Grant it by default so the poll body runs.
+    (prisma.$queryRawUnsafe as any).mockResolvedValue([{ locked: true }]);
     (prisma.product.update as any).mockImplementation(
       async ({ data }: any) => ({
         id: "p1",
@@ -160,6 +163,16 @@ describe("Product3dService", () => {
   });
 
   describe("pollPendingModels → SUCCEEDED downloads + re-hosts", () => {
+    it("skips polling when the advisory lock is held by another replica", async () => {
+      svc = new Product3dService(
+        prisma as any,
+        makeConfig({ MESHY_API_KEY: "k" }) as any,
+      );
+      (prisma.$queryRawUnsafe as any).mockResolvedValue([{ locked: false }]);
+      await svc.pollPendingModels();
+      expect(prisma.product.findMany).not.toHaveBeenCalled();
+    });
+
     it("downloads GLB+USDZ and marks READY with local URLs", async () => {
       svc = new Product3dService(
         prisma as any,

--- a/backend/src/modules/menu/services/product-3d.service.ts
+++ b/backend/src/modules/menu/services/product-3d.service.ts
@@ -11,6 +11,7 @@ import { promises as fs } from "fs";
 import * as path from "path";
 import axios from "axios";
 import { PrismaService } from "../../../prisma/prisma.service";
+import { withAdvisoryLock } from "../../../common/scheduling/advisory-lock";
 
 const MESHY_BASE = "https://api.meshy.ai/openapi/v1/image-to-3d";
 
@@ -164,11 +165,23 @@ export class Product3dService {
   /**
    * Poll all PENDING (real, non-simulated) tasks every 30s: on SUCCEEDED,
    * download the GLB + USDZ and re-host them; on FAILED, record the reason.
-   * Advisory-lock-free + tenant-agnostic — the taskId is globally unique.
+   * Advisory-locked so only one replica polls (and re-downloads) per tick;
+   * tenant-agnostic — the taskId is globally unique.
    */
   @Cron(CronExpression.EVERY_30_SECONDS)
   async pollPendingModels(): Promise<void> {
     if (!this.apiKey) return; // real polling only; simulator finishes inline
+    // Multi-replica guard: one replica per tick polls the Meshy task queue,
+    // so N replicas don't re-poll (and re-download) the same tasks.
+    await withAdvisoryLock(
+      this.prisma,
+      "product3d.pollPendingModels",
+      () => this.pollPendingModelsInner(),
+      this.logger,
+    );
+  }
+
+  private async pollPendingModelsInner(): Promise<void> {
     const pending = await this.prisma.product.findMany({
       where: {
         model3dStatus: "PENDING",

--- a/backend/src/modules/menu/services/product-media.service.spec.ts
+++ b/backend/src/modules/menu/services/product-media.service.spec.ts
@@ -35,6 +35,9 @@ describe("ProductMediaService", () => {
     jest.clearAllMocks();
     prisma = mockPrismaClient();
     (prisma as any).$transaction = jest.fn(async (cb: any) => cb(prisma));
+    // pollPendingJobs now runs under a Postgres advisory lock (multi-replica
+    // guard). Grant it by default so the poll body runs.
+    (prisma.$queryRawUnsafe as any).mockResolvedValue([{ locked: true }]);
     let seq = 0;
     (prisma.productMediaJob.create as any).mockImplementation(
       async ({ data }: any) => ({ id: `job${++seq}`, ...data }),
@@ -225,6 +228,13 @@ describe("ProductMediaService", () => {
   describe("pollPendingJobs", () => {
     it("no-op without a key", async () => {
       svc = make({ FAL_SIMULATOR: "true" });
+      await svc.pollPendingJobs();
+      expect(prisma.productMediaJob.findMany).not.toHaveBeenCalled();
+    });
+
+    it("skips polling when the advisory lock is held by another replica", async () => {
+      svc = make({ FAL_KEY: "k" });
+      (prisma.$queryRawUnsafe as any).mockResolvedValue([{ locked: false }]);
       await svc.pollPendingJobs();
       expect(prisma.productMediaJob.findMany).not.toHaveBeenCalled();
     });

--- a/backend/src/modules/menu/services/product-media.service.ts
+++ b/backend/src/modules/menu/services/product-media.service.ts
@@ -11,6 +11,7 @@ import { promises as fs } from "fs";
 import * as path from "path";
 import axios from "axios";
 import { PrismaService } from "../../../prisma/prisma.service";
+import { withAdvisoryLock } from "../../../common/scheduling/advisory-lock";
 
 const FAL_QUEUE = "https://queue.fal.run";
 const MAX_POLL_ATTEMPTS = 40; // ~20 min at 30s ticks → FAILED (timeout)
@@ -327,6 +328,18 @@ export class ProductMediaService {
   @Cron(CronExpression.EVERY_30_SECONDS)
   async pollPendingJobs(): Promise<void> {
     if (!this.key) return; // real polling only; simulator finishes inline
+    // Multi-replica guard: one replica per tick polls the fal.ai queue.
+    // Without it every replica polls the same in-flight jobs, burning
+    // duplicate external API quota.
+    await withAdvisoryLock(
+      this.prisma,
+      "productMedia.pollPendingJobs",
+      () => this.pollPendingJobsInner(),
+      this.logger,
+    );
+  }
+
+  private async pollPendingJobsInner(): Promise<void> {
     const jobs = await this.prisma.productMediaJob.findMany({
       where: {
         status: { in: ["IN_QUEUE", "IN_PROGRESS"] },

--- a/backend/src/modules/payment-terminal/payment-terminal.provisioning.spec.ts
+++ b/backend/src/modules/payment-terminal/payment-terminal.provisioning.spec.ts
@@ -20,6 +20,9 @@ describe("PaymentTerminalService (provisioning + activation gate)", () => {
 
   beforeEach(() => {
     prisma = mockPrismaClient();
+    // recoverApprovedUnrecorded now runs under a Postgres advisory lock
+    // (multi-replica guard). Grant it so the recovery body runs.
+    (prisma.$queryRawUnsafe as any).mockResolvedValue([{ locked: true }]);
     const registry = new PaymentTerminalProviderRegistry();
     registry.register(new SimulatorTerminalProvider());
     registry.register(new Gmp3CardTerminalProvider(registry));

--- a/backend/src/modules/payment-terminal/payment-terminal.service.ts
+++ b/backend/src/modules/payment-terminal/payment-terminal.service.ts
@@ -9,6 +9,7 @@ import { Cron, CronExpression } from "@nestjs/schedule";
 import { randomUUID } from "crypto";
 import { Prisma } from "@prisma/client";
 import { PrismaService } from "../../prisma/prisma.service";
+import { withAdvisoryLock } from "../../common/scheduling/advisory-lock";
 import { BranchScope, branchScope } from "../../common/scoping/branch-scope";
 import { OrderStatus } from "../../common/constants/order-status.enum";
 import { CommandQueueService } from "../device-mesh/command-queue.service";
@@ -752,6 +753,18 @@ export class PaymentTerminalService {
    */
   @Cron(CronExpression.EVERY_5_MINUTES)
   async recoverApprovedUnrecorded() {
+    // Multi-replica guard: one replica per tick sweeps the stuck charges.
+    // Payment idempotencyKey already prevents double-booking, but the lock
+    // avoids N replicas re-driving the same provider record() calls.
+    await withAdvisoryLock(
+      this.prisma,
+      "paymentTerminal.recoverApprovedUnrecorded",
+      () => this.recoverApprovedUnrecordedInner(),
+      this.logger,
+    );
+  }
+
+  private async recoverApprovedUnrecordedInner() {
     const stuck = await this.prisma.paymentTerminalCharge.findMany({
       where: {
         status: "APPROVED",

--- a/backend/src/modules/stock-management/services/stock-deduction.service.spec.ts
+++ b/backend/src/modules/stock-management/services/stock-deduction.service.spec.ts
@@ -211,3 +211,116 @@ describe('StockDeductionService.deductForOrder (v3 per-branch recipe selection)'
     expect((prisma.$transaction as any).mock.calls.length).toBe(0);
   });
 });
+
+/**
+ * Security/data-integrity audit (2026-07). currentStock is the AUTHORITATIVE
+ * on-hand total and INCLUDES batch quantities: purchase-orders.receive()
+ * increments currentStock by the received qty AND creates a StockBatch of the
+ * same qty; waste-logs decrements currentStock by the FULL waste qty and draws
+ * batches down only for costing. The old applyDeduction() decremented
+ * currentStock only by the leftover AFTER batches were exhausted, so every
+ * batch-covered sale left currentStock inflated — silently corrupting the
+ * authoritative ledger, defeating the oversell guard, and never firing
+ * low-stock alerts. Fix: decrement currentStock by the FULL quantity; batches
+ * are a FIFO COST sub-ledger only (mirrors waste-logs).
+ */
+describe('StockDeductionService.deductForOrder — currentStock is the authoritative ledger (audit 2026-07)', () => {
+  let prisma: MockPrismaClient;
+  let svc: StockDeductionService;
+
+  beforeEach(() => {
+    prisma = mockPrismaClient();
+    const settings: any = {
+      get: jest.fn().mockResolvedValue({
+        enableAutoDeduction: true,
+        deductOnStatus: null,
+        allowNegativeStock: false,
+      }),
+    };
+    svc = new StockDeductionService(prisma as any, settings);
+  });
+
+  function orderNeeding(qtyPerServing: string, servings: number) {
+    return {
+      id: 'ord-1',
+      orderNumber: 'ORD-1',
+      tenantId: 't1',
+      branchId: 'b1',
+      stockDeducted: false,
+      orderItems: [
+        {
+          quantity: servings,
+          product: {
+            recipes: [
+              {
+                branchId: 'b1',
+                yield: 1,
+                ingredients: [
+                  { stockItemId: 'sugar', quantity: qtyPerServing, stockItem: { name: 'Sugar' } },
+                ],
+              },
+            ],
+          },
+        },
+      ],
+    } as any;
+  }
+
+  it('decrements currentStock by the FULL quantity even when a batch fully covers it', async () => {
+    (prisma.order.findFirst as any).mockResolvedValue(orderNeeding('1', 10)); // needs 10 sugar
+
+    const txMock: any = {
+      order: { updateMany: jest.fn().mockResolvedValue({ count: 1 }) },
+      stockItem: {
+        findFirst: jest
+          .fn()
+          .mockResolvedValue({ id: 'sugar', tenantId: 't1', currentStock: '100', costPerUnit: '2', minStock: '0' }),
+        updateMany: jest.fn().mockResolvedValue({ count: 1 }),
+      },
+      // A single batch of 100 fully covers the 10 needed — the exact case the
+      // old code mishandled (batch drawn down, currentStock left untouched).
+      stockBatch: {
+        findMany: jest.fn().mockResolvedValue([{ id: 'batch-1', quantity: '100', costPerUnit: '2' }]),
+        updateMany: jest.fn().mockResolvedValue({ count: 1 }),
+      },
+      ingredientMovement: { create: jest.fn().mockResolvedValue({}) },
+    };
+    (prisma.$transaction as any).mockImplementation(async (cb: any) => cb(txMock));
+
+    await svc.deductForOrder('ord-1', 't1', undefined, 'user-1');
+
+    // The batch is still drawn down for FIFO costing.
+    expect(txMock.stockBatch.updateMany).toHaveBeenCalled();
+    // currentStock MUST be decremented by the full 10 (the bug left it untouched).
+    expect(txMock.stockItem.updateMany).toHaveBeenCalledTimes(1);
+    const call = txMock.stockItem.updateMany.mock.calls[0][0];
+    expect(call.data.currentStock.decrement.toString()).toBe('10');
+    // The oversell guard is on the FULL quantity, not the post-batch leftover.
+    expect(call.where.currentStock.gte.toString()).toBe('10');
+  });
+
+  it('throws Insufficient stock when currentStock < full quantity even if a batch could cover it', async () => {
+    (prisma.order.findFirst as any).mockResolvedValue(orderNeeding('1', 10)); // needs 10
+
+    const txMock: any = {
+      order: { updateMany: jest.fn().mockResolvedValue({ count: 1 }) },
+      stockItem: {
+        findFirst: jest
+          .fn()
+          .mockResolvedValue({ id: 'sugar', tenantId: 't1', currentStock: '4', costPerUnit: '2', minStock: '0' }),
+        // gte:10 guard fails against currentStock=4 → count 0.
+        updateMany: jest.fn().mockResolvedValue({ count: 0 }),
+      },
+      stockBatch: {
+        findMany: jest.fn().mockResolvedValue([{ id: 'batch-1', quantity: '100', costPerUnit: '2' }]),
+        updateMany: jest.fn().mockResolvedValue({ count: 1 }),
+      },
+      ingredientMovement: { create: jest.fn().mockResolvedValue({}) },
+    };
+    (prisma.$transaction as any).mockImplementation(async (cb: any) => cb(txMock));
+
+    await expect(svc.deductForOrder('ord-1', 't1', undefined, 'user-1')).rejects.toThrow(
+      /Insufficient stock/,
+    );
+  });
+});

--- a/backend/src/modules/stock-management/services/stock-deduction.service.ts
+++ b/backend/src/modules/stock-management/services/stock-deduction.service.ts
@@ -164,11 +164,13 @@ export class StockDeductionService {
     });
     if (!stockItem) return;
 
+    // FIFO batch drawdown — a COST sub-ledger only. The authoritative on-hand
+    // total (stockItem.currentStock) is decremented by the FULL quantity below
+    // regardless of batches; this loop exists purely to compute the
+    // weighted-average cost of the units actually shipped (oldest batches
+    // first). Deployments without batches simply skip it and fall back to
+    // stockItem.costPerUnit.
     let remaining = deduction.quantity;
-    // FIFO batch drawdown: consume the oldest (by expiryDate, then
-    // receivedAt) batches first. If we run out of batches before the
-    // full quantity is consumed, fall through to the bare stockItem
-    // path below so legacy deployments without batches still work.
     //
     // v2.8.93 — explicit `nulls: 'last'` on expiryDate. Without it, the
     // sort order for NULL expiry depends on the underlying DB's ASC
@@ -221,30 +223,35 @@ export class StockDeductionService {
         ? weightedCostAccumulator.div(consumedFromBatches)
         : (stockItem.costPerUnit ?? null);
 
-    // After batch drawdown `remaining` is what the bare stockItem row
-    // needs to absorb. Do this as a conditional UPDATE: if
-    // allowNegativeStock=false we require currentStock >= remaining,
-    // otherwise we allow the decrement unconditionally. `updateMany`
-    // returns `count: 0` when the guard fails (no race window).
-    if (remaining.gt(0)) {
-      const update = allowNegativeStock
-        ? await tx.stockItem.updateMany({
-            where: { id: deduction.stockItemId, tenantId },
-            data: { currentStock: { decrement: remaining as any } },
-          })
-        : await tx.stockItem.updateMany({
-            where: {
-              id: deduction.stockItemId,
-              tenantId,
-              currentStock: { gte: remaining as any },
-            },
-            data: { currentStock: { decrement: remaining as any } },
-          });
-      if (update.count === 0) {
-        throw new ConflictException(
-          `Insufficient stock for ${deduction.stockItemName}`,
-        );
-      }
+    // currentStock is the AUTHORITATIVE on-hand total and already INCLUDES
+    // batch quantities: purchase-orders.receive() increments currentStock by
+    // the received qty AND creates a StockBatch of the same qty; waste-logs
+    // decrements currentStock by the FULL waste qty and draws batches down only
+    // for costing. So the on-hand decrement must be the FULL deduction
+    // quantity, NOT the post-batch leftover. Decrementing only the leftover (the
+    // old behaviour) left currentStock inflated on every batch-covered sale,
+    // which silently corrupted the ledger, defeated the oversell guard, and
+    // suppressed low-stock alerts. Conditional UPDATE: when
+    // allowNegativeStock=false we require currentStock >= quantity, so a
+    // `count: 0` (guard failure) is the race-free "insufficient stock" signal.
+    const qty = deduction.quantity;
+    const update = allowNegativeStock
+      ? await tx.stockItem.updateMany({
+          where: { id: deduction.stockItemId, tenantId },
+          data: { currentStock: { decrement: qty as any } },
+        })
+      : await tx.stockItem.updateMany({
+          where: {
+            id: deduction.stockItemId,
+            tenantId,
+            currentStock: { gte: qty as any },
+          },
+          data: { currentStock: { decrement: qty as any } },
+        });
+    if (update.count === 0) {
+      throw new ConflictException(
+        `Insufficient stock for ${deduction.stockItemName}`,
+      );
     }
 
     const totalDeducted = deduction.quantity;
@@ -344,8 +351,16 @@ export class StockDeductionService {
           });
           if (!stockItem) continue;
 
-          // Defence-in-depth: tenantId in the WHERE so a regression of
-          // the pre-check can't expose cross-tenant stock writes.
+          // Restore the FULL deducted quantity to the authoritative on-hand
+          // total. This is symmetric with deductForOrder, which now decrements
+          // currentStock by the full quantity — so a deduct+reverse nets zero
+          // and no phantom stock is minted. Batches are a consume-only FIFO
+          // COST sub-ledger (like waste-logs) and are deliberately NOT restored
+          // here; the per-batch breakdown isn't recorded on the movement, and
+          // currentStock — not the batch sum — is what every consumer
+          // (counts / dashboards / oversell / alerts) treats as authoritative.
+          // Defence-in-depth: tenantId in the WHERE so a regression of the
+          // pre-check can't expose cross-tenant stock writes.
           await tx.stockItem.updateMany({
             where: { id: movement.stockItemId, tenantId },
             data: { currentStock: { increment: reverseQty as any } },

--- a/backend/src/modules/users/users.controller.spec.ts
+++ b/backend/src/modules/users/users.controller.spec.ts
@@ -75,9 +75,9 @@ describe('UsersController', () => {
     expect(usersService.update).toHaveBeenCalledWith('u1', dto, 't1', actor);
   });
 
-  it('remove forwards id, tenantId and the actor id only', () => {
-    ctrl.remove('u1', req as any, 'admin-1');
-    expect(usersService.remove).toHaveBeenCalledWith('u1', 't1', 'admin-1');
+  it('remove forwards id, tenantId and the current actor', () => {
+    ctrl.remove('u1', req as any, actor);
+    expect(usersService.remove).toHaveBeenCalledWith('u1', 't1', actor);
   });
 
   it('getMyProfile reads the current user id', () => {

--- a/backend/src/modules/users/users.controller.ts
+++ b/backend/src/modules/users/users.controller.ts
@@ -129,9 +129,9 @@ export class UsersController {
   remove(
     @Param("id") id: string,
     @Request() req,
-    @CurrentUser("id") actorId: string,
+    @CurrentUser() actor: { id: string; role: string },
   ) {
-    return this.usersService.remove(id, req.tenantId, actorId);
+    return this.usersService.remove(id, req.tenantId, actor);
   }
 
   // Profile endpoints (all authenticated users)

--- a/backend/src/modules/users/users.service.spec.ts
+++ b/backend/src/modules/users/users.service.spec.ts
@@ -1,4 +1,4 @@
-import { BadRequestException } from '@nestjs/common';
+import { BadRequestException, ForbiddenException } from '@nestjs/common';
 import { UsersService } from './users.service';
 import { mockPrismaClient, MockPrismaClient } from '../../common/test/prisma-mock.service';
 
@@ -148,5 +148,86 @@ describe('UsersService.create — front-line branch pinning (sweep-3 B2)', () =>
     await svc.create({ ...dto, role: 'ADMIN' }, 't1', admin);
     expect((prisma.user.create as any).mock.calls[0][0].data.primaryBranchId).toBeNull();
     expect(prisma.userBranchAssignment.create).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * Security audit (2026-07): PATCH /users/:id and DELETE /users/:id are open to
+ * both ADMIN and MANAGER. update() gated only the ROLE field on the actor's
+ * role — credential fields (password/email) and account state were ungated by
+ * the TARGET's privilege. So a MANAGER could `PATCH /users/{adminId}` with a new
+ * password, revoke the admin's sessions, and log in as that admin: full account
+ * takeover / privilege escalation. remove() had the same gap (deactivate any
+ * non-last admin). Fix: a lower-privileged actor may not mutate an ADMIN target.
+ */
+describe('UsersService.update/remove — target-privilege authorization (audit: MANAGER cannot take over ADMIN)', () => {
+  let prisma: MockPrismaClient;
+  let svc: UsersService;
+
+  beforeEach(() => {
+    prisma = mockPrismaClient();
+    svc = new UsersService(
+      prisma as any,
+      { get: () => undefined } as any,
+      {} as any,
+      { getForTenant: jest.fn().mockResolvedValue({ features: {}, limits: {}, integrations: {}, computedAt: '' }) } as any,
+    );
+    (prisma.$transaction as any).mockImplementation(async (cb: any) => cb(prisma));
+    (prisma.user.updateMany as any).mockResolvedValue({ count: 1 });
+    (prisma.user.findUnique as any).mockResolvedValue({ id: 'target', role: 'ADMIN', status: 'ACTIVE' });
+    (prisma.refreshToken.updateMany as any).mockResolvedValue({ count: 0 });
+    (prisma.userActivity.create as any).mockResolvedValue({});
+    (prisma.user.count as any).mockResolvedValue(2); // other admins exist → last-admin guard passes
+  });
+
+  const manager = { id: 'mgr-1', role: 'MANAGER' };
+  const admin = { id: 'adm-1', role: 'ADMIN' };
+  const adminTarget = { id: 'adm-2', role: 'ADMIN', email: 'a@x.y', status: 'ACTIVE' };
+  const waiterTarget = { id: 'w-1', role: 'WAITER', email: 'w@x.y', status: 'ACTIVE' };
+
+  it('forbids a MANAGER from changing an ADMIN password (the account-takeover vector)', async () => {
+    (prisma.user.findFirst as any).mockResolvedValue(adminTarget);
+    await expect(
+      svc.update('adm-2', { password: 'Hijacked1' } as any, 't1', manager),
+    ).rejects.toBeInstanceOf(ForbiddenException);
+    expect(prisma.user.updateMany).not.toHaveBeenCalled();
+  });
+
+  it('forbids a MANAGER from changing an ADMIN email', async () => {
+    (prisma.user.findFirst as any).mockResolvedValue(adminTarget);
+    await expect(
+      svc.update('adm-2', { email: 'attacker@x.y' } as any, 't1', manager),
+    ).rejects.toBeInstanceOf(ForbiddenException);
+    expect(prisma.user.updateMany).not.toHaveBeenCalled();
+  });
+
+  it('lets a MANAGER update a non-admin (WAITER)', async () => {
+    (prisma.user.findFirst as any).mockResolvedValue(waiterTarget);
+    await expect(
+      svc.update('w-1', { firstName: 'New' } as any, 't1', manager),
+    ).resolves.toBeDefined();
+    expect(prisma.user.updateMany).toHaveBeenCalled();
+  });
+
+  it('lets an ADMIN reset another ADMIN password', async () => {
+    (prisma.user.findFirst as any).mockResolvedValue(adminTarget);
+    await expect(
+      svc.update('adm-2', { password: 'Reset123' } as any, 't1', admin),
+    ).resolves.toBeDefined();
+    expect(prisma.user.updateMany).toHaveBeenCalled();
+  });
+
+  it('forbids a MANAGER from removing (deactivating) an ADMIN', async () => {
+    (prisma.user.findFirst as any).mockResolvedValue(adminTarget);
+    await expect(svc.remove('adm-2', 't1', manager)).rejects.toBeInstanceOf(
+      ForbiddenException,
+    );
+    expect(prisma.user.updateMany).not.toHaveBeenCalled();
+  });
+
+  it('lets an ADMIN remove another ADMIN (subject to the last-admin guard)', async () => {
+    (prisma.user.findFirst as any).mockResolvedValue(adminTarget);
+    await expect(svc.remove('adm-2', 't1', admin)).resolves.toBeDefined();
+    expect(prisma.user.updateMany).toHaveBeenCalled();
   });
 });

--- a/backend/src/modules/users/users.service.ts
+++ b/backend/src/modules/users/users.service.ts
@@ -360,6 +360,18 @@ export class UsersService {
       throw new NotFoundException(`User with ID ${id} not found`);
     }
 
+    // Security (audit 2026-07): a lower-privileged actor must not mutate an
+    // ADMIN target. The role-change block below gates only the ROLE field on
+    // the actor's role — credential fields (password/email) and status were
+    // ungated, so a MANAGER could PATCH an ADMIN's password, revoke its
+    // sessions, and log in as that admin (full account takeover). Block any
+    // sub-ADMIN actor from writing to an ADMIN target regardless of field.
+    if (existing.role === UserRole.ADMIN && actor.role !== UserRole.ADMIN) {
+      throw new ForbiddenException(
+        "Only an ADMIN can modify another ADMIN account",
+      );
+    }
+
     // Role changes are privileged: only ADMIN can do them, and nobody can
     // change their own role (avoids "MANAGER promotes self to ADMIN").
     if (dto.role !== undefined && dto.role !== existing.role) {
@@ -477,8 +489,12 @@ export class UsersService {
     });
   }
 
-  async remove(id: string, tenantId: string, actorId: string) {
-    if (id === actorId) {
+  async remove(
+    id: string,
+    tenantId: string,
+    actor: { id: string; role: string },
+  ) {
+    if (id === actor.id) {
       throw new BadRequestException("You cannot delete your own account");
     }
 
@@ -488,6 +504,15 @@ export class UsersService {
     });
     if (!target) {
       throw new NotFoundException(`User with ID ${id} not found`);
+    }
+
+    // Security (audit 2026-07): mirror update()'s privilege boundary — a
+    // MANAGER must not be able to deactivate an ADMIN (it would revoke the
+    // admin's sessions and lock them out). Only an ADMIN removes an ADMIN.
+    if (target.role === UserRole.ADMIN && actor.role !== UserRole.ADMIN) {
+      throw new ForbiddenException(
+        "Only an ADMIN can deactivate another ADMIN account",
+      );
     }
 
     // Cannot deactivate the only remaining active admin.


### PR DESCRIPTION
Remediation from the security / reliability / UX audit + the technical assessment. Every change is TDD'd; full backend suite **4420/4420 green**, typecheck clean.

## Security & correctness (the crown jewels)

**1. Privilege escalation — MANAGER could take over any ADMIN account** (`users.service.ts`)
`PATCH /users/:id` gated only the *role* field on the actor's role; password/email/status were ungated by the target's privilege. A MANAGER could reset an ADMIN's password, revoke its sessions, and log in as that admin. `DELETE /users/:id` had the same gap. Added a target-privilege check to both: a sub-ADMIN actor cannot mutate or deactivate an ADMIN target.

**2. Critical stock-ledger corruption** (`stock-deduction.service.ts`)
Order deduction drew down FIFO `StockBatch` rows but decremented `stockItem.currentStock` only by the *leftover* after batches were exhausted. Since `currentStock` is the authoritative on-hand total that *already includes* batch quantities (purchase-orders.receive + waste-logs both treat it that way), every batch-covered sale left `currentStock` inflated — silently corrupting inventory, defeating the oversell guard, and suppressing low-stock alerts. Now decrements `currentStock` by the full quantity; batches are a cost-only FIFO sub-ledger (mirrors waste-logs). Symmetric with reversal, so cancels no longer mint phantom stock.

## Performance (I/O — the real levers, not language)

**3. Heatmap N+1** (`heatmap.service.ts`) — `getTrafficFlowPaths` issued one query per tracking id (1+N, up to 51/call). Now a single `{trackingId: {in: ids}}` batched query grouped in one pass → 2 queries.

**4. Public QR menu Redis cache** (`menu-cache.service.ts` + `menu-query.service.ts`) — the hottest anonymous read (deep nested categories→products→modifiers on every scan) is now cached (30s TTL, degrade-only: falls back to the DB when Redis is unset/errors — never a failed request). The per-request table lookup stays uncached and is merged onto the cached base, so one entry serves every table.

## Scale-out hardening (safe / opt-in)

**5. Advisory locks on 4 unlocked crons** — `demo.resetDemoData` (destructive wipe/reseed), `paymentTerminal.recoverApprovedUnrecorded`, `productMedia.pollPendingJobs`, `product3d.pollPendingModels` would double-fire on every replica. Wrapped in the existing `withAdvisoryLock` helper.

**6. Socket.IO adapter fail-closed (opt-in)** (`redis-io.adapter.ts`) — silently latched to the in-memory adapter on Redis loss (drops cross-replica realtime events). New `SOCKET_ADAPTER_REQUIRE_REDIS=true` makes a missing/failed adapter crash boot (restart retries) for multi-replica operators. Default = unchanged single-node degrade-only behaviour.

## Deliberately deferred (with rationale — NOT done here)

- **Reports `paidAt`/SQL/index** — every option risks a prod financial surface: `paidAt` switch silently changes report semantics; a new index taxes the hot order-write path (Order already has 15 indexes); raw-SQL `date_trunc` has timezone-regression risk. Rare admin path, not CPU-bound. Needs a query-plan review + a call on report time-semantics.
- **Redis-backed rate limiter** — scale-out only (limits multiply by replica count); irrelevant single-instance, adds a dep + routes the auth-throttle through Redis. Do right before scaling past 1 replica.
- **bcryptjs → @node-rs/bcrypt** — marginal: bcryptjs is main-thread but cold (throttled logins, ~7% CPU). Native binary dep for event-loop offload on a rare path is premature on a compute-idle single box.

## Verification
- `jest`: 469 suites, **4420 tests pass**
- `tsc --noEmit`: clean (after `prisma generate`)
- `eslint`: clean (local CRLF noise only; git stores LF)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DrvuteKh6F7YXV3GhD78p3