### PR TITLE
feat(analytics-ui): camera management tab, calibration fix, insights actions, honest empty states

### DIFF
--- a/frontend/src/features/analytics/analyticsApi.test.tsx
+++ b/frontend/src/features/analytics/analyticsApi.test.tsx
@@ -31,6 +31,7 @@ import {
   useGenerateInsights,
   useCreateCamera,
   useDeleteCamera,
+  useSaveCameraCalibration,
   useGenerateMockData,
 } from './analyticsApi';
 
@@ -125,6 +126,23 @@ describe('analytics mutations', () => {
     const { result } = renderHook(() => useCreateCamera(), { wrapper });
     await result.current.mutateAsync({ name: 'Lobby' } as never);
     expect(h.post).toHaveBeenCalledWith('/analytics/cameras', { name: 'Lobby' });
+    expect(invalidate).toHaveBeenCalledWith({
+      queryKey: analyticsKeys.cameras(),
+    });
+  });
+
+  it('useSaveCameraCalibration PUTs the calibration endpoint and invalidates cameras', async () => {
+    // Backend route is PUT /analytics/cameras/:id/calibration — this hook
+    // replaced a bare fetch() that POSTed (wrong method, no auth/branch
+    // headers). The method + URL here are the contract.
+    h.put.mockResolvedValue({ data: { id: 'c1' } });
+    const invalidate = vi.spyOn(client, 'invalidateQueries');
+    const { result } = renderHook(() => useSaveCameraCalibration(), { wrapper });
+    await result.current.mutateAsync({ id: 'c1', data: { points: [] } });
+    expect(h.put).toHaveBeenCalledWith('/analytics/cameras/c1/calibration', {
+      points: [],
+    });
+    expect(h.post).not.toHaveBeenCalled();
     expect(invalidate).toHaveBeenCalledWith({
       queryKey: analyticsKeys.cameras(),
     });

--- a/frontend/src/features/analytics/analyticsApi.ts
+++ b/frontend/src/features/analytics/analyticsApi.ts
@@ -362,6 +362,32 @@ export const useDeleteCamera = () => {
   });
 };
 
+// Backend route is PUT /analytics/cameras/:id/calibration (see
+// analytics.controller.ts updateCameraCalibration). Goes through the shared
+// api client so auth + X-Branch-Id headers are attached — a bare fetch()
+// here would be rejected by the BranchGuard.
+export const useSaveCameraCalibration = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({
+      id,
+      data,
+    }: {
+      id: string;
+      data: Record<string, unknown>;
+    }): Promise<Camera> => {
+      const response = await api.put(`/analytics/cameras/${id}/calibration`, data);
+      return response.data;
+    },
+    onSuccess: () => {
+      // analyticsKeys.camera(id) nests under cameras(), so this covers both
+      // the list and the detail entry.
+      queryClient.invalidateQueries({ queryKey: analyticsKeys.cameras() });
+    },
+  });
+};
+
 // ==================== MOCK DATA HOOKS (DEV ONLY) ====================
 
 export const useGenerateMockData = () => {

--- a/frontend/src/features/analytics/components/CameraCalibration.tsx
+++ b/frontend/src/features/analytics/components/CameraCalibration.tsx
@@ -1,7 +1,7 @@
 import { useState, useRef, useCallback, useEffect } from 'react';
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
 import { scalePointerToCanvas } from './calibrationGeometry';
+import { useSaveCameraCalibration } from '../analyticsApi';
 
 // Types
 interface CalibrationPoint {
@@ -39,7 +39,6 @@ export function CameraCalibration({
   onCalibrationComplete,
   onCancel,
 }: CameraCalibrationProps) {
-  const queryClient = useQueryClient();
   const { t } = useTranslation('analytics');
 
   // State
@@ -291,42 +290,29 @@ export function CameraCalibration({
     return { points };
   }, [imagePoints, floorPoints]);
 
-  // Save calibration to backend
-  const saveCalibrationMutation = useMutation({
-    mutationFn: async (data: CameraCalibrationData) => {
-      const response = await fetch(`/api/analytics/cameras/${cameraId}/calibration`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(data),
-      });
-
-      if (!response.ok) {
-        throw new Error(
-          t('calibration.saveFailed'),
-        );
-      }
-
-      return response.json();
-    },
-    onSuccess: (data) => {
-      queryClient.invalidateQueries({ queryKey: ['cameras', cameraId] });
-      setStep('complete');
-      onCalibrationComplete?.(data);
-    },
-    onError: (err) => {
-      setError(
-        err instanceof Error ? err.message : t('calibration.saveFailed'),
-      );
-    },
-  });
+  // Save calibration to backend (shared api client, PUT — matches the
+  // backend route and carries auth/branch headers; invalidation of the
+  // camera query keys happens inside the hook).
+  const saveCalibrationMutation = useSaveCameraCalibration();
 
   // Handle save
   const handleSave = useCallback(() => {
     const data = calculateHomography();
-    if (data) {
-      saveCalibrationMutation.mutate(data);
-    }
-  }, [calculateHomography, saveCalibrationMutation]);
+    if (!data) return;
+    setError(null);
+    saveCalibrationMutation.mutate(
+      { id: cameraId, data: data as unknown as Record<string, unknown> },
+      {
+        onSuccess: () => {
+          setStep('complete');
+          onCalibrationComplete?.(data);
+        },
+        onError: () => {
+          setError(t('calibration.saveFailed'));
+        },
+      },
+    );
+  }, [calculateHomography, saveCalibrationMutation, cameraId, onCalibrationComplete, t]);
 
   // Render step content
   const renderStepContent = () => {

--- a/frontend/src/features/analytics/components/CameraManagement.test.tsx
+++ b/frontend/src/features/analytics/components/CameraManagement.test.tsx
@@ -1,0 +1,144 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import React from 'react';
+
+const h = vi.hoisted(() => ({
+  get: vi.fn(),
+  post: vi.fn(),
+  put: vi.fn(),
+  del: vi.fn(),
+}));
+vi.mock('../../../lib/api', () => ({
+  default: {
+    get: (...a: unknown[]) => h.get(...a),
+    post: (...a: unknown[]) => h.post(...a),
+    put: (...a: unknown[]) => h.put(...a),
+    delete: (...a: unknown[]) => h.del(...a),
+  },
+}));
+vi.mock('../../../store/branchScopeStore', () => ({
+  useBranchScopeStore: (sel: (s: { branchId: string | null }) => unknown) =>
+    sel({ branchId: 'branch-A' }),
+}));
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+import CameraManagement from './CameraManagement';
+
+// ErrorState -> lib/api-error -> i18n/config pulls the FULL locale bundle
+// into this test, so t() resolves to the real English strings (unlike the
+// key-echo harness some sibling tests rely on). Assert on the en copy.
+const CAM = {
+  id: 'cam-1',
+  name: 'Salon',
+  description: 'Above the entrance',
+  streamUrl: 'rtsp://cam/1',
+  streamType: 'RTSP',
+  status: 'ONLINE',
+  lastSeenAt: '2026-07-10T10:00:00.000Z',
+  createdAt: '2026-07-01T10:00:00.000Z',
+  updatedAt: '2026-07-10T10:00:00.000Z',
+};
+
+function mockBackend(cameras: unknown[]) {
+  h.get.mockImplementation(async (url: string) => {
+    if (url === '/analytics/cameras/health') {
+      return {
+        data: {
+          total: cameras.length,
+          online: cameras.length,
+          offline: 0,
+          error: 0,
+          calibrating: 0,
+        },
+      };
+    }
+    return { data: cameras };
+  });
+}
+
+function renderCameras() {
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0 },
+      mutations: { retry: false },
+    },
+  });
+  return render(
+    <QueryClientProvider client={client}>
+      <CameraManagement />
+    </QueryClientProvider>,
+  );
+}
+
+beforeEach(() => {
+  Object.values(h).forEach((fn) => (fn as ReturnType<typeof vi.fn>).mockReset());
+});
+
+describe('CameraManagement', () => {
+  it('shows the honest empty state with a setup CTA when no cameras exist', async () => {
+    mockBackend([]);
+    renderCameras();
+
+    expect(
+      await screen.findByText('No cameras connected yet'),
+    ).toBeInTheDocument();
+    // Honest copy: hardware requirement + what still works without it.
+    expect(
+      screen.getByText(/requires an on-site camera installation/i),
+    ).toBeInTheDocument();
+    // Empty-state CTA opens the add-camera modal.
+    const ctas = screen.getAllByRole('button', { name: 'Add Camera' });
+    await userEvent.click(ctas[ctas.length - 1]);
+    expect(screen.getByLabelText('Camera name')).toBeInTheDocument();
+  });
+
+  it('creates a camera through the add form (POST /analytics/cameras)', async () => {
+    mockBackend([]);
+    h.post.mockResolvedValue({ data: { ...CAM, id: 'cam-new' } });
+    renderCameras();
+
+    const ctas = await screen.findAllByRole('button', { name: 'Add Camera' });
+    await userEvent.click(ctas[ctas.length - 1]);
+
+    await userEvent.type(screen.getByLabelText('Camera name'), 'Salon');
+    await userEvent.type(screen.getByLabelText('Stream URL'), 'rtsp://cam/1');
+    // Submit button is the last "Add Camera" (empty-state CTA + modal submit).
+    const buttons = screen.getAllByRole('button', { name: 'Add Camera' });
+    await userEvent.click(buttons[buttons.length - 1]);
+
+    await waitFor(() =>
+      expect(h.post).toHaveBeenCalledWith('/analytics/cameras', {
+        name: 'Salon',
+        description: undefined,
+        streamUrl: 'rtsp://cam/1',
+        streamType: 'RTSP',
+      }),
+    );
+  });
+
+  it('deletes a camera only after the confirmation step', async () => {
+    mockBackend([CAM]);
+    h.del.mockResolvedValue({ data: undefined });
+    renderCameras();
+
+    expect(await screen.findByText('Salon')).toBeInTheDocument();
+
+    // Row action opens the confirm modal — nothing deleted yet.
+    await userEvent.click(screen.getByRole('button', { name: 'Delete' }));
+    expect(h.del).not.toHaveBeenCalled();
+    expect(
+      screen.getByText(/delete the camera "Salon"/i),
+    ).toBeInTheDocument();
+
+    // Confirm — DELETE fires with the camera id.
+    const confirmButtons = screen.getAllByRole('button', { name: 'Delete' });
+    await userEvent.click(confirmButtons[confirmButtons.length - 1]);
+    await waitFor(() =>
+      expect(h.del).toHaveBeenCalledWith('/analytics/cameras/cam-1'),
+    );
+  });
+});

