### PR TITLE
fix(accounting): sync hardening — buyer validation, stuck-SYNCING recovery, VKN format, provider cancel interface

### DIFF
--- a/backend/src/modules/accounting/adapters/accounting-adapter.interface.ts
+++ b/backend/src/modules/accounting/adapters/accounting-adapter.interface.ts
@@ -49,5 +49,19 @@ export interface AccountingAdapter {
     companyId: string,
     invoice: AccountingInvoiceData,
   ): Promise<{ externalId: string }>;
+  /**
+   * Void/cancel an invoice previously pushed to the provider (audit A3).
+   * Never throws for a provider-side refusal — returns `{ success: false,
+   * error }` so the caller can flag the row for manual cancellation.
+   *
+   * GATED: every current implementation is an honest stub returning
+   * `success: false` ("cancel manually in the provider panel") until the
+   * providers' real void/cancel APIs are integrated.
+   */
+  cancelInvoice(
+    accessToken: string,
+    companyId: string,
+    externalInvoiceId: string,
+  ): Promise<{ success: boolean; error?: string }>;
   testConnection(credentials: Record<string, string>): Promise<boolean>;
 }

--- a/backend/src/modules/accounting/adapters/accounting-adapters.spec.ts
+++ b/backend/src/modules/accounting/adapters/accounting-adapters.spec.ts
@@ -337,3 +337,33 @@ describe('ForibaEfaturaAdapter.setApiBase', () => {
     expect(http.post.mock.calls[0][0]).toContain('https://sandbox.foriba.example');
   });
 });
