### PR TITLE
feat(expenses,analytics): expense update + period lock + daily insights scheduler

### DIFF
--- a/backend/prisma/migrations/20260712090000_expense_period_lock/down.sql
+++ b/backend/prisma/migrations/20260712090000_expense_period_lock/down.sql
@@ -1,0 +1,5 @@
+-- Rollback for 20260712090000_expense_period_lock.
+-- Tam ters çevirir: yalnızca bu migration'ın eklediği tabloyu (ve onunla
+-- birlikte index'ini) kaldırır. Başka hiçbir tabloya/veriye dokunmaz.
+-- Idempotent: tablo zaten yoksa no-op.
+DROP TABLE IF EXISTS "expense_period_locks";

--- a/backend/prisma/migrations/20260712090000_expense_period_lock/migration.sql
+++ b/backend/prisma/migrations/20260712090000_expense_period_lock/migration.sql
@@ -1,0 +1,13 @@
+-- Accounting period lock for the OpEx ledger: once a (tenant, year, month) is
+-- locked, expense create/update/delete in that month is rejected so closed
+-- books can't drift. Idempotent (IF NOT EXISTS) — safe to re-apply.
+CREATE TABLE IF NOT EXISTS "expense_period_locks" (
+    "id" TEXT NOT NULL,
+    "tenantId" TEXT NOT NULL,
+    "year" INTEGER NOT NULL,
+    "month" INTEGER NOT NULL,
+    "lockedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "lockedByUserId" TEXT,
+    CONSTRAINT "expense_period_locks_pkey" PRIMARY KEY ("id")
+);
+CREATE UNIQUE INDEX IF NOT EXISTS "expense_period_locks_tenantId_year_month_key" ON "expense_period_locks"("tenantId", "year", "month");

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -3500,6 +3500,23 @@ model Budget {
   @@map("budgets")
 }
 
+// Accounting period lock for the OpEx ledger. Once a (tenant, year, month) is
+// locked, any expense create/update/delete whose expenseDate falls in that
+// month is rejected (400 "Dönem kilitli") so closed books can't drift.
+// Tenant-wide by design: the accountant closes the month for the whole
+// company, not per branch. Scalar tenantId (no DB FK) like Expense/Budget.
+model ExpensePeriodLock {
+  id             String   @id @default(uuid())
+  tenantId       String
+  year           Int
+  month          Int // 1-12
+  lockedAt       DateTime @default(now())
+  lockedByUserId String?
+
+  @@unique([tenantId, year, month])
+  @@map("expense_period_locks")
+}
+
 // Accounts-Payable vendor bill. Optionally linked to a PurchaseOrder for the
 // 3-way match (ordered ↔ received/GRN ↔ invoiced): a mismatch beyond tolerance
 // flags DISCREPANCY so it can't be paid blind. taxAmount is the indirilecek KDV

--- a/backend/src/modules/analytics/analytics.module.ts
+++ b/backend/src/modules/analytics/analytics.module.ts
@@ -3,6 +3,7 @@ import { JwtModule } from "@nestjs/jwt";
 import { ConfigModule, ConfigService } from "@nestjs/config";
 import { PrismaModule } from "../../prisma/prisma.module";
 import { AnalyticsController } from "./analytics.controller";
