### PR TITLE
fix(auth): www.hummytummy.com üzerinden sessiz login başarısızlığı

### DIFF
--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -140,9 +140,23 @@ async function bootstrap() {
 
   app.setGlobalPrefix("api");
 
-  const allowedOrigins = process.env.CORS_ORIGIN
+  const baseOrigins = process.env.CORS_ORIGIN
     ? process.env.CORS_ORIGIN.split(",")
     : ["http://localhost:5173", "http://localhost:5179"];
+  // Belt & braces for the canonical-host redirect: the SPA is also reachable
+  // on the www vhost, and a cached bundle there may still fire API calls from
+  // the www origin. Auto-allow the `www.` twin of every configured origin so
+  // those requests don't die in CORS (login used to fail silently on www).
+  const allowedOrigins = baseOrigins.flatMap((o) => {
+    try {
+      const u = new URL(o.trim());
+      if (u.hostname.startsWith("www.") || u.hostname === "localhost")
+        return [o.trim()];
+      return [o.trim(), `${u.protocol}//www.${u.host}`];
+    } catch {
+      return [o.trim()];
+    }
+  });
 
   // v2.8.94 — explicit tenant-subdomain regex with structural caps and
   // a reserved-name deny-list. Pre-fix `[a-z0-9-]+` matched any length

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2,7 +2,26 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <script>
+      // Canonical host: the SPA is reachable on www.hummytummy.com (default
+      // vhost), but the API + auth cookies live on the apex — cross-origin
+      // calls from www die in CORS and login silently fails. Bounce to the
+      // apex BEFORE the app boots, preserving the full path.
+      (function () {
+        var h = window.location.hostname;
+        if (h.indexOf("www.") === 0) {
+          window.location.replace(
+            window.location.protocol +
+              "//" +
+              h.slice(4) +
+              window.location.pathname +
+              window.location.search +
+              window.location.hash,
+          );
+        }
+      })();
+    </script>
+    <link rel="icon" type="image/png" href="/logo.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="HummyTummy — bulut tabanlı restoran yönetim sistemi. QR menü, POS, mutfak ekranı (KDS), sipariş & masa yönetimi, stok ve raporlar tek panelde. Cloud-based restaurant management: QR menu, POS, kitchen display, orders, inventory & reports." />
     <link rel="preconnect" href="https://fonts.googleapis.com">


### PR DESCRIPTION
## Kök neden
SPA `www.hummytummy.com`'da da servis ediliyor (443'te default vhost'a düşüyor) ama API mutlak `https://hummytummy.com/api` adresine gidiyor. `www` origin'i CORS allowlist'inde olmadığından **login isteği preflight'ta ölüyor ve ekranda hiçbir hata görünmüyor** — www ile gelen herkes (eski link/Google araması/alışkanlıkla www yazan) giremiyordu.

Headless tarayıcıyla reproduce edildi:
```
www.hummytummy.com/login → POST hummytummy.com/api/auth/login
→ 'blocked by CORS policy' → toast YOK, sayfada kalıyor
```
Apex üzerinden login üç senaryoda sağlıklı kanıtlandı (taze hesap 201→/dashboard, bayat oturum, yanlış şifre düzgün 401).

## Düzeltme
1. **frontend/index.html**: uygulama boot olmadan çalışan kanonik host script'i — `www.*` → apex `location.replace` (path/query/hash korunur).
2. **backend CORS**: `CORS_ORIGIN`'deki her origin'in `www.` ikizi otomatik allowlist'e eklenir (redirect yayılana kadar cache'lenmiş www bundle'ları için).
3. Login sayfasındaki 404: olmayan `/vite.svg` favicon → `/logo.png`.

## Not
Kalıcı altyapı çözümü olarak host nginx'ine 443 için `www → apex 301` eklemek (veya Cloudflare redirect rule) iyi olur — bu PR uygulama katmanında sorunu tamamen kapatıyor.