+
+/**
+ * A3 — cancelInvoice GATED stubs. Until the providers' real void/cancel
+ * APIs are integrated, every adapter must HONESTLY refuse (success:false +
+ * a manual-cancel instruction) and must never touch the network — a stub
+ * that pretended success would silently leave live documents at GİB.
+ */
+describe('cancelInvoice — honest GATED stubs (A3)', () => {
+  it.each([
+    ['ParasutAdapter', () => new ParasutAdapter(), /Parasut panel/],
+    ['LogoAdapter', () => new LogoAdapter(), /Logo panel/],
+    [
+      'ForibaEfaturaAdapter',
+      () => new ForibaEfaturaAdapter(),
+      /Foriba panel/,
+    ],
+  ])('%s refuses with a manual-cancel error and no HTTP call', async (_name, make, panelRe) => {
+    const adapter: any = make();
+    const http = fakeHttp();
+    adapter.httpClient = http;
+
+    const out = await adapter.cancelInvoice('tok', 'co-1', 'EXT-1');
+
+    expect(out.success).toBe(false);
+    expect(out.error).toMatch(/cancel API not yet integrated/i);
+    expect(out.error).toMatch(panelRe);
+    expect(http.post).not.toHaveBeenCalled();
+    expect(http.get).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/modules/accounting/adapters/foriba-efatura.adapter.ts
+++ b/backend/src/modules/accounting/adapters/foriba-efatura.adapter.ts
@@ -106,6 +106,22 @@ export class ForibaEfaturaAdapter implements AccountingAdapter {
     return { externalId };
   }
 
+  // GATED: gerçek void API'si sandbox erişimi gelince doldurulacak — GİB
+  // iptal/itiraz akışı (e-Arşiv iptal raporu / e-Fatura red) Foriba üzerinden
+  // entegre edilene kadar DÜRÜST stub: asla "iptal edildi" diye yalan
+  // söylemez, operatöre manuel iptali bildirir.
+  async cancelInvoice(
+    _accessToken: string,
+    _companyId: string,
+    _externalInvoiceId: string,
+  ): Promise<{ success: boolean; error?: string }> {
+    return {
+      success: false,
+      error:
+        "Provider cancel API not yet integrated — cancel manually in the Foriba panel",
+    };
+  }
+
   async testConnection(credentials: Record<string, string>): Promise<boolean> {
     try {
       await this.authenticate(credentials);

--- a/backend/src/modules/accounting/adapters/logo.adapter.ts
+++ b/backend/src/modules/accounting/adapters/logo.adapter.ts
@@ -79,6 +79,21 @@ export class LogoAdapter implements AccountingAdapter {
     return { externalId };
   }
 
+  // GATED: gerçek void API'si sandbox erişimi gelince doldurulacak — Logo'nun
+  // fatura iptal/void servisi entegre edilene kadar DÜRÜST stub: asla "iptal
+  // edildi" diye yalan söylemez, operatöre manuel iptali bildirir.
+  async cancelInvoice(
+    _accessToken: string,
+    _companyId: string,
+    _externalInvoiceId: string,
+  ): Promise<{ success: boolean; error?: string }> {
+    return {
+      success: false,
+      error:
+        "Provider cancel API not yet integrated — cancel manually in the Logo panel",
+    };
+  }
+
   async testConnection(credentials: Record<string, string>): Promise<boolean> {
     try {
       await this.authenticate(credentials);

--- a/backend/src/modules/accounting/adapters/parasut.adapter.ts
+++ b/backend/src/modules/accounting/adapters/parasut.adapter.ts
@@ -106,6 +106,21 @@ export class ParasutAdapter implements AccountingAdapter {
     return { externalId: salesInvoiceId };
   }
 
+  // GATED: gerçek void API'si sandbox erişimi gelince doldurulacak — Paraşüt
+  // sales_invoices #cancel endpoint'i entegre edilene kadar DÜRÜST stub:
+  // asla "iptal edildi" diye yalan söylemez, operatöre manuel iptali bildirir.
+  async cancelInvoice(
+    _accessToken: string,
+    _companyId: string,
+    _externalInvoiceId: string,
+  ): Promise<{ success: boolean; error?: string }> {
+    return {
+      success: false,
+      error:
+        "Provider cancel API not yet integrated — cancel manually in the Parasut panel",
+    };
+  }
+
   async testConnection(credentials: Record<string, string>): Promise<boolean> {
     try {
       await this.authenticate(credentials);

--- a/backend/src/modules/accounting/constants/accounting.enum.ts
+++ b/backend/src/modules/accounting/constants/accounting.enum.ts
@@ -25,3 +25,12 @@ export enum InvoiceType {
   SALES = "SALES",
   REFUND = "REFUND",
 }
+
+/**
+ * A sales invoice stuck in externalStatus=SYNCING for longer than this is
+ * considered crash-stuck (audit A6): the worker died between the SYNCING
+ * claim and the outcome write, so nothing will ever move the row again.
+ * Shared by the resync recovery sweep and the sync-status "stuck" counter
+ * so both use the same definition of "stuck".
+ */
+export const STUCK_SYNCING_THRESHOLD_MS = 15 * 60 * 1000;

--- a/backend/src/modules/accounting/dto/accounting-dtos.spec.ts
+++ b/backend/src/modules/accounting/dto/accounting-dtos.spec.ts
@@ -43,6 +43,53 @@ describe("UpdateAccountingSettingsDto", () => {
       true,
     );
   });
+
+  // V6: nextInvoiceNumber must be ACCEPTED (not stripped) so the operator
+  // can re-align the fiscal counter; the service persists the DTO as-is.
+  it("accepts and coerces a valid nextInvoiceNumber", async () => {
+    const dto = plainToInstance(UpdateAccountingSettingsDto, {
+      nextInvoiceNumber: "42",
+    });
+    expect(await errs(dto)).toEqual([]);
+    expect(dto.nextInvoiceNumber).toBe(42);
+  });
+
+  // A7: the seller tax id rides the sellerTaxId snapshot into every issued
+  // document — a malformed one only surfaces as a GİB rejection after sync,
+  // so it must be shaped like customerTaxId: 10 (VKN) or 11 (TCKN) digits.
+  it("accepts a 10-digit VKN and an 11-digit TCKN companyTaxId (A7)", async () => {
+    expect(
+      await errs(
+        plainToInstance(UpdateAccountingSettingsDto, {
+          companyTaxId: "1234567890",
+        }),
+      ),
+    ).toEqual([]);
+    expect(
+      await errs(
+        plainToInstance(UpdateAccountingSettingsDto, {
+          companyTaxId: "12345678901",
+        }),
+      ),
+    ).toEqual([]);
+  });
+
+  it("rejects a companyTaxId that is not 10/11 digits (A7)", async () => {
+    for (const bad of ["123", "12345678901234", "12345abcde", "12 34567890"]) {
+      const dto = plainToInstance(UpdateAccountingSettingsDto, {
+        companyTaxId: bad,
+      });
+      expect((await errs(dto)).some((m) => /companyTaxId/.test(m))).toBe(true);
+    }
+  });
+
+  it("lets an empty companyTaxId pass (optional field cleared by a form)", async () => {
+    const dto = plainToInstance(UpdateAccountingSettingsDto, {
+      companyTaxId: "",
+    });
+    expect(await errs(dto)).toEqual([]);
+    expect(dto.companyTaxId).toBeUndefined();
+  });
 });
 
 describe("CreateSalesInvoiceDto", () => {

--- a/backend/src/modules/accounting/dto/accounting-settings.dto.ts
+++ b/backend/src/modules/accounting/dto/accounting-settings.dto.ts
@@ -3,12 +3,14 @@ import {
   IsOptional,
   IsString,
   IsInt,
+  Matches,
   Min,
   IsIn,
 } from "class-validator";
 import { ApiPropertyOptional } from "@nestjs/swagger";
 import {
   EmptyStringToNumber,
+  EmptyStringToUndefined,
   StringToBoolean,
 } from "../../../common/dto/transforms";
 
@@ -20,7 +22,20 @@ export class UpdateAccountingSettingsDto {
   autoGenerateInvoice?: boolean;
 
   @ApiPropertyOptional() @IsString() @IsOptional() companyName?: string;
-  @ApiPropertyOptional() @IsString() @IsOptional() companyTaxId?: string;
+  // A7: same VKN/TCKN shape rule as CreateSalesInvoiceDto.customerTaxId — a
+  // malformed seller tax id would ride the sellerTaxId snapshot into every
+  // issued document and only surface as a GİB rejection after sync.
+  // EmptyStringToUndefined lets a form clear the field ("" → skip validation).
+  @ApiPropertyOptional({
+    description: "TR VKN (10 digits) or TCKN (11 digits)",
+  })
+  @EmptyStringToUndefined()
+  @IsString()
+  @IsOptional()
+  @Matches(/^\d{10}(\d)?$/, {
+    message: "companyTaxId must be 10 (VKN) or 11 (TCKN) digits",
+  })
+  companyTaxId?: string;
   @ApiPropertyOptional() @IsString() @IsOptional() companyTaxOffice?: string;
   @ApiPropertyOptional() @IsString() @IsOptional() companyAddress?: string;
   @ApiPropertyOptional() @IsString() @IsOptional() companyPhone?: string;

--- a/backend/src/modules/accounting/schedulers/accounting-resync.scheduler.spec.ts
+++ b/backend/src/modules/accounting/schedulers/accounting-resync.scheduler.spec.ts
@@ -1,0 +1,56 @@
+import { AccountingResyncScheduler } from "./accounting-resync.scheduler";
+
+/**
+ * A6 — the hourly recovery sweep must discover tenants with FAILED
+ * invoices AND tenants whose only broken rows are crash-stuck SYNCING ones
+ * (updatedAt older than the 15-minute threshold). Pre-fix the tenant query
+ * matched FAILED only, so a tenant whose worker died mid-sync never even
+ * entered the sweep and its invoice stayed SYNCING forever.
+ */
+describe("AccountingResyncScheduler.resyncFailed", () => {
+  function build(tenants: Array<{ tenantId: string }>) {
+    const prisma: any = {
+      salesInvoice: { findMany: jest.fn().mockResolvedValue(tenants) },
+    };
+    const sync: any = { resyncFailedInvoices: jest.fn().mockResolvedValue(1) };
+    const scheduler = new AccountingResyncScheduler(prisma, sync);
+    return { prisma, sync, scheduler };
+  }
+
+  it("discovers tenants via FAILED OR stale-SYNCING (15min threshold), distinct + bounded", async () => {
+    const { prisma, scheduler } = build([]);
+
+    const before = Date.now();
+    await scheduler.resyncFailed();
+    const after = Date.now();
+
+    const args = prisma.salesInvoice.findMany.mock.calls[0][0];
+    expect(args.distinct).toEqual(["tenantId"]);
+    expect(args.take).toBe(500);
+
+    const or = args.where.OR;
+    expect(or).toHaveLength(2);
+    expect(or[0]).toEqual({ externalStatus: "FAILED" });
+    expect(or[1].externalStatus).toBe("SYNCING");
+    const cutoff = or[1].updatedAt.lt as Date;
+    expect(cutoff).toBeInstanceOf(Date);
+    expect(cutoff.getTime()).toBeGreaterThanOrEqual(before - 15 * 60 * 1000);
+    expect(cutoff.getTime()).toBeLessThanOrEqual(after - 15 * 60 * 1000);
+  });
+
+  it("retries each discovered tenant's batch independently", async () => {
+    const { sync, scheduler } = build([
+      { tenantId: "t1" },
+      { tenantId: "t2" },
+    ]);
+    sync.resyncFailedInvoices
+      .mockRejectedValueOnce(new Error("tenant boom"))
+      .mockResolvedValueOnce(3);
+
+    await scheduler.resyncFailed(); // must not throw
+
+    expect(sync.resyncFailedInvoices).toHaveBeenCalledTimes(2);
+    expect(sync.resyncFailedInvoices).toHaveBeenCalledWith("t1");
+    expect(sync.resyncFailedInvoices).toHaveBeenCalledWith("t2");
+  });
+});

--- a/backend/src/modules/accounting/schedulers/accounting-resync.scheduler.ts
+++ b/backend/src/modules/accounting/schedulers/accounting-resync.scheduler.ts
@@ -2,12 +2,15 @@ import { Injectable, Logger } from "@nestjs/common";
 import { Cron, CronExpression } from "@nestjs/schedule";
 import { PrismaService } from "../../../prisma/prisma.service";
 import { AccountingSyncService } from "../services/accounting-sync.service";
+import { STUCK_SYNCING_THRESHOLD_MS } from "../constants/accounting.enum";
 
 /**
  * Hourly re-sync of e-documents the provider rejected (externalStatus=FAILED) —
  * the async GİB accept lifecycle's recovery path. Finds tenants with FAILED
- * invoices and retries each tenant's batch; per-tenant + per-invoice failures
- * are isolated so one bad row can't stall the rest.
+ * invoices — or crash-stuck SYNCING ones past the staleness threshold (audit
+ * A6: a worker that died mid-sync leaves the row parked in SYNCING forever) —
+ * and retries each tenant's batch; per-tenant + per-invoice failures are
+ * isolated so one bad row can't stall the rest.
  */
 @Injectable()
 export class AccountingResyncScheduler {
@@ -20,8 +23,20 @@ export class AccountingResyncScheduler {
 
   @Cron(CronExpression.EVERY_HOUR)
   async resyncFailed(): Promise<void> {
+    const stuckBefore = new Date(Date.now() - STUCK_SYNCING_THRESHOLD_MS);
     const tenants = await this.prisma.salesInvoice.findMany({
-      where: { externalStatus: "FAILED" },
+      where: {
+        OR: [
+          { externalStatus: "FAILED" },
+          // A6: crash-stuck SYNCING rows. resyncFailedInvoices releases them
+          // back to FAILED (with a syncError trail) before its retry pass;
+          // without this OR their tenants would never even enter the sweep.
+          {
+            externalStatus: "SYNCING",
+            updatedAt: { lt: stuckBefore },
+          },
+        ],
+      },
       select: { tenantId: true },
       distinct: ["tenantId"],
       take: 500,

--- a/backend/src/modules/accounting/services/accounting-settings.service.spec.ts
+++ b/backend/src/modules/accounting/services/accounting-settings.service.spec.ts
@@ -311,11 +311,12 @@ describe('AccountingSettingsService', () => {
         autoGenerateInvoice: true,
         autoSync: true,
       });
-      // total=10, synced=7, failed=2 → pending = 10 - 7 - 2 = 1
+      // total=10, synced=7, failed=2 → pending = 10 - 7 - 2 = 1; stuck=1
       (prisma.salesInvoice.count as any)
         .mockResolvedValueOnce(10)
         .mockResolvedValueOnce(7)
-        .mockResolvedValueOnce(2);
+        .mockResolvedValueOnce(2)
+        .mockResolvedValueOnce(1);
       (prisma.salesInvoice.findFirst as any).mockResolvedValue({
         syncedAt: new Date('2026-06-24T00:00:00Z'),
       });
@@ -329,9 +330,39 @@ describe('AccountingSettingsService', () => {
         total: 10,
         synced: 7,
         failed: 2,
+        stuck: 1,
         pending: 1,
       });
       expect(out.lastSyncedAt).toEqual(new Date('2026-06-24T00:00:00Z'));
+    });
+
+    it('counts crash-stuck rows as SYNCING older than the 15-minute threshold (A6)', async () => {
+      (prisma.accountingSettings.findFirst as any).mockResolvedValue({
+        tenantId: 't-1',
+        branchId: null,
+        provider: 'FORIBA',
+        autoGenerateInvoice: false,
+        autoSync: true,
+      });
+      (prisma.salesInvoice.count as any).mockResolvedValue(0);
+      (prisma.salesInvoice.findFirst as any).mockResolvedValue(null);
+
+      const before = Date.now();
+      await svc.getSyncStatus('t-1');
+      const after = Date.now();
+
+      // 4th count = the stuck counter: externalStatus SYNCING + updatedAt
+      // older than now-15min (the shared STUCK_SYNCING_THRESHOLD_MS).
+      const stuckWhere = (prisma.salesInvoice.count as any).mock.calls[3][0]
+        .where;
+      expect(stuckWhere.tenantId).toBe('t-1');
+      expect(stuckWhere.externalStatus).toBe('SYNCING');
+      const cutoff = stuckWhere.updatedAt.lt as Date;
+      expect(cutoff).toBeInstanceOf(Date);
+      expect(cutoff.getTime()).toBeGreaterThanOrEqual(
+        before - 15 * 60 * 1000,
+      );
+      expect(cutoff.getTime()).toBeLessThanOrEqual(after - 15 * 60 * 1000);
     });
 
     it('never returns a negative pending count when counts race', async () => {
@@ -346,7 +377,8 @@ describe('AccountingSettingsService', () => {
       (prisma.salesInvoice.count as any)
         .mockResolvedValueOnce(5)
         .mockResolvedValueOnce(6)
-        .mockResolvedValueOnce(2);
+        .mockResolvedValueOnce(2)
+        .mockResolvedValueOnce(0);
       (prisma.salesInvoice.findFirst as any).mockResolvedValue(null);
 
       const out = await svc.getSyncStatus('t-1');

--- a/backend/src/modules/accounting/services/accounting-settings.service.ts
+++ b/backend/src/modules/accounting/services/accounting-settings.service.ts
@@ -6,6 +6,7 @@ import {
   encryptString,
   decryptString,
 } from "../../../common/helpers/encryption.helper";
+import { STUCK_SYNCING_THRESHOLD_MS } from "../constants/accounting.enum";
 
 /**
  * Field names that contain secrets and must be encrypted at rest with
@@ -69,13 +70,23 @@ export class AccountingSettingsService {
    */
   async getSyncStatus(tenantId: string) {
     const settings = await this.findByTenant(tenantId);
-    const [total, synced, failed, last] = await Promise.all([
+    const [total, synced, failed, stuck, last] = await Promise.all([
       this.prisma.salesInvoice.count({ where: { tenantId } }),
       this.prisma.salesInvoice.count({
         where: { tenantId, syncedAt: { not: null } },
       }),
       this.prisma.salesInvoice.count({
         where: { tenantId, syncedAt: null, syncError: { not: null } },
+      }),
+      // A6: crash-stuck mid-flight rows — SYNCING with no write since the
+      // staleness threshold. Same definition the resync recovery sweep uses,
+      // so a non-zero stuck count here self-heals on the next hourly run.
+      this.prisma.salesInvoice.count({
+        where: {
+          tenantId,
+          externalStatus: "SYNCING",
+          updatedAt: { lt: new Date(Date.now() - STUCK_SYNCING_THRESHOLD_MS) },
+        },
       }),
       this.prisma.salesInvoice.findFirst({
         where: { tenantId, syncedAt: { not: null } },
@@ -90,6 +101,7 @@ export class AccountingSettingsService {
       total,
       synced,
       failed,
+      stuck,
       // total - synced - failed; never negative if counts race.
       pending: Math.max(0, total - synced - failed),
       lastSyncedAt: last?.syncedAt ?? null,

--- a/backend/src/modules/accounting/services/accounting-sync.service.spec.ts
+++ b/backend/src/modules/accounting/services/accounting-sync.service.spec.ts
@@ -448,7 +448,10 @@ describe('AccountingSyncService — e-document readiness + FAILED re-sync', () =
 
   it('retries every FAILED invoice and counts the successes', async () => {
     const prisma: any = {
-      salesInvoice: { findMany: jest.fn().mockResolvedValue([{ id: 'i1' }, { id: 'i2' }]) },
+      salesInvoice: {
+        findMany: jest.fn().mockResolvedValue([{ id: 'i1' }, { id: 'i2' }]),
+        updateMany: jest.fn().mockResolvedValue({ count: 0 }),
+      },
     };
     const svc = new AccountingSyncService(prisma, {} as any, mukellef, signer);
     const syncSpy = jest.spyOn(svc, 'syncInvoice').mockResolvedValue(undefined as any);
@@ -462,7 +465,10 @@ describe('AccountingSyncService — e-document readiness + FAILED re-sync', () =
 
   it('keeps going when one invoice re-sync throws', async () => {
     const prisma: any = {
-      salesInvoice: { findMany: jest.fn().mockResolvedValue([{ id: 'i1' }, { id: 'i2' }]) },
+      salesInvoice: {
+        findMany: jest.fn().mockResolvedValue([{ id: 'i1' }, { id: 'i2' }]),
+        updateMany: jest.fn().mockResolvedValue({ count: 0 }),
+      },
     };
     const svc = new AccountingSyncService(prisma, {} as any, mukellef, signer);
     jest.spyOn(svc, 'syncInvoice')
@@ -471,5 +477,327 @@ describe('AccountingSyncService — e-document readiness + FAILED re-sync', () =
 
     const retried = await svc.resyncFailedInvoices('t1');
     expect(retried).toBe(1); // one succeeded, one threw
+  });
+
+  it('A6: releases crash-stuck SYNCING rows (updatedAt older than 15min) back to FAILED before the retry pass', async () => {
+    const prisma: any = {
+      salesInvoice: {
+        findMany: jest.fn().mockResolvedValue([{ id: 'i-stuck' }]),
+        updateMany: jest.fn().mockResolvedValue({ count: 1 }),
+      },
+    };
+    const svc = new AccountingSyncService(prisma, {} as any, mukellef, signer);
+    jest.spyOn(svc, 'syncInvoice').mockResolvedValue(undefined as any);
+
+    const before = Date.now();
+    const retried = await svc.resyncFailedInvoices('t1');
+    const after = Date.now();
+
+    // The release write: SYNCING + stale updatedAt → FAILED + a syncError
+    // trail, tenant-scoped. Fresh SYNCING rows (in-flight syncs) excluded
+    // via the updatedAt cutoff.
+    const release = prisma.salesInvoice.updateMany.mock.calls[0][0];
+    expect(release.where.tenantId).toBe('t1');
+    expect(release.where.externalStatus).toBe('SYNCING');
+    const cutoff = release.where.updatedAt.lt as Date;
+    expect(cutoff).toBeInstanceOf(Date);
+    expect(cutoff.getTime()).toBeGreaterThanOrEqual(before - 15 * 60 * 1000);
+    expect(cutoff.getTime()).toBeLessThanOrEqual(after - 15 * 60 * 1000);
+    expect(release.data.externalStatus).toBe('FAILED');
+    expect(release.data.syncError).toMatch(/stuck SYNCING/i);
+
+    // Release runs BEFORE the FAILED query so just-released rows are
+    // picked up by the same sweep.
+    expect(
+      prisma.salesInvoice.updateMany.mock.invocationCallOrder[0],
+    ).toBeLessThan(prisma.salesInvoice.findMany.mock.invocationCallOrder[0]);
+    expect(retried).toBe(1);
+  });
+});
+
+/**
+ * A5 — validateBuyerFor is WIRED into the sync flow: an e-Fatura with an
+ * incomplete buyer party (missing vergi dairesi) must be failed LOCALLY
+ * (FAILED + syncError) without any provider traffic — invalid XML must
+ * never reach GİB.
+ */
+describe('AccountingSyncService — A5 buyer validation', () => {
+  let prisma: MockPrismaClient;
+  let settings: { findByTenant: jest.Mock; getDecryptedCredentials: jest.Mock };
+  let svc: AccountingSyncService;
+
+  const TENANT = 't-1';
+  const INVOICE_ID = 'inv-1';
+
+  const foribaSettings = {
+    provider: AccountingProvider.FORIBA,
+    foribaApiUrl: 'https://foriba.test',
+    foribaUsername: 'u',
+    foribaPassword: 'p',
+  };
+
+  const eFaturaInvoice = {
+    id: INVOICE_ID,
+    tenantId: TENANT,
+    invoiceNumber: 'FTR-000001',
+    issueDate: new Date('2026-01-15T00:00:00.000Z'),
+    dueDate: null,
+    customerName: 'Acme A.Ş.',
+    customerTaxId: '1234567890', // valid VKN
+    customerTaxOffice: null, // MISSING → e-Fatura buyer party incomplete
+    currency: 'TRY',
+    paymentMethod: 'CARD',
+    totalAmount: 120,
+    externalId: null,
+    externalProvider: null,
+    externalStatus: null,
+    items: [{ description: 'Burger', quantity: 2, unitPrice: 50, taxRate: 10 }],
+  };
+
+  function fakeAdapter() {
+    return {
+      name: 'foriba',
+      authenticate: jest.fn().mockResolvedValue({ accessToken: 'tok' }),
+      pushInvoice: jest.fn().mockResolvedValue({ externalId: 'EXT-999' }),
+      cancelInvoice: jest.fn(),
+      testConnection: jest.fn().mockResolvedValue(true),
+    };
+  }
+
+  beforeEach(() => {
+    prisma = mockPrismaClient();
+    settings = {
+      findByTenant: jest.fn().mockResolvedValue(foribaSettings),
+      getDecryptedCredentials: jest.fn().mockResolvedValue(null),
+    };
+    // mukellef query says the buyer IS a registered e-Fatura user → the
+    // invoice routes to EFATURA, which REQUIRES a complete buyer party.
+    svc = new AccountingSyncService(
+      prisma as any,
+      settings as any,
+      { name: 'MOCK', isRegisteredEFaturaUser: async () => true } as any,
+      { name: 'MOCK', isConfigured: () => true, sign: async (x: string) => x } as any,
+    );
+  });
+
+  it('marks FAILED + syncError and never calls the provider when the e-Fatura buyer party is incomplete', async () => {
+    (prisma.salesInvoice.findFirst as any).mockResolvedValue({
+      ...eFaturaInvoice,
+    });
+    (prisma.salesInvoice.updateMany as any).mockResolvedValue({ count: 1 });
+    const adapter = fakeAdapter();
+    jest.spyOn(svc as any, 'getAdapter').mockReturnValue(adapter);
+
+    await svc.syncInvoice(INVOICE_ID, TENANT); // must not throw
+
+    // NO provider traffic at all — not even auth.
+    expect(adapter.authenticate).not.toHaveBeenCalled();
+    expect(adapter.pushInvoice).not.toHaveBeenCalled();
+
+    // 1st updateMany = SYNCING claim, 2nd = the FAILED write (the existing
+    // re-claimable failure pattern) carrying the human-readable problem.
+    const failCall = (prisma.salesInvoice.updateMany as any).mock.calls[1][0];
+    expect(failCall.where.tenantId).toBe(TENANT);
+    expect(failCall.data.externalStatus).toBe('FAILED');
+    expect(failCall.data.syncError).toMatch(/vergi dairesi/i);
+  });
+
+  it('pushes a COMPLETE registered buyer as EFATURA (validation does not overblock)', async () => {
+    (prisma.salesInvoice.findFirst as any).mockResolvedValue({
+      ...eFaturaInvoice,
+      customerTaxOffice: 'Kadıköy',
+    });
+    (prisma.salesInvoice.updateMany as any).mockResolvedValue({ count: 1 });
+    const adapter = fakeAdapter();
+    jest.spyOn(svc as any, 'getAdapter').mockReturnValue(adapter);
+
+    await svc.syncInvoice(INVOICE_ID, TENANT);
+
+    expect(adapter.pushInvoice).toHaveBeenCalledTimes(1);
+    expect(adapter.pushInvoice.mock.calls[0][2].eDocumentType).toBe('EFATURA');
+    const anyFailedWrite = (
+      prisma.salesInvoice.updateMany as any
+    ).mock.calls.some((c: any[]) => c[0]?.data?.externalStatus === 'FAILED');
+    expect(anyFailedWrite).toBe(false);
+  });
+
+  it('still pushes a B2C sale (no tax id) as EARSIVFATURA — minimal buyer data is valid there', async () => {
+    (prisma.salesInvoice.findFirst as any).mockResolvedValue({
+      ...eFaturaInvoice,
+      customerTaxId: null,
+      customerTaxOffice: null,
+    });
+    (prisma.salesInvoice.updateMany as any).mockResolvedValue({ count: 1 });
+    const adapter = fakeAdapter();
+    jest.spyOn(svc as any, 'getAdapter').mockReturnValue(adapter);
+
+    await svc.syncInvoice(INVOICE_ID, TENANT);
+
+    expect(adapter.pushInvoice).toHaveBeenCalledTimes(1);
+    expect(adapter.pushInvoice.mock.calls[0][2].eDocumentType).toBe(
+      'EARSIVFATURA',
+    );
+  });
+});
+
+/**
+ * A3 — provider-side cancel flow. The adapters are honest GATED stubs
+ * (success:false) until the real void APIs are integrated, so the contract
+ * under test is the SERVICE's: resolve the adapter from the invoice's OWN
+ * externalProvider, and on any failure flag the row CANCEL_PENDING with a
+ * "Manuel iptal gerekli" syncError instead of pretending the cancel worked.
+ */
+describe('AccountingSyncService.cancelInvoiceAtProvider (A3)', () => {
+  let prisma: MockPrismaClient;
+  let settings: { findByTenant: jest.Mock; getDecryptedCredentials: jest.Mock };
+  let svc: AccountingSyncService;
+
+  const TENANT = 't-1';
+  const INVOICE_ID = 'inv-1';
+
+  const foribaSettings = {
+    provider: AccountingProvider.FORIBA,
+    foribaApiUrl: 'https://foriba.test',
+    foribaUsername: 'u',
+    foribaPassword: 'p',
+  };
+
+  const syncedInvoice = {
+    id: INVOICE_ID,
+    tenantId: TENANT,
+    invoiceNumber: 'FTR-000001',
+    externalId: 'EXT-999',
+    externalProvider: AccountingProvider.FORIBA,
+    externalStatus: 'SYNCED',
+  };
+
+  function fakeAdapter() {
+    return {
+      name: 'foriba',
+      authenticate: jest.fn().mockResolvedValue({ accessToken: 'tok' }),
+      pushInvoice: jest.fn(),
+      cancelInvoice: jest.fn().mockResolvedValue({
+        success: false,
+        error:
+          'Provider cancel API not yet integrated — cancel manually in the Foriba panel',
+      }),
+      testConnection: jest.fn().mockResolvedValue(true),
+    };
+  }
+
+  beforeEach(() => {
+    prisma = mockPrismaClient();
+    settings = {
+      findByTenant: jest.fn().mockResolvedValue(foribaSettings),
+      getDecryptedCredentials: jest.fn().mockResolvedValue(null),
+    };
+    svc = new AccountingSyncService(
+      prisma as any,
+      settings as any,
+      { name: 'MOCK', isRegisteredEFaturaUser: async () => false } as any,
+      { name: 'MOCK', isConfigured: () => true, sign: async (x: string) => x } as any,
+    );
+  });
+
+  it('is a successful no-op for an invoice that never reached a provider', async () => {
+    (prisma.salesInvoice.findFirst as any).mockResolvedValue({
+      ...syncedInvoice,
+      externalId: null,
+      externalProvider: null,
+      externalStatus: null,
+    });
+    const adapterSpy = jest.spyOn(svc as any, 'getAdapter');
+
+    const out = await svc.cancelInvoiceAtProvider(INVOICE_ID, TENANT);
+
+    expect(out).toEqual({ success: true });
+    expect(adapterSpy).not.toHaveBeenCalled();
+    expect(prisma.salesInvoice.updateMany).not.toHaveBeenCalled();
+  });
+
+  it('flags CANCEL_PENDING + "Manuel iptal gerekli" when the adapter refuses (the GATED stub path)', async () => {
+    (prisma.salesInvoice.findFirst as any).mockResolvedValue({
+      ...syncedInvoice,
+    });
+    (prisma.salesInvoice.updateMany as any).mockResolvedValue({ count: 1 });
+    const adapter = fakeAdapter();
+    jest.spyOn(svc as any, 'getAdapter').mockReturnValue(adapter);
+
+    const out = await svc.cancelInvoiceAtProvider(INVOICE_ID, TENANT);
+
+    expect(out.success).toBe(false);
+    expect(adapter.cancelInvoice).toHaveBeenCalledWith(
+      'tok',
+      expect.any(String),
+      'EXT-999',
+    );
+    const write = (prisma.salesInvoice.updateMany as any).mock.calls[0][0];
+    expect(write.where).toMatchObject({ id: INVOICE_ID, tenantId: TENANT });
+    expect(write.data.externalStatus).toBe('CANCEL_PENDING');
+    expect(write.data.syncError).toMatch(/^Manuel iptal gerekli: /);
+    expect(write.data.syncError).toContain('cancel manually');
+  });
+
+  it('records CANCELLED + clears syncError when the provider cancel succeeds (future ungated adapters)', async () => {
+    (prisma.salesInvoice.findFirst as any).mockResolvedValue({
+      ...syncedInvoice,
+    });
+    (prisma.salesInvoice.updateMany as any).mockResolvedValue({ count: 1 });
+    const adapter = fakeAdapter();
+    adapter.cancelInvoice.mockResolvedValue({ success: true });
+    jest.spyOn(svc as any, 'getAdapter').mockReturnValue(adapter);
+
+    const out = await svc.cancelInvoiceAtProvider(INVOICE_ID, TENANT);
+
+    expect(out.success).toBe(true);
+    const write = (prisma.salesInvoice.updateMany as any).mock.calls[0][0];
+    expect(write.data.externalStatus).toBe('CANCELLED');
+    expect(write.data.syncError).toBeNull();
+  });
+
+  it('resolves adapter + credentials from the invoice\'s externalProvider, not the CURRENT settings.provider', async () => {
+    // Tenant has since swapped to Parasut, but the document lives at Foriba.
+    settings.findByTenant.mockResolvedValue({
+      ...foribaSettings,
+      provider: AccountingProvider.PARASUT,
+      parasutUsername: 'pu',
+      parasutPassword: 'pp',
+    });
+    (prisma.salesInvoice.findFirst as any).mockResolvedValue({
+      ...syncedInvoice,
+    });
+    (prisma.salesInvoice.updateMany as any).mockResolvedValue({ count: 1 });
+    const adapter = fakeAdapter();
+    const getAdapterSpy = jest
+      .spyOn(svc as any, 'getAdapter')
+      .mockReturnValue(adapter);
+
+    await svc.cancelInvoiceAtProvider(INVOICE_ID, TENANT);
+
+    expect(getAdapterSpy).toHaveBeenCalledWith(AccountingProvider.FORIBA);
+    // The FORIBA credential columns are read, not the active Parasut ones.
+    const creds = adapter.authenticate.mock.calls[0][0];
+    expect(creds).toMatchObject({
+      apiUrl: 'https://foriba.test',
+      username: 'u',
+      password: 'p',
+    });
+  });
+
+  it('flags CANCEL_PENDING when auth/setup throws (provider still holds the document)', async () => {
+    (prisma.salesInvoice.findFirst as any).mockResolvedValue({
+      ...syncedInvoice,
+    });
+    (prisma.salesInvoice.updateMany as any).mockResolvedValue({ count: 1 });
+    const adapter = fakeAdapter();
+    adapter.authenticate.mockRejectedValue(new Error('bad creds'));
+    jest.spyOn(svc as any, 'getAdapter').mockReturnValue(adapter);
+
+    const out = await svc.cancelInvoiceAtProvider(INVOICE_ID, TENANT); // no throw
+
+    expect(out.success).toBe(false);
+    const write = (prisma.salesInvoice.updateMany as any).mock.calls[0][0];
+    expect(write.data.externalStatus).toBe('CANCEL_PENDING');
+    expect(write.data.syncError).toBe('Manuel iptal gerekli: bad creds');
   });
 });

--- a/backend/src/modules/accounting/services/accounting-sync.service.ts
+++ b/backend/src/modules/accounting/services/accounting-sync.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, Logger, Inject } from "@nestjs/common";
 import { PrismaService } from "../../../prisma/prisma.service";
 import { AccountingSettingsService } from "./accounting-settings.service";
-import { resolveEDocumentType } from "../e-document-routing";
+import { resolveEDocumentType, validateBuyerFor } from "../e-document-routing";
 import {
   MUKELLEF_QUERY,
   MukellefQueryProvider,
@@ -17,7 +17,10 @@ import {
 import { ParasutAdapter } from "../adapters/parasut.adapter";
 import { ForibaEfaturaAdapter } from "../adapters/foriba-efatura.adapter";
 import { LogoAdapter } from "../adapters/logo.adapter";
-import { AccountingProvider } from "../constants/accounting.enum";
+import {
+  AccountingProvider,
+  STUCK_SYNCING_THRESHOLD_MS,
+} from "../constants/accounting.enum";
 
 @Injectable()
 export class AccountingSyncService {
@@ -41,11 +44,42 @@ export class AccountingSyncService {
   }
 
   /**
-   * Re-sync invoices the provider previously rejected (externalStatus=FAILED).
+   * Re-sync invoices the provider previously rejected (externalStatus=FAILED),
+   * plus crash-stuck SYNCING rows past the staleness threshold (audit A6).
    * Bounded batch; each retried independently so one failure doesn't stop the
    * rest. Driven by a scheduler + callable on demand.
    */
   async resyncFailedInvoices(tenantId: string, limit = 50): Promise<number> {
+    // A6: release crash-stuck SYNCING claims first. A worker that died
+    // between the SYNCING claim and the outcome write leaves the row
+    // unclaimable forever (the claim allow-list deliberately excludes
+    // SYNCING). Past the staleness threshold we flip it back to FAILED —
+    // with an explicit syncError — so the ordinary FAILED retry below
+    // re-claims it. `updatedAt` in the WHERE means a genuinely in-flight
+    // sync (fresh SYNCING) is never touched. Residual risk, accepted by the
+    // A6 audit decision: if the crash happened AFTER the provider accepted
+    // the push but BEFORE the local SYNCED write (F-Acc-7), the retry can
+    // duplicate the document at the provider — the syncError text records
+    // the recovery so provider-side reconciliation can spot it.
+    const stuckBefore = new Date(Date.now() - STUCK_SYNCING_THRESHOLD_MS);
+    const released = await this.prisma.salesInvoice.updateMany({
+      where: {
+        tenantId,
+        externalStatus: "SYNCING",
+        updatedAt: { lt: stuckBefore },
+      },
+      data: {
+        externalStatus: "FAILED",
+        syncError:
+          "Recovered from stuck SYNCING (worker crashed mid-sync); queued for retry — verify at the provider that no duplicate was pushed",
+      },
+    });
+    if (released.count > 0) {
+      this.logger.warn(
+        `Released ${released.count} crash-stuck SYNCING invoice(s) for tenant ${tenantId} back to FAILED for retry`,
+      );
+    }
+
     const failed = await this.prisma.salesInvoice.findMany({
       where: { tenantId, externalStatus: "FAILED" },
       select: { id: true },
@@ -127,6 +161,35 @@ export class AccountingSyncService {
       const adapter = this.getAdapter(settings.provider);
       if (!adapter) return;
 
+      // Route e-Fatura (B2B) vs e-Arşiv (B2C). isRegisteredEFaturaUser comes
+      // from a GİB mükellef query via the pluggable provider (mock in dev,
+      // HTTP in prod). Registered VKN → e-Fatura, otherwise e-Arşiv — the
+      // safe final-consumer default that never wrongly issues a B2B e-Fatura
+      // the buyer can't receive.
+      const eDocumentType = resolveEDocumentType({
+        taxId: invoice.customerTaxId,
+        taxOffice: invoice.customerTaxOffice,
+        isRegisteredEFaturaUser: invoice.customerTaxId
+          ? await this.mukellefQuery.isRegisteredEFaturaUser(
+              invoice.customerTaxId,
+            )
+          : false,
+      });
+
+      // A5: validate the buyer party for the chosen document type BEFORE any
+      // provider traffic. An e-Fatura with an incomplete
+      // AccountingCustomerParty produces invalid XML that GİB rejects — fail
+      // the sync locally (the throw lands in the FAILED + syncError catch
+      // below, the same re-claimable path as an adapter error) instead of
+      // transmitting a document we already know is bad.
+      const buyerProblems = validateBuyerFor(eDocumentType, {
+        taxId: invoice.customerTaxId,
+        taxOffice: invoice.customerTaxOffice,
+      });
+      if (buyerProblems.length > 0) {
+        throw new Error(`Buyer validation failed: ${buyerProblems.join("; ")}`);
+      }
+
       // The secret credential fields (parasutClientSecret/parasutPassword/
       // logoPassword/foribaPassword) are stored AES-256-GCM encrypted (`v1:…`).
       // findByTenant returns them encrypted; we MUST decrypt before handing
@@ -152,21 +215,8 @@ export class AccountingSyncService {
         customerName: invoice.customerName || undefined,
         customerTaxId: invoice.customerTaxId || undefined,
         customerTaxOffice: invoice.customerTaxOffice || undefined,
-        // Route e-Fatura (B2B) vs e-Arşiv (B2C). isRegisteredEFaturaUser comes
-        // from a GİB mükellef query (needs integrator credentials); unset here
-        // → e-Arşiv, the safe final-consumer default. Wire the query result in
-        // to enable automatic B2B e-Fatura routing.
-        eDocumentType: resolveEDocumentType({
-          taxId: invoice.customerTaxId,
-          taxOffice: invoice.customerTaxOffice,
-          // GİB mükellef check via the pluggable provider (mock in dev, HTTP in
-          // prod). Registered VKN → e-Fatura, otherwise e-Arşiv.
-          isRegisteredEFaturaUser: invoice.customerTaxId
-            ? await this.mukellefQuery.isRegisteredEFaturaUser(
-                invoice.customerTaxId,
-              )
-            : false,
-        }),
+        // Resolved + buyer-validated above (A5) before any provider traffic.
+        eDocumentType,
         withholdingTaxAmount:
           invoice.withholdingTaxAmount != null
             ? Number(invoice.withholdingTaxAmount)
@@ -268,6 +318,96 @@ export class AccountingSyncService {
     }
   }
 
+  /**
+   * A3 — best-effort provider-side void of a locally cancelled invoice.
+   * Locally cancelling a fatura that was already SYNCED leaves the provider
+   * (and thus GİB) holding it as a live document; this pushes the cancel to
+   * the provider it was synced to. Never throws for a provider refusal:
+   * on failure the row is flagged externalStatus=CANCEL_PENDING with a
+   * "Manuel iptal gerekli" syncError so the operator cancels it in the
+   * provider panel. CANCEL_PENDING is deliberately NOT in the sync claim
+   * allow-list, so the resync loop can never re-push a cancelled invoice.
+   *
+   * NOTE: all current adapters ship an honest GATED stub (success:false),
+   * so today every synced cancel lands in CANCEL_PENDING — by design, until
+   * the providers' real void APIs are integrated.
+   */
+  async cancelInvoiceAtProvider(
+    invoiceId: string,
+    tenantId: string,
+  ): Promise<{ success: boolean; error?: string }> {
+    const invoice = await this.prisma.salesInvoice.findFirst({
+      where: { id: invoiceId, tenantId },
+    });
+    if (!invoice) return { success: false, error: "Invoice not found" };
+    // Never reached a provider — nothing external to void.
+    if (!invoice.externalId || !invoice.externalProvider) {
+      return { success: true };
+    }
+
+    // The document lives at the provider it was SYNCED to — which after a
+    // provider swap may differ from the tenant's CURRENT settings.provider —
+    // so the adapter + credentials resolve from the invoice's own
+    // externalProvider, not the settings row's active one.
+    const provider = invoice.externalProvider;
+    const adapter = this.getAdapter(provider);
+    let outcome: { success: boolean; error?: string };
+    if (!adapter) {
+      outcome = {
+        success: false,
+        error: `No adapter available for provider ${provider}`,
+      };
+    } else {
+      try {
+        const settings = await this.settingsService.findByTenant(tenantId);
+        const creds =
+          await this.settingsService.getDecryptedCredentials(tenantId);
+        if (adapter instanceof ForibaEfaturaAdapter) {
+          adapter.setApiBase(((creds ?? settings) as any).foribaApiUrl || "");
+        }
+        const token = await this.getToken(
+          tenantId,
+          creds ?? settings,
+          adapter,
+          provider,
+        );
+        const companyId = this.getCompanyId(creds ?? settings, provider);
+        outcome = await adapter.cancelInvoice(
+          token,
+          companyId,
+          invoice.externalId,
+        );
+      } catch (err: any) {
+        // Auth/setup failure — the provider still holds the document, so it
+        // needs the same manual-cancel flag as an explicit refusal.
+        outcome = { success: false, error: err?.message ?? String(err) };
+      }
+    }
+
+    if (!outcome.success) {
+      this.logger.warn(
+        `Provider-side cancel failed for invoice ${invoice.invoiceNumber} at ${provider}: ${outcome.error}`,
+      );
+      await this.prisma.salesInvoice.updateMany({
+        where: { id: invoiceId, tenantId },
+        data: {
+          externalStatus: "CANCEL_PENDING",
+          syncError: `Manuel iptal gerekli: ${outcome.error ?? "unknown provider error"}`,
+        },
+      });
+      return outcome;
+    }
+
+    await this.prisma.salesInvoice.updateMany({
+      where: { id: invoiceId, tenantId },
+      data: { externalStatus: "CANCELLED", syncError: null },
+    });
+    this.logger.log(
+      `Invoice ${invoice.invoiceNumber} cancelled at ${provider}`,
+    );
+    return outcome;
+  }
+
   private getAdapter(provider: string): AccountingAdapter | null {
     switch (provider) {
       case AccountingProvider.PARASUT:
@@ -286,12 +426,16 @@ export class AccountingSyncService {
     tenantId: string,
     settings: any,
     adapter: AccountingAdapter,
+    // Which provider's credentials to read off the settings row; defaults to
+    // the active settings.provider. cancelInvoiceAtProvider passes the
+    // invoice's own externalProvider (may differ after a provider swap).
+    provider?: string,
   ): Promise<string> {
     const cacheKey = `${tenantId}:${adapter.name}`;
     const cached = this.tokenCache.get(cacheKey);
     if (cached && cached.expiresAt > new Date()) return cached.token;
 
-    const credentials = this.getCredentials(settings);
+    const credentials = this.getCredentials(settings, provider);
     const result = await adapter.authenticate(credentials);
     this.tokenCache.set(cacheKey, {
       token: result.accessToken,
@@ -300,8 +444,11 @@ export class AccountingSyncService {
     return result.accessToken;
   }
 
-  private getCredentials(settings: any): Record<string, string> {
-    switch (settings.provider) {
+  private getCredentials(
+    settings: any,
+    provider: string = settings?.provider,
+  ): Record<string, string> {
+    switch (provider) {
       case AccountingProvider.PARASUT:
         return {
           clientId: settings.parasutClientId || "",
@@ -327,8 +474,11 @@ export class AccountingSyncService {
     }
   }
 
-  private getCompanyId(settings: any): string {
-    switch (settings.provider) {
+  private getCompanyId(
+    settings: any,
+    provider: string = settings?.provider,
+  ): string {
+    switch (provider) {
       case AccountingProvider.PARASUT:
         return settings.parasutCompanyId || "";
       case AccountingProvider.LOGO:

--- a/backend/src/modules/accounting/services/sales-invoice.service.spec.ts
+++ b/backend/src/modules/accounting/services/sales-invoice.service.spec.ts
@@ -450,3 +450,85 @@ describe('SalesInvoiceService.createCreditNote', () => {
     await expect(svc.createCreditNote('inv-1', 't1')).rejects.toThrow();
   });
 });
+
+/**
+ * A3 — cancel() must trigger a best-effort provider-side void AFTER the
+ * local cancel, and a provider/sync failure must never roll back or block
+ * the local cancellation (the sync service flags CANCEL_PENDING on the row
+ * itself; cancel() only logs).
+ */
+describe("SalesInvoiceService.cancel — provider void wiring (A3)", () => {
+  let prisma: MockPrismaClient;
+  let syncService: { cancelInvoiceAtProvider: jest.Mock };
+  let svc: SalesInvoiceService;
+
+  const invoice = { id: "inv-1", tenantId: "t1", status: "ISSUED" };
+
+  beforeEach(() => {
+    prisma = mockPrismaClient();
+    syncService = {
+      cancelInvoiceAtProvider: jest
+        .fn()
+        .mockResolvedValue({ success: false, error: "gated" }),
+    };
+    const settings: any = { findByTenant: jest.fn() };
+    svc = new SalesInvoiceService(
+      prisma as any,
+      settings,
+      new TaxCalculationService(),
+      syncService as any,
+    );
+    (prisma.salesInvoice.findFirst as any).mockResolvedValue({ ...invoice });
+    (prisma.salesInvoice.updateMany as any).mockResolvedValue({ count: 1 });
+    (prisma.salesInvoice.findUniqueOrThrow as any).mockResolvedValue({
+      ...invoice,
+      status: "CANCELLED",
+    });
+  });
+
+  it("calls cancelInvoiceAtProvider AFTER the local cancel claim", async () => {
+    const out = await svc.cancel("inv-1", "t1");
+
+    expect(syncService.cancelInvoiceAtProvider).toHaveBeenCalledWith(
+      "inv-1",
+      "t1",
+    );
+    expect(
+      (prisma.salesInvoice.updateMany as any).mock.invocationCallOrder[0],
+    ).toBeLessThan(
+      syncService.cancelInvoiceAtProvider.mock.invocationCallOrder[0],
+    );
+    expect(out.status).toBe("CANCELLED");
+  });
+
+  it("still cancels locally when the provider void throws (best-effort, logged only)", async () => {
+    syncService.cancelInvoiceAtProvider.mockRejectedValue(
+      new Error("provider exploded"),
+    );
+
+    const out = await svc.cancel("inv-1", "t1");
+
+    expect(out.status).toBe("CANCELLED");
+  });
+
+  it("does not attempt a provider void when the local claim loses (already cancelled)", async () => {
+    (prisma.salesInvoice.updateMany as any).mockResolvedValue({ count: 0 });
+
+    await expect(svc.cancel("inv-1", "t1")).rejects.toThrow(
+      /already cancelled/i,
+    );
+    expect(syncService.cancelInvoiceAtProvider).not.toHaveBeenCalled();
+  });
+
+  it("works without a sync service (optional dependency)", async () => {
+    const settings: any = { findByTenant: jest.fn() };
+    const bare = new SalesInvoiceService(
+      prisma as any,
+      settings,
+      new TaxCalculationService(),
+    );
+
+    const out = await bare.cancel("inv-1", "t1");
+    expect(out.status).toBe("CANCELLED");
+  });
+});

--- a/backend/src/modules/accounting/services/sales-invoice.service.ts
+++ b/backend/src/modules/accounting/services/sales-invoice.service.ts
@@ -624,6 +624,21 @@ export class SalesInvoiceService {
     if (claim.count === 0) {
       throw new BadRequestException("Invoice already cancelled");
     }
+    // A3: after the local cancel, best-effort void at the accounting
+    // provider — a SYNCED fatura left standing at the provider stays a live
+    // legal document there. Failure must never roll back or block the local
+    // cancel; cancelInvoiceAtProvider itself records CANCEL_PENDING +
+    // "Manuel iptal gerekli" on the row for the operator, and any unexpected
+    // throw is only logged.
+    if (this.syncService) {
+      try {
+        await this.syncService.cancelInvoiceAtProvider(id, tenantId);
+      } catch (err: any) {
+        this.logger.error(
+          `Provider-side cancel failed for invoice ${id}: ${err?.message ?? err}`,
+        );
+      }
+    }
     return this.prisma.salesInvoice.findUniqueOrThrow({ where: { id } });
   }
 


### PR DESCRIPTION
Muhasebe senkron sertleştirme — denetim maddeleri A5 / A6 / A7 / V6 / A3. Kapsam yalnız `backend/src/modules/accounting/**` (+ spec'ler); `createRefundCreditNote`/`reverseInvoice` bölgesine dokunulmadı, sales-invoice tarafında yalnız `cancel()` değişti.

## A5 — validateBuyerFor artık bağlı (dead code idi)
- `syncInvoice` içinde eDocumentType çözüldükten sonra, provider'a HİÇBİR trafik gitmeden önce `validateBuyerFor` çağrılıyor.
- Eksik alıcı bilgisi olan e-Fatura (ör. vergi dairesi yok) yerel olarak `externalStatus=FAILED` + `syncError=<mesaj>` ile düşüyor (mevcut FAILED deseni, yeniden denenebilir) — geçersiz XML GİB'e ulaşmıyor.
- B2C (e-Arşiv) satışlar etkilenmiyor; tam bilgili kayıtlı mükellef EFATURA olarak gönderilmeye devam ediyor (aşırı bloklamaya karşı test var).

## A6 — SYNCING'de takılı kalan faturaların kurtarılması
- `resyncFailedInvoices`: retry turundan önce `SYNCING + updatedAt < now-15dk` satırları FAILED'a geri açıyor (syncError'a kurtarma izi yazılıyor); taze SYNCING (uçuşta) satırlara dokunulmuyor.
- `accounting-resync.scheduler`: tenant keşif sorgusu artık `FAILED OR (SYNCING + 15dk'dan eski)` — önceden yalnız FAILED'lı tenant'lar süpürülüyordu, crash'te takılan tenant süpürmeye hiç girmiyordu.
- `getSyncStatus`: ayrı `stuck` sayacı eklendi (SYNCING + 15dk eşiği, aynı `STUCK_SYNCING_THRESHOLD_MS` sabiti).
- Not (bilinçli risk, kodda yorumla belgeli): push sağlanıp yerel SYNCED yazımı çökmüşse (F-Acc-7 senaryosu) 15dk sonrası retry provider'da mükerrer belge üretebilir; syncError metni mutabakat için kurtarmayı kayıt altına alıyor.

## A7 — companyTaxId VKN/TCKN format doğrulaması
- `UpdateAccountingSettingsDto.companyTaxId`: `@Matches(/^\d{10}(\d)?$/)` (10 hane VKN / 11 hane TCKN) + anlamlı mesaj; `@EmptyStringToUndefined` ile boş string doğrulamadan muaf (form temizleme kırılmıyor).

## V6 — nextInvoiceNumber (doğrulandı, değişiklik YOK)
- DTO'da zaten `@IsInt @Min(1)` ile kabul ediliyor ve `AccountingSettingsService.update` `data: safeDto` ile aynen persist ediyor — uçtan uca çalışıyor; DTO spec'iyle kilitlendi.

## A3 — fatura iptali provider senkronu (arayüz + akış; adaptörler GATED)
- `AccountingAdapter.cancelInvoice(accessToken, companyId, externalInvoiceId)` arayüze eklendi.
- Paraşüt/Logo/Foriba adaptörlerinde DÜRÜST stub: her zaman `{ success:false, error: "Provider cancel API not yet integrated — cancel manually in the <Provider> panel" }` — üstünde 'GATED: gerçek void API'si sandbox erişimi gelince doldurulacak' notu. Asla başarı taklidi yok, ağ çağrısı yok.
- `AccountingSyncService.cancelInvoiceAtProvider(invoiceId, tenantId)`: `externalId+externalProvider` doluysa faturanın KENDİ provider'ının (settings.provider değil — swap sonrası doğru hedef) adaptörünü auth ile çağırır; başarısızlıkta `externalStatus='CANCEL_PENDING'` + `syncError='Manuel iptal gerekli: <error>'` yazar. CANCEL_PENDING claim allow-list'inde olmadığı için resync döngüsü iptal edilmiş faturayı asla yeniden push'layamaz. (externalStatus düz string alan; şemada enum yok.)
- `SalesInvoiceService.cancel()`: yerel iptalden SONRA best-effort (try/catch + log) `cancelInvoiceAtProvider` — provider hatası yerel iptali asla bloklamaz/geri almaz.

## Test & kalite kapıları
- `npx tsc --noEmit` temiz
- `npx jest src/modules/accounting --silent`: 12 suite / 133 test yeşil (1 skip = realdb spec, gerçek DB ister)
- `npm run lint:ci`: 0 error (51 pre-existing warning, hiçbiri yeni değil)
- Yeni/güncellenen spec'ler: A5 (geçersiz buyer → FAILED, auth+push çağrılmadı; overblock yok), A6 (release sorgu kapsamı + sıra + scheduler OR sorgusu + stuck sayacı), A3 (stub refusal → CANCEL_PENDING + syncError; success → CANCELLED; provider swap'ta doğru adaptör/kimlik; cancel() wiring), A7/V6 DTO spec'leri, adaptör stub spec'leri.