+import { AnalyticsScheduler } from "./analytics.scheduler";
 import { AnalyticsGateway } from "./gateways/analytics.gateway";
 import {
   MockDataGeneratorService,
@@ -41,6 +42,7 @@ import {
     InsightsService,
     CameraService,
     AnalyticsGateway,
+    AnalyticsScheduler,
   ],
   exports: [
     MockDataGeneratorService,

--- a/backend/src/modules/analytics/analytics.scheduler.spec.ts
+++ b/backend/src/modules/analytics/analytics.scheduler.spec.ts
@@ -1,0 +1,160 @@
+import { AnalyticsScheduler } from './analytics.scheduler';
+
+/**
+ * Spec for the nightly AnalyticsScheduler. Covers the real control flow:
+ *  - advisory lock not acquired → no tenant work, no unlock
+ *  - lock acquired → generateInsights per ACTIVE branch of each ACTIVE
+ *    tenant + archiveExpiredInsights per tenant, then releases the lock
+ *  - a failing branch/tenant is isolated (others still processed; no throw)
+ *  - re-entrancy guard (isRunning) skips overlapping runs
+ */
+function makePrisma() {
+  return {
+    $queryRawUnsafe: jest.fn(),
+    tenant: { findMany: jest.fn().mockResolvedValue([]) },
+  };
+}
+
+function makeInsights() {
+  return {
+    generateInsights: jest.fn().mockResolvedValue(0),
+    archiveExpiredInsights: jest.fn().mockResolvedValue(0),
+  };
+}
+
+describe('AnalyticsScheduler.handleDailyInsights', () => {
+  it('does no tenant work and does not unlock when the advisory lock is not acquired', async () => {
+    const prisma = makePrisma();
+    prisma.$queryRawUnsafe.mockResolvedValueOnce([{ locked: false }]);
+    const insights = makeInsights();
+    const sched = new AnalyticsScheduler(prisma as any, insights as any);
+
+    await sched.handleDailyInsights();
+
+    expect(prisma.tenant.findMany).not.toHaveBeenCalled();
+    expect(insights.generateInsights).not.toHaveBeenCalled();
+    expect(insights.archiveExpiredInsights).not.toHaveBeenCalled();
+    // only the try-lock SELECT ran (no unlock) since the lock wasn't held
+    expect(prisma.$queryRawUnsafe).toHaveBeenCalledTimes(1);
+  });
+
+  it('generates insights per ACTIVE branch and archives per tenant, then releases the lock', async () => {
+    const prisma = makePrisma();
+    prisma.$queryRawUnsafe
+      .mockResolvedValueOnce([{ locked: true }]) // acquire
+      .mockResolvedValueOnce([{}]); // unlock
+    prisma.tenant.findMany.mockResolvedValue([
+      { id: 't1', branches: [{ id: 'b1' }, { id: 'b2' }] },
+      { id: 't2', branches: [{ id: 'b3' }] },
+    ]);
+    const insights = makeInsights();
+    const sched = new AnalyticsScheduler(prisma as any, insights as any);
+
+    await sched.handleDailyInsights();
+
+    // generateInsights signature is (tenantId, branchId) — one call per branch
+    expect(insights.generateInsights).toHaveBeenCalledTimes(3);
+    expect(insights.generateInsights).toHaveBeenCalledWith('t1', 'b1');
+    expect(insights.generateInsights).toHaveBeenCalledWith('t1', 'b2');
+    expect(insights.generateInsights).toHaveBeenCalledWith('t2', 'b3');
+    // archive is tenant-wide — one call per tenant
+    expect(insights.archiveExpiredInsights).toHaveBeenCalledTimes(2);
+    expect(insights.archiveExpiredInsights).toHaveBeenCalledWith('t1');
+    expect(insights.archiveExpiredInsights).toHaveBeenCalledWith('t2');
+    // last query is the advisory unlock
+    const lastCall = prisma.$queryRawUnsafe.mock.calls.at(-1)![0] as string;
+    expect(lastCall).toMatch(/pg_advisory_unlock/);
+  });
+
+  it('only loads ACTIVE tenants and their ACTIVE branches', async () => {
+    const prisma = makePrisma();
+    prisma.$queryRawUnsafe
+      .mockResolvedValueOnce([{ locked: true }])
+      .mockResolvedValueOnce([{}]);
+    const sched = new AnalyticsScheduler(prisma as any, makeInsights() as any);
+
+    await sched.handleDailyInsights();
+
+    const arg = prisma.tenant.findMany.mock.calls[0][0];
+    expect(arg.where).toEqual({ status: 'ACTIVE' });
+    expect(arg.select.branches.where).toEqual({ status: 'active' });
+  });
+
+  it('isolates a failing branch so the other branches + the archive still run, without throwing', async () => {
+    const prisma = makePrisma();
+    prisma.$queryRawUnsafe
+      .mockResolvedValueOnce([{ locked: true }])
+      .mockResolvedValueOnce([{}]);
+    prisma.tenant.findMany.mockResolvedValue([
+      { id: 't1', branches: [{ id: 'bad' }, { id: 'good' }] },
+    ]);
+    const insights = makeInsights();
+    insights.generateInsights
+      .mockImplementationOnce(() => Promise.reject(new Error('boom'))) // branch "bad"
+      .mockResolvedValue(0);
+    const sched = new AnalyticsScheduler(prisma as any, insights as any);
+
+    await expect(sched.handleDailyInsights()).resolves.toBeUndefined();
+    expect(insights.generateInsights).toHaveBeenCalledWith('t1', 'good');
+    expect(insights.archiveExpiredInsights).toHaveBeenCalledWith('t1');
+    // lock still released in finally
+    expect(prisma.$queryRawUnsafe.mock.calls.at(-1)![0] as string).toMatch(
+      /pg_advisory_unlock/,
+    );
+  });
+
+  it('isolates a failing archive so the next tenant is still processed', async () => {
+    const prisma = makePrisma();
+    prisma.$queryRawUnsafe
+      .mockResolvedValueOnce([{ locked: true }])
+      .mockResolvedValueOnce([{}]);
+    prisma.tenant.findMany.mockResolvedValue([
+      { id: 't1', branches: [] },
+      { id: 't2', branches: [{ id: 'b2' }] },
+    ]);
+    const insights = makeInsights();
+    insights.archiveExpiredInsights
+      .mockImplementationOnce(() => Promise.reject(new Error('archive boom')))
+      .mockResolvedValue(0);
+    const sched = new AnalyticsScheduler(prisma as any, insights as any);
+
+    await expect(sched.handleDailyInsights()).resolves.toBeUndefined();
+    expect(insights.generateInsights).toHaveBeenCalledWith('t2', 'b2');
+    expect(insights.archiveExpiredInsights).toHaveBeenCalledWith('t2');
+  });
+
+  it('uses a deterministic, stable lockId for both acquire and release', async () => {
+    const prisma = makePrisma();
+    prisma.$queryRawUnsafe
+      .mockResolvedValueOnce([{ locked: true }])
+      .mockResolvedValueOnce([{}]);
+    const sched = new AnalyticsScheduler(prisma as any, makeInsights() as any);
+
+    await sched.handleDailyInsights();
+
+    const acquireSql = prisma.$queryRawUnsafe.mock.calls[0][0] as string;
+    const releaseSql = prisma.$queryRawUnsafe.mock.calls[1][0] as string;
+    const acquireId = acquireSql.match(/pg_try_advisory_lock\((-?\d+)\)/)![1];
+    const releaseId = releaseSql.match(/pg_advisory_unlock\((-?\d+)\)/)![1];
+    expect(acquireId).toBe(releaseId);
+    expect(Number(acquireId)).toBe((sched as any).lockId('analytics-insights'));
+  });
+
+  it('skips overlapping runs via the isRunning re-entrancy guard', async () => {
+    const prisma = makePrisma();
+    let releaseLockQuery: (v: any) => void;
+    prisma.$queryRawUnsafe.mockImplementationOnce(
+      () => new Promise((resolve) => (releaseLockQuery = resolve)),
+    );
+    const insights = makeInsights();
+    const sched = new AnalyticsScheduler(prisma as any, insights as any);
+
+    const first = sched.handleDailyInsights(); // parks on the try-lock query
+    await sched.handleDailyInsights(); // overlapping call → guard returns
+
+    expect(prisma.$queryRawUnsafe).toHaveBeenCalledTimes(1);
+
+    releaseLockQuery!([{ locked: false }]);
+    await first;
+  });
+});

--- a/backend/src/modules/analytics/analytics.scheduler.ts
+++ b/backend/src/modules/analytics/analytics.scheduler.ts
@@ -1,0 +1,102 @@
+import { Injectable, Logger } from "@nestjs/common";
+import { Cron } from "@nestjs/schedule";
+import { PrismaService } from "../../prisma/prisma.service";
+import { InsightsService } from "./services/insights.service";
+
+/**
+ * Nightly insights refresh. InsightsService.generateInsights previously only
+ * ran when a client happened to call the on-demand endpoint — in production
+ * nothing called it, so insights were simply never produced. This cron runs
+ * once a day (03:30, low-traffic window) for every ACTIVE branch of every
+ * ACTIVE tenant, then prunes expired implemented/dismissed insights per
+ * tenant.
+ *
+ * Advisory lock keeps horizontally-scaled replicas from generating duplicate
+ * insights for the same tenants — matches the stock-alerts / z-report /
+ * subscription-scheduler pattern already in use.
+ */
+@Injectable()
+export class AnalyticsScheduler {
+  private readonly logger = new Logger(AnalyticsScheduler.name);
+  private isRunning = false;
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly insightsService: InsightsService,
+  ) {}
+
+  @Cron("30 3 * * *", { name: "analytics-insights-daily" })
+  async handleDailyInsights() {
+    if (this.isRunning) return;
+    this.isRunning = true;
+    try {
+      const [{ locked }] = await this.prisma.$queryRawUnsafe<
+        { locked: boolean }[]
+      >(
+        `SELECT pg_try_advisory_lock(${this.lockId("analytics-insights")}) AS locked`,
+      );
+      if (!locked) {
+        this.logger.debug(
+          "Another replica holds the analytics-insights scheduler lock",
+        );
+        return;
+      }
+
+      try {
+        // Pull every ACTIVE tenant together with its ACTIVE branches in one
+        // query (bounded: tenants × their own branches, no N+1). Insights are
+        // per-branch (they derive from branch-scoped tableAnalytics /
+        // trafficFlowRecord rows), so generation iterates branches; the
+        // expired-insight prune is tenant-wide.
+        const tenants = await this.prisma.tenant.findMany({
+          where: { status: "ACTIVE" },
+          select: {
+            id: true,
+            branches: {
+              where: { status: "active" },
+              select: { id: true },
+            },
+          },
+        });
+
+        for (const tenant of tenants) {
+          for (const branch of tenant.branches) {
+            try {
+              await this.insightsService.generateInsights(tenant.id, branch.id);
+            } catch (err: any) {
+              this.logger.error(
+                `Insight generation failed for tenant ${tenant.id} branch ${branch.id}: ${err?.message}`,
+              );
+            }
+          }
+          try {
+            await this.insightsService.archiveExpiredInsights(tenant.id);
+          } catch (err: any) {
+            this.logger.error(
+              `Insight archival failed for tenant ${tenant.id}: ${err?.message}`,
+            );
+          }
+        }
+      } finally {
+        await this.prisma.$queryRawUnsafe(
+          `SELECT pg_advisory_unlock(${this.lockId("analytics-insights")})`,
+        );
+      }
+    } catch (error: any) {
+      this.logger.error(
+        `Failed to run daily insights job: ${error.message}`,
+        error.stack,
+      );
+    } finally {
+      this.isRunning = false;
+    }
+  }
+
+  private lockId(name: string): number {
+    let hash = 5381;
+    for (let i = 0; i < name.length; i += 1) {
+      hash = ((hash << 5) + hash + name.charCodeAt(i)) | 0;
+    }
+    return hash;
+  }
+}

--- a/backend/src/modules/expenses/dto/lock-period.dto.ts
+++ b/backend/src/modules/expenses/dto/lock-period.dto.ts
@@ -1,0 +1,16 @@
+import { ApiProperty } from "@nestjs/swagger";
+import { IsInt, Max, Min } from "class-validator";
+
+export class LockPeriodDto {
+  @ApiProperty({ example: 2026 })
+  @IsInt()
+  @Min(2000)
+  @Max(2100)
+  year: number;
+
+  @ApiProperty({ example: 6, minimum: 1, maximum: 12 })
+  @IsInt()
+  @Min(1)
+  @Max(12)
+  month: number;
+}

--- a/backend/src/modules/expenses/dto/update-expense.dto.ts
+++ b/backend/src/modules/expenses/dto/update-expense.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from "@nestjs/swagger";
+import { CreateExpenseDto } from "./create-expense.dto";
+
+export class UpdateExpenseDto extends PartialType(CreateExpenseDto) {}

--- a/backend/src/modules/expenses/expenses.controller.ts
+++ b/backend/src/modules/expenses/expenses.controller.ts
@@ -4,8 +4,11 @@ import {
   Delete,
   Get,
   Param,
+  ParseIntPipe,
   ParseUUIDPipe,
+  Patch,
   Post,
+  Put,
   Query,
   UseGuards,
 } from "@nestjs/common";
@@ -17,6 +20,8 @@ import { Roles } from "../auth/decorators/roles.decorator";
 import { UserRole } from "../../common/constants/roles.enum";
 import { ExpensesService } from "./expenses.service";
 import { CreateExpenseDto } from "./dto/create-expense.dto";
+import { UpdateExpenseDto } from "./dto/update-expense.dto";
+import { LockPeriodDto } from "./dto/lock-period.dto";
 import { SetBudgetDto } from "./dto/set-budget.dto";
 import { CurrentScope } from "../auth/decorators/current-scope.decorator";
 import { BranchScope } from "../../common/scoping/branch-scope";
@@ -83,6 +88,42 @@ export class ExpensesController {
       parseInt(year, 10),
       parseInt(month, 10),
     );
+  }
+
+  @Put("period-lock")
+  @Roles(UserRole.ADMIN)
+  @ApiOperation({ summary: "Lock an accounting period (year + month)" })
+  lockPeriod(@CurrentScope() scope: BranchScope, @Body() dto: LockPeriodDto) {
+    return this.service.lockPeriod(scope, dto);
+  }
+
+  @Delete("period-lock/:year/:month")
+  @Roles(UserRole.ADMIN)
+  @ApiOperation({ summary: "Unlock an accounting period" })
+  unlockPeriod(
+    @CurrentScope() scope: BranchScope,
+    @Param("year", ParseIntPipe) year: number,
+    @Param("month", ParseIntPipe) month: number,
+  ) {
+    return this.service.unlockPeriod(scope, year, month);
+  }
+
+  @Get("period-locks")
+  @Roles(UserRole.ADMIN)
+  @ApiOperation({ summary: "List locked accounting periods" })
+  listPeriodLocks(@CurrentScope() scope: BranchScope) {
+    return this.service.listPeriodLocks(scope);
+  }
+
+  @Patch(":id")
+  @Roles(UserRole.ADMIN, UserRole.MANAGER)
+  @ApiOperation({ summary: "Update an expense" })
+  update(
+    @Param("id", ParseUUIDPipe) id: string,
+    @CurrentScope() scope: BranchScope,
+    @Body() dto: UpdateExpenseDto,
+  ) {
+    return this.service.update(scope, id, dto);
   }
 
   @Delete(":id")

