### PR TITLE
fix(accounting): reverse every invoice on refund + platform-refund credit notes + inventory branch scope

### DIFF
--- a/backend/src/modules/accounting/services/sales-invoice.service.spec.ts
+++ b/backend/src/modules/accounting/services/sales-invoice.service.spec.ts
@@ -450,3 +450,225 @@ describe('SalesInvoiceService.createCreditNote', () => {
     await expect(svc.createCreditNote('inv-1', 't1')).rejects.toThrow();
   });
 });
+
+/**
+ * A2 (analytics/accounting completion): createRefundCreditNote must reverse
+ * EVERY un-reversed invoice on the order (split-bill orders carry one invoice
+ * per Payment), with idempotency keyed PER ORIGINAL via originalInvoiceId —
+ * the old order-level key reversed only the newest invoice and then blocked
+ * the rest. Legacy orders that already carry a pre-semantics REFUND
+ * (originalInvoiceId null) keep the old contract to avoid double-reversal.
+ */
+describe("SalesInvoiceService.createRefundCreditNote (multi-invoice)", () => {
+  let prisma: MockPrismaClient;
+  let svc: SalesInvoiceService;
+
+  const mkOriginal = (id: string) => ({
+    id,
+    type: "SALES",
+    status: "ISSUED",
+    orderId: "o1",
+    invoiceNumber: `INV-${id}`,
+    customerName: null,
+    customerPhone: null,
+    customerEmail: null,
+    customerTaxId: null,
+    customerTaxOffice: null,
+    subtotal: 100,
+    taxAmount: 10,
+    totalAmount: 110,
+    discount: 0,
+    taxBreakdown: null,
+    paymentMethod: "CASH",
+    items: [
+      {
+        description: "Kola",
+        quantity: 1,
+        unitPrice: 100,
+        taxRate: 10,
+        taxAmount: 10,
+        subtotal: 100,
+        total: 110,
+      },
+    ],
+  });
+
+  beforeEach(() => {
+    prisma = mockPrismaClient();
+    const settings: any = {
+      findByTenant: jest
+        .fn()
+        .mockResolvedValue({ autoSync: false, provider: "NONE" }),
+      getNextInvoiceNumber: jest
+        .fn()
+        .mockResolvedValueOnce("CN-1")
+        .mockResolvedValueOnce("CN-2"),
+    };
+    svc = new SalesInvoiceService(
+      prisma as any,
+      settings,
+      new TaxCalculationService(),
+    );
+    (prisma.$transaction as any).mockImplementation(async (cb: any) =>
+      cb(prisma),
+    );
+    (prisma.salesInvoice.create as any).mockImplementation(
+      async ({ data }: any) => ({
+        id: `cn-for-${data.originalInvoiceId}`,
+        ...data,
+        items: data.items.create,
+      }),
+    );
+  });
+
+  it("reverses EVERY un-reversed invoice of a split-bill order, linking each via originalInvoiceId", async () => {
+    // findFirst sequence: legacy-guard → per-original existing checks.
+    (prisma.salesInvoice.findFirst as any)
+      .mockResolvedValueOnce(null) // no legacy refund
+      .mockResolvedValueOnce(null) // i1 not yet reversed
+      .mockResolvedValueOnce(null); // i2 not yet reversed
+    (prisma.salesInvoice.findMany as any).mockResolvedValue([
+      mkOriginal("i1"),
+      mkOriginal("i2"),
+    ]);
+
+    const last = await svc.createRefundCreditNote("o1", "t1");
+
+    const creates = (prisma.salesInvoice.create as any).mock.calls;
+    expect(creates).toHaveLength(2);
+    expect(creates[0][0].data.originalInvoiceId).toBe("i1");
+    expect(creates[1][0].data.originalInvoiceId).toBe("i2");
+    // Reversal is a true negation, tied back to the order.
+    expect(Number(creates[0][0].data.totalAmount)).toBe(-110);
+    expect(creates[0][0].data.orderId).toBe("o1");
+    expect(creates[0][0].data.type).toBe("REFUND");
+    // The note must NOT copy paymentId — the partial unique (one invoice per
+    // payment) belongs to the original.
+    expect(creates[0][0].data.paymentId).toBeUndefined();
+    expect((last as any).originalInvoiceId).toBe("i2");
+  });
+
+  it("is idempotent PER ORIGINAL: an already-reversed invoice is skipped, the other still gets its note", async () => {
+    (prisma.salesInvoice.findFirst as any)
+      .mockResolvedValueOnce(null) // no legacy refund
+      .mockResolvedValueOnce({ id: "cn-old" }) // i1 already reversed
+      .mockResolvedValueOnce(null); // i2 not yet
+    (prisma.salesInvoice.findUnique as any).mockResolvedValue({
+      id: "cn-old",
+      originalInvoiceId: "i1",
+    });
+    (prisma.salesInvoice.findMany as any).mockResolvedValue([
+      mkOriginal("i1"),
+      mkOriginal("i2"),
+    ]);
+
+    await svc.createRefundCreditNote("o1", "t1");
+
+    const creates = (prisma.salesInvoice.create as any).mock.calls;
+    expect(creates).toHaveLength(1);
+    expect(creates[0][0].data.originalInvoiceId).toBe("i2");
+  });
+
+  it("MIGRATION GUARD: a legacy order-level refund (originalInvoiceId null) short-circuits — never double-reverses", async () => {
+    (prisma.salesInvoice.findFirst as any).mockResolvedValueOnce({
+      id: "legacy-cn",
+      type: "REFUND",
+      originalInvoiceId: null,
+    });
+
+    const out = await svc.createRefundCreditNote("o1", "t1");
+
+    expect((out as any).id).toBe("legacy-cn");
+    expect((prisma.salesInvoice.findMany as any).mock.calls).toHaveLength(0);
+    expect((prisma.salesInvoice.create as any).mock.calls).toHaveLength(0);
+  });
+
+  it("returns null when nothing was invoiced", async () => {
+    (prisma.salesInvoice.findFirst as any).mockResolvedValue(null);
+    (prisma.salesInvoice.findMany as any).mockResolvedValue([]);
+    expect(await svc.createRefundCreditNote("o1", "t1")).toBeNull();
+  });
+});
+
+/**
+ * A2 (split-bill partial refund): refunding ONE customer's payment on a
+ * still-open order must reverse only THAT payment's own invoice — the other
+ * customers' invoices stand, so the order-level path would over-reverse.
+ */
+describe("SalesInvoiceService.createRefundCreditNoteForPayment", () => {
+  let prisma: MockPrismaClient;
+  let svc: SalesInvoiceService;
+
+  beforeEach(() => {
+    prisma = mockPrismaClient();
+    const settings: any = {
+      findByTenant: jest
+        .fn()
+        .mockResolvedValue({ autoSync: false, provider: "NONE" }),
+      getNextInvoiceNumber: jest.fn().mockResolvedValue("CN-P1"),
+    };
+    svc = new SalesInvoiceService(
+      prisma as any,
+      settings,
+      new TaxCalculationService(),
+    );
+    (prisma.$transaction as any).mockImplementation(async (cb: any) =>
+      cb(prisma),
+    );
+    (prisma.salesInvoice.create as any).mockImplementation(
+      async ({ data }: any) => ({ id: "cn-p", ...data, items: data.items.create }),
+    );
+  });
+
+  it("reverses the refunded payment's own invoice once (idempotent)", async () => {
+    (prisma.salesInvoice.findFirst as any)
+      .mockResolvedValueOnce({
+        id: "i-pay",
+        type: "SALES",
+        status: "ISSUED",
+        orderId: "o1",
+        invoiceNumber: "INV-i-pay",
+        customerName: null,
+        customerPhone: null,
+        customerEmail: null,
+        customerTaxId: null,
+        customerTaxOffice: null,
+        subtotal: 50,
+        taxAmount: 5,
+        totalAmount: 55,
+        discount: 0,
+        taxBreakdown: null,
+        paymentMethod: "CARD",
+        items: [
+          {
+            description: "Pay share",
+            quantity: 1,
+            unitPrice: 50,
+            taxRate: 10,
+            taxAmount: 5,
+            subtotal: 50,
+            total: 55,
+          },
+        ],
+      })
+      .mockResolvedValueOnce(null); // not yet reversed
+
+    const cn = await svc.createRefundCreditNoteForPayment("pay-1", "t1");
+
+    // Lookup keyed by paymentId + tenant, never order-wide.
+    const firstWhere = (prisma.salesInvoice.findFirst as any).mock.calls[0][0]
+      .where;
+    expect(firstWhere.paymentId).toBe("pay-1");
+    expect(firstWhere.tenantId).toBe("t1");
+    expect((cn as any).originalInvoiceId).toBe("i-pay");
+    expect(Number((cn as any).totalAmount)).toBe(-55);
+  });
+
+  it("no-ops (null) when the payment never had its own invoice", async () => {
+    (prisma.salesInvoice.findFirst as any).mockResolvedValue(null);
+    expect(
+      await svc.createRefundCreditNoteForPayment("pay-x", "t1"),
+    ).toBeNull();
+    expect((prisma.salesInvoice.create as any).mock.calls).toHaveLength(0);
+  });
+});