--- a/frontend/src/features/analytics/components/CameraManagement.tsx
+++ b/frontend/src/features/analytics/components/CameraManagement.tsx
@@ -1,0 +1,423 @@
+import { useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { useTranslation } from 'react-i18next';
+import { format } from 'date-fns';
+import { toast } from 'sonner';
+import {
+  Video,
+  Plus,
+  Pencil,
+  Trash2,
+  Crosshair,
+  Wifi,
+  WifiOff,
+  AlertTriangle,
+  Loader2,
+} from 'lucide-react';
+import { Card, CardHeader, CardTitle, CardContent } from '../../../components/ui/Card';
+import Button from '../../../components/ui/Button';
+import Input from '../../../components/ui/Input';
+import FormSelect from '../../../components/ui/FormSelect';
+import Modal from '../../../components/ui/Modal';
+import Spinner from '../../../components/ui/Spinner';
+import EmptyState from '../../../components/ui/EmptyState';
+import ErrorState from '../../../components/ui/ErrorState';
+import {
+  useCameras,
+  useCameraHealth,
+  useCreateCamera,
+  useUpdateCamera,
+  useDeleteCamera,
+} from '../analyticsApi';
+import { Camera, CameraStatus } from '../types';
+import CameraCalibration from './CameraCalibration';
+
+// Matches the backend CameraStreamType enum (analytics.enum.ts).
+const STREAM_TYPES = ['RTSP', 'ONVIF', 'HLS', 'WEBRTC'] as const;
+
+// Calibration maps camera pixels onto the occupancy grid; the analytics
+// backend works on a 20×20 m default floor extent (heatmap gridWidth ×
+// cellSize). Kept as a constant until per-branch floor-plan dimensions
+// are exposed to this screen.
+const FLOOR_PLAN_SIZE_METERS = 20;
+
+interface CameraFormValues {
+  name: string;
+  description: string;
+  streamUrl: string;
+  streamType: string;
+}
+
+const STATUS_STYLES: Record<CameraStatus, string> = {
+  [CameraStatus.ONLINE]: 'bg-green-100 text-green-800',
+  [CameraStatus.OFFLINE]: 'bg-slate-100 text-slate-600',
+  [CameraStatus.ERROR]: 'bg-red-100 text-red-800',
+  [CameraStatus.CALIBRATING]: 'bg-blue-100 text-blue-800',
+};
+
+const CameraManagement = () => {
+  const { t } = useTranslation(['analytics', 'common']);
+
+  const camerasQuery = useCameras();
+  const healthQuery = useCameraHealth();
+  const createCamera = useCreateCamera();
+  const updateCamera = useUpdateCamera();
+  const deleteCamera = useDeleteCamera();
+
+  const [formOpen, setFormOpen] = useState(false);
+  const [editingCamera, setEditingCamera] = useState<Camera | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<Camera | null>(null);
+  const [calibrateTarget, setCalibrateTarget] = useState<Camera | null>(null);
+
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors },
+  } = useForm<CameraFormValues>({
+    defaultValues: { name: '', description: '', streamUrl: '', streamType: 'RTSP' },
+  });
+
+  const openCreate = () => {
+    setEditingCamera(null);
+    reset({ name: '', description: '', streamUrl: '', streamType: 'RTSP' });
+    setFormOpen(true);
+  };
+
+  const openEdit = (camera: Camera) => {
+    setEditingCamera(camera);
+    reset({
+      name: camera.name,
+      description: camera.description ?? '',
+      streamUrl: camera.streamUrl,
+      streamType: camera.streamType || 'RTSP',
+    });
+    setFormOpen(true);
+  };
+
+  const onSubmit = async (values: CameraFormValues) => {
+    const payload = {
+      name: values.name.trim(),
+      description: values.description.trim() || undefined,
+      streamUrl: values.streamUrl.trim(),
+      streamType: values.streamType,
+    };
+    try {
+      if (editingCamera) {
+        await updateCamera.mutateAsync({ id: editingCamera.id, data: payload });
+        toast.success(t('analytics:cameras.updated'));
+      } else {
+        await createCamera.mutateAsync(payload);
+        toast.success(t('analytics:cameras.created'));
+      }
+      setFormOpen(false);
+    } catch {
+      toast.error(
+        editingCamera
+          ? t('analytics:cameras.updateFailed')
+          : t('analytics:cameras.createFailed'),
+      );
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!deleteTarget) return;
+    try {
+      await deleteCamera.mutateAsync(deleteTarget.id);
+      toast.success(t('analytics:cameras.deleted'));
+      setDeleteTarget(null);
+    } catch {
+      toast.error(t('analytics:cameras.deleteFailed'));
+    }
+  };
+
+  const cameras = camerasQuery.data ?? [];
+  const health = healthQuery.data;
+  const saving = createCamera.isPending || updateCamera.isPending;
+
+  if (camerasQuery.isLoading) {
+    return <Spinner />;
+  }
+
+  if (camerasQuery.isError) {
+    return (
+      <Card>
+        <CardContent>
+          <ErrorState
+            error={camerasQuery.error}
+            onRetry={() => camerasQuery.refetch()}
+          />
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <div className="space-y-4 md:space-y-6">
+      {/* Health summary */}
+      {cameras.length > 0 && health && (
+        <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-3 md:gap-4">
+          <Card>
+            <CardContent className="pt-6">
+              <div className="flex items-center gap-3">
+                <div className="p-2.5 rounded-full bg-slate-500">
+                  <Video className="h-5 w-5 text-white" />
+                </div>
+                <div>
+                  <p className="text-xs text-slate-500">{t('analytics:cameras.health.total')}</p>
+                  <p className="text-xl font-bold">{health.total}</p>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardContent className="pt-6">
+              <div className="flex items-center gap-3">
+                <div className="p-2.5 rounded-full bg-green-500">
+                  <Wifi className="h-5 w-5 text-white" />
+                </div>
+                <div>
+                  <p className="text-xs text-slate-500">{t('analytics:cameras.health.online')}</p>
+                  <p className="text-xl font-bold">{health.online}</p>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardContent className="pt-6">
+              <div className="flex items-center gap-3">
+                <div className="p-2.5 rounded-full bg-slate-400">
+                  <WifiOff className="h-5 w-5 text-white" />
+                </div>
+                <div>
+                  <p className="text-xs text-slate-500">{t('analytics:cameras.health.offline')}</p>
+                  <p className="text-xl font-bold">{health.offline}</p>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardContent className="pt-6">
+              <div className="flex items-center gap-3">
+                <div className="p-2.5 rounded-full bg-red-500">
+                  <AlertTriangle className="h-5 w-5 text-white" />
+                </div>
+                <div>
+                  <p className="text-xs text-slate-500">{t('analytics:cameras.health.error')}</p>
+                  <p className="text-xl font-bold">{health.error}</p>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardContent className="pt-6">
+              <div className="flex items-center gap-3">
+                <div className="p-2.5 rounded-full bg-blue-500">
+                  <Loader2 className="h-5 w-5 text-white" />
+                </div>
+                <div>
+                  <p className="text-xs text-slate-500">{t('analytics:cameras.health.calibrating')}</p>
+                  <p className="text-xl font-bold">{health.calibrating}</p>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      )}
+
+      {/* Camera list */}
+      <Card>
+        <CardHeader>
+          <div className="flex items-center justify-between gap-3">
+            <CardTitle className="flex items-center gap-2">
+              <Video className="h-5 w-5 text-slate-500" />
+              {t('analytics:cameras.title')}
+            </CardTitle>
+            {cameras.length > 0 && (
+              <Button size="sm" onClick={openCreate}>
+                <Plus className="h-4 w-4 mr-2" />
+                {t('analytics:cameras.add')}
+              </Button>
+            )}
+          </div>
+        </CardHeader>
+        <CardContent>
+          {cameras.length === 0 ? (
+            <EmptyState
+              icon={Video}
+              title={t('analytics:cameras.emptyTitle')}
+              description={t('analytics:cameras.emptyDescription')}
+              actionLabel={t('analytics:cameras.add')}
+              onAction={openCreate}
+            />
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="w-full">
+                <thead>
+                  <tr className="border-b">
+                    <th className="text-left py-3 px-4">{t('analytics:cameras.columns.name')}</th>
+                    <th className="text-left py-3 px-4">{t('analytics:cameras.columns.location')}</th>
+                    <th className="text-left py-3 px-4">{t('analytics:cameras.columns.status')}</th>
+                    <th className="text-left py-3 px-4">{t('analytics:cameras.columns.lastSeen')}</th>
+                    <th className="text-right py-3 px-4">{t('analytics:cameras.columns.actions')}</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {cameras.map((camera) => (
+                    <tr key={camera.id} className="border-b hover:bg-slate-50">
+                      <td className="py-3 px-4 font-medium">{camera.name}</td>
+                      <td className="py-3 px-4 text-slate-500">{camera.description || '-'}</td>
+                      <td className="py-3 px-4">
+                        <span
+                          className={`px-2 py-1 rounded-full text-xs font-medium ${
+                            STATUS_STYLES[camera.status] ?? STATUS_STYLES[CameraStatus.OFFLINE]
+                          }`}
+                        >
+                          {t(`analytics:cameras.statusValues.${camera.status}`, {
+                            defaultValue: camera.status,
+                          })}
+                        </span>
+                        {camera.status === CameraStatus.ERROR && camera.errorMessage && (
+                          <p className="text-xs text-red-600 mt-1">{camera.errorMessage}</p>
+                        )}
+                      </td>
+                      <td className="py-3 px-4 text-slate-500">
+                        {camera.lastSeenAt
+                          ? format(new Date(camera.lastSeenAt), 'dd.MM.yyyy HH:mm')
+                          : t('analytics:cameras.neverSeen')}
+                      </td>
+                      <td className="py-3 px-4">
+                        <div className="flex justify-end gap-1">
+                          <button
+                            onClick={() => setCalibrateTarget(camera)}
+                            className="p-2 hover:bg-blue-50 rounded-lg transition-colors text-blue-600"
+                            title={t('analytics:cameras.calibrate')}
+                            aria-label={t('analytics:cameras.calibrate')}
+                          >
+                            <Crosshair className="h-4 w-4" />
+                          </button>
+                          <button
+                            onClick={() => openEdit(camera)}
+                            className="p-2 hover:bg-slate-100 rounded-lg transition-colors text-slate-600"
+                            title={t('common:app.edit')}
+                            aria-label={t('common:app.edit')}
+                          >
+                            <Pencil className="h-4 w-4" />
+                          </button>
+                          <button
+                            onClick={() => setDeleteTarget(camera)}
+                            className="p-2 hover:bg-red-50 rounded-lg transition-colors text-red-600"
+                            title={t('common:app.delete')}
+                            aria-label={t('common:app.delete')}
+                          >
+                            <Trash2 className="h-4 w-4" />
+                          </button>
+                        </div>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Create / edit modal */}
+      <Modal
+        isOpen={formOpen}
+        onClose={() => setFormOpen(false)}
+        title={
+          editingCamera
+            ? t('analytics:cameras.editTitle')
+            : t('analytics:cameras.addTitle')
+        }
+      >
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+          <Input
+            label={t('analytics:cameras.form.name')}
+            placeholder={t('analytics:cameras.form.namePlaceholder')}
+            error={errors.name?.message}
+            {...register('name', {
+              required: t('analytics:cameras.form.nameRequired'),
+            })}
+          />
+          <Input
+            label={t('analytics:cameras.form.location')}
+            placeholder={t('analytics:cameras.form.locationPlaceholder')}
+            {...register('description')}
+          />
+          <Input
+            label={t('analytics:cameras.form.streamUrl')}
+            placeholder="rtsp://user:pass@192.168.1.100:554/stream1"
+            hint={t('analytics:cameras.form.streamUrlHint')}
+            error={errors.streamUrl?.message}
+            {...register('streamUrl', {
+              required: t('analytics:cameras.form.streamUrlRequired'),
+            })}
+          />
+          <FormSelect
+            label={t('analytics:cameras.form.streamType')}
+            options={STREAM_TYPES.map((type) => ({ value: type, label: type }))}
+            {...register('streamType')}
+          />
+          <div className="flex justify-end gap-2 pt-2">
+            <Button type="button" variant="outline" onClick={() => setFormOpen(false)}>
+              {t('common:app.cancel')}
+            </Button>
+            <Button type="submit" isLoading={saving}>
+              {editingCamera ? t('common:app.save') : t('analytics:cameras.add')}
+            </Button>
+          </div>
+        </form>
+      </Modal>
+
+      {/* Delete confirmation */}
+      <Modal
+        isOpen={!!deleteTarget}
+        onClose={() => setDeleteTarget(null)}
+        title={t('analytics:cameras.deleteTitle')}
+        size="sm"
+      >
+        <p className="text-sm text-slate-600">
+          {t('analytics:cameras.deleteConfirm', { name: deleteTarget?.name ?? '' })}
+        </p>
+        <div className="flex justify-end gap-2 mt-6">
+          <Button variant="outline" onClick={() => setDeleteTarget(null)}>
+            {t('common:app.cancel')}
+          </Button>
+          <Button
+            variant="danger"
+            onClick={handleDelete}
+            isLoading={deleteCamera.isPending}
+          >
+            {t('common:app.delete')}
+          </Button>
+        </div>
+      </Modal>
+
+      {/* Calibration modal */}
+      <Modal
+        isOpen={!!calibrateTarget}
+        onClose={() => setCalibrateTarget(null)}
+        size="xl"
+      >
+        {calibrateTarget && (
+          <CameraCalibration
+            cameraId={calibrateTarget.id}
+            streamUrl={calibrateTarget.streamUrl}
+            floorPlanWidth={FLOOR_PLAN_SIZE_METERS}
+            floorPlanHeight={FLOOR_PLAN_SIZE_METERS}
+            onCalibrationComplete={() => {
+              toast.success(t('analytics:cameras.calibrationSaved'));
+            }}
+            onCancel={() => setCalibrateTarget(null)}
+          />
+        )}
+      </Modal>
+    </div>
+  );
+};
+
+export default CameraManagement;
+export { CameraManagement };

--- a/frontend/src/features/analytics/components/index.ts
+++ b/frontend/src/features/analytics/components/index.ts
@@ -1,3 +1,4 @@
 export * from './HeatmapLegend';
 export * from './HeatmapControls';
 export * from './CameraCalibration';
+export * from './CameraManagement';

--- a/frontend/src/i18n/locales/ar/analytics.json
+++ b/frontend/src/i18n/locales/ar/analytics.json
@@ -1,72 +1,247 @@
 {
+  "page": {
+    "title": "تحليلات المطعم",
+    "subtitle": "رؤى مدعومة بالذكاء الاصطناعي وتحليل استخدام المساحة",
+    "tabsAriaLabel": "علامات تبويب التحليلات"
+  },
+  "tabs": {
+    "overview": "نظرة عامة",
+    "tables": "تحليلات الطاولات",
+    "traffic": "حركة الزوار",
+    "behavior": "سلوك العملاء",
+    "insights": "رؤى الذكاء الاصطناعي",
+    "cameras": "الكاميرات"
+  },
+  "dateFilter": {
+    "from": "من",
+    "to": "إلى",
+    "apply": "تطبيق"
+  },
+  "devTools": {
+    "generate": "إنشاء بيانات تجريبية",
+    "generating": "جارٍ الإنشاء...",
+    "clear": "مسح البيانات",
+    "generated": "تم إنشاء بيانات تجريبية: {{records}} سجل إشغال، {{insights}} رؤية",
+    "generateFailed": "تعذّر إنشاء البيانات التجريبية",
+    "cleared": "تم مسح جميع بيانات التحليلات",
+    "clearFailed": "تعذّر مسح بيانات التحليلات"
+  },
+  "stats": {
+    "avgTableUtilization": "متوسط استخدام الطاولات",
+    "tablesCount": "{{value}} طاولة",
+    "totalRevenuePeriod": "إجمالي الإيرادات (الفترة)",
+    "tableTurns": "{{value}} دورة طاولة",
+    "congestionScore": "مؤشر الازدحام",
+    "hotspotsCount": "{{value}} نقطة ازدحام",
+    "activeInsights": "الرؤى النشطة",
+    "totalInsightsCount": "إجمالي الرؤى: {{value}}",
+    "totalTables": "إجمالي الطاولات",
+    "avgUtilization": "متوسط الاستخدام",
+    "peakHour": "ساعة الذروة",
+    "peakOccupancy": "إشغال {{percent}}%",
+    "totalSessions": "إجمالي الجلسات",
+    "higherIsBetter": "الأعلى أفضل",
+    "congestionHotspots": "نقاط الازدحام",
+    "highTrafficAreas": "مناطق ذات حركة مرتفعة",
+    "recommendations": "التوصيات",
+    "flowSuggestions": "اقتراحات لتحسين الحركة",
+    "avgDiningTime": "متوسط مدة تناول الطعام",
+    "avgIdleTime": "متوسط وقت الخمول",
+    "timeAfterDining": "الوقت بعد تناول الطعام",
+    "avgPartySize": "متوسط حجم المجموعة",
+    "avgOrderValue": "متوسط قيمة الطلب",
+    "totalInsights": "إجمالي الرؤى",
+    "new": "جديدة",
+    "inProgress": "قيد التنفيذ",
+    "implemented": "منفّذة",
+    "minutesValue": "{{minutes}} دقيقة"
+  },
+  "columns": {
+    "table": "الطاولة",
+    "section": "القسم",
+    "capacity": "السعة",
+    "utilization": "الاستخدام",
+    "revenue": "الإيرادات",
+    "sessions": "الجلسات",
+    "avgOrder": "متوسط الطلب",
+    "location": "الموقع",
+    "severity": "الشدة",
+    "avgWaitTime": "متوسط الانتظار",
+    "peakHour": "ساعة الذروة"
+  },
+  "tableLabel": "طاولة {{number}}",
+  "overview": {
+    "actionableInsights": "رؤى قابلة للتنفيذ",
+    "underutilizedTables": "طاولات قليلة الاستخدام",
+    "noInsightsTitle": "لا توجد رؤى قابلة للتنفيذ حاليًا",
+    "noInsightsDescription": "تُنشأ الرؤى تلقائيًا كل ليلة من بيانات طلباتك وطاولاتك. يمكنك أيضًا إنشاؤها يدويًا من علامة تبويب رؤى الذكاء الاصطناعي."
+  },
+  "insightCard": {
+    "potentialImpact": "التأثير المحتمل: {{impact}}",
+    "impact": "التأثير: {{impact}}",
+    "confidence": "الثقة: {{percent}}%",
+    "created": "تاريخ الإنشاء: {{date}}",
+    "markImplemented": "وضع علامة \"منفّذة\"",
+    "markInProgress": "وضع علامة \"قيد التنفيذ\"",
+    "dismiss": "تجاهل",
+    "statusUpdated": "تم تحديث حالة الرؤية",
+    "statusUpdateFailed": "تعذّر تحديث حالة الرؤية"
+  },
+  "tableDetails": {
+    "title": "تفاصيل استخدام الطاولات",
+    "emptyTitle": "لا يوجد نشاط للطاولات في هذه الفترة",
+    "emptyDescription": "يُحسب الاستخدام من جلسات الطاولات في نقطة البيع. بمجرد استلام طلبات على الطاولات — أو بعد توسيع الفترة الزمنية — ستظهر التفاصيل هنا."
+  },
+  "traffic": {
+    "recommendationsTitle": "توصيات حركة الزوار",
+    "hotspotsTitle": "نقاط الازدحام",
+    "gridCell": "الشبكة ({{x}}، {{z}})",
+    "emptyTitle": "يتطلب تحليل الحركة كاميرات إشغال",
+    "emptyDescription": "لا توجد بيانات كاميرا لهذه الفترة، لذا يتعذّر حساب نقاط الازدحام وتوصيات الحركة. تعمل تحليلات الطاولات ورؤى الذكاء الاصطناعي دون كاميرات باستخدام بيانات نقطة البيع.",
+    "goToCameras": "إعداد الكاميرات"
+  },
+  "behavior": {
+    "journeyTitle": "رؤى رحلة العميل",
+    "peakHours": "ساعات الذروة",
+    "peakArrival": "ذروة الوصول",
+    "peakDeparture": "ذروة المغادرة",
+    "timeBreakdown": "توزيع الوقت",
+    "dining": "تناول الطعام",
+    "idlePostDining": "خمول (بعد تناول الطعام)",
+    "idleDiningRatio": "نسبة الخمول/تناول الطعام",
+    "highIdleTitle": "تم رصد وقت خمول مرتفع",
+    "highIdleDescription": "يقضي العملاء {{minutes}} دقيقة على الطاولات بعد تناول الطعام. فكّر في تقديم الفاتورة استباقيًا أو عرض حلويات خارجية لتحسين دوران الطاولات.",
+    "emptyTitle": "لا توجد بيانات سلوك عملاء بعد",
+    "emptyDescription": "تُشتق مقاييس مدة تناول الطعام من جلسات الطاولات في نقطة البيع؛ وتحتاج مقاييس التواجد إضافةً إلى ذلك إلى كاميرات إشغال. ستظهر البيانات هنا بمجرد تدفق طلبات الطاولات."
+  },
+  "insightsTab": {
+    "allTitle": "جميع الرؤى",
+    "refresh": "تحديث الرؤى",
+    "refreshing": "جارٍ الإنشاء...",
+    "generatedCount": "تم إنشاء {{value}} رؤية",
+    "generateFailed": "تعذّر إنشاء الرؤى",
+    "emptyTitle": "لم تُنشأ أي رؤى بعد",
+    "emptyDescription": "يُنشئ النظام الرؤى تلقائيًا كل ليلة من بيانات طلباتك وطاولاتك. انقر أدناه لإنشائها الآن.",
+    "generateNow": "إنشاء الآن"
+  },
+  "cameras": {
+    "title": "الكاميرات",
+    "add": "إضافة كاميرا",
+    "emptyTitle": "لا توجد كاميرات متصلة بعد",
+    "emptyDescription": "تتطلب تحليلات المساحة (حركة الزوار، الإشغال، وقت البقاء) تركيب كاميرات في الموقع. تعمل تحليلات الطاولات ورؤى الذكاء الاصطناعي بالفعل دون كاميرات باستخدام بيانات نقطة البيع.",
+    "neverSeen": "لم تُرَ مطلقًا",
+    "calibrate": "معايرة",
+    "calibrationSaved": "تم حفظ معايرة الكاميرا",
+    "addTitle": "إضافة كاميرا",
+    "editTitle": "تعديل الكاميرا",
+    "deleteTitle": "حذف الكاميرا",
+    "deleteConfirm": "هل أنت متأكد من حذف الكاميرا \"{{name}}\"؟ سيتوقف معالجة بث الإشغال الخاص بها. لا يمكن التراجع عن هذا الإجراء.",
+    "created": "تمت إضافة الكاميرا",
+    "createFailed": "تعذّرت إضافة الكاميرا",
+    "updated": "تم تحديث الكاميرا",
+    "updateFailed": "تعذّر تحديث الكاميرا",
+    "deleted": "تم حذف الكاميرا",
+    "deleteFailed": "تعذّر حذف الكاميرا",
+    "health": {
+      "total": "الإجمالي",
+      "online": "متصلة",
+      "offline": "غير متصلة",
+      "error": "خطأ",
+      "calibrating": "قيد المعايرة"
+    },
+    "columns": {
+      "name": "الاسم",
+      "location": "الموقع",
+      "status": "الحالة",
+      "lastSeen": "آخر ظهور",
+      "actions": "الإجراءات"
+    },
+    "statusValues": {
+      "ONLINE": "متصلة",
+      "OFFLINE": "غير متصلة",
+      "ERROR": "خطأ",
+      "CALIBRATING": "قيد المعايرة"
+    },
+    "form": {
+      "name": "اسم الكاميرا",
+      "namePlaceholder": "مثال: كاميرا المدخل الرئيسي",
+      "nameRequired": "اسم الكاميرا مطلوب",
+      "location": "الموقع / الوصف",
+      "locationPlaceholder": "مثال: صالة الطعام، فوق المدخل",
+      "streamUrl": "رابط البث",
+      "streamUrlHint": "عنوان RTSP/ONVIF للكاميرا على شبكتك المحلية",
+      "streamUrlRequired": "رابط البث مطلوب",
+      "streamType": "نوع البث"
+    }
+  },
   "cvDisclosure": {
     "requiresCameras": "يتطلب كاميرات إشغال",
     "noData": "لا توجد بيانات كاميرا",
     "noOccupancyTelemetry": "تتطلب هذه المقاييس كاميرات إشغال في الموقع لقياسها. بدون أجهزة الكاميرا تظهر كصفر/قيمة افتراضية ولا تعكس النشاط الفعلي."
   },
   "heatmap": {
-    "settings": "Heatmap Settings",
-    "visualizationType": "Visualization Type",
-    "colorScheme": "Color Scheme",
-    "opacity": "Opacity: {{percent}}%",
-    "loadingData": "Loading heatmap data...",
+    "settings": "إعدادات الخريطة الحرارية",
+    "visualizationType": "نوع العرض",
+    "colorScheme": "نظام الألوان",
+    "opacity": "الشفافية: {{percent}}%",
+    "loadingData": "جارٍ تحميل بيانات الخريطة الحرارية...",
     "types": {
-      "none": { "label": "None", "description": "Hide heatmap" },
-      "occupancy": { "label": "Occupancy", "description": "Show customer density" },
-      "traffic": { "label": "Traffic Flow", "description": "Show movement patterns" },
-      "dwellTime": { "label": "Dwell Time", "description": "Show time spent in areas" }
+      "none": { "label": "بدون", "description": "إخفاء الخريطة الحرارية" },
+      "occupancy": { "label": "الإشغال", "description": "عرض كثافة العملاء" },
+      "traffic": { "label": "حركة الزوار", "description": "عرض أنماط الحركة" },
+      "dwellTime": { "label": "وقت البقاء", "description": "عرض الوقت المُمضى في المناطق" }
     },
     "schemes": {
-      "heat": "Heat (Red)",
-      "viridis": "Viridis (Green-Purple)",
-      "plasma": "Plasma (Yellow-Purple)",
-      "coolwarm": "Cool-Warm (Blue-Red)",
-      "blues": "Blues"
+      "heat": "حراري (أحمر)",
+      "viridis": "فيريديس (أخضر-بنفسجي)",
+      "plasma": "بلازما (أصفر-بنفسجي)",
+      "coolwarm": "بارد-دافئ (أزرق-أحمر)",
+      "blues": "درجات الأزرق"
     },
     "legend": {
-      "customerDensity": "Customer Density",
-      "trafficVolume": "Traffic Volume",
-      "dwellTime": "Dwell Time",
-      "low": "Low",
-      "high": "High"
+      "customerDensity": "كثافة العملاء",
+      "trafficVolume": "حجم الحركة",
+      "dwellTime": "وقت البقاء",
+      "low": "منخفض",
+      "high": "مرتفع"
     }
   },
   "calibration": {
-    "title": "Camera Calibration",
-    "saveFailed": "Failed to save calibration",
+    "title": "معايرة الكاميرا",
+    "saveFailed": "تعذّر حفظ المعايرة",
     "pointLabels": {
-      "topLeft": "Top-Left",
-      "topRight": "Top-Right",
-      "bottomRight": "Bottom-Right",
-      "bottomLeft": "Bottom-Left"
+      "topLeft": "أعلى اليسار",
+      "topRight": "أعلى اليمين",
+      "bottomRight": "أسفل اليمين",
+      "bottomLeft": "أسفل اليسار"
     },
     "step1": {
-      "heading": "Step 1: Select Camera Points",
-      "instructions": "Click on 4 corners of a rectangular area in the camera view. Start from the top-left corner and go clockwise."
+      "heading": "الخطوة 1: حدد نقاط الكاميرا",
+      "instructions": "انقر على 4 زوايا لمنطقة مستطيلة في عرض الكاميرا. ابدأ من الزاوية العلوية اليسرى وتحرك باتجاه عقارب الساعة."
     },
     "step2": {
-      "heading": "Step 2: Select Floor Plan Points",
-      "instructions": "Click on the corresponding 4 points on the floor plan grid. Match the same order as the camera points (top-left, top-right, bottom-right, bottom-left).",
-      "cameraView": "Camera View",
-      "floorPlan": "Floor Plan"
+      "heading": "الخطوة 2: حدد نقاط مخطط الطابق",
+      "instructions": "انقر على النقاط الأربع المقابلة على شبكة مخطط الطابق. اتبع نفس ترتيب نقاط الكاميرا (أعلى اليسار، أعلى اليمين، أسفل اليمين، أسفل اليسار).",
+      "cameraView": "عرض الكاميرا",
+      "floorPlan": "مخطط الطابق"
     },
     "step3": {
-      "heading": "Step 3: Review Calibration",
-      "instructions": "Verify that the camera and floor plan points are correctly aligned. The transformation will map positions from the camera view to the floor plan.",
-      "cameraPoints": "Camera Points",
-      "floorPlanPoints": "Floor Plan Points"
+      "heading": "الخطوة 3: راجع المعايرة",
+      "instructions": "تحقق من محاذاة نقاط الكاميرا ومخطط الطابق بشكل صحيح. سيحوّل التحويل المواقع من عرض الكاميرا إلى مخطط الطابق.",
+      "cameraPoints": "نقاط الكاميرا",
+      "floorPlanPoints": "نقاط مخطط الطابق"
     },
     "complete": {
-      "heading": "Calibration Complete",
-      "message": "The camera has been successfully calibrated. Position data will now be mapped to the floor plan coordinates."
+      "heading": "اكتملت المعايرة",
+      "message": "تمت معايرة الكاميرا بنجاح. سيتم الآن ربط بيانات المواقع بإحداثيات مخطط الطابق."
     },
-    "pointsSelected": "Points selected: {{count}} / {{total}}",
-    "captureFrame": "Capture Frame",
-    "undo": "Undo",
-    "reset": "Reset",
-    "back": "Back",
-    "next": "Next",
-    "save": "Save Calibration",
-    "saving": "Saving..."
+    "pointsSelected": "النقاط المحددة: {{count}} / {{total}}",
+    "captureFrame": "التقاط إطار",
+    "undo": "تراجع",
+    "reset": "إعادة تعيين",
+    "back": "رجوع",
+    "next": "التالي",
+    "save": "حفظ المعايرة",
+    "saving": "جارٍ الحفظ..."
   }
 }

--- a/frontend/src/i18n/locales/en/analytics.json
+++ b/frontend/src/i18n/locales/en/analytics.json
@@ -1,4 +1,179 @@
 {
+  "page": {
+    "title": "Restaurant Analytics",
+    "subtitle": "AI-powered insights and space utilization analysis",
+    "tabsAriaLabel": "Analytics tabs"
+  },
+  "tabs": {
+    "overview": "Overview",
+    "tables": "Table Analytics",
+    "traffic": "Traffic Flow",
+    "behavior": "Customer Behavior",
+    "insights": "AI Insights",
+    "cameras": "Cameras"
+  },
+  "dateFilter": {
+    "from": "From",
+    "to": "To",
+    "apply": "Apply"
+  },
+  "devTools": {
+    "generate": "Generate Mock Data",
+    "generating": "Generating...",
+    "clear": "Clear Data",
+    "generated": "Mock data generated: {{records}} occupancy records, {{insights}} insights",
+    "generateFailed": "Failed to generate mock data",
+    "cleared": "All analytics data cleared",
+    "clearFailed": "Failed to clear analytics data"
+  },
+  "stats": {
+    "avgTableUtilization": "Average Table Utilization",
+    "tablesCount": "{{value}} tables",
+    "totalRevenuePeriod": "Total Revenue (Period)",
+    "tableTurns": "{{value}} table turns",
+    "congestionScore": "Congestion Score",
+    "hotspotsCount": "{{value}} hotspots",
+    "activeInsights": "Active Insights",
+    "totalInsightsCount": "{{value}} total insights",
+    "totalTables": "Total Tables",
+    "avgUtilization": "Average Utilization",
+    "peakHour": "Peak Hour",
+    "peakOccupancy": "{{percent}}% occupancy",
+    "totalSessions": "Total Sessions",
+    "higherIsBetter": "Higher is better",
+    "congestionHotspots": "Congestion Hotspots",
+    "highTrafficAreas": "Areas with high traffic",
+    "recommendations": "Recommendations",
+    "flowSuggestions": "Suggestions to improve flow",
+    "avgDiningTime": "Avg Dining Time",
+    "avgIdleTime": "Avg Idle Time",
+    "timeAfterDining": "Time after dining",
+    "avgPartySize": "Avg Party Size",
+    "avgOrderValue": "Avg Order Value",
+    "totalInsights": "Total Insights",
+    "new": "New",
+    "inProgress": "In Progress",
+    "implemented": "Implemented",
+    "minutesValue": "{{minutes}} min"
+  },
+  "columns": {
+    "table": "Table",
+    "section": "Section",
+    "capacity": "Capacity",
+    "utilization": "Utilization",
+    "revenue": "Revenue",
+    "sessions": "Sessions",
+    "avgOrder": "Avg Order",
+    "location": "Location",
+    "severity": "Severity",
+    "avgWaitTime": "Avg Wait Time",
+    "peakHour": "Peak Hour"
+  },
+  "tableLabel": "Table {{number}}",
+  "overview": {
+    "actionableInsights": "Actionable Insights",
+    "underutilizedTables": "Underutilized Tables",
+    "noInsightsTitle": "No actionable insights right now",
+    "noInsightsDescription": "Insights are generated automatically every night from your order and table data. You can also trigger generation manually from the AI Insights tab."
+  },
+  "insightCard": {
+    "potentialImpact": "Potential impact: {{impact}}",
+    "impact": "Impact: {{impact}}",
+    "confidence": "Confidence: {{percent}}%",
+    "created": "Created: {{date}}",
+    "markImplemented": "Mark as implemented",
+    "markInProgress": "Mark as in progress",
+    "dismiss": "Dismiss",
+    "statusUpdated": "Insight status updated",
+    "statusUpdateFailed": "Failed to update insight status"
+  },
+  "tableDetails": {
+    "title": "Table Utilization Details",
+    "emptyTitle": "No table activity in this date range",
+    "emptyDescription": "Utilization is calculated from POS table sessions. Once orders are taken on tables — or after widening the date range — the details appear here."
+  },
+  "traffic": {
+    "recommendationsTitle": "Traffic Flow Recommendations",
+    "hotspotsTitle": "Congestion Hotspots",
+    "gridCell": "Grid ({{x}}, {{z}})",
+    "emptyTitle": "Traffic analysis requires occupancy cameras",
+    "emptyDescription": "No camera telemetry exists for this period, so hotspots and flow recommendations cannot be computed. Table analytics and AI insights work without cameras, using your POS data.",
+    "goToCameras": "Set up cameras"
+  },
+  "behavior": {
+    "journeyTitle": "Customer Journey Insights",
+    "peakHours": "Peak Hours",
+    "peakArrival": "Peak Arrival",
+    "peakDeparture": "Peak Departure",
+    "timeBreakdown": "Time Breakdown",
+    "dining": "Dining",
+    "idlePostDining": "Idle (post-dining)",
+    "idleDiningRatio": "Idle/Dining Ratio",
+    "highIdleTitle": "High Idle Time Detected",
+    "highIdleDescription": "Customers are spending {{minutes}} minutes at tables after dining. Consider presenting the bill proactively or offering takeaway desserts to improve table turnover.",
+    "emptyTitle": "No customer behavior data yet",
+    "emptyDescription": "Dining-time metrics are derived from POS table sessions; presence metrics additionally need occupancy cameras. Data appears here once table orders flow in."
+  },
+  "insightsTab": {
+    "allTitle": "All Insights",
+    "refresh": "Refresh Insights",
+    "refreshing": "Generating...",
+    "generatedCount": "{{value}} insight(s) generated",
+    "generateFailed": "Failed to generate insights",
+    "emptyTitle": "No insights generated yet",
+    "emptyDescription": "The system generates insights automatically every night from your order and table data. Click below to generate them now.",
+    "generateNow": "Generate now"
+  },
+  "cameras": {
+    "title": "Cameras",
+    "add": "Add Camera",
+    "emptyTitle": "No cameras connected yet",
+    "emptyDescription": "Space analytics (traffic flow, occupancy, dwell time) requires an on-site camera installation. Table analytics and AI insights already work without cameras, using your POS data.",
+    "neverSeen": "Never seen",
+    "calibrate": "Calibrate",
+    "calibrationSaved": "Camera calibration saved",
+    "addTitle": "Add Camera",
+    "editTitle": "Edit Camera",
+    "deleteTitle": "Delete Camera",
+    "deleteConfirm": "Are you sure you want to delete the camera \"{{name}}\"? Its occupancy stream will stop being processed. This action cannot be undone.",
+    "created": "Camera added",
+    "createFailed": "Failed to add camera",
+    "updated": "Camera updated",
+    "updateFailed": "Failed to update camera",
+    "deleted": "Camera deleted",
+    "deleteFailed": "Failed to delete camera",
+    "health": {
+      "total": "Total",
+      "online": "Online",
+      "offline": "Offline",
+      "error": "Error",
+      "calibrating": "Calibrating"
+    },
+    "columns": {
+      "name": "Name",
+      "location": "Location",
+      "status": "Status",
+      "lastSeen": "Last Seen",
+      "actions": "Actions"
+    },
+    "statusValues": {
+      "ONLINE": "Online",
+      "OFFLINE": "Offline",
+      "ERROR": "Error",
+      "CALIBRATING": "Calibrating"
+    },
+    "form": {
+      "name": "Camera name",
+      "namePlaceholder": "e.g. Main entrance camera",
+      "nameRequired": "Camera name is required",
+      "location": "Location / description",
+      "locationPlaceholder": "e.g. Dining hall, above the entrance",
+      "streamUrl": "Stream URL",
+      "streamUrlHint": "RTSP/ONVIF address of the camera on your local network",
+      "streamUrlRequired": "Stream URL is required",
+      "streamType": "Stream type"
+    }
+  },
   "cvDisclosure": {
     "requiresCameras": "Requires occupancy cameras",
     "noData": "No camera data",

--- a/frontend/src/i18n/locales/ru/analytics.json
+++ b/frontend/src/i18n/locales/ru/analytics.json
@@ -1,72 +1,247 @@
 {
+  "page": {
+    "title": "Аналитика ресторана",
+    "subtitle": "Инсайты на базе ИИ и анализ использования пространства",
+    "tabsAriaLabel": "Вкладки аналитики"
+  },
+  "tabs": {
+    "overview": "Обзор",
+    "tables": "Аналитика столов",
+    "traffic": "Поток посетителей",
+    "behavior": "Поведение клиентов",
+    "insights": "ИИ-инсайты",
+    "cameras": "Камеры"
+  },
+  "dateFilter": {
+    "from": "С",
+    "to": "По",
+    "apply": "Применить"
+  },
+  "devTools": {
+    "generate": "Сгенерировать тестовые данные",
+    "generating": "Генерация...",
+    "clear": "Очистить данные",
+    "generated": "Тестовые данные созданы: {{records}} записей заполняемости, {{insights}} инсайтов",
+    "generateFailed": "Не удалось сгенерировать тестовые данные",
+    "cleared": "Все данные аналитики очищены",
+    "clearFailed": "Не удалось очистить данные аналитики"
+  },
+  "stats": {
+    "avgTableUtilization": "Средняя загрузка столов",
+    "tablesCount": "Столов: {{value}}",
+    "totalRevenuePeriod": "Общая выручка (период)",
+    "tableTurns": "Оборотов столов: {{value}}",
+    "congestionScore": "Индекс загруженности",
+    "hotspotsCount": "Горячих точек: {{value}}",
+    "activeInsights": "Активные инсайты",
+    "totalInsightsCount": "Всего инсайтов: {{value}}",
+    "totalTables": "Всего столов",
+    "avgUtilization": "Средняя загрузка",
+    "peakHour": "Пиковый час",
+    "peakOccupancy": "Заполняемость {{percent}}%",
+    "totalSessions": "Всего сессий",
+    "higherIsBetter": "Чем выше, тем лучше",
+    "congestionHotspots": "Точки скопления",
+    "highTrafficAreas": "Зоны с высоким трафиком",
+    "recommendations": "Рекомендации",
+    "flowSuggestions": "Советы по улучшению потока",
+    "avgDiningTime": "Ср. время трапезы",
+    "avgIdleTime": "Ср. время простоя",
+    "timeAfterDining": "Время после трапезы",
+    "avgPartySize": "Ср. размер компании",
+    "avgOrderValue": "Ср. чек",
+    "totalInsights": "Всего инсайтов",
+    "new": "Новые",
+    "inProgress": "В работе",
+    "implemented": "Внедрено",
+    "minutesValue": "{{minutes}} мин"
+  },
+  "columns": {
+    "table": "Стол",
+    "section": "Зона",
+    "capacity": "Вместимость",
+    "utilization": "Загрузка",
+    "revenue": "Выручка",
+    "sessions": "Сессии",
+    "avgOrder": "Ср. заказ",
+    "location": "Расположение",
+    "severity": "Серьёзность",
+    "avgWaitTime": "Ср. ожидание",
+    "peakHour": "Пиковый час"
+  },
+  "tableLabel": "Стол {{number}}",
+  "overview": {
+    "actionableInsights": "Практические инсайты",
+    "underutilizedTables": "Недозагруженные столы",
+    "noInsightsTitle": "Сейчас нет практических инсайтов",
+    "noInsightsDescription": "Инсайты генерируются автоматически каждую ночь на основе данных о заказах и столах. Их также можно сгенерировать вручную на вкладке «ИИ-инсайты»."
+  },
+  "insightCard": {
+    "potentialImpact": "Потенциальный эффект: {{impact}}",
+    "impact": "Эффект: {{impact}}",
+    "confidence": "Достоверность: {{percent}}%",
+    "created": "Создан: {{date}}",
+    "markImplemented": "Отметить как внедрённый",
+    "markInProgress": "Отметить как «в работе»",
+    "dismiss": "Отклонить",
+    "statusUpdated": "Статус инсайта обновлён",
+    "statusUpdateFailed": "Не удалось обновить статус инсайта"
+  },
+  "tableDetails": {
+    "title": "Детали загрузки столов",
+    "emptyTitle": "Нет активности столов за этот период",
+    "emptyDescription": "Загрузка рассчитывается по сессиям столов в POS. Как только на столах появятся заказы — или после расширения периода — детали отобразятся здесь."
+  },
+  "traffic": {
+    "recommendationsTitle": "Рекомендации по потоку посетителей",
+    "hotspotsTitle": "Точки скопления",
+    "gridCell": "Сетка ({{x}}, {{z}})",
+    "emptyTitle": "Для анализа трафика нужны камеры заполняемости",
+    "emptyDescription": "За этот период нет данных с камер, поэтому точки скопления и рекомендации по потоку рассчитать невозможно. Аналитика столов и ИИ-инсайты работают без камер — на данных POS.",
+    "goToCameras": "Настроить камеры"
+  },
+  "behavior": {
+    "journeyTitle": "Инсайты клиентского пути",
+    "peakHours": "Пиковые часы",
+    "peakArrival": "Пик прихода",
+    "peakDeparture": "Пик ухода",
+    "timeBreakdown": "Распределение времени",
+    "dining": "Трапеза",
+    "idlePostDining": "Простой (после трапезы)",
+    "idleDiningRatio": "Отношение простой/трапеза",
+    "highIdleTitle": "Обнаружен долгий простой",
+    "highIdleDescription": "Клиенты проводят за столами {{minutes}} минут после трапезы. Чтобы ускорить оборот столов, предлагайте счёт заранее или десерты навынос.",
+    "emptyTitle": "Данных о поведении клиентов пока нет",
+    "emptyDescription": "Метрики времени трапезы рассчитываются по сессиям столов в POS; для метрик присутствия дополнительно нужны камеры заполняемости. Данные появятся здесь, как только пойдут заказы на столах."
+  },
+  "insightsTab": {
+    "allTitle": "Все инсайты",
+    "refresh": "Обновить инсайты",
+    "refreshing": "Генерация...",
+    "generatedCount": "Сгенерировано инсайтов: {{value}}",
+    "generateFailed": "Не удалось сгенерировать инсайты",
+    "emptyTitle": "Инсайты ещё не сгенерированы",
+    "emptyDescription": "Система автоматически генерирует инсайты каждую ночь на основе данных о заказах и столах. Нажмите ниже, чтобы сгенерировать их сейчас.",
+    "generateNow": "Сгенерировать сейчас"
+  },
+  "cameras": {
+    "title": "Камеры",
+    "add": "Добавить камеру",
+    "emptyTitle": "Камеры ещё не подключены",
+    "emptyDescription": "Для пространственной аналитики (поток, заполняемость, время пребывания) требуется установка камер на объекте. Аналитика столов и ИИ-инсайты уже работают без камер — на данных POS.",
+    "neverSeen": "Не выходила на связь",
+    "calibrate": "Калибровать",
+    "calibrationSaved": "Калибровка камеры сохранена",
+    "addTitle": "Добавить камеру",
+    "editTitle": "Изменить камеру",
+    "deleteTitle": "Удалить камеру",
+    "deleteConfirm": "Удалить камеру «{{name}}»? Её поток заполняемости перестанет обрабатываться. Это действие необратимо.",
+    "created": "Камера добавлена",
+    "createFailed": "Не удалось добавить камеру",
+    "updated": "Камера обновлена",
+    "updateFailed": "Не удалось обновить камеру",
+    "deleted": "Камера удалена",
+    "deleteFailed": "Не удалось удалить камеру",
+    "health": {
+      "total": "Всего",
+      "online": "В сети",
+      "offline": "Не в сети",
+      "error": "Ошибка",
+      "calibrating": "Калибровка"
+    },
+    "columns": {
+      "name": "Название",
+      "location": "Расположение",
+      "status": "Статус",
+      "lastSeen": "Последняя активность",
+      "actions": "Действия"
+    },
+    "statusValues": {
+      "ONLINE": "В сети",
+      "OFFLINE": "Не в сети",
+      "ERROR": "Ошибка",
+      "CALIBRATING": "Калибровка"
+    },
+    "form": {
+      "name": "Название камеры",
+      "namePlaceholder": "напр. Камера главного входа",
+      "nameRequired": "Укажите название камеры",
+      "location": "Расположение / описание",
+      "locationPlaceholder": "напр. Зал, над входом",
+      "streamUrl": "URL потока",
+      "streamUrlHint": "RTSP/ONVIF-адрес камеры в вашей локальной сети",
+      "streamUrlRequired": "Укажите URL потока",
+      "streamType": "Тип потока"
+    }
+  },
   "cvDisclosure": {
     "requiresCameras": "Требуются камеры заполняемости",
     "noData": "Нет данных с камер",
     "noOccupancyTelemetry": "Для измерения этих показателей нужны камеры заполняемости на объекте. Без камер они отображаются как ноль/значение по умолчанию и не отражают реальную активность."
   },
   "heatmap": {
-    "settings": "Heatmap Settings",
-    "visualizationType": "Visualization Type",
-    "colorScheme": "Color Scheme",
-    "opacity": "Opacity: {{percent}}%",
-    "loadingData": "Loading heatmap data...",
+    "settings": "Настройки тепловой карты",
+    "visualizationType": "Тип визуализации",
+    "colorScheme": "Цветовая схема",
+    "opacity": "Непрозрачность: {{percent}}%",
+    "loadingData": "Загрузка данных тепловой карты...",
     "types": {
-      "none": { "label": "None", "description": "Hide heatmap" },
-      "occupancy": { "label": "Occupancy", "description": "Show customer density" },
-      "traffic": { "label": "Traffic Flow", "description": "Show movement patterns" },
-      "dwellTime": { "label": "Dwell Time", "description": "Show time spent in areas" }
+      "none": { "label": "Нет", "description": "Скрыть тепловую карту" },
+      "occupancy": { "label": "Заполняемость", "description": "Показать плотность клиентов" },
+      "traffic": { "label": "Поток посетителей", "description": "Показать схемы перемещения" },
+      "dwellTime": { "label": "Время пребывания", "description": "Показать время, проведённое в зонах" }
     },
     "schemes": {
-      "heat": "Heat (Red)",
-      "viridis": "Viridis (Green-Purple)",
-      "plasma": "Plasma (Yellow-Purple)",
-      "coolwarm": "Cool-Warm (Blue-Red)",
-      "blues": "Blues"
+      "heat": "Тепло (красный)",
+      "viridis": "Viridis (зелёно-фиолетовый)",
+      "plasma": "Plasma (жёлто-фиолетовый)",
+      "coolwarm": "Холод-тепло (сине-красный)",
+      "blues": "Оттенки синего"
     },
     "legend": {
-      "customerDensity": "Customer Density",
-      "trafficVolume": "Traffic Volume",
-      "dwellTime": "Dwell Time",
-      "low": "Low",
-      "high": "High"
+      "customerDensity": "Плотность клиентов",
+      "trafficVolume": "Объём трафика",
+      "dwellTime": "Время пребывания",
+      "low": "Низк.",
+      "high": "Выс."
     }
   },
   "calibration": {
-    "title": "Camera Calibration",
-    "saveFailed": "Failed to save calibration",
+    "title": "Калибровка камеры",
+    "saveFailed": "Не удалось сохранить калибровку",
     "pointLabels": {
-      "topLeft": "Top-Left",
-      "topRight": "Top-Right",
-      "bottomRight": "Bottom-Right",
-      "bottomLeft": "Bottom-Left"
+      "topLeft": "Верх-лево",
+      "topRight": "Верх-право",
+      "bottomRight": "Низ-право",
+      "bottomLeft": "Низ-лево"
     },
     "step1": {
-      "heading": "Step 1: Select Camera Points",
-      "instructions": "Click on 4 corners of a rectangular area in the camera view. Start from the top-left corner and go clockwise."
+      "heading": "Шаг 1: выберите точки на камере",
+      "instructions": "Кликните по 4 углам прямоугольной области в изображении камеры. Начните с левого верхнего угла и двигайтесь по часовой стрелке."
     },
     "step2": {
-      "heading": "Step 2: Select Floor Plan Points",
-      "instructions": "Click on the corresponding 4 points on the floor plan grid. Match the same order as the camera points (top-left, top-right, bottom-right, bottom-left).",
-      "cameraView": "Camera View",
-      "floorPlan": "Floor Plan"
+      "heading": "Шаг 2: выберите точки на плане зала",
+      "instructions": "Кликните по соответствующим 4 точкам на сетке плана зала. Соблюдайте тот же порядок, что и на камере (верх-лево, верх-право, низ-право, низ-лево).",
+      "cameraView": "Вид с камеры",
+      "floorPlan": "План зала"
     },
     "step3": {
-      "heading": "Step 3: Review Calibration",
-      "instructions": "Verify that the camera and floor plan points are correctly aligned. The transformation will map positions from the camera view to the floor plan.",
-      "cameraPoints": "Camera Points",
-      "floorPlanPoints": "Floor Plan Points"
+      "heading": "Шаг 3: проверьте калибровку",
+      "instructions": "Убедитесь, что точки камеры и плана зала выровнены правильно. Преобразование будет переносить позиции из вида камеры на план зала.",
+      "cameraPoints": "Точки камеры",
+      "floorPlanPoints": "Точки плана зала"
     },
     "complete": {
-      "heading": "Calibration Complete",
-      "message": "The camera has been successfully calibrated. Position data will now be mapped to the floor plan coordinates."
+      "heading": "Калибровка завершена",
+      "message": "Камера успешно откалибрована. Данные о позициях теперь будут привязаны к координатам плана зала."
     },
-    "pointsSelected": "Points selected: {{count}} / {{total}}",
-    "captureFrame": "Capture Frame",
-    "undo": "Undo",
-    "reset": "Reset",
-    "back": "Back",
-    "next": "Next",
-    "save": "Save Calibration",
-    "saving": "Saving..."
+    "pointsSelected": "Выбрано точек: {{count}} / {{total}}",
+    "captureFrame": "Захватить кадр",
+    "undo": "Отменить",
+    "reset": "Сбросить",
+    "back": "Назад",
+    "next": "Далее",
+    "save": "Сохранить калибровку",
+    "saving": "Сохранение..."
   }
 }

--- a/frontend/src/i18n/locales/tr/analytics.json
+++ b/frontend/src/i18n/locales/tr/analytics.json
@@ -1,4 +1,179 @@
 {
+  "page": {
+    "title": "Restoran Analitiği",
+    "subtitle": "Yapay zekâ destekli içgörüler ve mekân kullanımı analizi",
+    "tabsAriaLabel": "Analitik sekmeleri"
+  },
+  "tabs": {
+    "overview": "Genel Bakış",
+    "tables": "Masa Analitiği",
+    "traffic": "Trafik Akışı",
+    "behavior": "Müşteri Davranışı",
+    "insights": "Yapay Zekâ İçgörüleri",
+    "cameras": "Kameralar"
+  },
+  "dateFilter": {
+    "from": "Başlangıç",
+    "to": "Bitiş",
+    "apply": "Uygula"
+  },
+  "devTools": {
+    "generate": "Örnek Veri Üret",
+    "generating": "Üretiliyor...",
+    "clear": "Verileri Temizle",
+    "generated": "Örnek veri üretildi: {{records}} doluluk kaydı, {{insights}} içgörü",
+    "generateFailed": "Örnek veri üretilemedi",
+    "cleared": "Tüm analitik verileri temizlendi",
+    "clearFailed": "Analitik verileri temizlenemedi"
+  },
+  "stats": {
+    "avgTableUtilization": "Ortalama Masa Kullanımı",
+    "tablesCount": "{{value}} masa",
+    "totalRevenuePeriod": "Toplam Ciro (Dönem)",
+    "tableTurns": "{{value}} masa devri",
+    "congestionScore": "Yoğunluk Skoru",
+    "hotspotsCount": "{{value}} yoğun nokta",
+    "activeInsights": "Aktif İçgörüler",
+    "totalInsightsCount": "toplam {{value}} içgörü",
+    "totalTables": "Toplam Masa",
+    "avgUtilization": "Ortalama Kullanım",
+    "peakHour": "Yoğun Saat",
+    "peakOccupancy": "%{{percent}} doluluk",
+    "totalSessions": "Toplam Oturum",
+    "higherIsBetter": "Yüksek olması iyidir",
+    "congestionHotspots": "Yoğunluk Noktaları",
+    "highTrafficAreas": "Trafiği yüksek alanlar",
+    "recommendations": "Öneriler",
+    "flowSuggestions": "Akışı iyileştirme önerileri",
+    "avgDiningTime": "Ort. Yemek Süresi",
+    "avgIdleTime": "Ort. Boşta Kalma",
+    "timeAfterDining": "Yemek sonrası süre",
+    "avgPartySize": "Ort. Grup Büyüklüğü",
+    "avgOrderValue": "Ort. Sipariş Tutarı",
+    "totalInsights": "Toplam İçgörü",
+    "new": "Yeni",
+    "inProgress": "Devam Ediyor",
+    "implemented": "Uygulandı",
+    "minutesValue": "{{minutes}} dk"
+  },
+  "columns": {
+    "table": "Masa",
+    "section": "Bölüm",
+    "capacity": "Kapasite",
+    "utilization": "Kullanım",
+    "revenue": "Ciro",
+    "sessions": "Oturum",
+    "avgOrder": "Ort. Sipariş",
+    "location": "Konum",
+    "severity": "Şiddet",
+    "avgWaitTime": "Ort. Bekleme",
+    "peakHour": "Yoğun Saat"
+  },
+  "tableLabel": "Masa {{number}}",
+  "overview": {
+    "actionableInsights": "Uygulanabilir İçgörüler",
+    "underutilizedTables": "Az Kullanılan Masalar",
+    "noInsightsTitle": "Şu anda uygulanabilir içgörü yok",
+    "noInsightsDescription": "İçgörüler, sipariş ve masa verilerinizden her gece otomatik üretilir. Yapay Zekâ İçgörüleri sekmesinden elle de üretebilirsiniz."
+  },
+  "insightCard": {
+    "potentialImpact": "Olası etki: {{impact}}",
+    "impact": "Etki: {{impact}}",
+    "confidence": "Güven: %{{percent}}",
+    "created": "Oluşturulma: {{date}}",
+    "markImplemented": "Uygulandı olarak işaretle",
+    "markInProgress": "Devam ediyor olarak işaretle",
+    "dismiss": "Yok say",
+    "statusUpdated": "İçgörü durumu güncellendi",
+    "statusUpdateFailed": "İçgörü durumu güncellenemedi"
+  },
+  "tableDetails": {
+    "title": "Masa Kullanım Detayları",
+    "emptyTitle": "Bu tarih aralığında masa hareketi yok",
+    "emptyDescription": "Kullanım, POS masa oturumlarından hesaplanır. Masalarda sipariş alındığında — veya tarih aralığını genişlettiğinizde — detaylar burada görünür."
+  },
+  "traffic": {
+    "recommendationsTitle": "Trafik Akışı Önerileri",
+    "hotspotsTitle": "Yoğunluk Noktaları",
+    "gridCell": "Izgara ({{x}}, {{z}})",
+    "emptyTitle": "Trafik analizi doluluk kameraları gerektirir",
+    "emptyDescription": "Bu dönem için kamera verisi yok; yoğun noktalar ve akış önerileri hesaplanamıyor. Masa analitiği ve yapay zekâ içgörüleri, POS verilerinizle kamerasız da çalışır.",
+    "goToCameras": "Kamera kur"
+  },
+  "behavior": {
+    "journeyTitle": "Müşteri Yolculuğu İçgörüleri",
+    "peakHours": "Yoğun Saatler",
+    "peakArrival": "Yoğun Geliş",
+    "peakDeparture": "Yoğun Ayrılış",
+    "timeBreakdown": "Süre Dağılımı",
+    "dining": "Yemek",
+    "idlePostDining": "Boşta (yemek sonrası)",
+    "idleDiningRatio": "Boşta/Yemek Oranı",
+    "highIdleTitle": "Yüksek Boşta Kalma Tespit Edildi",
+    "highIdleDescription": "Müşteriler yemek sonrası masalarda {{minutes}} dakika kalıyor. Masa devrini artırmak için hesabı önceden sunmayı veya paket tatlı ikram etmeyi değerlendirin.",
+    "emptyTitle": "Henüz müşteri davranışı verisi yok",
+    "emptyDescription": "Yemek süresi metrikleri POS masa oturumlarından türetilir; mekân içi metrikler için ayrıca doluluk kamerası gerekir. Masalardan sipariş akmaya başlayınca veriler burada görünür."
+  },
+  "insightsTab": {
+    "allTitle": "Tüm İçgörüler",
+    "refresh": "İçgörüleri Yenile",
+    "refreshing": "Üretiliyor...",
+    "generatedCount": "{{value}} içgörü üretildi",
+    "generateFailed": "İçgörüler üretilemedi",
+    "emptyTitle": "Henüz içgörü üretilmedi",
+    "emptyDescription": "Sistem, sipariş ve masa verilerinizden her gece otomatik içgörü üretir. Şimdi üretmek için aşağıya tıklayın.",
+    "generateNow": "Şimdi üret"
+  },
+  "cameras": {
+    "title": "Kameralar",
+    "add": "Kamera Ekle",
+    "emptyTitle": "Henüz kamera bağlı değil",
+    "emptyDescription": "Mekân analitiği (trafik akışı, doluluk, bekleme süresi) için sahada kamera kurulumu gerekir. Masa analitiği ve yapay zekâ içgörüleri, POS verilerinizle kamerasız da çalışır.",
+    "neverSeen": "Hiç görülmedi",
+    "calibrate": "Kalibre et",
+    "calibrationSaved": "Kamera kalibrasyonu kaydedildi",
+    "addTitle": "Kamera Ekle",
+    "editTitle": "Kamerayı Düzenle",
+    "deleteTitle": "Kamerayı Sil",
+    "deleteConfirm": "\"{{name}}\" kamerasını silmek istediğinizden emin misiniz? Doluluk akışı artık işlenmeyecek. Bu işlem geri alınamaz.",
+    "created": "Kamera eklendi",
+    "createFailed": "Kamera eklenemedi",
+    "updated": "Kamera güncellendi",
+    "updateFailed": "Kamera güncellenemedi",
+    "deleted": "Kamera silindi",
+    "deleteFailed": "Kamera silinemedi",
+    "health": {
+      "total": "Toplam",
+      "online": "Çevrimiçi",
+      "offline": "Çevrimdışı",
+      "error": "Hatalı",
+      "calibrating": "Kalibre ediliyor"
+    },
+    "columns": {
+      "name": "Ad",
+      "location": "Konum",
+      "status": "Durum",
+      "lastSeen": "Son Görülme",
+      "actions": "İşlemler"
+    },
+    "statusValues": {
+      "ONLINE": "Çevrimiçi",
+      "OFFLINE": "Çevrimdışı",
+      "ERROR": "Hata",
+      "CALIBRATING": "Kalibre ediliyor"
+    },
+    "form": {
+      "name": "Kamera adı",
+      "namePlaceholder": "örn. Ana giriş kamerası",
+      "nameRequired": "Kamera adı zorunludur",
+      "location": "Konum / açıklama",
+      "locationPlaceholder": "örn. Yemek salonu, giriş üstü",
+      "streamUrl": "Yayın URL'si",
+      "streamUrlHint": "Kameranın yerel ağınızdaki RTSP/ONVIF adresi",
+      "streamUrlRequired": "Yayın URL'si zorunludur",
+      "streamType": "Yayın türü"
+    }
+  },
   "cvDisclosure": {
     "requiresCameras": "Doluluk kameraları gerektirir",
     "noData": "Kamera verisi yok",

--- a/frontend/src/i18n/locales/uz/analytics.json
+++ b/frontend/src/i18n/locales/uz/analytics.json
@@ -1,72 +1,247 @@
 {
+  "page": {
+    "title": "Restoran analitikasi",
+    "subtitle": "Sun'iy intellektga asoslangan tahlillar va makon foydalanish tahlili",
+    "tabsAriaLabel": "Analitika bo'limlari"
+  },
+  "tabs": {
+    "overview": "Umumiy ko'rinish",
+    "tables": "Stol analitikasi",
+    "traffic": "Trafik oqimi",
+    "behavior": "Mijoz xatti-harakati",
+    "insights": "AI tahlillari",
+    "cameras": "Kameralar"
+  },
+  "dateFilter": {
+    "from": "Boshlanish",
+    "to": "Tugash",
+    "apply": "Qo'llash"
+  },
+  "devTools": {
+    "generate": "Namuna ma'lumot yaratish",
+    "generating": "Yaratilmoqda...",
+    "clear": "Ma'lumotlarni tozalash",
+    "generated": "Namuna ma'lumot yaratildi: {{records}} bandlik yozuvi, {{insights}} tahlil",
+    "generateFailed": "Namuna ma'lumot yaratib bo'lmadi",
+    "cleared": "Barcha analitika ma'lumotlari tozalandi",
+    "clearFailed": "Analitika ma'lumotlarini tozalab bo'lmadi"
+  },
+  "stats": {
+    "avgTableUtilization": "O'rtacha stol bandligi",
+    "tablesCount": "{{value}} ta stol",
+    "totalRevenuePeriod": "Umumiy tushum (davr)",
+    "tableTurns": "{{value}} ta stol aylanishi",
+    "congestionScore": "Tirbandlik ko'rsatkichi",
+    "hotspotsCount": "{{value}} ta tirband nuqta",
+    "activeInsights": "Faol tahlillar",
+    "totalInsightsCount": "jami {{value}} ta tahlil",
+    "totalTables": "Jami stollar",
+    "avgUtilization": "O'rtacha bandlik",
+    "peakHour": "Eng gavjum soat",
+    "peakOccupancy": "{{percent}}% bandlik",
+    "totalSessions": "Jami seanslar",
+    "higherIsBetter": "Yuqori bo'lgani yaxshi",
+    "congestionHotspots": "Tirband nuqtalar",
+    "highTrafficAreas": "Trafigi yuqori hududlar",
+    "recommendations": "Tavsiyalar",
+    "flowSuggestions": "Oqimni yaxshilash bo'yicha takliflar",
+    "avgDiningTime": "O'rt. ovqatlanish vaqti",
+    "avgIdleTime": "O'rt. bo'sh o'tirish",
+    "timeAfterDining": "Ovqatdan keyingi vaqt",
+    "avgPartySize": "O'rt. guruh hajmi",
+    "avgOrderValue": "O'rt. buyurtma summasi",
+    "totalInsights": "Jami tahlillar",
+    "new": "Yangi",
+    "inProgress": "Jarayonda",
+    "implemented": "Amalga oshirilgan",
+    "minutesValue": "{{minutes}} daqiqa"
+  },
+  "columns": {
+    "table": "Stol",
+    "section": "Bo'lim",
+    "capacity": "Sig'im",
+    "utilization": "Bandlik",
+    "revenue": "Tushum",
+    "sessions": "Seanslar",
+    "avgOrder": "O'rt. buyurtma",
+    "location": "Joylashuv",
+    "severity": "Darajasi",
+    "avgWaitTime": "O'rt. kutish",
+    "peakHour": "Eng gavjum soat"
+  },
+  "tableLabel": "Stol {{number}}",
+  "overview": {
+    "actionableInsights": "Amaliy tahlillar",
+    "underutilizedTables": "Kam ishlatiladigan stollar",
+    "noInsightsTitle": "Hozircha amaliy tahlillar yo'q",
+    "noInsightsDescription": "Tahlillar buyurtma va stol ma'lumotlaringiz asosida har kecha avtomatik yaratiladi. Ularni AI tahlillari bo'limidan qo'lda ham yaratishingiz mumkin."
+  },
+  "insightCard": {
+    "potentialImpact": "Kutilayotgan ta'sir: {{impact}}",
+    "impact": "Ta'sir: {{impact}}",
+    "confidence": "Ishonchlilik: {{percent}}%",
+    "created": "Yaratilgan: {{date}}",
+    "markImplemented": "Amalga oshirilgan deb belgilash",
+    "markInProgress": "Jarayonda deb belgilash",
+    "dismiss": "Rad etish",
+    "statusUpdated": "Tahlil holati yangilandi",
+    "statusUpdateFailed": "Tahlil holatini yangilab bo'lmadi"
+  },
+  "tableDetails": {
+    "title": "Stol bandligi tafsilotlari",
+    "emptyTitle": "Bu sana oralig'ida stol faoliyati yo'q",
+    "emptyDescription": "Bandlik POS stol seanslaridan hisoblanadi. Stollarda buyurtma olinganda — yoki sana oralig'ini kengaytirganingizda — tafsilotlar shu yerda ko'rinadi."
+  },
+  "traffic": {
+    "recommendationsTitle": "Trafik oqimi tavsiyalari",
+    "hotspotsTitle": "Tirband nuqtalar",
+    "gridCell": "Katak ({{x}}, {{z}})",
+    "emptyTitle": "Trafik tahlili bandlik kameralarini talab qiladi",
+    "emptyDescription": "Bu davr uchun kamera ma'lumotlari yo'q, shuning uchun tirband nuqtalar va oqim tavsiyalarini hisoblab bo'lmaydi. Stol analitikasi va AI tahlillari POS ma'lumotlaringiz bilan kamerasiz ham ishlaydi.",
+    "goToCameras": "Kamera o'rnatish"
+  },
+  "behavior": {
+    "journeyTitle": "Mijoz yo'li tahlillari",
+    "peakHours": "Eng gavjum soatlar",
+    "peakArrival": "Kelish cho'qqisi",
+    "peakDeparture": "Ketish cho'qqisi",
+    "timeBreakdown": "Vaqt taqsimoti",
+    "dining": "Ovqatlanish",
+    "idlePostDining": "Bo'sh (ovqatdan keyin)",
+    "idleDiningRatio": "Bo'sh/Ovqatlanish nisbati",
+    "highIdleTitle": "Uzoq bo'sh o'tirish aniqlandi",
+    "highIdleDescription": "Mijozlar ovqatdan keyin stollarda {{minutes}} daqiqa o'tirmoqda. Stol aylanishini oshirish uchun hisobni oldindan taqdim etishni yoki olib ketish uchun shirinlik taklif qilishni ko'rib chiqing.",
+    "emptyTitle": "Hozircha mijoz xatti-harakati ma'lumotlari yo'q",
+    "emptyDescription": "Ovqatlanish vaqti ko'rsatkichlari POS stol seanslaridan olinadi; makondagi ko'rsatkichlar uchun qo'shimcha bandlik kameralari kerak. Stollardan buyurtmalar kela boshlagach, ma'lumotlar shu yerda ko'rinadi."
+  },
+  "insightsTab": {
+    "allTitle": "Barcha tahlillar",
+    "refresh": "Tahlillarni yangilash",
+    "refreshing": "Yaratilmoqda...",
+    "generatedCount": "{{value}} ta tahlil yaratildi",
+    "generateFailed": "Tahlillarni yaratib bo'lmadi",
+    "emptyTitle": "Hozircha tahlil yaratilmagan",
+    "emptyDescription": "Tizim buyurtma va stol ma'lumotlaringiz asosida har kecha avtomatik tahlil yaratadi. Hozir yaratish uchun pastga bosing.",
+    "generateNow": "Hozir yaratish"
+  },
+  "cameras": {
+    "title": "Kameralar",
+    "add": "Kamera qo'shish",
+    "emptyTitle": "Hali kamera ulanmagan",
+    "emptyDescription": "Makon analitikasi (trafik oqimi, bandlik, o'tirish vaqti) uchun joyda kamera o'rnatilishi kerak. Stol analitikasi va AI tahlillari POS ma'lumotlaringiz bilan kamerasiz ham ishlaydi.",
+    "neverSeen": "Hech ko'rinmagan",
+    "calibrate": "Kalibrlash",
+    "calibrationSaved": "Kamera kalibrlanishi saqlandi",
+    "addTitle": "Kamera qo'shish",
+    "editTitle": "Kamerani tahrirlash",
+    "deleteTitle": "Kamerani o'chirish",
+    "deleteConfirm": "\"{{name}}\" kamerasini o'chirishga ishonchingiz komilmi? Uning bandlik oqimi endi qayta ishlanmaydi. Bu amalni bekor qilib bo'lmaydi.",
+    "created": "Kamera qo'shildi",
+    "createFailed": "Kamerani qo'shib bo'lmadi",
+    "updated": "Kamera yangilandi",
+    "updateFailed": "Kamerani yangilab bo'lmadi",
+    "deleted": "Kamera o'chirildi",
+    "deleteFailed": "Kamerani o'chirib bo'lmadi",
+    "health": {
+      "total": "Jami",
+      "online": "Onlayn",
+      "offline": "Oflayn",
+      "error": "Xato",
+      "calibrating": "Kalibrlanmoqda"
+    },
+    "columns": {
+      "name": "Nomi",
+      "location": "Joylashuv",
+      "status": "Holati",
+      "lastSeen": "Oxirgi ko'rinish",
+      "actions": "Amallar"
+    },
+    "statusValues": {
+      "ONLINE": "Onlayn",
+      "OFFLINE": "Oflayn",
+      "ERROR": "Xato",
+      "CALIBRATING": "Kalibrlanmoqda"
+    },
+    "form": {
+      "name": "Kamera nomi",
+      "namePlaceholder": "mas. Asosiy kirish kamerasi",
+      "nameRequired": "Kamera nomi majburiy",
+      "location": "Joylashuv / tavsif",
+      "locationPlaceholder": "mas. Ovqatlanish zali, kirish tepasida",
+      "streamUrl": "Oqim URL manzili",
+      "streamUrlHint": "Kameraning mahalliy tarmog'ingizdagi RTSP/ONVIF manzili",
+      "streamUrlRequired": "Oqim URL manzili majburiy",
+      "streamType": "Oqim turi"
+    }
+  },
   "cvDisclosure": {
     "requiresCameras": "Bandlik kameralari talab qilinadi",
     "noData": "Kamera ma'lumotlari yo'q",
     "noOccupancyTelemetry": "Bu ko'rsatkichlarni o'lchash uchun joyda bandlik kameralari kerak. Kamera uskunasisiz ular nol/standart qiymat sifatida ko'rinadi va haqiqiy faollikni aks ettirmaydi."
   },
   "heatmap": {
-    "settings": "Heatmap Settings",
-    "visualizationType": "Visualization Type",
-    "colorScheme": "Color Scheme",
-    "opacity": "Opacity: {{percent}}%",
-    "loadingData": "Loading heatmap data...",
+    "settings": "Issiqlik xaritasi sozlamalari",
+    "visualizationType": "Vizualizatsiya turi",
+    "colorScheme": "Rang sxemasi",
+    "opacity": "Shaffoflik: {{percent}}%",
+    "loadingData": "Issiqlik xaritasi ma'lumotlari yuklanmoqda...",
     "types": {
-      "none": { "label": "None", "description": "Hide heatmap" },
-      "occupancy": { "label": "Occupancy", "description": "Show customer density" },
-      "traffic": { "label": "Traffic Flow", "description": "Show movement patterns" },
-      "dwellTime": { "label": "Dwell Time", "description": "Show time spent in areas" }
+      "none": { "label": "Yo'q", "description": "Issiqlik xaritasini yashirish" },
+      "occupancy": { "label": "Bandlik", "description": "Mijozlar zichligini ko'rsatish" },
+      "traffic": { "label": "Trafik oqimi", "description": "Harakat yo'nalishlarini ko'rsatish" },
+      "dwellTime": { "label": "O'tirish vaqti", "description": "Hududlarda o'tkazilgan vaqtni ko'rsatish" }
     },
     "schemes": {
-      "heat": "Heat (Red)",
-      "viridis": "Viridis (Green-Purple)",
-      "plasma": "Plasma (Yellow-Purple)",
-      "coolwarm": "Cool-Warm (Blue-Red)",
-      "blues": "Blues"
+      "heat": "Issiqlik (qizil)",
+      "viridis": "Viridis (yashil-binafsha)",
+      "plasma": "Plasma (sariq-binafsha)",
+      "coolwarm": "Sovuq-issiq (ko'k-qizil)",
+      "blues": "Ko'k ranglar"
     },
     "legend": {
-      "customerDensity": "Customer Density",
-      "trafficVolume": "Traffic Volume",
-      "dwellTime": "Dwell Time",
-      "low": "Low",
-      "high": "High"
+      "customerDensity": "Mijozlar zichligi",
+      "trafficVolume": "Trafik hajmi",
+      "dwellTime": "O'tirish vaqti",
+      "low": "Past",
+      "high": "Yuqori"
     }
   },
   "calibration": {
-    "title": "Camera Calibration",
-    "saveFailed": "Failed to save calibration",
+    "title": "Kamera kalibrlanishi",
+    "saveFailed": "Kalibrlanishni saqlab bo'lmadi",
     "pointLabels": {
-      "topLeft": "Top-Left",
-      "topRight": "Top-Right",
-      "bottomRight": "Bottom-Right",
-      "bottomLeft": "Bottom-Left"
+      "topLeft": "Yuqori chap",
+      "topRight": "Yuqori o'ng",
+      "bottomRight": "Pastki o'ng",
+      "bottomLeft": "Pastki chap"
     },
     "step1": {
-      "heading": "Step 1: Select Camera Points",
-      "instructions": "Click on 4 corners of a rectangular area in the camera view. Start from the top-left corner and go clockwise."
+      "heading": "1-qadam: Kamera nuqtalarini tanlang",
+      "instructions": "Kamera ko'rinishida to'rtburchak hududning 4 burchagiga bosing. Yuqori chap burchakdan boshlab, soat yo'nalishida davom eting."
     },
     "step2": {
-      "heading": "Step 2: Select Floor Plan Points",
-      "instructions": "Click on the corresponding 4 points on the floor plan grid. Match the same order as the camera points (top-left, top-right, bottom-right, bottom-left).",
-      "cameraView": "Camera View",
-      "floorPlan": "Floor Plan"
+      "heading": "2-qadam: Qavat rejasi nuqtalarini tanlang",
+      "instructions": "Qavat rejasi katagida mos keladigan 4 nuqtaga bosing. Kamera nuqtalari bilan bir xil tartibda (yuqori chap, yuqori o'ng, pastki o'ng, pastki chap).",
+      "cameraView": "Kamera ko'rinishi",
+      "floorPlan": "Qavat rejasi"
     },
     "step3": {
-      "heading": "Step 3: Review Calibration",
-      "instructions": "Verify that the camera and floor plan points are correctly aligned. The transformation will map positions from the camera view to the floor plan.",
-      "cameraPoints": "Camera Points",
-      "floorPlanPoints": "Floor Plan Points"
+      "heading": "3-qadam: Kalibrlanishni tekshiring",
+      "instructions": "Kamera va qavat rejasi nuqtalari to'g'ri moslanganini tekshiring. O'zgartirish pozitsiyalarni kamera ko'rinishidan qavat rejasiga o'tkazadi.",
+      "cameraPoints": "Kamera nuqtalari",
+      "floorPlanPoints": "Qavat rejasi nuqtalari"
     },
     "complete": {
-      "heading": "Calibration Complete",
-      "message": "The camera has been successfully calibrated. Position data will now be mapped to the floor plan coordinates."
+      "heading": "Kalibrlash yakunlandi",
+      "message": "Kamera muvaffaqiyatli kalibrlandi. Pozitsiya ma'lumotlari endi qavat rejasi koordinatalariga bog'lanadi."
     },
-    "pointsSelected": "Points selected: {{count}} / {{total}}",
-    "captureFrame": "Capture Frame",
-    "undo": "Undo",
-    "reset": "Reset",
-    "back": "Back",
-    "next": "Next",
-    "save": "Save Calibration",
-    "saving": "Saving..."
+    "pointsSelected": "Tanlangan nuqtalar: {{count}} / {{total}}",
+    "captureFrame": "Kadrni olish",
+    "undo": "Bekor qilish",
+    "reset": "Qayta boshlash",
+    "back": "Orqaga",
+    "next": "Keyingi",
+    "save": "Kalibrlanishni saqlash",
+    "saving": "Saqlanmoqda..."
   }
 }

--- a/frontend/src/pages/admin/AnalyticsPage.tsx
+++ b/frontend/src/pages/admin/AnalyticsPage.tsx
@@ -11,12 +11,15 @@ import {
   useGenerateMockData,
   useClearMockData,
   useUpdateInsightStatus,
+  useGenerateInsights,
+  CameraManagement,
 } from '../../features/analytics';
 import { InsightSeverity, InsightStatus } from '../../features/analytics/types';
 import { Card, CardHeader, CardTitle, CardContent } from '../../components/ui/Card';
 import Button from '../../components/ui/Button';
 import Input from '../../components/ui/Input';
 import Spinner from '../../components/ui/Spinner';
+import EmptyState from '../../components/ui/EmptyState';
 import { useFormatCurrency } from '../../hooks/useFormatCurrency';
 import { toast } from 'sonner';
 import {
@@ -33,6 +36,8 @@ import {
   Activity,
   Database,
   Trash2,
+  Video,
+  RefreshCw,
 } from 'lucide-react';
 
 interface DateRangeForm {
@@ -40,7 +45,7 @@ interface DateRangeForm {
   endDate: string;
 }
 
-type TabType = 'overview' | 'tables' | 'traffic' | 'behavior' | 'insights';
+type TabType = 'overview' | 'tables' | 'traffic' | 'behavior' | 'insights' | 'cameras';
 
 const AnalyticsPage = () => {
   const { t } = useTranslation(['analytics', 'common']);
@@ -72,6 +77,7 @@ const AnalyticsPage = () => {
   const generateMockData = useGenerateMockData();
   const clearMockData = useClearMockData();
   const updateInsightStatus = useUpdateInsightStatus();
+  const generateInsights = useGenerateInsights();
 
   const onSubmit = (data: DateRangeForm) => {
     setDateRange(data);
@@ -88,36 +94,51 @@ const AnalyticsPage = () => {
   const handleGenerateMockData = async () => {
     try {
       const result = await generateMockData.mutateAsync(7);
-      toast.success(`Generated mock data: ${result.occupancyRecords} occupancy records, ${result.insights} insights`);
+      toast.success(
+        t('analytics:devTools.generated', {
+          records: result.occupancyRecords,
+          insights: result.insights,
+        }),
+      );
     } catch {
-      toast.error('Failed to generate mock data');
+      toast.error(t('analytics:devTools.generateFailed'));
     }
   };
 
   const handleClearMockData = async () => {
     try {
       await clearMockData.mutateAsync();
-      toast.success('Cleared all analytics data');
+      toast.success(t('analytics:devTools.cleared'));
     } catch {
-      toast.error('Failed to clear analytics data');
+      toast.error(t('analytics:devTools.clearFailed'));
     }
   };
 
   const handleInsightAction = async (insightId: string, status: InsightStatus) => {
     try {
       await updateInsightStatus.mutateAsync({ id: insightId, status });
-      toast.success('Insight status updated');
+      toast.success(t('analytics:insightCard.statusUpdated'));
     } catch {
-      toast.error('Failed to update insight status');
+      toast.error(t('analytics:insightCard.statusUpdateFailed'));
+    }
+  };
+
+  const handleGenerateInsights = async () => {
+    try {
+      const result = await generateInsights.mutateAsync();
+      toast.success(t('analytics:insightsTab.generatedCount', { value: result.generated }));
+    } catch {
+      toast.error(t('analytics:insightsTab.generateFailed'));
     }
   };
 
   const tabs = [
-    { id: 'overview' as TabType, label: 'Overview', icon: BarChart3 },
-    { id: 'tables' as TabType, label: 'Table Analytics', icon: Table2 },
-    { id: 'traffic' as TabType, label: 'Traffic Flow', icon: Map },
-    { id: 'behavior' as TabType, label: 'Customer Behavior', icon: Users },
-    { id: 'insights' as TabType, label: 'AI Insights', icon: Lightbulb },
+    { id: 'overview' as TabType, label: t('analytics:tabs.overview'), icon: BarChart3 },
+    { id: 'tables' as TabType, label: t('analytics:tabs.tables'), icon: Table2 },
+    { id: 'traffic' as TabType, label: t('analytics:tabs.traffic'), icon: Map },
+    { id: 'behavior' as TabType, label: t('analytics:tabs.behavior'), icon: Users },
+    { id: 'insights' as TabType, label: t('analytics:tabs.insights'), icon: Lightbulb },
+    { id: 'cameras' as TabType, label: t('analytics:tabs.cameras'), icon: Video },
   ];
 
   const getSeverityColor = (severity: InsightSeverity) => {
@@ -148,14 +169,12 @@ const AnalyticsPage = () => {
     subtitle,
     icon: Icon,
     color,
-    trend,
   }: {
     title: string;
     value: string | number;
     subtitle?: string;
     icon: React.ComponentType<{ className?: string }>;
     color: string;
-    trend?: { value: number; isPositive: boolean };
   }) => (
     <Card>
       <CardContent className="pt-6">
@@ -164,11 +183,6 @@ const AnalyticsPage = () => {
             <p className="text-sm text-slate-500 mb-1">{title}</p>
             <p className="text-2xl font-bold">{value}</p>
             {subtitle && <p className="text-xs text-slate-400 mt-1">{subtitle}</p>}
-            {trend && (
-              <p className={`text-xs mt-1 ${trend.isPositive ? 'text-green-600' : 'text-red-600'}`}>
-                {trend.isPositive ? '↑' : '↓'} {Math.abs(trend.value)}% vs last period
-              </p>
-            )}
           </div>
           <div className={`p-3 rounded-full ${color}`}>
             <Icon className="h-6 w-6 text-white" />
@@ -182,8 +196,10 @@ const AnalyticsPage = () => {
     <div>
       <div className="mb-8 flex justify-between items-start">
         <div>
-          <h1 className="text-2xl font-heading font-bold text-slate-900">Restaurant Analytics</h1>
-          <p className="text-slate-500 mt-1">AI-powered insights and space utilization analysis</p>
+          <h1 className="text-2xl font-heading font-bold text-slate-900">
+            {t('analytics:page.title')}
+          </h1>
+          <p className="text-slate-500 mt-1">{t('analytics:page.subtitle')}</p>
         </div>
         {/* Dev tools - only show in development */}
         {import.meta.env.DEV && (
@@ -195,7 +211,9 @@ const AnalyticsPage = () => {
               disabled={generateMockData.isPending}
             >
               <Database className="h-4 w-4 mr-2" />
-              {generateMockData.isPending ? 'Generating...' : 'Generate Mock Data'}
+              {generateMockData.isPending
+                ? t('analytics:devTools.generating')
+                : t('analytics:devTools.generate')}
             </Button>
             <Button
               variant="outline"
@@ -205,7 +223,7 @@ const AnalyticsPage = () => {
               className="text-red-600 hover:bg-red-50"
             >
               <Trash2 className="h-4 w-4 mr-2" />
-              Clear Data
+              {t('analytics:devTools.clear')}
             </Button>
           </div>
         )}
@@ -213,7 +231,7 @@ const AnalyticsPage = () => {
 
       {/* Tabs */}
       <div className="mb-4 md:mb-6 border-b border-slate-200/60 overflow-x-auto">
-        <nav className="flex space-x-4 min-w-max" aria-label="Analytics tabs">
+        <nav className="flex space-x-4 min-w-max" aria-label={t('analytics:page.tabsAriaLabel')}>
           {tabs.map((tab) => {
             const Icon = tab.icon;
             return (
@@ -235,25 +253,27 @@ const AnalyticsPage = () => {
       </div>
 
       {/* Date Range Filter */}
-      {activeTab !== 'insights' && (
+      {activeTab !== 'insights' && activeTab !== 'cameras' && (
         <Card className="mb-4 md:mb-6">
           <CardContent className="pt-4 md:pt-6">
             <form onSubmit={handleSubmit(onSubmit)} className="flex flex-col sm:flex-row gap-3 sm:gap-4 sm:items-end">
               <div className="flex-1">
                 <Input
-                  label="From"
+                  label={t('analytics:dateFilter.from')}
                   type="date"
                   {...register('startDate')}
                 />
               </div>
               <div className="flex-1">
                 <Input
-                  label="To"
+                  label={t('analytics:dateFilter.to')}
                   type="date"
                   {...register('endDate')}
                 />
               </div>
-              <Button type="submit" className="w-full sm:w-auto">Apply</Button>
+              <Button type="submit" className="w-full sm:w-auto">
+                {t('analytics:dateFilter.apply')}
+              </Button>
             </form>
           </CardContent>
         </Card>
@@ -269,30 +289,42 @@ const AnalyticsPage = () => {
               {/* Summary Stats */}
               <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3 md:gap-4 lg:gap-6 mb-4 md:mb-6">
                 <StatCard
-                  title="Average Table Utilization"
+                  title={t('analytics:stats.avgTableUtilization')}
                   value={`${tableUtilization?.summary?.avgUtilization?.toFixed(1) || 0}%`}
-                  subtitle={`${tableUtilization?.summary?.totalTables || 0} tables`}
+                  subtitle={t('analytics:stats.tablesCount', {
+                    value: tableUtilization?.summary?.totalTables || 0,
+                  })}
                   icon={Table2}
                   color="bg-blue-500"
                 />
                 <StatCard
-                  title="Total Revenue (Period)"
+                  title={t('analytics:stats.totalRevenuePeriod')}
                   value={formatCurrency(tableUtilization?.summary?.totalRevenue || 0)}
-                  subtitle={`${tableUtilization?.summary?.totalSessions || 0} table turns`}
+                  subtitle={t('analytics:stats.tableTurns', {
+                    value: tableUtilization?.summary?.totalSessions || 0,
+                  })}
                   icon={TrendingUp}
                   color="bg-green-500"
                 />
                 <StatCard
-                  title="Congestion Score"
+                  title={t('analytics:stats.congestionScore')}
                   value={hasCameraData ? `${congestion?.overallScore ?? 0}/100` : t('analytics:cvDisclosure.noData')}
-                  subtitle={hasCameraData ? `${congestion?.congestionPoints?.length || 0} hotspots` : t('analytics:cvDisclosure.requiresCameras')}
+                  subtitle={
+                    hasCameraData
+                      ? t('analytics:stats.hotspotsCount', {
+                          value: congestion?.congestionPoints?.length || 0,
+                        })
+                      : t('analytics:cvDisclosure.requiresCameras')
+                  }
                   icon={Activity}
                   color={!hasCameraData ? 'bg-slate-400' : congestion?.overallScore && congestion.overallScore < 70 ? 'bg-yellow-500' : 'bg-green-500'}
                 />
                 <StatCard
-                  title="Active Insights"
+                  title={t('analytics:stats.activeInsights')}
                   value={insightSummary?.byStatus?.NEW || 0}
-                  subtitle={`${insightSummary?.total || 0} total insights`}
+                  subtitle={t('analytics:stats.totalInsightsCount', {
+                    value: insightSummary?.total || 0,
+                  })}
                   icon={Lightbulb}
                   color="bg-purple-500"
                 />
@@ -303,7 +335,7 @@ const AnalyticsPage = () => {
                 <CardHeader>
                   <CardTitle className="flex items-center gap-2">
                     <Lightbulb className="h-5 w-5 text-yellow-500" />
-                    Actionable Insights
+                    {t('analytics:overview.actionableInsights')}
                   </CardTitle>
                 </CardHeader>
                 <CardContent>
@@ -324,7 +356,9 @@ const AnalyticsPage = () => {
                               </p>
                               {insight.potentialImpact && (
                                 <p className="text-xs mt-2 text-green-700">
-                                  Potential Impact: {insight.potentialImpact}
+                                  {t('analytics:insightCard.potentialImpact', {
+                                    impact: insight.potentialImpact,
+                                  })}
                                 </p>
                               )}
                             </div>
@@ -332,14 +366,14 @@ const AnalyticsPage = () => {
                               <button
                                 onClick={() => handleInsightAction(insight.id, InsightStatus.IMPLEMENTED)}
                                 className="p-2 hover:bg-green-100 rounded-lg transition-colors"
-                                title="Mark as implemented"
+                                title={t('analytics:insightCard.markImplemented')}
                               >
                                 <CheckCircle className="h-4 w-4 text-green-600" />
                               </button>
                               <button
                                 onClick={() => handleInsightAction(insight.id, InsightStatus.DISMISSED)}
                                 className="p-2 hover:bg-red-100 rounded-lg transition-colors"
-                                title="Dismiss"
+                                title={t('analytics:insightCard.dismiss')}
                               >
                                 <XCircle className="h-4 w-4 text-red-600" />
                               </button>
@@ -349,9 +383,11 @@ const AnalyticsPage = () => {
                       ))}
                     </div>
                   ) : (
-                    <p className="text-slate-500 text-center py-8">
-                      No actionable insights at this time. Generate mock data to see sample insights.
-                    </p>
+                    <EmptyState
+                      icon={Lightbulb}
+                      title={t('analytics:overview.noInsightsTitle')}
+                      description={t('analytics:overview.noInsightsDescription')}
+                    />
                   )}
                 </CardContent>
               </Card>
@@ -362,7 +398,7 @@ const AnalyticsPage = () => {
                   <CardHeader>
                     <CardTitle className="flex items-center gap-2">
                       <AlertTriangle className="h-5 w-5 text-yellow-500" />
-                      Underutilized Tables
+                      {t('analytics:overview.underutilizedTables')}
                     </CardTitle>
                   </CardHeader>
                   <CardContent>
@@ -370,16 +406,18 @@ const AnalyticsPage = () => {
                       <table className="w-full">
                         <thead>
                           <tr className="border-b">
-                            <th className="text-left py-3 px-4">Table</th>
-                            <th className="text-right py-3 px-4">Utilization</th>
-                            <th className="text-right py-3 px-4">Revenue</th>
-                            <th className="text-right py-3 px-4">Sessions</th>
+                            <th className="text-left py-3 px-4">{t('analytics:columns.table')}</th>
+                            <th className="text-right py-3 px-4">{t('analytics:columns.utilization')}</th>
+                            <th className="text-right py-3 px-4">{t('analytics:columns.revenue')}</th>
+                            <th className="text-right py-3 px-4">{t('analytics:columns.sessions')}</th>
                           </tr>
                         </thead>
                         <tbody>
                           {tableUtilization.summary.underutilizedTables.map((table) => (
                             <tr key={table.tableId} className="border-b">
-                              <td className="py-3 px-4 font-medium">Table {table.tableNumber}</td>
+                              <td className="py-3 px-4 font-medium">
+                                {t('analytics:tableLabel', { number: table.tableNumber })}
+                              </td>
                               <td className="py-3 px-4 text-right">
                                 <span className="text-red-600 font-semibold">
                                   {table.utilizationScore.toFixed(1)}%
@@ -410,26 +448,28 @@ const AnalyticsPage = () => {
               {/* Table Summary */}
               <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3 md:gap-4 lg:gap-6 mb-4 md:mb-6">
                 <StatCard
-                  title="Total Tables"
+                  title={t('analytics:stats.totalTables')}
                   value={tableUtilization?.summary?.totalTables || 0}
                   icon={Table2}
                   color="bg-blue-500"
                 />
                 <StatCard
-                  title="Average Utilization"
+                  title={t('analytics:stats.avgUtilization')}
                   value={`${tableUtilization?.summary?.avgUtilization?.toFixed(1) || 0}%`}
                   icon={BarChart3}
                   color="bg-green-500"
                 />
                 <StatCard
-                  title="Peak Hour"
+                  title={t('analytics:stats.peakHour')}
                   value={`${tableUtilization?.summary?.peakHour || 0}:00`}
-                  subtitle={`${tableUtilization?.summary?.peakOccupancy?.toFixed(0) || 0}% occupancy`}
+                  subtitle={t('analytics:stats.peakOccupancy', {
+                    percent: tableUtilization?.summary?.peakOccupancy?.toFixed(0) || 0,
+                  })}
                   icon={Clock}
                   color="bg-purple-500"
                 />
                 <StatCard
-                  title="Total Sessions"
+                  title={t('analytics:stats.totalSessions')}
                   value={tableUtilization?.summary?.totalSessions || 0}
                   icon={Users}
                   color="bg-orange-500"
@@ -439,59 +479,69 @@ const AnalyticsPage = () => {
               {/* All Tables */}
               <Card>
                 <CardHeader>
-                  <CardTitle>Table Utilization Details</CardTitle>
+                  <CardTitle>{t('analytics:tableDetails.title')}</CardTitle>
                 </CardHeader>
                 <CardContent>
-                  <div className="overflow-x-auto">
-                    <table className="w-full">
-                      <thead>
-                        <tr className="border-b">
-                          <th className="text-left py-3 px-4">Table</th>
-                          <th className="text-left py-3 px-4">Section</th>
-                          <th className="text-center py-3 px-4">Capacity</th>
-                          <th className="text-right py-3 px-4">Utilization</th>
-                          <th className="text-right py-3 px-4">Revenue</th>
-                          <th className="text-right py-3 px-4">Sessions</th>
-                          <th className="text-right py-3 px-4">Avg Order</th>
-                        </tr>
-                      </thead>
-                      <tbody>
-                        {tableUtilization?.tables?.map((table) => (
-                          <tr key={table.tableId} className="border-b hover:bg-slate-50">
-                            <td className="py-3 px-4 font-medium">Table {table.tableNumber}</td>
-                            <td className="py-3 px-4 text-slate-500">{table.section || '-'}</td>
-                            <td className="py-3 px-4 text-center">{table.capacity}</td>
-                            <td className="py-3 px-4 text-right">
-                              <div className="flex items-center justify-end gap-2">
-                                <div className="w-16 bg-slate-200 rounded-full h-2">
-                                  <div
-                                    className={`h-2 rounded-full ${
-                                      table.utilizationScore >= 70
-                                        ? 'bg-green-500'
-                                        : table.utilizationScore >= 50
-                                          ? 'bg-yellow-500'
-                                          : 'bg-red-500'
-                                    }`}
-                                    style={{ width: `${Math.min(table.utilizationScore, 100)}%` }}
-                                  />
-                                </div>
-                                <span className="font-semibold w-12 text-right">
-                                  {table.utilizationScore.toFixed(0)}%
-                                </span>
-                              </div>
-                            </td>
-                            <td className="py-3 px-4 text-right font-medium text-green-600">
-                              {formatCurrency(table.revenue)}
-                            </td>
-                            <td className="py-3 px-4 text-right">{table.sessions}</td>
-                            <td className="py-3 px-4 text-right">
-                              {table.avgOrderValue ? formatCurrency(table.avgOrderValue) : '-'}
-                            </td>
+                  {tableUtilization?.tables && tableUtilization.tables.length > 0 ? (
+                    <div className="overflow-x-auto">
+                      <table className="w-full">
+                        <thead>
+                          <tr className="border-b">
+                            <th className="text-left py-3 px-4">{t('analytics:columns.table')}</th>
+                            <th className="text-left py-3 px-4">{t('analytics:columns.section')}</th>
+                            <th className="text-center py-3 px-4">{t('analytics:columns.capacity')}</th>
+                            <th className="text-right py-3 px-4">{t('analytics:columns.utilization')}</th>
+                            <th className="text-right py-3 px-4">{t('analytics:columns.revenue')}</th>
+                            <th className="text-right py-3 px-4">{t('analytics:columns.sessions')}</th>
+                            <th className="text-right py-3 px-4">{t('analytics:columns.avgOrder')}</th>
                           </tr>
-                        ))}
-                      </tbody>
-                    </table>
-                  </div>
+                        </thead>
+                        <tbody>
+                          {tableUtilization.tables.map((table) => (
+                            <tr key={table.tableId} className="border-b hover:bg-slate-50">
+                              <td className="py-3 px-4 font-medium">
+                                {t('analytics:tableLabel', { number: table.tableNumber })}
+                              </td>
+                              <td className="py-3 px-4 text-slate-500">{table.section || '-'}</td>
+                              <td className="py-3 px-4 text-center">{table.capacity}</td>
+                              <td className="py-3 px-4 text-right">
+                                <div className="flex items-center justify-end gap-2">
+                                  <div className="w-16 bg-slate-200 rounded-full h-2">
+                                    <div
+                                      className={`h-2 rounded-full ${
+                                        table.utilizationScore >= 70
+                                          ? 'bg-green-500'
+                                          : table.utilizationScore >= 50
+                                            ? 'bg-yellow-500'
+                                            : 'bg-red-500'
+                                      }`}
+                                      style={{ width: `${Math.min(table.utilizationScore, 100)}%` }}
+                                    />
+                                  </div>
+                                  <span className="font-semibold w-12 text-right">
+                                    {table.utilizationScore.toFixed(0)}%
+                                  </span>
+                                </div>
+                              </td>
+                              <td className="py-3 px-4 text-right font-medium text-green-600">
+                                {formatCurrency(table.revenue)}
+                              </td>
+                              <td className="py-3 px-4 text-right">{table.sessions}</td>
+                              <td className="py-3 px-4 text-right">
+                                {table.avgOrderValue ? formatCurrency(table.avgOrderValue) : '-'}
+                              </td>
+                            </tr>
+                          ))}
+                        </tbody>
+                      </table>
+                    </div>
+                  ) : (
+                    <EmptyState
+                      icon={Table2}
+                      title={t('analytics:tableDetails.emptyTitle')}
+                      description={t('analytics:tableDetails.emptyDescription')}
+                    />
+                  )}
                 </CardContent>
               </Card>
             </>
@@ -509,33 +559,49 @@ const AnalyticsPage = () => {
               {/* Congestion Summary */}
               <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 md:gap-4 lg:gap-6 mb-4 md:mb-6">
                 <StatCard
-                  title="Congestion Score"
+                  title={t('analytics:stats.congestionScore')}
                   value={hasCameraData ? `${congestion?.overallScore ?? 0}/100` : t('analytics:cvDisclosure.noData')}
-                  subtitle={hasCameraData ? 'Higher is better' : t('analytics:cvDisclosure.requiresCameras')}
+                  subtitle={hasCameraData ? t('analytics:stats.higherIsBetter') : t('analytics:cvDisclosure.requiresCameras')}
                   icon={Activity}
                   color={!hasCameraData ? 'bg-slate-400' : congestion?.overallScore && congestion.overallScore < 70 ? 'bg-yellow-500' : 'bg-green-500'}
                 />
                 <StatCard
-                  title="Congestion Hotspots"
+                  title={t('analytics:stats.congestionHotspots')}
                   value={congestion?.congestionPoints?.length || 0}
-                  subtitle="Areas with high traffic"
+                  subtitle={t('analytics:stats.highTrafficAreas')}
                   icon={Map}
                   color="bg-red-500"
                 />
                 <StatCard
-                  title="Recommendations"
+                  title={t('analytics:stats.recommendations')}
                   value={congestion?.recommendations?.length || 0}
-                  subtitle="Suggestions to improve flow"
+                  subtitle={t('analytics:stats.flowSuggestions')}
                   icon={Lightbulb}
                   color="bg-blue-500"
                 />
               </div>
 
+              {/* No camera telemetry: explain honestly what this tab needs
+                  and point to the software-only analytics that work today. */}
+              {!hasCameraData && (
+                <Card className="mb-4 md:mb-6">
+                  <CardContent>
+                    <EmptyState
+                      icon={Video}
+                      title={t('analytics:traffic.emptyTitle')}
+                      description={t('analytics:traffic.emptyDescription')}
+                      actionLabel={t('analytics:traffic.goToCameras')}
+                      onAction={() => setActiveTab('cameras')}
+                    />
+                  </CardContent>
+                </Card>
+              )}
+
               {/* Recommendations */}
               {congestion?.recommendations && congestion.recommendations.length > 0 && (
                 <Card className="mb-4 md:mb-6">
                   <CardHeader>
-                    <CardTitle>Traffic Flow Recommendations</CardTitle>
+                    <CardTitle>{t('analytics:traffic.recommendationsTitle')}</CardTitle>
                   </CardHeader>
                   <CardContent>
                     <ul className="space-y-3">
@@ -551,27 +617,27 @@ const AnalyticsPage = () => {
               )}
 
               {/* Congestion Points */}
-              {congestion?.congestionPoints && congestion.congestionPoints.length > 0 && (
+              {hasCameraData && (
                 <Card>
                   <CardHeader>
-                    <CardTitle>Congestion Hotspots</CardTitle>
+                    <CardTitle>{t('analytics:traffic.hotspotsTitle')}</CardTitle>
                   </CardHeader>
                   <CardContent>
                     <div className="overflow-x-auto">
                       <table className="w-full">
                         <thead>
                           <tr className="border-b">
-                            <th className="text-left py-3 px-4">Location</th>
-                            <th className="text-right py-3 px-4">Severity</th>
-                            <th className="text-right py-3 px-4">Avg Wait Time</th>
-                            <th className="text-right py-3 px-4">Peak Hour</th>
+                            <th className="text-left py-3 px-4">{t('analytics:columns.location')}</th>
+                            <th className="text-right py-3 px-4">{t('analytics:columns.severity')}</th>
+                            <th className="text-right py-3 px-4">{t('analytics:columns.avgWaitTime')}</th>
+                            <th className="text-right py-3 px-4">{t('analytics:columns.peakHour')}</th>
                           </tr>
                         </thead>
                         <tbody>
-                          {congestion.congestionPoints.map((point, index) => (
+                          {congestion?.congestionPoints?.map((point, index) => (
                             <tr key={index} className="border-b">
                               <td className="py-3 px-4">
-                                Grid ({point.x}, {point.z})
+                                {t('analytics:traffic.gridCell', { x: point.x, z: point.z })}
                               </td>
                               <td className="py-3 px-4 text-right">
                                 <span
@@ -629,27 +695,35 @@ const AnalyticsPage = () => {
               {/* Behavior Stats */}
               <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3 md:gap-4 lg:gap-6 mb-4 md:mb-6">
                 <StatCard
-                  title="Avg Dining Time"
-                  value={`${customerBehavior.avgDiningTime.toFixed(0)} min`}
+                  title={t('analytics:stats.avgDiningTime')}
+                  value={t('analytics:stats.minutesValue', {
+                    minutes: customerBehavior.avgDiningTime.toFixed(0),
+                  })}
                   icon={Clock}
                   color="bg-blue-500"
                 />
                 <StatCard
-                  title="Avg Idle Time"
-                  value={hasCameraData ? `${customerBehavior.avgIdleTime.toFixed(0)} min` : t('analytics:cvDisclosure.noData')}
-                  subtitle={hasCameraData ? 'Time after dining' : t('analytics:cvDisclosure.requiresCameras')}
+                  title={t('analytics:stats.avgIdleTime')}
+                  value={
+                    hasCameraData
+                      ? t('analytics:stats.minutesValue', {
+                          minutes: customerBehavior.avgIdleTime.toFixed(0),
+                        })
+                      : t('analytics:cvDisclosure.noData')
+                  }
+                  subtitle={hasCameraData ? t('analytics:stats.timeAfterDining') : t('analytics:cvDisclosure.requiresCameras')}
                   icon={Clock}
                   color={hasCameraData ? 'bg-yellow-500' : 'bg-slate-400'}
                 />
                 <StatCard
-                  title="Avg Party Size"
+                  title={t('analytics:stats.avgPartySize')}
                   value={hasCameraData ? customerBehavior.avgPartySize.toFixed(1) : t('analytics:cvDisclosure.noData')}
                   subtitle={hasCameraData ? undefined : t('analytics:cvDisclosure.requiresCameras')}
                   icon={Users}
                   color={hasCameraData ? 'bg-green-500' : 'bg-slate-400'}
                 />
                 <StatCard
-                  title="Avg Order Value"
+                  title={t('analytics:stats.avgOrderValue')}
                   value={formatCurrency(customerBehavior.avgOrderValue)}
                   icon={TrendingUp}
                   color="bg-purple-500"
@@ -659,37 +733,45 @@ const AnalyticsPage = () => {
               {/* Customer Journey Insights */}
               <Card className="mb-4 md:mb-6">
                 <CardHeader>
-                  <CardTitle>Customer Journey Insights</CardTitle>
+                  <CardTitle>{t('analytics:behavior.journeyTitle')}</CardTitle>
                 </CardHeader>
                 <CardContent>
                   <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
                     <div className="p-4 bg-slate-50 rounded-xl">
-                      <h4 className="font-semibold mb-3">Peak Hours</h4>
+                      <h4 className="font-semibold mb-3">{t('analytics:behavior.peakHours')}</h4>
                       <div className="space-y-2">
                         <div className="flex justify-between">
-                          <span className="text-slate-600">Peak Arrival</span>
+                          <span className="text-slate-600">{t('analytics:behavior.peakArrival')}</span>
                           <span className="font-medium">{customerBehavior.peakArrivalHour}:00</span>
                         </div>
                         <div className="flex justify-between">
-                          <span className="text-slate-600">Peak Departure</span>
+                          <span className="text-slate-600">{t('analytics:behavior.peakDeparture')}</span>
                           <span className="font-medium">{customerBehavior.peakDepartureHour}:00</span>
                         </div>
                       </div>
                     </div>
 
                     <div className="p-4 bg-slate-50 rounded-xl">
-                      <h4 className="font-semibold mb-3">Time Breakdown</h4>
+                      <h4 className="font-semibold mb-3">{t('analytics:behavior.timeBreakdown')}</h4>
                       <div className="space-y-2">
                         <div className="flex justify-between">
-                          <span className="text-slate-600">Dining</span>
-                          <span className="font-medium">{customerBehavior.avgDiningTime.toFixed(0)} min</span>
+                          <span className="text-slate-600">{t('analytics:behavior.dining')}</span>
+                          <span className="font-medium">
+                            {t('analytics:stats.minutesValue', {
+                              minutes: customerBehavior.avgDiningTime.toFixed(0),
+                            })}
+                          </span>
                         </div>
                         <div className="flex justify-between">
-                          <span className="text-slate-600">Idle (post-dining)</span>
-                          <span className="font-medium">{customerBehavior.avgIdleTime.toFixed(0)} min</span>
+                          <span className="text-slate-600">{t('analytics:behavior.idlePostDining')}</span>
+                          <span className="font-medium">
+                            {t('analytics:stats.minutesValue', {
+                              minutes: customerBehavior.avgIdleTime.toFixed(0),
+                            })}
+                          </span>
                         </div>
                         <div className="flex justify-between">
-                          <span className="text-slate-600">Idle/Dining Ratio</span>
+                          <span className="text-slate-600">{t('analytics:behavior.idleDiningRatio')}</span>
                           <span className={`font-medium ${customerBehavior.idleToDiningRatio > 0.5 ? 'text-yellow-600' : 'text-green-600'}`}>
                             {(customerBehavior.idleToDiningRatio * 100).toFixed(0)}%
                           </span>
@@ -703,10 +785,13 @@ const AnalyticsPage = () => {
                       <div className="flex items-start gap-3">
                         <AlertTriangle className="h-5 w-5 text-yellow-600 mt-0.5" />
                         <div>
-                          <h4 className="font-semibold text-yellow-800">High Idle Time Detected</h4>
+                          <h4 className="font-semibold text-yellow-800">
+                            {t('analytics:behavior.highIdleTitle')}
+                          </h4>
                           <p className="text-sm text-yellow-700 mt-1">
-                            Customers are spending {customerBehavior.avgIdleTime.toFixed(0)} minutes at tables after dining.
-                            Consider presenting the bill proactively or offering takeaway desserts to improve table turnover.
+                            {t('analytics:behavior.highIdleDescription', {
+                              minutes: customerBehavior.avgIdleTime.toFixed(0),
+                            })}
                           </p>
                         </div>
                       </div>
@@ -717,10 +802,12 @@ const AnalyticsPage = () => {
             </>
           ) : (
             <Card>
-              <CardContent className="py-12">
-                <p className="text-center text-slate-500">
-                  No customer behavior data available. Generate mock data to see analytics.
-                </p>
+              <CardContent>
+                <EmptyState
+                  icon={Users}
+                  title={t('analytics:behavior.emptyTitle')}
+                  description={t('analytics:behavior.emptyDescription')}
+                />
               </CardContent>
             </Card>
           )}
@@ -737,25 +824,25 @@ const AnalyticsPage = () => {
               {/* Insight Summary */}
               <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3 md:gap-4 lg:gap-6 mb-4 md:mb-6">
                 <StatCard
-                  title="Total Insights"
+                  title={t('analytics:stats.totalInsights')}
                   value={insightSummary?.total || 0}
                   icon={Lightbulb}
                   color="bg-blue-500"
                 />
                 <StatCard
-                  title="New"
+                  title={t('analytics:stats.new')}
                   value={insightSummary?.byStatus?.NEW || 0}
                   icon={AlertTriangle}
                   color="bg-yellow-500"
                 />
                 <StatCard
-                  title="In Progress"
+                  title={t('analytics:stats.inProgress')}
                   value={insightSummary?.byStatus?.IN_PROGRESS || 0}
                   icon={Activity}
                   color="bg-purple-500"
                 />
                 <StatCard
-                  title="Implemented"
+                  title={t('analytics:stats.implemented')}
                   value={insightSummary?.byStatus?.IMPLEMENTED || 0}
                   icon={CheckCircle}
                   color="bg-green-500"
@@ -765,7 +852,22 @@ const AnalyticsPage = () => {
               {/* All Actionable Insights */}
               <Card>
                 <CardHeader>
-                  <CardTitle>All Insights</CardTitle>
+                  <div className="flex items-center justify-between gap-3">
+                    <CardTitle>{t('analytics:insightsTab.allTitle')}</CardTitle>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={handleGenerateInsights}
+                      disabled={generateInsights.isPending}
+                    >
+                      <RefreshCw
+                        className={`h-4 w-4 mr-2 ${generateInsights.isPending ? 'animate-spin' : ''}`}
+                      />
+                      {generateInsights.isPending
+                        ? t('analytics:insightsTab.refreshing')
+                        : t('analytics:insightsTab.refresh')}
+                    </Button>
+                  </div>
                 </CardHeader>
                 <CardContent>
                   {actionableInsights && actionableInsights.length > 0 ? (
@@ -790,33 +892,43 @@ const AnalyticsPage = () => {
                               </p>
                               {insight.potentialImpact && (
                                 <p className="text-xs mt-2 opacity-70">
-                                  Impact: {insight.potentialImpact}
+                                  {t('analytics:insightCard.impact', {
+                                    impact: insight.potentialImpact,
+                                  })}
                                 </p>
                               )}
                               <div className="flex items-center gap-4 mt-3 text-xs opacity-60">
-                                <span>Confidence: {(insight.confidenceScore * 100).toFixed(0)}%</span>
-                                <span>Created: {format(new Date(insight.createdAt), 'MMM d, yyyy')}</span>
+                                <span>
+                                  {t('analytics:insightCard.confidence', {
+                                    percent: (insight.confidenceScore * 100).toFixed(0),
+                                  })}
+                                </span>
+                                <span>
+                                  {t('analytics:insightCard.created', {
+                                    date: format(new Date(insight.createdAt), 'MMM d, yyyy'),
+                                  })}
+                                </span>
                               </div>
                             </div>
                             <div className="flex flex-col gap-2">
                               <button
                                 onClick={() => handleInsightAction(insight.id, InsightStatus.IMPLEMENTED)}
                                 className="p-2 hover:bg-green-100 rounded-lg transition-colors"
-                                title="Mark as implemented"
+                                title={t('analytics:insightCard.markImplemented')}
                               >
                                 <CheckCircle className="h-4 w-4 text-green-600" />
                               </button>
                               <button
                                 onClick={() => handleInsightAction(insight.id, InsightStatus.IN_PROGRESS)}
                                 className="p-2 hover:bg-blue-100 rounded-lg transition-colors"
-                                title="Mark as in progress"
+                                title={t('analytics:insightCard.markInProgress')}
                               >
                                 <Activity className="h-4 w-4 text-blue-600" />
                               </button>
                               <button
                                 onClick={() => handleInsightAction(insight.id, InsightStatus.DISMISSED)}
                                 className="p-2 hover:bg-red-100 rounded-lg transition-colors"
-                                title="Dismiss"
+                                title={t('analytics:insightCard.dismiss')}
                               >
                                 <XCircle className="h-4 w-4 text-red-600" />
                               </button>
@@ -826,9 +938,13 @@ const AnalyticsPage = () => {
                       ))}
                     </div>
                   ) : (
-                    <p className="text-slate-500 text-center py-8">
-                      No insights available. Generate mock data to see AI-powered insights.
-                    </p>
+                    <EmptyState
+                      icon={Lightbulb}
+                      title={t('analytics:insightsTab.emptyTitle')}
+                      description={t('analytics:insightsTab.emptyDescription')}
+                      actionLabel={t('analytics:insightsTab.generateNow')}
+                      onAction={handleGenerateInsights}
+                    />
                   )}
                 </CardContent>
               </Card>
@@ -836,6 +952,9 @@ const AnalyticsPage = () => {
           )}
         </>
       )}
+
+      {/* Cameras Tab */}
+      {activeTab === 'cameras' && <CameraManagement />}
     </div>
   );
 };


### PR DESCRIPTION
## Özet

Analitik denetiminin D5 / V1 / C1-FE bulgularının frontend teslimi. Yalnızca `frontend/src/pages/admin/AnalyticsPage.tsx` ve `frontend/src/features/analytics/**` dokunuldu.

### D5 — Kamera yönetimi sekmesi
- `useCameras/useCreateCamera/useUpdateCamera/useDeleteCamera/useCameraHealth` hook'ları artık kullanımda: Analytics sayfasına **Kameralar** sekmesi eklendi (`CameraManagement` bileşeni).
- Kamera listesi: ad, konum (açıklama), durum rozeti (çevrimiçi/çevrimdışı/hata/kalibre ediliyor), son görülme; hata mesajı varsa satırda gösteriliyor.
- Ekle/düzenle modal formu (ad, konum, yayın URL'si, yayın türü RTSP/ONVIF/HLS/WEBRTC — backend `CreateCameraDto` ile uyumlu), onaylı silme modali, sağlık özeti kartları.
- Boş durumda dürüst kurulum CTA'sı: "Henüz kamera bağlı değil…" + kamera gerektiren/gerektirmeyen analitiklerin açık ayrımı + ekleme butonu.

### V1 — CameraCalibration düzeltmesi
- Bileşen çıplak `fetch()` ile **POST** atıyordu; backend ucu **PUT** `/analytics/cameras/:id/calibration` (analytics.controller.ts'ten doğrulandı). Ayrıca çıplak fetch auth + `X-Branch-Id` başlıklarını taşımadığından BranchGuard'a takılırdı.
- Yeni `useSaveCameraCalibration` hook'u: paylaşılan `api` client + doğru metot + doğru query-key invalidation (`analyticsKeys.cameras()`).
- Kameralar sekmesindeki her satıra "Kalibre et" aksiyonu eklendi (modal içinde sihirbaz).

### C1-FE — Insights canlandırma
- `useGenerateInsights` artık bağlı: Insights sekmesinde **"İçgörüleri Yenile"** butonu (mutation → invalidate + toast, dönen adet bildiriliyor).
- Boş durumda "Henüz içgörü üretilmedi — sistem her gece otomatik üretir" + "Şimdi üret" aksiyonu.

### Dürüst boş-durumlar
- "Generate mock data to see…" türü geliştirici-ağızlı metinler kaldırıldı (Overview/Behavior/Insights).
- Tables sekmesi: boş tbody yerine açıklayıcı EmptyState (POS masa oturumlarından hesaplandığı bilgisi).
- Traffic sekmesi: kamera verisi yokken dürüst açıklama + Kameralar sekmesine yönlendiren CTA; POS-tabanlı analitiklerin kamerasız çalıştığı vurgusu.

### i18n
- AnalyticsPage'deki ~80 hardcoded İngilizce metnin tamamı `t()`'ye taşındı.
- `analytics` namespace 5 locale'de (ar/en/ru/tr/uz) gerçek çevirilerle genişletildi; ru/uz/ar'da İngilizce kalmış mevcut `heatmap`/`calibration` değerleri de bu geçişte çevrildi.
- `node scripts/check-i18n-parity.mjs` ✅ ve CI'daki `check-i18n-value-drift.mjs --gate-new` ✅.

### Testler
- `CameraManagement.test.tsx`: dürüst boş-durum + CTA, ekleme formu POST sözleşmesi, yalnızca onay sonrası DELETE.
- `analyticsApi.test.tsx`: `useSaveCameraCalibration` PUT sözleşme testi (yanlış POST regresyonuna karşı `post` çağrılmadığı da doğrulanıyor).

## Doğrulama
- `npx tsc --noEmit` ✅
- `npx vitest run` (tam suite) ✅ — 264 dosya, 1952 test geçti (1 pre-existing skip)
- `npx eslint <değişen dosyalar>` ✅ — 0 error (4 pre-existing warning)
- `node scripts/check-i18n-parity.mjs` ✅
- `npm run build` ✅