--- a/backend/src/modules/expenses/expenses.service.spec.ts
+++ b/backend/src/modules/expenses/expenses.service.spec.ts
@@ -11,6 +11,9 @@ describe('ExpensesService', () => {
         create: jest.fn().mockImplementation(async ({ data }: any) => ({ id: 'e1', ...data })),
         groupBy: jest.fn(),
       },
+      expensePeriodLock: {
+        findUnique: jest.fn().mockResolvedValue(null),
+      },
     };
     svc = new ExpensesService(prisma);
   });
@@ -35,6 +38,183 @@ describe('ExpensesService', () => {
     expect(res.total).toBe(17000);
     expect(res.byCategory[0]).toMatchObject({ category: 'SALARY', amount: 12000, count: 3 });
     expect(res.byCategory[1]).toMatchObject({ category: 'RENT', amount: 5000 });
+  });
+});
+
+describe('ExpensesService.update', () => {
+  const SCOPE = { tenantId: 't1', branchId: 'b1', userId: 'u1', role: 'ADMIN' } as const;
+  let prisma: any;
+  let svc: ExpensesService;
+
+  beforeEach(() => {
+    prisma = {
+      expense: {
+        findFirst: jest.fn().mockResolvedValue({ expenseDate: new Date('2026-06-01T00:00:00Z') }),
+        updateMany: jest.fn().mockResolvedValue({ count: 1 }),
+        findUnique: jest.fn().mockResolvedValue({ id: 'e1', description: 'updated' }),
+      },
+      expensePeriodLock: {
+        findUnique: jest.fn().mockResolvedValue(null),
+      },
+    };
+    svc = new ExpensesService(prisma);
+  });
+
+  it('updates via a branch-scoped compound WHERE on BOTH the pre-read and the mutation (IDOR guard)', async () => {
+    const res = await svc.update(SCOPE, 'e1', { description: 'updated', amount: 250.5 });
+
+    expect(prisma.expense.findFirst.mock.calls[0][0].where).toMatchObject({
+      id: 'e1', tenantId: 't1', branchId: 'b1',
+    });
+    const arg = prisma.expense.updateMany.mock.calls[0][0];
+    expect(arg.where).toEqual({ id: 'e1', tenantId: 't1', branchId: 'b1' });
+    expect(arg.data.description).toBe('updated');
+    expect(arg.data.amount.toString()).toBe('250.5');
+    expect(res).toMatchObject({ id: 'e1' });
+  });
+
+  it('only writes the provided fields (partial update)', async () => {
+    await svc.update(SCOPE, 'e1', { notes: 'n' });
+    const { data } = prisma.expense.updateMany.mock.calls[0][0];
+    expect(Object.keys(data)).toEqual(['notes']);
+  });
+
+  it('404s when the id belongs to another tenant/branch (pre-read misses)', async () => {
+    prisma.expense.findFirst.mockResolvedValue(null);
+    await expect(svc.update(SCOPE, 'foreign', { amount: 1 })).rejects.toThrow('Expense not found');
+    expect(prisma.expense.updateMany).not.toHaveBeenCalled();
+  });
+
+  it('404s when the compound-WHERE mutation claims nothing (pre-read race)', async () => {
+    prisma.expense.updateMany.mockResolvedValue({ count: 0 });
+    await expect(svc.update(SCOPE, 'e1', { amount: 1 })).rejects.toThrow('Expense not found');
+  });
+
+  it("400s 'Dönem kilitli' when the record's current month is locked", async () => {
+    prisma.expensePeriodLock.findUnique.mockResolvedValue({ id: 'lock1' });
+    await expect(svc.update(SCOPE, 'e1', { amount: 1 })).rejects.toThrow('Dönem kilitli');
+    expect(prisma.expense.updateMany).not.toHaveBeenCalled();
+    // lock lookup keyed on the tenant + the existing record's UTC month
+    expect(prisma.expensePeriodLock.findUnique.mock.calls[0][0].where).toEqual({
+      tenantId_year_month: { tenantId: 't1', year: 2026, month: 6 },
+    });
+  });
+
+  it("400s 'Dönem kilitli' when the expense is being MOVED INTO a locked month", async () => {
+    // current month (June) open, target month (May) locked
+    prisma.expensePeriodLock.findUnique
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({ id: 'lock-may' });
+    await expect(
+      svc.update(SCOPE, 'e1', { expenseDate: '2026-05-15' }),
+    ).rejects.toThrow('Dönem kilitli');
+    expect(prisma.expense.updateMany).not.toHaveBeenCalled();
+    expect(prisma.expensePeriodLock.findUnique.mock.calls[1][0].where).toEqual({
+      tenantId_year_month: { tenantId: 't1', year: 2026, month: 5 },
+    });
+  });
+});
+
+describe('ExpensesService create/remove period-lock enforcement', () => {
+  const SCOPE = { tenantId: 't1', branchId: 'b1', userId: 'u1', role: 'ADMIN' } as const;
+
+  it("create 400s 'Dönem kilitli' when the expense date falls in a locked month", async () => {
+    const prisma: any = {
+      expense: { create: jest.fn() },
+      expensePeriodLock: { findUnique: jest.fn().mockResolvedValue({ id: 'lock1' }) },
+    };
+    const svc = new ExpensesService(prisma);
+    await expect(
+      svc.create(SCOPE, 'u1', {
+        category: 'RENT', description: 'June rent', amount: 5000, expenseDate: '2026-06-01',
+      }),
+    ).rejects.toThrow('Dönem kilitli');
+    expect(prisma.expense.create).not.toHaveBeenCalled();
+  });
+
+  it("remove 400s 'Dönem kilitli' for a record inside a locked month (nothing deleted)", async () => {
+    const prisma: any = {
+      expense: {
+        findFirst: jest.fn().mockResolvedValue({ expenseDate: new Date('2026-06-10T00:00:00Z') }),
+        deleteMany: jest.fn(),
+      },
+      expensePeriodLock: { findUnique: jest.fn().mockResolvedValue({ id: 'lock1' }) },
+    };
+    const svc = new ExpensesService(prisma);
+    await expect(svc.remove(SCOPE, 'e1')).rejects.toThrow('Dönem kilitli');
+    expect(prisma.expense.deleteMany).not.toHaveBeenCalled();
+  });
+
+  it('remove still deletes through the branch-scoped compound WHERE when the month is open', async () => {
+    const prisma: any = {
+      expense: {
+        findFirst: jest.fn().mockResolvedValue({ expenseDate: new Date('2026-06-10T00:00:00Z') }),
+        deleteMany: jest.fn().mockResolvedValue({ count: 1 }),
+      },
+      expensePeriodLock: { findUnique: jest.fn().mockResolvedValue(null) },
+    };
+    const svc = new ExpensesService(prisma);
+    await expect(svc.remove(SCOPE, 'e1')).resolves.toEqual({ id: 'e1' });
+    expect(prisma.expense.deleteMany.mock.calls[0][0].where).toEqual({
+      id: 'e1', tenantId: 't1', branchId: 'b1',
+    });
+  });
+
+  it('remove 404s for a cross-branch id without touching the period-lock table', async () => {
+    const prisma: any = {
+      expense: {
+        findFirst: jest.fn().mockResolvedValue(null),
+        deleteMany: jest.fn(),
+      },
+      expensePeriodLock: { findUnique: jest.fn() },
+    };
+    const svc = new ExpensesService(prisma);
+    await expect(svc.remove(SCOPE, 'foreign')).rejects.toThrow('Expense not found');
+    expect(prisma.expensePeriodLock.findUnique).not.toHaveBeenCalled();
+    expect(prisma.expense.deleteMany).not.toHaveBeenCalled();
+  });
+});
+
+describe('ExpensesService period-lock CRUD', () => {
+  const SCOPE = { tenantId: 't1', branchId: 'b1', userId: 'u1', role: 'ADMIN' } as const;
+
+  it('lockPeriod upserts on the (tenant, year, month) natural key recording who locked', async () => {
+    const prisma: any = {
+      expensePeriodLock: { upsert: jest.fn().mockResolvedValue({ id: 'lock1' }) },
+    };
+    const svc = new ExpensesService(prisma);
+    await svc.lockPeriod(SCOPE, { year: 2026, month: 6 });
+
+    const arg = prisma.expensePeriodLock.upsert.mock.calls[0][0];
+    expect(arg.where.tenantId_year_month).toEqual({ tenantId: 't1', year: 2026, month: 6 });
+    expect(arg.create).toMatchObject({ tenantId: 't1', year: 2026, month: 6, lockedByUserId: 'u1' });
+    // idempotent re-lock: no fields are rewritten on conflict
+    expect(arg.update).toEqual({});
+  });
+
+  it('unlockPeriod deletes tenant-scoped and 404s when no lock exists', async () => {
+    const prisma: any = {
+      expensePeriodLock: { deleteMany: jest.fn().mockResolvedValue({ count: 1 }) },
+    };
+    const svc = new ExpensesService(prisma);
+    await expect(svc.unlockPeriod(SCOPE, 2026, 6)).resolves.toEqual({ year: 2026, month: 6 });
+    expect(prisma.expensePeriodLock.deleteMany.mock.calls[0][0].where).toEqual({
+      tenantId: 't1', year: 2026, month: 6,
+    });
+
+    prisma.expensePeriodLock.deleteMany.mockResolvedValue({ count: 0 });
+    await expect(svc.unlockPeriod(SCOPE, 2026, 7)).rejects.toThrow('Period lock not found');
+  });
+
+  it('listPeriodLocks lists only this tenant, newest first', async () => {
+    const prisma: any = {
+      expensePeriodLock: { findMany: jest.fn().mockResolvedValue([]) },
+    };
+    const svc = new ExpensesService(prisma);
+    await svc.listPeriodLocks(SCOPE);
+    const arg = prisma.expensePeriodLock.findMany.mock.calls[0][0];
+    expect(arg.where).toEqual({ tenantId: 't1' });
+    expect(arg.orderBy).toEqual([{ year: 'desc' }, { month: 'desc' }]);
   });
 });
 

