### PR TITLE
feat(device-mesh): bridge attach/detach endpoint + unsigned-build visibility

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -292,6 +292,18 @@ jobs:
             Write-Host "✅ Signing completed"
           } else {
             Write-Host "⚠️ Windows certificate not configured, skipping signing"
+            # Surface the unsigned build LOUDLY. A buried log line let unsigned
+            # binaries ship silently — every customer install then hits a
+            # Windows SmartScreen warning. The ::warning:: annotation shows on
+            # the run page + PR checks; the step summary makes it unmissable.
+            Write-Output "::warning title=UNSIGNED Windows build::WINDOWS_CERTIFICATE secret is not configured - this release ships an UNSIGNED .msi/.exe (SmartScreen warns on every install). Set WINDOWS_CERTIFICATE / WINDOWS_CERTIFICATE_PASSWORD to sign."
+            @'
+          ## ⚠️ UNSIGNED Windows build
+
+          `WINDOWS_CERTIFICATE` is not configured, so the Windows installer in this release is **unsigned** — Windows SmartScreen will warn every customer at install time.
+
+          **Fix:** obtain an Authenticode/EV code-signing certificate and set the `WINDOWS_CERTIFICATE` (base64 PFX) and `WINDOWS_CERTIFICATE_PASSWORD` repo secrets; signing then happens automatically.
+          '@ | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
           }
 
       - name: Find and rename artifacts

--- a/backend/src/modules/device-mesh/device.service.spec.ts
+++ b/backend/src/modules/device-mesh/device.service.spec.ts
@@ -321,6 +321,17 @@ describe("DeviceService heartbeat", () => {
     expect(updateArg.data.status).toBe("online");
     expect(updateArg.data.lastSeenAt).toBeInstanceOf(Date);
 
+    // REGRESSION LOCK: every heartbeat must slide tokenExpiresAt forward by
+    // the full token TTL (default 24h). Without the slide an
+    // actively-heartbeating fleet hard-fails authenticateToken() a day after
+    // pairing and every KDS/POS/printer needs a manual re-pair.
+    const slid = updateArg.data.tokenExpiresAt;
+    expect(slid).toBeInstanceOf(Date);
+    const expectedTtlMs = 24 * 3600 * 1000;
+    const delta = slid.getTime() - Date.now();
+    expect(delta).toBeGreaterThan(expectedTtlMs - 60_000);
+    expect(delta).toBeLessThanOrEqual(expectedTtlMs + 60_000);
+
     // Empty payload => no deviceLog row written.
     expect((prisma.deviceLog.create as any).mock.calls.length).toBe(0);
 
@@ -682,5 +693,99 @@ describe("DeviceService slot lifecycle + tallies (branch hub)", () => {
       expect(created).toBe(2);
       expect(create).toHaveBeenCalledTimes(3);
     });
+  });
+});
+
+/**
+ * assignBridge() is the only writer of Device.bridgeId (the topology
+ * parent-link the branch hub + claimNextForBridge fan-in key on). These
+ * specs lock the guards: tenant ownership, branch-scope 404, same-branch
+ * bridge requirement, retired-bridge rejection, and null-detach.
+ */
+describe("DeviceService assignBridge", () => {
+  let prisma: MockPrismaClient;
+  let outbox: { append: jest.Mock };
+  let svc: DeviceService;
+
+  const DEVICE = { id: "dev-1", tenantId: "t1", branchId: "b1" };
+
+  beforeEach(() => {
+    prisma = mockPrismaClient();
+    outbox = { append: jest.fn().mockResolvedValue("outbox-id") };
+    svc = new DeviceService(prisma as any, outbox as any, makeConfig());
+    (prisma.device.findFirst as any).mockResolvedValue(DEVICE);
+    (prisma.device.updateMany as any).mockResolvedValue({ count: 1 });
+    (prisma.device.findFirstOrThrow as any).mockResolvedValue({
+      ...DEVICE,
+      bridgeId: "br-1",
+    });
+  });
+
+  it("attaches the device to a same-branch bridge (tenant-fenced write)", async () => {
+    (prisma.localBridgeAgent.findFirst as any).mockResolvedValue({
+      id: "br-1",
+      branchId: "b1",
+      status: "online",
+    });
+
+    const out = await svc.assignBridge("t1", "dev-1", "br-1");
+
+    // Bridge lookup is tenant-fenced.
+    expect(
+      (prisma.localBridgeAgent.findFirst as any).mock.calls[0][0].where,
+    ).toEqual({ id: "br-1", tenantId: "t1" });
+    // Write carries the compound tenant WHERE (B41-B45 pattern).
+    const write = (prisma.device.updateMany as any).mock.calls[0][0];
+    expect(write.where).toEqual({ id: "dev-1", tenantId: "t1" });
+    expect(write.data).toEqual({ bridgeId: "br-1" });
+    expect(out.bridgeId).toBe("br-1");
+  });
+
+  it("detaches back to cloud-direct with bridgeId=null (no bridge lookup)", async () => {
+    await svc.assignBridge("t1", "dev-1", null);
+    expect((prisma.localBridgeAgent.findFirst as any).mock.calls.length).toBe(
+      0,
+    );
+    const write = (prisma.device.updateMany as any).mock.calls[0][0];
+    expect(write.data).toEqual({ bridgeId: null });
+  });
+
+  it("404s when the branch scope does not match the device branch (no cross-branch probe)", async () => {
+    await expect(
+      svc.assignBridge("t1", "dev-1", "br-1", "OTHER-branch"),
+    ).rejects.toThrow("Device not found");
+    expect((prisma.device.updateMany as any).mock.calls.length).toBe(0);
+  });
+
+  it("404s on an unknown or cross-tenant bridge", async () => {
+    (prisma.localBridgeAgent.findFirst as any).mockResolvedValue(null);
+    await expect(svc.assignBridge("t1", "dev-1", "nope")).rejects.toThrow(
+      "Bridge not found",
+    );
+    expect((prisma.device.updateMany as any).mock.calls.length).toBe(0);
+  });
+
+  it("rejects a retired bridge", async () => {
+    (prisma.localBridgeAgent.findFirst as any).mockResolvedValue({
+      id: "br-1",
+      branchId: "b1",
+      status: "retired",
+    });
+    await expect(svc.assignBridge("t1", "dev-1", "br-1")).rejects.toThrow(
+      /retired/,
+    );
+    expect((prisma.device.updateMany as any).mock.calls.length).toBe(0);
+  });
+
+  it("rejects a bridge in a different branch (a bridge only serves its own LAN)", async () => {
+    (prisma.localBridgeAgent.findFirst as any).mockResolvedValue({
+      id: "br-1",
+      branchId: "OTHER",
+      status: "online",
+    });
+    await expect(svc.assignBridge("t1", "dev-1", "br-1")).rejects.toThrow(
+      /same branch/,
+    );
+    expect((prisma.device.updateMany as any).mock.calls.length).toBe(0);
   });
 });

