### PR TITLE
style(backend): fix prettier lint errors blocking v3.2.102 deploy

### DIFF
--- a/backend/src/modules/accounting/services/sales-invoice.service.ts
+++ b/backend/src/modules/accounting/services/sales-invoice.service.ts
@@ -359,29 +359,29 @@ export class SalesInvoiceService {
     const invoiceItems = payment.orderItemPayments
       .filter((alloc) => alloc.orderItem?.product?.productType !== "COMBO")
       .map((alloc) => {
-      const item = alloc.orderItem;
-      if (!item.quantity || item.quantity <= 0) {
-        throw new BadRequestException(
-          `Invoice cannot be generated: order item "${item.product?.name ?? item.id}" has non-positive quantity`,
-        );
-      }
-      const lineTotal = Number(alloc.amount);
-      const taxRate = item.taxRate ?? 10;
-      const tax = this.taxService.extractTax(lineTotal, taxRate);
-      return {
-        description: item.product?.name || "Ürün",
-        quantity: alloc.quantity,
-        unitPrice:
-          alloc.quantity > 0
-            ? Math.round((tax.subtotalExcludingTax / alloc.quantity) * 100) /
-              100
-            : 0,
-        taxRate,
-        taxAmount: tax.taxAmount,
-        subtotal: tax.subtotalExcludingTax,
-        total: lineTotal,
-      };
-    });
+        const item = alloc.orderItem;
+        if (!item.quantity || item.quantity <= 0) {
+          throw new BadRequestException(
+            `Invoice cannot be generated: order item "${item.product?.name ?? item.id}" has non-positive quantity`,
+          );
+        }
+        const lineTotal = Number(alloc.amount);
+        const taxRate = item.taxRate ?? 10;
+        const tax = this.taxService.extractTax(lineTotal, taxRate);
+        return {
+          description: item.product?.name || "Ürün",
+          quantity: alloc.quantity,
+          unitPrice:
+            alloc.quantity > 0
+              ? Math.round((tax.subtotalExcludingTax / alloc.quantity) * 100) /
+                100
+              : 0,
+          taxRate,
+          taxAmount: tax.taxAmount,
+          subtotal: tax.subtotalExcludingTax,
+          total: lineTotal,
+        };
+      });
 
     const subtotal = invoiceItems.reduce((s, i) => s + i.subtotal, 0);
     const taxAmount = invoiceItems.reduce((s, i) => s + i.taxAmount, 0);
@@ -660,8 +660,7 @@ export class SalesInvoiceService {
     }
 
     const settings = await this.settingsService.findByTenant(tenantId);
-    const neg = (v: Prisma.Decimal | number | string) =>
-      -Math.abs(Number(v));
+    const neg = (v: Prisma.Decimal | number | string) => -Math.abs(Number(v));
     const negBreakdown = (tb: any) => {
       if (!tb || typeof tb !== "object") return tb ?? undefined;
       const out: Record<string, any> = {};

--- a/backend/src/modules/orders/services/orders.service.ts
+++ b/backend/src/modules/orders/services/orders.service.ts
@@ -310,9 +310,14 @@ export class OrdersService {
       const normalizedSelections = (item.comboSelections ?? []).map((sel) => {
         if (sel.groupId) return sel;
         const g = catalog.groups.find((gr) =>
-          gr.items.some((it) => it.componentProductId === sel.componentProductId),
+          gr.items.some(
+            (it) => it.componentProductId === sel.componentProductId,
+          ),
         );
-        return { groupId: g?.id ?? "", componentProductId: sel.componentProductId };
+        return {
+          groupId: g?.id ?? "",
+          componentProductId: sel.componentProductId,
+        };
       });
 
       let exploded;

--- a/backend/src/modules/orders/services/receipt-snapshot.builder.ts
+++ b/backend/src/modules/orders/services/receipt-snapshot.builder.ts
@@ -136,7 +136,9 @@ export class ReceiptSnapshotBuilder {
         lines.push({
           name: item.product.name,
           quantity: item.quantity,
-          unitPrice: fmt(item.quantity > 0 ? comboTotal / item.quantity : comboTotal),
+          unitPrice: fmt(
+            item.quantity > 0 ? comboTotal / item.quantity : comboTotal,
+          ),
           totalPrice: fmt(comboTotal),
           modifiers: kids.map((k) => k.product.name),
           notes: item.notes ?? null,


### PR DESCRIPTION
The combo+backoffice merge (PR #284) preserved pre-merge indentation and line-widths that violate the `prettier/prettier` eslint rule. `lint:ci` (eslint **without** `--fix`) treats these as errors, which failed the "Backend lint + typecheck + tests" quality gate and blocked the v3.2.102 release deploy.

Fix: ran `eslint --fix` on the 3 affected files (sales-invoice leaf-filter `.filter()` nesting + long combo lines in orders.service / receipt-snapshot). **No logic change** — pure formatting (`git diff --ignore-all-space` shows only line-wrapping).

Verified locally: `npm run lint:ci` → 0 errors.