--- a/backend/src/modules/accounting/services/sales-invoice.service.ts
+++ b/backend/src/modules/accounting/services/sales-invoice.service.ts
@@ -628,15 +628,30 @@ export class SalesInvoiceService {
   }
 
   /**
-   * İade faturası (credit note): a reversing REFUND-type SalesInvoice for a
-   * refunded/cancelled order that already carried an ISSUED fatura. Negates the
-   * original's totals + line items so the two documents net to zero — closing
-   * the compliance gap where a refund left the ISSUED invoice standing with no
-   * reversing record. Idempotent per order; returns null when nothing was
-   * invoiced (a refund of an un-invoiced order needs no credit note).
+   * İade faturası (credit note): reversing REFUND-type SalesInvoice(s) for a
+   * refunded/cancelled order that already carried ISSUED fatura(s).
+   *
+   * Split-bill / progressive orders carry MULTIPLE ISSUED invoices (one per
+   * Payment via createFromPayment, plus possibly an order-level one), so a
+   * full refund must reverse EVERY un-reversed original — the previous
+   * single-findFirst reversed only the newest and its order-level idempotency
+   * key then blocked the rest, leaving standing invoices with no reversing
+   * record. Idempotency is now PER ORIGINAL INVOICE via originalInvoiceId.
+   * Returns the last created/found credit note (single-invoice orders keep
+   * their old contract); null when nothing was invoiced.
    */
   async createRefundCreditNote(orderId: string, tenantId: string) {
-    const original = await this.prisma.salesInvoice.findFirst({
+    // MIGRATION GUARD: a REFUND written before per-invoice semantics has
+    // originalInvoiceId null — which original it reversed is unrecorded, so
+    // re-issuing per-invoice notes could double-reverse. Never risk that:
+    // such orders keep the legacy idempotent contract untouched.
+    const legacy = await this.prisma.salesInvoice.findFirst({
+      where: { orderId, tenantId, type: "REFUND", originalInvoiceId: null },
+      include: { items: true },
+    });
+    if (legacy) return legacy;
+
+    const originals = await this.prisma.salesInvoice.findMany({
       where: {
         orderId,
         tenantId,
@@ -644,12 +659,52 @@ export class SalesInvoiceService {
         type: { not: "REFUND" },
       },
       include: { items: true },
-      orderBy: { createdAt: "desc" },
+      orderBy: { createdAt: "asc" },
     });
-    if (!original) return null; // nothing invoiced → nothing to reverse
+    if (originals.length === 0) return null; // nothing invoiced → nothing to reverse
 
+    let last: Awaited<
+      ReturnType<SalesInvoiceService["createRefundCreditNoteForPayment"]>
+    > = null;
+    for (const original of originals) {
+      last = await this.reverseInvoice(original, tenantId);
+    }
+    return last;
+  }
+
+  /**
+   * Split-bill partial refund: reverse ONLY the refunded Payment's own
+   * per-payment invoice (createFromPayment sets paymentId). The order stays
+   * open (SERVED) and the other customers' invoices must stand, so the
+   * order-level createRefundCreditNote above would over-reverse here.
+   * No-ops (null) when the payment never had its own invoice.
+   */
+  async createRefundCreditNoteForPayment(paymentId: string, tenantId: string) {
+    const original = await this.prisma.salesInvoice.findFirst({
+      where: {
+        paymentId,
+        tenantId,
+        status: { not: InvoiceStatus.CANCELLED },
+        type: { not: "REFUND" },
+      },
+      include: { items: true },
+    });
+    if (!original) return null;
+    return this.reverseInvoice(original, tenantId);
+  }
+
+  /**
+   * Reverse ONE original invoice into a REFUND credit note. Idempotent per
+   * original via originalInvoiceId. The note deliberately does NOT copy
+   * paymentId — the partial unique index (one invoice per payment) belongs to
+   * the original; the link back is originalInvoiceId.
+   */
+  private async reverseInvoice(
+    original: Prisma.SalesInvoiceGetPayload<{ include: { items: true } }>,
+    tenantId: string,
+  ) {
     const existing = await this.prisma.salesInvoice.findFirst({
-      where: { orderId, tenantId, type: "REFUND" },
+      where: { tenantId, type: "REFUND", originalInvoiceId: original.id },
       select: { id: true },
     });
     if (existing) {
@@ -695,7 +750,8 @@ export class SalesInvoiceService {
             totalAmount: neg(original.totalAmount),
             discount: neg(original.discount),
             taxBreakdown: negBreakdown(original.taxBreakdown),
-            orderId,
+            orderId: original.orderId,
+            originalInvoiceId: original.id,
             paymentMethod: original.paymentMethod,
             issueDate: new Date(),
             dueDate: new Date(),

--- a/backend/src/modules/delivery-platforms/delivery-platforms.module.ts
+++ b/backend/src/modules/delivery-platforms/delivery-platforms.module.ts
@@ -8,6 +8,10 @@ import { SubscriptionsModule } from "../subscriptions/subscriptions.module";
 // orders via the SAME device-mesh print rail POS orders use. No cycle:
 // DeviceMeshModule imports only Prisma/LocalBridge/Subscriptions.
 import { DeviceMeshModule } from "../device-mesh/device-mesh.module";
+// AccountingModule provides SalesInvoiceService so a platform-initiated full
+// refund reverses the order's İade faturası (credit note). No cycle:
+// AccountingModule imports only Prisma/Subscriptions.
+import { AccountingModule } from "../accounting/accounting.module";
 
 // Adapters
 import { GetirAdapter } from "./adapters/getir.adapter";
@@ -48,6 +52,7 @@ import { WebhookAuthGuard } from "./guards/webhook-auth.guard";
     forwardRef(() => KdsModule),
     SubscriptionsModule,
     DeviceMeshModule,
+    AccountingModule,
   ],
   controllers: [
     DeliveryPlatformsController,

--- a/backend/src/modules/delivery-platforms/services/delivery-order.service.ts
+++ b/backend/src/modules/delivery-platforms/services/delivery-order.service.ts
@@ -23,6 +23,7 @@ import { CommandQueueService } from "../../device-mesh/command-queue.service";
 import { EscPosBuilderService } from "../../device-mesh/printing/escpos-builder.service";
 import { ReceiptSnapshotBuilder } from "../../orders/services/receipt-snapshot.builder";
 import { OutboxService } from "../../outbox/outbox.service";
+import { SalesInvoiceService } from "../../accounting/services/sales-invoice.service";
 import { captureSwallowedEmit } from "../../../common/observability/capture-swallowed-emit";
 
 /**
@@ -93,6 +94,9 @@ export class DeliveryOrderService {
     // this service bare keep working and a missing bus can never break a
     // refund/amendment write path — the domain-event emit is best-effort.
     @Optional() private readonly outbox?: OutboxService,
+    // @Optional for the same bare-unit-test reason; the credit-note emit on a
+    // platform full-refund is best-effort and must never break the refund write.
+    @Optional() private readonly salesInvoiceService?: SalesInvoiceService,
   ) {}
 
   /**
@@ -876,6 +880,30 @@ export class DeliveryOrderService {
     });
     if (refreshed) {
       this.kdsGateway.emitNewOrder(tenantId, refreshed.branchId, refreshed);
+    }
+
+    // Fiscal reversal: a NEWLY-applied full refund that moved the order to
+    // CANCELLED must reverse any ISSUED fatura with an İade faturası (credit
+    // note), exactly like the POS refund rail (payments.service). Best-effort
+    // + idempotent — an un-invoiced order or missing accounting config no-ops,
+    // and a failure never breaks the already-committed refund write. Without
+    // this, a platform-initiated refund left the sales invoice standing with
+    // no reversing record (GİB compliance gap the POS rail already closed).
+    if (
+      outcome.applied &&
+      (outcome as any).statusChangedToCancelled &&
+      this.salesInvoiceService
+    ) {
+      try {
+        await this.salesInvoiceService.createRefundCreditNote(
+          (outcome as any).orderId,
+          tenantId,
+        );
+      } catch (err: any) {
+        this.logger.error(
+          `Credit-note (İade faturası) generation failed for platform-refunded order ${(outcome as any).orderId}: ${err.message}`,
+        );
+      }
     }
 
     await this.logService.log({

--- a/backend/src/modules/orders/services/payments.service.ts
+++ b/backend/src/modules/orders/services/payments.service.ts
@@ -878,6 +878,22 @@ export class PaymentsService {
             `Credit-note (İade faturası) generation failed for refunded order ${payment.orderId}: ${err.message}`,
           );
         }
+      } else if (this.salesInvoiceService) {
+        // Partial unwind (split-bill / progressive): the order stays open, but
+        // if THIS refunded payment carried its own per-payment invoice
+        // (createFromPayment), that invoice must still be reversed — the other
+        // customers' invoices stand. Best-effort + idempotent; no-ops when the
+        // payment was never individually invoiced.
+        try {
+          await this.salesInvoiceService.createRefundCreditNoteForPayment(
+            id,
+            tenantId,
+          );
+        } catch (err: any) {
+          this.logger.error(
+            `Per-payment credit-note generation failed for refunded payment ${id}: ${err.message}`,
+          );
+        }
       }
 
       return result;

--- a/backend/src/modules/reports/reports.controller.spec.ts
+++ b/backend/src/modules/reports/reports.controller.spec.ts
@@ -73,9 +73,11 @@ describe("ReportsController", () => {
     expect(branchId).toBe("b2");
   });
 
-  it("getInventoryReport just forwards the tenantId", async () => {
-    await ctrl.getInventoryReport(req);
-    expect(svc.getInventoryReport).toHaveBeenCalledWith("t1");
+  it("getInventoryReport threads the branch scope (A4 — was the only report ignoring branchFor)", async () => {
+    await ctrl.getInventoryReport(req, { branchId: "b2" });
+    const [tenantId, branchId] = svc.getInventoryReport.mock.calls[0];
+    expect(tenantId).toBe("t1");
+    expect(branchId).toBe("b2");
   });
 });
 

--- a/backend/src/modules/reports/reports.controller.ts
+++ b/backend/src/modules/reports/reports.controller.ts
@@ -321,8 +321,15 @@ export class ReportsController {
   @Roles(UserRole.ADMIN, UserRole.MANAGER)
   @RequiresFeature(PlanFeature.INVENTORY_TRACKING)
   @ApiOperation({ summary: "Get inventory report (ADMIN, MANAGER)" })
-  async getInventoryReport(@Request() req) {
-    return this.reportsService.getInventoryReport(req.tenantId);
+  async getInventoryReport(@Request() req, @Query() query: DateRangeQueryDto) {
+    // Branch-scope parity with every other report: pre-fix this was the ONLY
+    // endpoint ignoring branchFor, so a branch-restricted MANAGER could read
+    // tenant-wide stock movements. Product stock levels remain tenant-level
+    // by data model (Product has no branchId); movements are branch-scoped.
+    return this.reportsService.getInventoryReport(
+      req.tenantId,
+      this.branchFor(req, query),
+    );
   }
 
   @Get("staff-performance")

--- a/backend/src/modules/reports/reports.service.ts
+++ b/backend/src/modules/reports/reports.service.ts
@@ -1270,8 +1270,10 @@ export class ReportsService {
   /**
    * Get inventory report
    */
-  async getInventoryReport(tenantId: string) {
-    // Get all tracked products
+  async getInventoryReport(tenantId: string, branchId?: string) {
+    // Get all tracked products. Products (and their currentStock) are
+    // tenant-level by data model — no branchId column — so the stock-level
+    // section is deliberately tenant-wide; only movements below carry branch.
     const products = await this.prisma.product.findMany({
       where: {
         tenantId,
@@ -1321,9 +1323,10 @@ export class ReportsService {
     }, 0);
     const totalStockValue = centsToCurrency(totalStockValueCents);
 
-    // Get recent stock movements
+    // Get recent stock movements — branch-scoped when the caller is
+    // branch-restricted (StockMovement.branchId is NOT NULL since v3.0.0).
     const recentMovements = await this.prisma.stockMovement.findMany({
-      where: { tenantId },
+      where: { tenantId, ...(branchId ? { branchId } : {}) },
       take: 20,
       orderBy: { createdAt: "desc" },
       include: {


### PR DESCRIPTION
Mali bütünlük bloğu (analitik+muhasebe tamamlama denetimi, PR 1/12).

## 1. Çoklu-fatura iade tersleme (A2)
Split-bill/progressive siparişler Payment başına fatura taşır; `createRefundCreditNote` yalnız en yenisini tersliyor, order-bazlı idempotens kalanları blokluyordu → ters kaydı olmayan ayakta faturalar. İdempotens artık **fatura-bazlı** (`originalInvoiceId` — şemada vardı, hiç yazılmıyordu). Legacy migration guard: eski usül REFUND'u olan siparişler eski kontratta kalır, asla çift terslenmez. Yeni `createRefundCreditNoteForPayment` partial-unwind'de YALNIZ iade edilen ödemenin kendi faturasını tersler (diğer müşterilerin faturaları ayakta kalır) — payments.service refund rayına bağlandı.

## 2. Platform iadesi artık İade faturası kesiyor (A1)
Platform (YS/Getir/TY/Migros) tam iadesi siparişi CANCELLED yapıyordu ama faturayı hiç terslemiyordu — POS rayının kapattığı uyum açığının aynısı. `applyPlatformRefund` NEWLY-applied+cancel durumunda best-effort+idempotent credit-note keser.

## 3. /reports/inventory şube kapsamı (A4)
`branchFor`'u yok sayan TEK rapor ucu — şube-kısıtlı MANAGER tenant-geneli stok hareketi okuyabiliyordu. Hareketler artık şube-filtreli; ürün stok seviyeleri veri modeli gereği bilinçli tenant-seviyesi (yorumla belgelendi).

## Doğrulama
6 yeni refund-semantiği spec'i + controller branch-threading spec'i; accounting+orders+delivery+reports suite'leri **477 yeşil**, tsc temiz, lint:ci 0 error.