--- a/backend/src/modules/device-mesh/device.service.ts
+++ b/backend/src/modules/device-mesh/device.service.ts
@@ -677,6 +677,57 @@ export class DeviceService {
     return out;
   }
 
+  /**
+   * Attach a device behind a local bridge — or detach it back to cloud-direct
+   * with `bridgeId = null`. Until now NOTHING wrote Device.bridgeId, so
+   * bridge-fronted hardware (yazarkasa, card terminals) rendered as
+   * cloud-direct in the branch topology and `claimNextForBridge()` could never
+   * fan-in their commands. Guards: the bridge must belong to the same tenant
+   * AND the same branch as the device (a bridge only serves its own LAN) and
+   * must not be retired.
+   */
+  async assignBridge(
+    tenantId: string,
+    deviceId: string,
+    bridgeId: string | null,
+    scopedBranchId?: string,
+  ) {
+    const row = await this.findOrThrow(tenantId, deviceId);
+    // H14 parity: /v1/devices is a branch-scoped surface, so a
+    // branch-restricted caller may only re-home devices in the branch they
+    // are scoped to. 404 (not 403) so the response doesn't confirm the
+    // device exists in another branch.
+    if (scopedBranchId && row.branchId !== scopedBranchId) {
+      throw new NotFoundException("Device not found");
+    }
+    if (bridgeId !== null) {
+      const bridge = await this.prisma.localBridgeAgent.findFirst({
+        where: { id: bridgeId, tenantId },
+        select: { id: true, branchId: true, status: true },
+      });
+      if (!bridge) throw new NotFoundException("Bridge not found");
+      if (bridge.status === "retired") {
+        throw new BadRequestException(
+          "Bridge is retired — provision a new bridge first",
+        );
+      }
+      if (bridge.branchId !== row.branchId) {
+        throw new BadRequestException(
+          "Bridge and device must belong to the same branch",
+        );
+      }
+    }
+    // Compound WHERE on the write (B41-B45 pattern) — see retire() below.
+    const claim = await this.prisma.device.updateMany({
+      where: { id: row.id, tenantId },
+      data: { bridgeId },
+    });
+    if (claim.count === 0) throw new NotFoundException("Device not found");
+    return this.prisma.device.findFirstOrThrow({
+      where: { id: row.id, tenantId },
+    });
+  }
+
   async retire(tenantId: string, deviceId: string) {
     const row = await this.findOrThrow(tenantId, deviceId);
     // Compound WHERE (B41-B45 pattern, iter-31 onward). findOrThrow

--- a/backend/src/modules/device-mesh/devices.controller.ts
+++ b/backend/src/modules/device-mesh/devices.controller.ts
@@ -5,6 +5,7 @@ import {
   ForbiddenException,
   Get,
   Param,
+  Patch,
   Post,
   Query,
   Req,
@@ -27,6 +28,7 @@ import {
   HeartbeatDto,
   EnqueueCommandDto,
   AckCommandDto,
+  AssignBridgeDto,
 } from "./dto/device.dto";
 
 /**
@@ -130,6 +132,30 @@ export class DevicesController {
   @ApiOperation({ summary: "Retire a device (ADMIN only)" })
   retire(@Req() req: any, @Param("id") id: string) {
     return this.devices.retire(req.user.tenantId, id);
+  }
+
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(UserRole.ADMIN, UserRole.MANAGER)
+  @ApiBearerAuth()
+  @Patch(":id/bridge")
+  @ApiOperation({
+    summary:
+      "Attach the device behind a local bridge (bridgeId: null detaches back to cloud-direct)",
+  })
+  assignBridge(
+    @Req() req: any,
+    @Param("id") id: string,
+    @Body() dto: AssignBridgeDto,
+  ) {
+    // H14: forward the validated branch scope so a branch-restricted MANAGER
+    // can only re-home devices in the branch they are scoped to (same
+    // rationale as enqueueCommand above).
+    return this.devices.assignBridge(
+      req.user.tenantId,
+      id,
+      dto.bridgeId ?? null,
+      req.scope?.branchId,
+    );
   }
 
   @UseGuards(JwtAuthGuard, RolesGuard)

--- a/backend/src/modules/device-mesh/dto/device.dto.ts
+++ b/backend/src/modules/device-mesh/dto/device.dto.ts
@@ -12,6 +12,7 @@ import {
   Max,
   MaxLength,
   Min,
+  ValidateIf,
 } from "class-validator";
 import type { CommandKind } from "../device-mesh.types";
 
@@ -192,6 +193,21 @@ export class EnqueueCommandDto {
   @IsString()
   @MaxLength(128)
   idempotencyKey?: string;
+}
+
+export class AssignBridgeDto {
+  // Bridge to attach the device behind, or explicit `null` to detach back to
+  // cloud-direct. The body MUST carry the key (a missing bridgeId 400s) so an
+  // accidental empty PATCH can never silently detach a fleet. String, not
+  // @IsUUID — mirrors branchId handling above.
+  @ApiPropertyOptional({
+    nullable: true,
+    description: "Bridge id, or null to detach",
+  })
+  @ValidateIf((o) => o.bridgeId !== null)
+  @IsString()
+  @MaxLength(64)
+  bridgeId!: string | null;
 }
 
 export class AckCommandDto {


### PR DESCRIPTION
Two hardware-readiness gaps from the electronics roadmap (pure software, no external dependency):

## 1. `Device.bridgeId` had no write path
The schema field existed but **nothing wrote it** — bridge-fronted hardware (yazarkasa, card terminals) rendered as cloud-direct in the branch topology and `claimNextForBridge()` could never fan-in their commands.

**New:** `PATCH /v1/devices/:id/bridge` (ADMIN/MANAGER) attaches a device behind a local bridge, `bridgeId: null` detaches back to cloud-direct.
Guards: tenant-fenced bridge lookup · same-branch requirement (a bridge only serves its own LAN) · retired-bridge rejection · H14 branch-scope 404 · compound tenant WHERE on the write · DTO requires the key explicitly (an empty PATCH can never silently detach a fleet).

## 2. Unsigned Windows builds shipped silently
`desktop-release.yml`: when `WINDOWS_CERTIFICATE` is absent, signing was skipped with a buried log line — unsigned .msi/.exe shipped unnoticed (SmartScreen warns every customer). Now emits a `::warning::` annotation + job-summary banner. Deliberately **non-blocking** until the cert is purchased (Faz 0 / A9); once secrets are set, signing resumes automatically.

## 3. Heartbeat token-TTL slide regression lock
The TTL slide already shipped; added an explicit spec assertion so a refactor can never reintroduce the 'whole fleet re-pairs every 24h' failure.

## Verification
6 new `assignBridge` specs + TTL-slide lock — device-mesh suite **139 green**, tsc clean, `lint:ci` 0 errors, workflow YAML validated.