--- a/backend/src/modules/expenses/expenses.service.ts
+++ b/backend/src/modules/expenses/expenses.service.ts
@@ -1,4 +1,8 @@
-import { Injectable, NotFoundException } from "@nestjs/common";
+import {
+  BadRequestException,
+  Injectable,
+  NotFoundException,
+} from "@nestjs/common";
 import { Prisma } from "@prisma/client";
 import { PrismaService } from "../../prisma/prisma.service";
 import { BranchScope, branchScope } from "../../common/scoping/branch-scope";
@@ -12,6 +16,8 @@ interface CreateExpenseInput {
   supplierId?: string;
   notes?: string;
 }
+
+type UpdateExpenseInput = Partial<CreateExpenseInput>;
 
 const centsOf = (d: Prisma.Decimal | number | null | undefined) =>
   d == null ? 0 : new Prisma.Decimal(d as any).mul(100).round().toNumber();
@@ -28,6 +34,7 @@ export class ExpensesService {
   constructor(private prisma: PrismaService) {}
 
   async create(scope: BranchScope, userId: string, dto: CreateExpenseInput) {
+    await this.assertPeriodUnlocked(scope.tenantId, new Date(dto.expenseDate));
     return this.prisma.expense.create({
       data: {
         tenantId: scope.tenantId,
@@ -68,12 +75,125 @@ export class ExpensesService {
     });
   }
 
+  /**
+   * Partial update. Same compound-WHERE IDOR guard as remove(): the mutation
+   * itself carries (tenantId, branchId) so a cross-tenant/cross-branch id can
+   * never be claimed even if the pre-read regresses. Period-lock is enforced
+   * on BOTH sides of a date move: the month the record currently sits in and
+   * the month it is being moved into.
+   */
+  async update(scope: BranchScope, id: string, dto: UpdateExpenseInput) {
+    const existing = await this.prisma.expense.findFirst({
+      where: { id, ...branchScope(scope) },
+      select: { expenseDate: true },
+    });
+    if (!existing) throw new NotFoundException("Expense not found");
+
+    await this.assertPeriodUnlocked(scope.tenantId, existing.expenseDate);
+    if (dto.expenseDate !== undefined) {
+      await this.assertPeriodUnlocked(
+        scope.tenantId,
+        new Date(dto.expenseDate),
+      );
+    }
+
+    const data: Prisma.ExpenseUpdateManyMutationInput = {};
+    if (dto.category !== undefined) data.category = dto.category;
+    if (dto.description !== undefined) data.description = dto.description;
+    if (dto.amount !== undefined) data.amount = new Prisma.Decimal(dto.amount);
+    if (dto.taxAmount !== undefined) {
+      data.taxAmount =
+        dto.taxAmount != null ? new Prisma.Decimal(dto.taxAmount) : null;
+    }
+    if (dto.expenseDate !== undefined) {
+      data.expenseDate = new Date(dto.expenseDate);
+    }
+    if (dto.supplierId !== undefined) data.supplierId = dto.supplierId ?? null;
+    if (dto.notes !== undefined) data.notes = dto.notes ?? null;
+
+    const claim = await this.prisma.expense.updateMany({
+      where: { id, ...branchScope(scope) },
+      data,
+    });
+    if (claim.count === 0) throw new NotFoundException("Expense not found");
+    return this.prisma.expense.findUnique({ where: { id } });
+  }
+
   async remove(scope: BranchScope, id: string) {
+    const existing = await this.prisma.expense.findFirst({
+      where: { id, ...branchScope(scope) },
+      select: { expenseDate: true },
+    });
+    if (!existing) throw new NotFoundException("Expense not found");
+    await this.assertPeriodUnlocked(scope.tenantId, existing.expenseDate);
+
     const claim = await this.prisma.expense.deleteMany({
       where: { id, ...branchScope(scope) },
     });
     if (claim.count === 0) throw new NotFoundException("Expense not found");
     return { id };
+  }
+
+  // ── Accounting period locks ────────────────────────────────────────────
+  // Tenant-wide (the accountant closes the month for the whole company).
+  // While a (year, month) is locked, any expense create/update/delete whose
+  // expenseDate falls in that month is rejected with 400 "Dönem kilitli".
+
+  /** Lock a month. Idempotent: re-locking an already-locked month is a no-op. */
+  async lockPeriod(scope: BranchScope, dto: { year: number; month: number }) {
+    return this.prisma.expensePeriodLock.upsert({
+      where: {
+        tenantId_year_month: {
+          tenantId: scope.tenantId,
+          year: dto.year,
+          month: dto.month,
+        },
+      },
+      create: {
+        tenantId: scope.tenantId,
+        year: dto.year,
+        month: dto.month,
+        lockedByUserId: scope.userId,
+      },
+      update: {},
+    });
+  }
+
+  /** Unlock a month. Compound WHERE keeps it tenant-scoped (IDOR guard). */
+  async unlockPeriod(scope: BranchScope, year: number, month: number) {
+    const claim = await this.prisma.expensePeriodLock.deleteMany({
+      where: { tenantId: scope.tenantId, year, month },
+    });
+    if (claim.count === 0) throw new NotFoundException("Period lock not found");
+    return { year, month };
+  }
+
+  /** List this tenant's locked months, newest first. */
+  async listPeriodLocks(scope: BranchScope) {
+    return this.prisma.expensePeriodLock.findMany({
+      where: { tenantId: scope.tenantId },
+      orderBy: [{ year: "desc" }, { month: "desc" }],
+    });
+  }
+
+  /**
+   * Reject the mutation when `date` falls inside a locked month. Uses the
+   * UTC calendar month — expenseDate arrives as an ISO date string
+   * ("2026-06-01" → UTC midnight), so UTC is the axis the row was bucketed
+   * on when it was written.
+   */
+  private async assertPeriodUnlocked(tenantId: string, date: Date) {
+    const lock = await this.prisma.expensePeriodLock.findUnique({
+      where: {
+        tenantId_year_month: {
+          tenantId,
+          year: date.getUTCFullYear(),
+          month: date.getUTCMonth() + 1,
+        },
+      },
+      select: { id: true },
+    });
+    if (lock) throw new BadRequestException("Dönem kilitli");
   }
 
   /** Set (upsert) a monthly budget for a category. */


### PR DESCRIPTION
## Özet
Denetim bulguları B1/B2/C1 için backend tamamlama.

### B1 — Gider güncelleme
- `PATCH /expenses/:id` + `ExpensesService.update`: mevcut `remove()` deseniyle birebir — branch-scoped compound-WHERE (`updateMany`) IDOR guard + ön-okuma + NotFound. Sadece gönderilen alanlar yazılır (kısmi güncelleme).
- `UpdateExpenseDto = PartialType(CreateExpenseDto)`.

### B2 — Dönem kilidi (ExpensePeriodLock)
- Yeni model: `(tenantId, year, month)` unique, `lockedAt`, `lockedByUserId` — tenant genelinde (muhasebeci ayı tüm şirket için kapatır).
- Endpoints (ADMIN): `PUT /expenses/period-lock`, `DELETE /expenses/period-lock/:year/:month`, `GET /expenses/period-locks`.
- Kilitli aya düşen gider create/update/delete → **400 "Dönem kilitli"**. Tarih taşıma durumunda hem kaynak hem hedef ay denetlenir.
- Migration **reversible up/down çifti**: `20260712090000_expense_period_lock/migration.sql` (idempotent, IF NOT EXISTS) + `down.sql` (yalnızca bu tabloyu DROP eder, idempotent).

### C1 — Insights scheduler
- `analytics.scheduler.ts`: günlük 03:30 cron — tüm ACTIVE tenant'ların ACTIVE şubeleri için `generateInsights(tenantId, branchId)` + tenant başına `archiveExpiredInsights(tenantId)`.
- Advisory-lock + `isRunning` guard + şube/tenant başına hata izolasyonu (stock-alerts / z-report scheduler deseni). Insights prod'da daha önce hiç üretilmiyordu (çağıran yoktu).

### Testler / kalite kapıları
- `npx prisma generate` sonrası `npx tsc --noEmit` temiz.
- `npx jest src/modules/expenses src/modules/analytics --silent` → **15 suite / 155 test yeşil** (yeni: update IDOR + branch scope + kilitli dönem 400, kilit CRUD, scheduler lock-skip + tenant döngüsü + hata izolasyonu).
- `npm run lint:ci` → 0 error (yeni dosyalarda uyarı yok).
- Migration up→down→up mantığı SQL düzeyinde gözden geçirildi (up idempotent, down sadece bu migration'ın eklediğini kaldırır).

Frontend'e dokunulmadı.