### PR TITLE
fix(accounting): Nilvera go-live hardening — 16 verified review findings (3 critical)

### DIFF
--- a/backend/src/modules/accounting/accounting.module.ts
+++ b/backend/src/modules/accounting/accounting.module.ts
@@ -20,6 +20,18 @@ import {
 } from "./providers/e-document-signer";
 import { AccountingResyncScheduler } from "./schedulers/accounting-resync.scheduler";
 
+/** Fail fast if the mock e-belge providers are about to boot in production. */
+function assertMockAllowed(): void {
+  if (
+    process.env.EBELGE_PROVIDER === "mock" &&
+    process.env.NODE_ENV === "production"
+  ) {
+    throw new Error(
+      "EBELGE_PROVIDER=mock is not allowed in production — mock mükellef/signer providers would corrupt real e-belge dispatches",
+    );
+  }
+}
+
 @Module({
   imports: [PrismaModule, SubscriptionsModule],
   controllers: [
@@ -37,19 +49,26 @@ import { AccountingResyncScheduler } from "./schedulers/accounting-resync.schedu
     // in-memory mükellef query + signer for the full flow; otherwise the Null
     // providers keep issuance safe (route to e-Arşiv, refuse to sign) until the
     // real integrator creds + certificate are installed under these tokens.
+    // The mock binding is REFUSED in production: a lingering EBELGE_PROVIDER=mock
+    // env var would fake mükellef answers and inject mock signatures into real
+    // integrator dispatches.
     {
       provide: MUKELLEF_QUERY,
-      useFactory: () =>
-        process.env.EBELGE_PROVIDER === "mock"
+      useFactory: () => {
+        assertMockAllowed();
+        return process.env.EBELGE_PROVIDER === "mock"
           ? new MockMukellefQueryProvider()
-          : new NullMukellefQueryProvider(),
+          : new NullMukellefQueryProvider();
+      },
     },
     {
       provide: E_DOCUMENT_SIGNER,
-      useFactory: () =>
-        process.env.EBELGE_PROVIDER === "mock"
+      useFactory: () => {
+        assertMockAllowed();
+        return process.env.EBELGE_PROVIDER === "mock"
           ? new MockEDocumentSigner()
-          : new NullEDocumentSigner(),
+          : new NullEDocumentSigner();
+      },
     },
   ],
   exports: [

--- a/backend/src/modules/accounting/adapters/accounting-adapters.spec.ts
+++ b/backend/src/modules/accounting/adapters/accounting-adapters.spec.ts
@@ -16,9 +16,7 @@ const invoice: AccountingInvoiceData = {
   issueDate: "2026-06-15",
   currency: "TRY",
   totalAmount: 120,
-  items: [
-    { description: "Coffee", quantity: 2, unitPrice: 50, taxRate: 20 },
-  ],
+  items: [{ description: "Coffee", quantity: 2, unitPrice: 50, taxRate: 20 }],
 };
 
 function fakeHttp() {
@@ -237,7 +235,7 @@ describe("ForibaEfaturaAdapter", () => {
     expect(xml).toContain("601"); // tevkifat code
     // payable reduced by the withheld amount: 118 − 9 = 109.00
     expect(xml).toContain(
-      "<cbc:PayableAmount currencyID=\"TRY\">109.00</cbc:PayableAmount>",
+      '<cbc:PayableAmount currencyID="TRY">109.00</cbc:PayableAmount>',
     );
   });
 
@@ -260,81 +258,116 @@ describe("ForibaEfaturaAdapter", () => {
   });
 });
 
-describe('ForibaEfaturaAdapter — signing before dispatch', () => {
-  it('signs the UBL with the configured signer before base64-encoding', async () => {
+describe("ForibaEfaturaAdapter — signing before dispatch", () => {
+  it("signs the UBL with the configured signer before base64-encoding", async () => {
     const adapter = new ForibaEfaturaAdapter();
     const signer: any = {
-      name: 'MOCK',
+      name: "MOCK",
       isConfigured: () => true,
-      sign: jest.fn().mockImplementation(async (xml: string) =>
-        xml.replace('</Invoice>', '<Signed/></Invoice>'),
-      ),
+      sign: jest
+        .fn()
+        .mockImplementation(async (xml: string) =>
+          xml.replace("</Invoice>", "<Signed/></Invoice>"),
+        ),
     };
     adapter.setSigner(signer);
     const http = fakeHttp();
-    http.post.mockResolvedValue({ data: { uuid: 'fb-signed' } });
+    http.post.mockResolvedValue({ data: { uuid: "fb-signed" } });
     (adapter as any).httpClient = http;
 
-    await adapter.pushInvoice('tok', 'co-1', invoice);
+    await adapter.pushInvoice("tok", "co-1", invoice);
 
     expect(signer.sign).toHaveBeenCalledTimes(1);
-    const dispatched = Buffer.from(http.post.mock.calls[0][1].content, 'base64').toString();
-    expect(dispatched).toContain('<Signed/>'); // the signed artifact is what gets dispatched
+    const dispatched = Buffer.from(
+      http.post.mock.calls[0][1].content,
+      "base64",
+    ).toString();
+    expect(dispatched).toContain("<Signed/>"); // the signed artifact is what gets dispatched
   });
 
-  it('dispatches unsigned when no signer is configured (isConfigured=false)', async () => {
+  it("dispatches unsigned when no signer is configured (isConfigured=false)", async () => {
     const adapter = new ForibaEfaturaAdapter();
-    adapter.setSigner({ name: 'NONE', isConfigured: () => false, sign: jest.fn() } as any);
+    adapter.setSigner({
+      name: "NONE",
+      isConfigured: () => false,
+      sign: jest.fn(),
+    } as any);
     const http = fakeHttp();
-    http.post.mockResolvedValue({ data: { uuid: 'fb-unsigned' } });
+    http.post.mockResolvedValue({ data: { uuid: "fb-unsigned" } });
     (adapter as any).httpClient = http;
 
-    const out = await adapter.pushInvoice('tok', 'co-1', invoice);
-    expect(out.externalId).toBe('fb-unsigned');
+    const out = await adapter.pushInvoice("tok", "co-1", invoice);
+    expect(out.externalId).toBe("fb-unsigned");
   });
 });
 
-describe('ForibaEfaturaAdapter — total reconciliation + configured host', () => {
-  it('emits the stored net line subtotal/tax (not unitPrice×qty) so totals reconcile', async () => {
+describe("ForibaEfaturaAdapter — total reconciliation + configured host", () => {
+  it("emits the stored net line subtotal/tax (not unitPrice×qty) so totals reconcile", async () => {
     const adapter = new ForibaEfaturaAdapter();
     const http = fakeHttp();
-    http.post.mockResolvedValue({ data: { uuid: 'fb-recon' } });
+    http.post.mockResolvedValue({ data: { uuid: "fb-recon" } });
     (adapter as any).httpClient = http;
     // unitPrice 8.33 × 3 = 24.99, but the stored net subtotal is 25.00.
-    await adapter.pushInvoice('tok', 'co-1', {
+    await adapter.pushInvoice("tok", "co-1", {
       ...invoice,
       totalAmount: 30,
-      items: [{ description: 'X', quantity: 3, unitPrice: 8.33, taxRate: 20, lineSubtotal: 25, lineTax: 5 }],
+      items: [
+        {
+          description: "X",
+          quantity: 3,
+          unitPrice: 8.33,
+          taxRate: 20,
+          lineSubtotal: 25,
+          lineTax: 5,
+        },
+      ],
     });
-    const xml = Buffer.from(http.post.mock.calls[0][1].content, 'base64').toString();
-    expect(xml).toContain('<cbc:LineExtensionAmount currencyID="TRY">25.00</cbc:LineExtensionAmount>');
+    const xml = Buffer.from(
+      http.post.mock.calls[0][1].content,
+      "base64",
+    ).toString();
+    expect(xml).toContain(
+      '<cbc:LineExtensionAmount currencyID="TRY">25.00</cbc:LineExtensionAmount>',
+    );
     // header TaxExclusive 25.00 + TaxTotal 5.00 == TaxInclusive 30.00 (reconciles)
-    expect(xml).toContain('<cbc:TaxExclusiveAmount currencyID="TRY">25.00</cbc:TaxExclusiveAmount>');
-    expect(xml).toContain('<cbc:TaxInclusiveAmount currencyID="TRY">30.00</cbc:TaxInclusiveAmount>');
+    expect(xml).toContain(
+      '<cbc:TaxExclusiveAmount currencyID="TRY">25.00</cbc:TaxExclusiveAmount>',
+    );
+    expect(xml).toContain(
+      '<cbc:TaxInclusiveAmount currencyID="TRY">30.00</cbc:TaxInclusiveAmount>',
+    );
   });
 
-  it('pins the client to the tenant apiUrl on authenticate (dispatch same host as auth)', async () => {
+  it("pins the client to the tenant apiUrl on authenticate (dispatch same host as auth)", async () => {
     const adapter = new ForibaEfaturaAdapter();
     const http = fakeHttp();
-    http.post.mockResolvedValue({ data: { access_token: 't', expires_in: 100 } });
+    http.post.mockResolvedValue({
+      data: { access_token: "t", expires_in: 100 },
+    });
     (adapter as any).httpClient = http;
-    await adapter.authenticate({ apiUrl: 'https://sandbox.foriba.example', username: 'u', password: 'p' });
-    expect(http.defaults.baseURL).toBe('https://sandbox.foriba.example');
+    await adapter.authenticate({
+      apiUrl: "https://sandbox.foriba.example",
+      username: "u",
+      password: "p",
+    });
+    expect(http.defaults.baseURL).toBe("https://sandbox.foriba.example");
   });
 });
 
-describe('ForibaEfaturaAdapter.setApiBase', () => {
-  it('pins the dispatch baseURL independent of authenticate (cached-token path)', async () => {
+describe("ForibaEfaturaAdapter.setApiBase", () => {
+  it("pins the dispatch baseURL independent of authenticate (cached-token path)", async () => {
     const adapter = new ForibaEfaturaAdapter();
-    adapter.setApiBase('https://sandbox.foriba.example');
+    adapter.setApiBase("https://sandbox.foriba.example");
     const http = fakeHttp();
-    http.post.mockResolvedValue({ data: { uuid: 'fb-x' } });
+    http.post.mockResolvedValue({ data: { uuid: "fb-x" } });
     // preserve the pinned baseURL on the injected client
-    http.defaults.baseURL = 'https://sandbox.foriba.example';
+    http.defaults.baseURL = "https://sandbox.foriba.example";
     (adapter as any).httpClient = http;
-    await adapter.pushInvoice('tok', 'co-1', invoice);
+    await adapter.pushInvoice("tok", "co-1", invoice);
     // dispatch URL resolves against the pinned host, not the hardcoded prod one
-    expect(http.post.mock.calls[0][0]).toContain('https://sandbox.foriba.example');
+    expect(http.post.mock.calls[0][0]).toContain(
+      "https://sandbox.foriba.example",
+    );
   });
 });
 
@@ -344,28 +377,27 @@ describe('ForibaEfaturaAdapter.setApiBase', () => {
  * a manual-cancel instruction) and must never touch the network — a stub
  * that pretended success would silently leave live documents at GİB.
  */
-describe('cancelInvoice — honest GATED stubs (A3)', () => {
+describe("cancelInvoice — honest GATED stubs (A3)", () => {
   it.each([
-    ['ParasutAdapter', () => new ParasutAdapter(), /Parasut panel/],
-    ['LogoAdapter', () => new LogoAdapter(), /Logo panel/],
-    [
-      'ForibaEfaturaAdapter',
-      () => new ForibaEfaturaAdapter(),
-      /Foriba panel/,
-    ],
-  ])('%s refuses with a manual-cancel error and no HTTP call', async (_name, make, panelRe) => {
-    const adapter: any = make();
-    const http = fakeHttp();
-    adapter.httpClient = http;
+    ["ParasutAdapter", () => new ParasutAdapter(), /Parasut panel/],
+    ["LogoAdapter", () => new LogoAdapter(), /Logo panel/],
+    ["ForibaEfaturaAdapter", () => new ForibaEfaturaAdapter(), /Foriba panel/],
+  ])(
+    "%s refuses with a manual-cancel error and no HTTP call",
+    async (_name, make, panelRe) => {
+      const adapter: any = make();
+      const http = fakeHttp();
+      adapter.httpClient = http;
 
-    const out = await adapter.cancelInvoice('tok', 'co-1', 'EXT-1');
+      const out = await adapter.cancelInvoice("tok", "co-1", "EXT-1");
 
-    expect(out.success).toBe(false);
-    expect(out.error).toMatch(/cancel API not yet integrated/i);
-    expect(out.error).toMatch(panelRe);
-    expect(http.post).not.toHaveBeenCalled();
-    expect(http.get).not.toHaveBeenCalled();
-  });
+      expect(out.success).toBe(false);
+      expect(out.error).toMatch(/cancel API not yet integrated/i);
+      expect(out.error).toMatch(panelRe);
+      expect(http.post).not.toHaveBeenCalled();
+      expect(http.get).not.toHaveBeenCalled();
+    },
+  );
 });
 
 /**
@@ -445,6 +477,30 @@ describe("NilveraAdapter", () => {
       /apiUrl/i,
     );
     expect(http.post).not.toHaveBeenCalled();
+  });
+
+  it("setApiBase pins the host independent of authenticate (cached-token path — Foriba parity)", async () => {
+    // The sync service builds a FRESH adapter per call and skips authenticate()
+    // on a warm token cache; authenticate() is otherwise the only baseURL
+    // writer. Without setApiBase every call after the first failed
+    // "apiUrl is not configured" for the whole 24h token TTL.
+    const { adapter, http } = nilvera();
+    http.post.mockResolvedValue({ data: { UUID: "uuid-pinned" } });
+    http.delete.mockResolvedValue({ data: {} });
+
+    adapter.setApiBase("https://apitest.nilvera.com");
+
+    const pushed = await adapter.pushInvoice("tok", "", invoice);
+    expect(pushed.externalId).toBe("uuid-pinned");
+    expect(http.post.mock.calls[0][0]).toBe(
+      "https://apitest.nilvera.com/earchive/Send/Xml",
+    );
+
+    const cancelled = await adapter.cancelInvoice("tok", "", "uuid-pinned");
+    expect(cancelled.success).toBe(true);
+    expect(http.delete.mock.calls[0][0]).toBe(
+      "https://apitest.nilvera.com/earchive/Cancel",
+    );
   });
 
   it("pushInvoice throws a clear error when the response carries no UUID", async () => {

--- a/backend/src/modules/accounting/adapters/nilvera.adapter.ts
+++ b/backend/src/modules/accounting/adapters/nilvera.adapter.ts
@@ -50,6 +50,19 @@ export class NilveraAdapter implements AccountingAdapter {
     return this;
   }
 
+  /**
+   * Pin the dispatch host to the tenant-configured apiUrl. Must be called on
+   * EVERY sync/cancel (mirrors ForibaEfaturaAdapter.setApiBase): the sync
+   * service builds a fresh adapter per call and getToken() skips
+   * authenticate() on a warm token cache — authenticate() is otherwise the
+   * only place baseURL gets set, so without this pin every call after the
+   * first would fail "apiUrl is not configured" for the whole 24h token TTL.
+   */
+  setApiBase(url: string): this {
+    if (url) this.httpClient.defaults.baseURL = url;
+    return this;
+  }
+
   private authHeaders(token: string) {
     return { Authorization: `Bearer ${token}` };
   }

--- a/backend/src/modules/accounting/controllers/accounting-settings.controller.spec.ts
+++ b/backend/src/modules/accounting/controllers/accounting-settings.controller.spec.ts
@@ -9,8 +9,12 @@ import { AccountingSyncService } from "../services/accounting-sync.service";
  * test-connection routes through the sync service.
  */
 describe("AccountingSettingsController", () => {
-  let service: { findByTenant: jest.Mock; update: jest.Mock; sanitize: jest.Mock };
-  let sync: { testConnection: jest.Mock };
+  let service: {
+    findByTenant: jest.Mock;
+    update: jest.Mock;
+    sanitize: jest.Mock;
+  };
+  let sync: { testConnection: jest.Mock; clearTokenCache: jest.Mock };
   let ctrl: AccountingSettingsController;
   const req = { tenantId: "t1" };
 
@@ -20,7 +24,10 @@ describe("AccountingSettingsController", () => {
       update: jest.fn().mockResolvedValue({ raw: "secret" }),
       sanitize: jest.fn().mockReturnValue({ safe: true }),
     };
-    sync = { testConnection: jest.fn().mockResolvedValue(true) };
+    sync = {
+      testConnection: jest.fn().mockResolvedValue(true),
+      clearTokenCache: jest.fn(),
+    };
     ctrl = new AccountingSettingsController(
       service as unknown as AccountingSettingsService,
       sync as unknown as AccountingSyncService,
@@ -40,6 +47,11 @@ describe("AccountingSettingsController", () => {
     expect(service.update).toHaveBeenCalledWith("t1", dto);
     expect(service.sanitize).toHaveBeenCalled();
     expect(out).toEqual({ safe: true });
+  });
+
+  it("update drops the tenant's cached provider tokens so rotated/corrected creds apply immediately", async () => {
+    await ctrl.update(req, { nilveraApiKey: "new-key" } as any);
+    expect(sync.clearTokenCache).toHaveBeenCalledWith("t1");
   });
 
   it("testConnection routes through the sync service", () => {

--- a/backend/src/modules/accounting/controllers/accounting-settings.controller.ts
+++ b/backend/src/modules/accounting/controllers/accounting-settings.controller.ts
@@ -47,6 +47,11 @@ export class AccountingSettingsController {
   @Roles(UserRole.ADMIN)
   async update(@Request() req, @Body() dto: UpdateAccountingSettingsDto) {
     const settings = await this.service.update(req.tenantId, dto);
+    // Corrected/rotated credentials must take effect immediately: the sync
+    // service caches provider tokens (Nilvera's static key for 24h), so
+    // without this a fixed key keeps failing — and a rotated key keeps being
+    // used — until the cache TTL lapses.
+    this.syncService.clearTokenCache(req.tenantId);
     return this.service.sanitize(settings);
   }
 

--- a/backend/src/modules/accounting/dto/accounting-settings.dto.ts
+++ b/backend/src/modules/accounting/dto/accounting-settings.dto.ts
@@ -52,26 +52,64 @@ export class UpdateAccountingSettingsDto {
   @IsOptional()
   autoSync?: boolean;
 
+  // SECRET fields carry @EmptyStringToUndefined: "" means "unchanged", never
+  // "clear". The FE already skips empty secrets, but any non-UI client
+  // (Swagger try-it-out, ops script round-tripping the settings object) would
+  // otherwise silently overwrite the stored encrypted credential with "" —
+  // and sanitize() never returns it, so it would be unrecoverable.
   @ApiPropertyOptional() @IsString() @IsOptional() parasutCompanyId?: string;
   @ApiPropertyOptional() @IsString() @IsOptional() parasutClientId?: string;
-  @ApiPropertyOptional() @IsString() @IsOptional() parasutClientSecret?: string;
+  @ApiPropertyOptional()
+  @EmptyStringToUndefined()
+  @IsString()
+  @IsOptional()
+  parasutClientSecret?: string;
   @ApiPropertyOptional() @IsString() @IsOptional() parasutUsername?: string;
-  @ApiPropertyOptional() @IsString() @IsOptional() parasutPassword?: string;
+  @ApiPropertyOptional()
+  @EmptyStringToUndefined()
+  @IsString()
+  @IsOptional()
+  parasutPassword?: string;
 
   @ApiPropertyOptional() @IsString() @IsOptional() logoApiUrl?: string;
   @ApiPropertyOptional() @IsString() @IsOptional() logoUsername?: string;
-  @ApiPropertyOptional() @IsString() @IsOptional() logoPassword?: string;
+  @ApiPropertyOptional()
+  @EmptyStringToUndefined()
+  @IsString()
+  @IsOptional()
+  logoPassword?: string;
   @ApiPropertyOptional() @IsString() @IsOptional() logoFirmNumber?: string;
 
   @ApiPropertyOptional() @IsString() @IsOptional() foribaApiUrl?: string;
   @ApiPropertyOptional() @IsString() @IsOptional() foribaUsername?: string;
-  @ApiPropertyOptional() @IsString() @IsOptional() foribaPassword?: string;
+  @ApiPropertyOptional()
+  @EmptyStringToUndefined()
+  @IsString()
+  @IsOptional()
+  foribaPassword?: string;
   @ApiPropertyOptional() @IsString() @IsOptional() foribaServiceType?: string;
 
   // Nilvera: statik "Persisted Access Token" modeli — kullanıcı adı/şifre yok,
   // panelden üretilen API anahtarı + tenant'ın panelinden teyit edilen apiUrl.
-  @ApiPropertyOptional() @IsString() @IsOptional() nilveraApiUrl?: string;
-  @ApiPropertyOptional() @IsString() @IsOptional() nilveraApiKey?: string;
+  // apiUrl https-zorunlu ve nilvera.com host'una kilitli: baseURL her isteğe
+  // Bearer anahtar + fatura içeriği taşır — serbest bir URL, anahtar
+  // sızdırma/SSRF hedefi olurdu. Bilinçli olarak EmptyStringToUndefined YOK:
+  // "" gönderimi sessiz silme yerine net bir 400 doğrulama hatası üretir
+  // (URL'siz Nilvera zaten çalışamaz; sağlayıcıyı kapatmak için provider=NONE).
+  @ApiPropertyOptional({
+    description: "Nilvera API host (https, *.nilvera.com)",
+  })
+  @IsString()
+  @IsOptional()
+  @Matches(/^https:\/\/([a-z0-9-]+\.)*nilvera\.com(\/|$)/i, {
+    message: "nilveraApiUrl must be an https URL on the nilvera.com domain",
+  })
+  nilveraApiUrl?: string;
+  @ApiPropertyOptional()
+  @EmptyStringToUndefined()
+  @IsString()
+  @IsOptional()
+  nilveraApiKey?: string;
 
   @ApiPropertyOptional() @IsString() @IsOptional() invoicePrefix?: string;
   @ApiPropertyOptional()

--- a/backend/src/modules/accounting/providers/e-document-signer.ts
+++ b/backend/src/modules/accounting/providers/e-document-signer.ts
@@ -28,9 +28,12 @@ export class MockEDocumentSigner implements EDocumentSigner {
 
   async sign(xml: string): Promise<string> {
     if (xml.includes("</Invoice>")) {
+      // Namespace declared inline so even a misrouted mock-signed dispatch is
+      // namespace-VALID XML — it fails at the provider for a debuggable
+      // reason (unknown element) instead of as an XML parse error.
       return xml.replace(
         "</Invoice>",
-        "  <ext:MockSignature>SIGNED</ext:MockSignature>\n</Invoice>",
+        '  <ext:MockSignature xmlns:ext="urn:hummytummy:mock-signature">SIGNED</ext:MockSignature>\n</Invoice>',
       );
     }
     return `${xml}\n<!-- MockSignature: SIGNED -->`;

--- a/backend/src/modules/accounting/services/accounting-settings.service.ts
+++ b/backend/src/modules/accounting/services/accounting-settings.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from "@nestjs/common";
+import { Injectable, Logger } from "@nestjs/common";
 import { Prisma } from "@prisma/client";
 import { PrismaService } from "../../../prisma/prisma.service";
 import { UpdateAccountingSettingsDto } from "../dto/accounting-settings.dto";
@@ -36,6 +36,8 @@ function encryptDto<T extends Record<string, any>>(dto: T): T {
 
 @Injectable()
 export class AccountingSettingsService {
+  private readonly logger = new Logger(AccountingSettingsService.name);
+
   constructor(private prisma: PrismaService) {}
 
   // v3.0.1 — findFirst + opportunistic create/update. The compound
@@ -160,8 +162,15 @@ export class AccountingSettingsService {
         try {
           (out as any)[k] = decryptString(v);
         } catch {
-          // Decryption failed (corrupted blob or rotated key) — surface
-          // as null so the caller can prompt re-entry instead of crashing.
+          // Decryption failed (corrupted blob or rotated master key) —
+          // surface as null so the caller can prompt re-entry instead of
+          // crashing. Logged loudly because downstream only sees a generic
+          // "credential missing" while sanitize() keeps reporting
+          // has*Credentials=true (the raw blob still exists) — without this
+          // line the operator has no signal that re-entry is what's needed.
+          this.logger.warn(
+            `Stored ${k} for tenant ${tenantId} could not be decrypted (master key rotated or row copied across environments) — treating as missing; re-enter it in accounting settings`,
+          );
           (out as any)[k] = null;
         }
       }

--- a/backend/src/modules/accounting/services/accounting-sync.service.spec.ts
+++ b/backend/src/modules/accounting/services/accounting-sync.service.spec.ts
@@ -17,9 +17,11 @@ import { AccountingProvider } from '../constants/accounting.enum';
  * to serialize concurrent pushes. These specs LOCK that dedupe contract:
  *
  *   - a row already mid-flight / SYNCED is NOT pushed again (claim count 0)
- *   - only null / FAILED / PENDING rows are claimable
- *   - the same-provider externalId short-circuit skips already-synced rows
- *   - a provider swap REOPENS sync (old externalId is a stale FK)
+ *   - only null / FAILED / PENDING rows are claimable (null via its own OR
+ *     branch — Prisma rejects null inside an `in` list at runtime)
+ *   - ANY externalId short-circuits: same provider = dedupe; a DIFFERENT
+ *     provider (post-swap) is deliberately NOT re-issued (fiscal-safe — a
+ *     second dispatch would duplicate a legal e-belge)
  *   - on push failure the row is recorded FAILED + syncError (claimable again)
  *   - all writes carry tenantId (cross-tenant defence-in-depth)
  */
@@ -46,9 +48,7 @@ describe('AccountingSyncService.syncInvoice', () => {
     externalId: null,
     externalProvider: null,
     externalStatus: null,
-    items: [
-      { description: 'Burger', quantity: 2, unitPrice: 50, taxRate: 10 },
-    ],
+    items: [{ description: 'Burger', quantity: 2, unitPrice: 50, taxRate: 10 }],
   };
 
   const foribaSettings = {
@@ -78,7 +78,16 @@ describe('AccountingSyncService.syncInvoice', () => {
       // the decrypted creds are what reach the adapter.
       getDecryptedCredentials: jest.fn().mockResolvedValue(null),
     };
-    svc = new AccountingSyncService(prisma as any, settings as any, { name: "MOCK", isRegisteredEFaturaUser: async () => false } as any, { name: "MOCK", isConfigured: () => true, sign: async (x: string) => x } as any);
+    svc = new AccountingSyncService(
+      prisma as any,
+      settings as any,
+      { name: 'MOCK', isRegisteredEFaturaUser: async () => false } as any,
+      {
+        name: 'MOCK',
+        isConfigured: () => true,
+        sign: async (x: string) => x,
+      } as any,
+    );
   });
 
   it('is a no-op when the tenant has no accounting provider configured', async () => {
@@ -120,20 +129,25 @@ describe('AccountingSyncService.syncInvoice', () => {
     expect(adapterSpy).not.toHaveBeenCalled();
   });
 
-  it('RE-OPENS sync after a provider swap (stale externalId is a foreign FK)', async () => {
+  it('does NOT re-issue a document already issued at ANOTHER provider (fiscal-safe swap)', async () => {
+    // The document legally exists at Parasut. Re-dispatching it at the new
+    // provider would create a duplicate e-belge; only rows that never reached
+    // a provider (externalId null) sync after a swap. (Previously the guard
+    // fell through here and the claim silently rejected the SYNCED row — the
+    // "re-open" promise was dead code.)
     settings.findByTenant.mockResolvedValue(foribaSettings);
     (prisma.salesInvoice.findFirst as any).mockResolvedValue({
       ...baseInvoice,
       externalId: 'PARASUT-123',
       externalProvider: AccountingProvider.PARASUT, // different from current FORIBA
+      externalStatus: 'SYNCED',
     });
-    (prisma.salesInvoice.updateMany as any).mockResolvedValue({ count: 1 });
-    const adapter = fakeAdapter();
-    jest.spyOn(svc as any, 'getAdapter').mockReturnValue(adapter);
+    const adapterSpy = jest.spyOn(svc as any, 'getAdapter');
 
     await svc.syncInvoice(INVOICE_ID, TENANT);
 
-    expect(adapter.pushInvoice).toHaveBeenCalled();
+    expect(prisma.salesInvoice.updateMany).not.toHaveBeenCalled();
+    expect(adapterSpy).not.toHaveBeenCalled();
   });
 
   it('authenticates with the DECRYPTED secret, never the stored v1: blob (M14 regression)', async () => {
@@ -147,7 +161,9 @@ describe('AccountingSyncService.syncInvoice', () => {
       ...foribaSettings,
       foribaPassword: 'real-plaintext-pass',
     });
-    (prisma.salesInvoice.findFirst as any).mockResolvedValue({ ...baseInvoice });
+    (prisma.salesInvoice.findFirst as any).mockResolvedValue({
+      ...baseInvoice,
+    });
     (prisma.salesInvoice.updateMany as any).mockResolvedValue({ count: 1 });
     const adapter = fakeAdapter();
     jest.spyOn(svc as any, 'getAdapter').mockReturnValue(adapter);
@@ -163,7 +179,9 @@ describe('AccountingSyncService.syncInvoice', () => {
 
   it('claims only null/FAILED/PENDING rows and aborts when the claim loses the race (count 0)', async () => {
     settings.findByTenant.mockResolvedValue(foribaSettings);
-    (prisma.salesInvoice.findFirst as any).mockResolvedValue({ ...baseInvoice });
+    (prisma.salesInvoice.findFirst as any).mockResolvedValue({
+      ...baseInvoice,
+    });
     // Another worker already owns it → claim transitions zero rows.
     (prisma.salesInvoice.updateMany as any).mockResolvedValue({ count: 0 });
     const adapter = fakeAdapter();
@@ -172,14 +190,21 @@ describe('AccountingSyncService.syncInvoice', () => {
     await svc.syncInvoice(INVOICE_ID, TENANT);
 
     // The claim where-clause only targets reclaimable states, never SYNCING.
+    // Shape matters: `null` must be its OWN OR branch — Prisma throws a
+    // PrismaClientValidationError at runtime for null inside an `in` list
+    // (the old `in: [null as any, ...]` killed every sync in production).
     const claimWhere = (prisma.salesInvoice.updateMany as any).mock.calls[0][0]
       .where;
     expect(claimWhere.tenantId).toBe(TENANT);
-    expect(claimWhere.externalStatus.in).toEqual(
-      expect.arrayContaining([null, 'FAILED', 'PENDING']),
-    );
-    expect(claimWhere.externalStatus.in).not.toContain('SYNCING');
-    expect(claimWhere.externalStatus.in).not.toContain('SYNCED');
+    expect(claimWhere.externalStatus).toBeUndefined();
+    expect(claimWhere.OR).toEqual([
+      { externalStatus: null },
+      { externalStatus: { in: ['FAILED', 'PENDING'] } },
+    ]);
+    const inList = claimWhere.OR[1].externalStatus.in;
+    expect(inList).not.toContain(null);
+    expect(inList).not.toContain('SYNCING');
+    expect(inList).not.toContain('SYNCED');
     // The claim flips to SYNCING (the serializing marker) and clears errors.
     const claimData = (prisma.salesInvoice.updateMany as any).mock.calls[0][0]
       .data;
@@ -191,9 +216,61 @@ describe('AccountingSyncService.syncInvoice', () => {
     expect((prisma.salesInvoice.updateMany as any).mock.calls.length).toBe(1);
   });
 
+  it('NILVERA: pins apiBase + feeds the mükellef bridge DECRYPTED creds; a registered VKN routes to EFATURA', async () => {
+    // Regression for two go-live killers: (1) the bridge previously received
+    // the raw settings row, so Nilvera got the AES `v1:` ciphertext as its
+    // Bearer key → 401 → silent e-Arşiv fallback for every B2B buyer;
+    // (2) the fresh-per-call adapter never had its baseURL pinned, so every
+    // push after the first (warm token cache) failed "apiUrl is not
+    // configured" for the whole 24h TTL.
+    const { NilveraAdapter } = require('../adapters/nilvera.adapter');
+    const nilveraSettings = {
+      provider: AccountingProvider.NILVERA,
+      nilveraApiUrl: 'https://apitest.nilvera.com',
+      nilveraApiKey: 'v1:nonce:tag:ciphertext',
+    };
+    settings.findByTenant.mockResolvedValue(nilveraSettings);
+    settings.getDecryptedCredentials.mockResolvedValue({
+      ...nilveraSettings,
+      nilveraApiKey: 'plain-nilvera-key',
+    });
+    (prisma.salesInvoice.findFirst as any).mockResolvedValue({
+      ...baseInvoice,
+    });
+    (prisma.salesInvoice.updateMany as any).mockResolvedValue({ count: 1 });
+
+    const adapter = new NilveraAdapter();
+    const setApiBase = jest.spyOn(adapter, 'setApiBase');
+    adapter.isRegisteredEFaturaUser = jest.fn().mockResolvedValue(true);
+    adapter.authenticate = jest
+      .fn()
+      .mockResolvedValue({ accessToken: 'plain-nilvera-key' });
+    adapter.pushInvoice = jest.fn().mockResolvedValue({ externalId: 'NLV-1' });
+    jest.spyOn(svc as any, 'getAdapter').mockReturnValue(adapter);
+
+    await svc.syncInvoice(INVOICE_ID, TENANT);
+
+    // Bridge received the DECRYPTED key + configured host, never the blob.
+    const [bridgeKey, bridgeUrl, bridgeTaxId] = (
+      adapter.isRegisteredEFaturaUser as jest.Mock
+    ).mock.calls[0];
+    expect(bridgeKey).toBe('plain-nilvera-key');
+    expect(bridgeKey).not.toMatch(/^v1:/);
+    expect(bridgeUrl).toBe('https://apitest.nilvera.com');
+    expect(bridgeTaxId).toBe('1234567890');
+    // apiBase pinned on this fresh instance (cached-token path stays safe).
+    expect(setApiBase).toHaveBeenCalledWith('https://apitest.nilvera.com');
+    // Authoritative bridge answer (true) routed the document to e-Fatura.
+    expect(
+      (adapter.pushInvoice as jest.Mock).mock.calls[0][2].eDocumentType,
+    ).toBe('EFATURA');
+  });
+
   it('on a successful push records externalId + provider + SYNCED, scoped to tenant', async () => {
     settings.findByTenant.mockResolvedValue(foribaSettings);
-    (prisma.salesInvoice.findFirst as any).mockResolvedValue({ ...baseInvoice });
+    (prisma.salesInvoice.findFirst as any).mockResolvedValue({
+      ...baseInvoice,
+    });
     (prisma.salesInvoice.updateMany as any).mockResolvedValue({ count: 1 });
     const adapter = fakeAdapter();
     jest.spyOn(svc as any, 'getAdapter').mockReturnValue(adapter);
@@ -208,7 +285,8 @@ describe('AccountingSyncService.syncInvoice', () => {
     expect(pushedData.items).toHaveLength(1);
 
     // Second updateMany is the success write.
-    const successCall = (prisma.salesInvoice.updateMany as any).mock.calls[1][0];
+    const successCall = (prisma.salesInvoice.updateMany as any).mock
+      .calls[1][0];
     expect(successCall.where.tenantId).toBe(TENANT);
     expect(successCall.data.externalId).toBe('EXT-999');
     expect(successCall.data.externalProvider).toBe(AccountingProvider.FORIBA);
@@ -269,7 +347,9 @@ describe('AccountingSyncService.syncInvoice', () => {
 
   it('records FAILED + syncError (so the row is reclaimable) when the adapter throws', async () => {
     settings.findByTenant.mockResolvedValue(foribaSettings);
-    (prisma.salesInvoice.findFirst as any).mockResolvedValue({ ...baseInvoice });
+    (prisma.salesInvoice.findFirst as any).mockResolvedValue({
+      ...baseInvoice,
+    });
     (prisma.salesInvoice.updateMany as any).mockResolvedValue({ count: 1 });
     const adapter = fakeAdapter();
     adapter.pushInvoice.mockRejectedValue(new Error('foriba 503'));
@@ -285,7 +365,9 @@ describe('AccountingSyncService.syncInvoice', () => {
 
   it('does NOT flip to FAILED when the push SUCCEEDED but the local SYNCED write fails (avoids a duplicate e-fatura)', async () => {
     settings.findByTenant.mockResolvedValue(foribaSettings);
-    (prisma.salesInvoice.findFirst as any).mockResolvedValue({ ...baseInvoice });
+    (prisma.salesInvoice.findFirst as any).mockResolvedValue({
+      ...baseInvoice,
+    });
     // 1st updateMany = the claim (→ SYNCING) succeeds; 2nd = the post-push
     // SYNCED write fails (DB hiccup). The remote provider already holds the
     // invoice, so a FAILED (reclaimable) status would let a retry duplicate it.
@@ -309,7 +391,9 @@ describe('AccountingSyncService.syncInvoice', () => {
 
   it('aborts after claiming when no adapter resolves for the provider', async () => {
     settings.findByTenant.mockResolvedValue(foribaSettings);
-    (prisma.salesInvoice.findFirst as any).mockResolvedValue({ ...baseInvoice });
+    (prisma.salesInvoice.findFirst as any).mockResolvedValue({
+      ...baseInvoice,
+    });
     (prisma.salesInvoice.updateMany as any).mockResolvedValue({ count: 1 });
     jest.spyOn(svc as any, 'getAdapter').mockReturnValue(null);
 
@@ -321,7 +405,9 @@ describe('AccountingSyncService.syncInvoice', () => {
 
   it('caches the auth token per tenant+adapter so a second sync does not re-authenticate', async () => {
     settings.findByTenant.mockResolvedValue(foribaSettings);
-    (prisma.salesInvoice.findFirst as any).mockResolvedValue({ ...baseInvoice });
+    (prisma.salesInvoice.findFirst as any).mockResolvedValue({
+      ...baseInvoice,
+    });
     (prisma.salesInvoice.updateMany as any).mockResolvedValue({ count: 1 });
     const adapter = fakeAdapter();
     adapter.authenticate.mockResolvedValue({
@@ -352,7 +438,16 @@ describe('AccountingSyncService.testConnection', () => {
       // the decrypted creds are what reach the adapter.
       getDecryptedCredentials: jest.fn().mockResolvedValue(null),
     };
-    svc = new AccountingSyncService(prisma as any, settings as any, { name: "MOCK", isRegisteredEFaturaUser: async () => false } as any, { name: "MOCK", isConfigured: () => true, sign: async (x: string) => x } as any);
+    svc = new AccountingSyncService(
+      prisma as any,
+      settings as any,
+      { name: 'MOCK', isRegisteredEFaturaUser: async () => false } as any,
+      {
+        name: 'MOCK',
+        isConfigured: () => true,
+        sign: async (x: string) => x,
+      } as any,
+    );
   });
 
   it('returns a clean failure when no provider is configured', async () => {
@@ -433,8 +528,15 @@ describe('AccountingSyncService.testConnection', () => {
 });
 
 describe('AccountingSyncService — e-document readiness + FAILED re-sync', () => {
-  const mukellef: any = { name: 'MOCK', isRegisteredEFaturaUser: async () => true };
-  const signer: any = { name: 'MOCK', isConfigured: () => true, sign: async (x: string) => x };
+  const mukellef: any = {
+    name: 'MOCK',
+    isRegisteredEFaturaUser: async () => true,
+  };
+  const signer: any = {
+    name: 'MOCK',
+    isConfigured: () => true,
+    sign: async (x: string) => x,
+  };
 
   it('reports external-provisioning readiness', () => {
     const prisma: any = { salesInvoice: {} };
@@ -454,13 +556,17 @@ describe('AccountingSyncService — e-document readiness + FAILED re-sync', () =
       },
     };
     const svc = new AccountingSyncService(prisma, {} as any, mukellef, signer);
-    const syncSpy = jest.spyOn(svc, 'syncInvoice').mockResolvedValue(undefined as any);
+    const syncSpy = jest
+      .spyOn(svc, 'syncInvoice')
+      .mockResolvedValue(undefined as any);
 
     const retried = await svc.resyncFailedInvoices('t1');
     expect(retried).toBe(2);
     expect(syncSpy).toHaveBeenCalledTimes(2);
     // only FAILED invoices queried
-    expect(prisma.salesInvoice.findMany.mock.calls[0][0].where.externalStatus).toBe('FAILED');
+    expect(
+      prisma.salesInvoice.findMany.mock.calls[0][0].where.externalStatus,
+    ).toBe('FAILED');
   });
 
   it('keeps going when one invoice re-sync throws', async () => {
@@ -471,7 +577,8 @@ describe('AccountingSyncService — e-document readiness + FAILED re-sync', () =
       },
     };
     const svc = new AccountingSyncService(prisma, {} as any, mukellef, signer);
-    jest.spyOn(svc, 'syncInvoice')
+    jest
+      .spyOn(svc, 'syncInvoice')
       .mockRejectedValueOnce(new Error('still failing'))
       .mockResolvedValueOnce(undefined as any);
 
@@ -576,7 +683,11 @@ describe('AccountingSyncService — A5 buyer validation', () => {
       prisma as any,
       settings as any,
       { name: 'MOCK', isRegisteredEFaturaUser: async () => true } as any,
-      { name: 'MOCK', isConfigured: () => true, sign: async (x: string) => x } as any,
+      {
+        name: 'MOCK',
+        isConfigured: () => true,
+        sign: async (x: string) => x,
+      } as any,
     );
   });
 
@@ -695,7 +806,11 @@ describe('AccountingSyncService.cancelInvoiceAtProvider (A3)', () => {
       prisma as any,
       settings as any,
       { name: 'MOCK', isRegisteredEFaturaUser: async () => false } as any,
-      { name: 'MOCK', isConfigured: () => true, sign: async (x: string) => x } as any,
+      {
+        name: 'MOCK',
+        isConfigured: () => true,
+        sign: async (x: string) => x,
+      } as any,
     );
   });
 
@@ -755,7 +870,7 @@ describe('AccountingSyncService.cancelInvoiceAtProvider (A3)', () => {
     expect(write.data.syncError).toBeNull();
   });
 
-  it('resolves adapter + credentials from the invoice\'s externalProvider, not the CURRENT settings.provider', async () => {
+  it("resolves adapter + credentials from the invoice's externalProvider, not the CURRENT settings.provider", async () => {
     // Tenant has since swapped to Parasut, but the document lives at Foriba.
     settings.findByTenant.mockResolvedValue({
       ...foribaSettings,

--- a/backend/src/modules/accounting/services/accounting-sync.service.ts
+++ b/backend/src/modules/accounting/services/accounting-sync.service.ts
@@ -119,10 +119,21 @@ export class AccountingSyncService {
       return;
     }
 
-    // M4: only skip when the existing externalId is for the SAME provider.
-    // After a provider swap (e.g. Parasut → Logo) the old externalId is
-    // a foreign key to a different system; re-sync must run.
-    if (invoice.externalId && invoice.externalProvider === settings.provider) {
+    // M4 (revised): an externalId means the document was ALREADY issued at an
+    // integrator. Same provider → plain dedupe skip. DIFFERENT provider (after
+    // a swap, e.g. Foriba → Nilvera) → deliberately NOT re-issued either:
+    // pushing it again would create a duplicate legal e-belge at a second
+    // integrator. Only rows that never reached a provider (externalId null —
+    // i.e. null/FAILED/PENDING states) sync after a swap; migrated documents
+    // need a manual/provider-side move. (Previously this branch fell through
+    // to the claim, which rejected SYNCED rows anyway — the re-sync promise
+    // was dead code with a misleading "duplicate push" debug line.)
+    if (invoice.externalId) {
+      if (invoice.externalProvider !== settings.provider) {
+        this.logger.warn(
+          `Invoice ${invoiceId} already issued at ${invoice.externalProvider}; NOT re-issuing at ${settings.provider} — manual/provider-side migration required`,
+        );
+      }
       return;
     }
 
@@ -146,7 +157,13 @@ export class AccountingSyncService {
         // Don't re-claim a row already mid-flight: SYNCING is itself a
         // serializing marker. If two `syncInvoice` calls race, the loser
         // sees count===0 here and skips. We also re-claim FAILED rows.
-        externalStatus: { in: [null as any, "FAILED", "PENDING"] },
+        // NOTE: `null` may NOT appear inside an `in` list — Prisma rejects it
+        // at runtime (PrismaClientValidationError), which silently killed
+        // every sync. The null state needs its own OR branch.
+        OR: [
+          { externalStatus: null },
+          { externalStatus: { in: ["FAILED", "PENDING"] } },
+        ],
       },
       data: { externalStatus: "SYNCING", syncError: null },
     });
@@ -162,6 +179,16 @@ export class AccountingSyncService {
       const adapter = this.getAdapter(settings.provider);
       if (!adapter) return;
 
+      // The secret credential fields (parasutClientSecret/parasutPassword/
+      // logoPassword/foribaPassword/nilveraApiKey) are stored AES-256-GCM
+      // encrypted (`v1:…`). findByTenant returns them encrypted; we MUST
+      // decrypt BEFORE the mükellef bridge below — otherwise Nilvera receives
+      // the ciphertext as its Bearer key, 401s, and every B2B buyer silently
+      // misroutes to e-Arşiv. Non-secret fields (companyId/firmNumber/apiUrl)
+      // pass through unchanged.
+      const creds =
+        await this.settingsService.getDecryptedCredentials(tenantId);
+
       // Route e-Fatura (B2B) vs e-Arşiv (B2C). isRegisteredEFaturaUser comes
       // from a GİB mükellef query via the pluggable provider (mock in dev,
       // HTTP in prod). Registered VKN → e-Fatura, otherwise e-Arşiv — the
@@ -176,7 +203,7 @@ export class AccountingSyncService {
       const registered = invoice.customerTaxId
         ? ((await this.nilveraMukellefCheck(
             adapter,
-            settings,
+            creds ?? settings,
             invoice.customerTaxId,
           )) ??
           (await this.mukellefQuery.isRegisteredEFaturaUser(
@@ -203,20 +230,16 @@ export class AccountingSyncService {
         throw new Error(`Buyer validation failed: ${buyerProblems.join("; ")}`);
       }
 
-      // The secret credential fields (parasutClientSecret/parasutPassword/
-      // logoPassword/foribaPassword) are stored AES-256-GCM encrypted (`v1:…`).
-      // findByTenant returns them encrypted; we MUST decrypt before handing
-      // them to the adapter or every authenticate() fails and the invoice
-      // never reaches the provider. Non-secret fields (companyId/firmNumber/
-      // apiUrl) pass through unchanged.
-      const creds =
-        await this.settingsService.getDecryptedCredentials(tenantId);
-      // Pin Foriba's dispatch host to the configured apiUrl on EVERY sync — the
+      // Pin the dispatch host to the configured apiUrl on EVERY sync — the
       // adapter is freshly constructed per call and getToken() may skip
-      // authenticate() on a cached token, so the baseURL set inside authenticate
-      // wouldn't be applied to this instance (would fall back to prod).
+      // authenticate() on a cached token, so the baseURL set inside
+      // authenticate wouldn't be applied to this instance. Foriba would fall
+      // back to its hardcoded prod host; Nilvera has NO fallback and would
+      // fail closed ("apiUrl is not configured") for the whole 24h token TTL.
       if (adapter instanceof ForibaEfaturaAdapter) {
         adapter.setApiBase(((creds ?? settings) as any).foribaApiUrl || "");
+      } else if (adapter instanceof NilveraAdapter) {
+        adapter.setApiBase(((creds ?? settings) as any).nilveraApiUrl || "");
       }
       const token = await this.getToken(tenantId, creds ?? settings, adapter);
       const companyId = this.getCompanyId(creds ?? settings);
@@ -377,6 +400,8 @@ export class AccountingSyncService {
           await this.settingsService.getDecryptedCredentials(tenantId);
         if (adapter instanceof ForibaEfaturaAdapter) {
           adapter.setApiBase(((creds ?? settings) as any).foribaApiUrl || "");
+        } else if (adapter instanceof NilveraAdapter) {
+          adapter.setApiBase(((creds ?? settings) as any).nilveraApiUrl || "");
         }
         const token = await this.getToken(
           tenantId,
@@ -431,9 +456,14 @@ export class AccountingSyncService {
       case AccountingProvider.LOGO:
         return new LogoAdapter();
       case AccountingProvider.NILVERA:
-        // Signer optional: when unconfigured, Nilvera seals with its own
-        // mali mühür (integrator-side signing) — adapter sends unsigned.
-        return new NilveraAdapter().setSigner(this.signer);
+        // Per-provider signing policy: Nilvera seals server-side with its OWN
+        // mali mühür, so the local signer is deliberately NOT attached. When
+        // one IS configured (e.g. EBELGE_PROVIDER=mock on a staging box, or a
+        // future cert-backed Foriba signer), attaching it here would inject a
+        // local signature into the dispatch — the mock even emits an
+        // undeclared-namespace element that corrupts the XML — and a real one
+        // would double-sign what Nilvera seals itself.
+        return new NilveraAdapter();
       default:
         return null;
     }
@@ -465,6 +495,19 @@ export class AccountingSyncService {
       );
     } catch {
       return null;
+    }
+  }
+
+  /**
+   * Drop cached provider tokens for a tenant. Called on accounting-settings
+   * updates so a corrected/rotated credential takes effect immediately —
+   * without this, Nilvera's 24h static-key cache keeps replaying the OLD key
+   * (a wrong first entry keeps failing, a rotated key keeps leaking) until
+   * the fake expiry lapses.
+   */
+  clearTokenCache(tenantId: string): void {
+    for (const key of this.tokenCache.keys()) {
+      if (key.startsWith(`${tenantId}:`)) this.tokenCache.delete(key);
     }
   }
 

--- a/frontend/src/features/accounting/types.ts
+++ b/frontend/src/features/accounting/types.ts
@@ -13,6 +13,19 @@ export interface AccountingSettings {
   hasParasutCredentials: boolean;
   hasLogoCredentials: boolean;
   hasForibaCredentials: boolean;
+  hasNilveraCredentials: boolean;
+  // Non-secret provider credential fields — returned by sanitize() so the
+  // settings form can hydrate them (secrets are never returned).
+  parasutCompanyId?: string;
+  parasutClientId?: string;
+  parasutUsername?: string;
+  logoApiUrl?: string;
+  logoUsername?: string;
+  logoFirmNumber?: string;
+  foribaApiUrl?: string;
+  foribaUsername?: string;
+  foribaServiceType?: string;
+  nilveraApiUrl?: string;
   invoicePrefix: string;
   nextInvoiceNumber: number;
   defaultPaymentTermDays: number;

--- a/frontend/src/i18n/locales/ar/settings.json
+++ b/frontend/src/i18n/locales/ar/settings.json
@@ -707,7 +707,9 @@
     "providerNilvera": "Nilvera",
     "nilveraApiUrl": "عنوان API الخاص بـ Nilvera",
     "nilveraApiKey": "مفتاح API الخاص بـ Nilvera",
-    "nilveraHint": "مفتاح ثابت يتم إنشاؤه من لوحة Nilvera (رمز وصول دائم). تأكد من عنوان API من اللوحة."
+    "nilveraApiUrlHint": "تأكد من عنوان API من لوحة Nilvera (https، ‎*.nilvera.com).",
+    "nilveraApiKeyHint": "مفتاح ثابت يتم إنشاؤه من لوحة Nilvera (رمز وصول دائم).",
+    "credentialStored": "محفوظ — أدخل قيمة جديدة للاستبدال"
   },
   "emailChannel": {
     "reservationSection": "البريد الإلكتروني — أحداث الحجز",

--- a/frontend/src/i18n/locales/en/settings.json
+++ b/frontend/src/i18n/locales/en/settings.json
@@ -707,7 +707,9 @@
     "providerNilvera": "Nilvera",
     "nilveraApiUrl": "Nilvera API URL",
     "nilveraApiKey": "Nilvera API Key",
-    "nilveraHint": "Static key generated in your Nilvera panel (Persisted Access Token). Confirm the API URL from the panel."
+    "nilveraApiUrlHint": "Confirm the API URL from your Nilvera panel (https, *.nilvera.com).",
+    "nilveraApiKeyHint": "Static key generated in your Nilvera panel (Persisted Access Token).",
+    "credentialStored": "Stored — enter a new value to replace"
   },
   "emailChannel": {
     "reservationSection": "Email — Reservation events",

--- a/frontend/src/i18n/locales/ru/settings.json
+++ b/frontend/src/i18n/locales/ru/settings.json
@@ -707,7 +707,9 @@
     "providerNilvera": "Nilvera",
     "nilveraApiUrl": "Адрес API Nilvera",
     "nilveraApiKey": "API-ключ Nilvera",
-    "nilveraHint": "Статический ключ из панели Nilvera (Persisted Access Token). Подтвердите адрес API в панели."
+    "nilveraApiUrlHint": "Подтвердите адрес API в панели Nilvera (https, *.nilvera.com).",
+    "nilveraApiKeyHint": "Статический ключ из панели Nilvera (Persisted Access Token).",
+    "credentialStored": "Сохранено — введите новое значение для замены"
   },
   "emailChannel": {
     "reservationSection": "Email — события брони",

--- a/frontend/src/i18n/locales/tr/settings.json
+++ b/frontend/src/i18n/locales/tr/settings.json
@@ -707,7 +707,9 @@
     "providerNilvera": "Nilvera",
     "nilveraApiUrl": "Nilvera API Adresi",
     "nilveraApiKey": "Nilvera API Anahtarı",
-    "nilveraHint": "Nilvera panelinizden üretilen sabit anahtar (Persisted Access Token). API adresini panelden teyit edin."
+    "nilveraApiUrlHint": "API adresini Nilvera panelinizden teyit edin (https, *.nilvera.com).",
+    "nilveraApiKeyHint": "Nilvera panelinizden üretilen sabit anahtar (Persisted Access Token).",
+    "credentialStored": "Kayıtlı — değiştirmek için yeni değer girin"
   },
   "emailChannel": {
     "reservationSection": "E-posta — Rezervasyon olayları",

--- a/frontend/src/i18n/locales/uz/settings.json
+++ b/frontend/src/i18n/locales/uz/settings.json
@@ -707,7 +707,9 @@
     "providerNilvera": "Nilvera",
     "nilveraApiUrl": "Nilvera API manzili",
     "nilveraApiKey": "Nilvera API kaliti",
-    "nilveraHint": "Nilvera panelida yaratilgan doimiy kalit (Persisted Access Token). API manzilini paneldan tasdiqlang."
+    "nilveraApiUrlHint": "API manzilini Nilvera panelidan tasdiqlang (https, *.nilvera.com).",
+    "nilveraApiKeyHint": "Nilvera panelida yaratilgan doimiy kalit (Persisted Access Token).",
+    "credentialStored": "Saqlangan — almashtirish uchun yangi qiymat kiriting"
   },
   "emailChannel": {
     "reservationSection": "Email — Bron hodisalari",

--- a/frontend/src/pages/settings/AccountingSettingsPage.test.tsx
+++ b/frontend/src/pages/settings/AccountingSettingsPage.test.tsx
@@ -7,6 +7,7 @@ const h = vi.hoisted(() => ({
   updateAsync: vi.fn(),
   testConnection: vi.fn(),
   triggerSave: vi.fn(),
+  flushSave: vi.fn(),
   toastSuccess: vi.fn(),
   toastError: vi.fn(),
 }));
@@ -23,7 +24,12 @@ vi.mock('../../features/accounting/accountingApi', () => ({
   useAccountingSyncStatus: () => ({ data: undefined }),
 }));
 vi.mock('../../hooks/useAutoSave', () => ({
-  useAutoSave: () => ({ status: 'idle', setValue: h.triggerSave, retry: vi.fn() }),
+  useAutoSave: () => ({
+    status: 'idle',
+    setValue: h.triggerSave,
+    retry: vi.fn(),
+    save: h.flushSave,
+  }),
 }));
 vi.mock('sonner', () => ({
   toast: {
@@ -52,6 +58,8 @@ beforeEach(() => {
   h.accounting.data = { provider: 'NONE' };
   h.accounting.isLoading = false;
   h.testConnection.mockReset();
+  h.flushSave.mockReset();
+  h.flushSave.mockResolvedValue(undefined);
   h.toastSuccess.mockReset();
   h.toastError.mockReset();
 });
@@ -93,6 +101,19 @@ describe('AccountingSettingsPage', () => {
     await userEvent.click(screen.getByText('accounting.testConnection'));
     expect(h.toastError).toHaveBeenCalledWith(
       expect.stringContaining('bad creds'),
+    );
+  });
+
+  it('flushes the pending autosave BEFORE probing the connection (no stale-creds test)', async () => {
+    // The probe validates the credentials stored in the DB; without the flush
+    // a click inside the 500ms debounce window tested the PREVIOUS values.
+    h.accounting.data = { provider: 'PARASUT' };
+    h.testConnection.mockResolvedValue({ success: true });
+    render(<AccountingSettingsPage />);
+    await userEvent.click(screen.getByText('accounting.testConnection'));
+    expect(h.flushSave).toHaveBeenCalledTimes(1);
+    expect(h.flushSave.mock.invocationCallOrder[0]).toBeLessThan(
+      h.testConnection.mock.invocationCallOrder[0],
     );
   });
 });

--- a/frontend/src/pages/settings/AccountingSettingsPage.tsx
+++ b/frontend/src/pages/settings/AccountingSettingsPage.tsx
@@ -100,6 +100,22 @@ export const AccountingSettingsPanel = () => {
         invoicePrefix: accountingSettings.invoicePrefix || 'INV',
         nextInvoiceNumber: accountingSettings.nextInvoiceNumber || 1,
         defaultPaymentTermDays: accountingSettings.defaultPaymentTermDays || 0,
+        // Non-secret provider credential fields MUST hydrate too: saveSettings
+        // PATCHes the whole state object and only skips the 5 SECRET fields,
+        // so leaving these unhydrated meant any autosave after a reload
+        // silently wiped the stored values (e.g. nilveraApiUrl → '' broke the
+        // whole e-invoice rail). Secrets stay blank by design — sanitize()
+        // never returns them; the has*Credentials placeholders signal storage.
+        parasutCompanyId: accountingSettings.parasutCompanyId || '',
+        parasutClientId: accountingSettings.parasutClientId || '',
+        parasutUsername: accountingSettings.parasutUsername || '',
+        logoApiUrl: accountingSettings.logoApiUrl || '',
+        logoUsername: accountingSettings.logoUsername || '',
+        logoFirmNumber: accountingSettings.logoFirmNumber || '',
+        foribaApiUrl: accountingSettings.foribaApiUrl || '',
+        foribaUsername: accountingSettings.foribaUsername || '',
+        foribaServiceType: accountingSettings.foribaServiceType || '',
+        nilveraApiUrl: accountingSettings.nilveraApiUrl || '',
       }));
     }
   }, [accountingSettings]);
@@ -140,6 +156,7 @@ export const AccountingSettingsPanel = () => {
     status: saveStatus,
     setValue: triggerSave,
     retry: retrySave,
+    save: flushSave,
   } = useAutoSave(settings, saveSettings, {
     debounceMs: 500,
     onSuccess: () => {
@@ -158,6 +175,11 @@ export const AccountingSettingsPanel = () => {
 
   const handleTestConnection = async () => {
     try {
+      // The probe tests the credentials STORED in the DB (the endpoint takes
+      // no body). Flush the debounced autosave first, otherwise a test click
+      // right after typing validates the PREVIOUS credentials and reports a
+      // misleading result.
+      await flushSave();
       const result = await testConnection();
       if (result.success) {
         toast.success(t('accounting.testSuccess'));
@@ -354,6 +376,7 @@ export const AccountingSettingsPanel = () => {
                     type="password"
                     value={settings.parasutClientSecret}
                     onChange={(e) => handleChange('parasutClientSecret', e.target.value)}
+                    placeholder={accountingSettings?.hasParasutCredentials && !settings.parasutClientSecret ? t('accounting.credentialStored') : undefined}
                     className="flex-shrink-0 min-w-[140px] px-3 py-1.5 text-sm border border-slate-300 rounded-lg bg-white focus:ring-2 focus:ring-primary-500/20 focus:border-primary-500"
                   />
                 </div>
@@ -372,6 +395,7 @@ export const AccountingSettingsPanel = () => {
                     type="password"
                     value={settings.parasutPassword}
                     onChange={(e) => handleChange('parasutPassword', e.target.value)}
+                    placeholder={accountingSettings?.hasParasutCredentials && !settings.parasutPassword ? t('accounting.credentialStored') : undefined}
                     className="flex-shrink-0 min-w-[140px] px-3 py-1.5 text-sm border border-slate-300 rounded-lg bg-white focus:ring-2 focus:ring-primary-500/20 focus:border-primary-500"
                   />
                 </div>
@@ -402,6 +426,7 @@ export const AccountingSettingsPanel = () => {
                     type="password"
                     value={settings.logoPassword}
                     onChange={(e) => handleChange('logoPassword', e.target.value)}
+                    placeholder={accountingSettings?.hasLogoCredentials && !settings.logoPassword ? t('accounting.credentialStored') : undefined}
                     className="flex-shrink-0 min-w-[140px] px-3 py-1.5 text-sm border border-slate-300 rounded-lg bg-white focus:ring-2 focus:ring-primary-500/20 focus:border-primary-500"
                   />
                 </div>
@@ -438,6 +463,7 @@ export const AccountingSettingsPanel = () => {
                     type="password"
                     value={settings.foribaPassword}
                     onChange={(e) => handleChange('foribaPassword', e.target.value)}
+                    placeholder={accountingSettings?.hasForibaCredentials && !settings.foribaPassword ? t('accounting.credentialStored') : undefined}
                     className="flex-shrink-0 min-w-[140px] px-3 py-1.5 text-sm border border-slate-300 rounded-lg bg-white focus:ring-2 focus:ring-primary-500/20 focus:border-primary-500"
                   />
                 </div>
@@ -456,7 +482,7 @@ export const AccountingSettingsPanel = () => {
                 <SettingsDivider />
                 <SettingsInput
                   label={t('accounting.nilveraApiUrl')}
-                  description={t('accounting.nilveraHint')}
+                  description={t('accounting.nilveraApiUrlHint')}
                   value={settings.nilveraApiUrl}
                   onChange={(val) => handleChange('nilveraApiUrl', val)}
                 />
@@ -464,11 +490,13 @@ export const AccountingSettingsPanel = () => {
                 <div className="flex items-start justify-between gap-4 py-3 px-1">
                   <div className="flex-1 min-w-0">
                     <p className="text-sm font-medium text-slate-900">{t('accounting.nilveraApiKey')}</p>
+                    <p className="text-sm text-slate-500 mt-0.5">{t('accounting.nilveraApiKeyHint')}</p>
                   </div>
                   <input
                     type="password"
                     value={settings.nilveraApiKey}
                     onChange={(e) => handleChange('nilveraApiKey', e.target.value)}
+                    placeholder={accountingSettings?.hasNilveraCredentials && !settings.nilveraApiKey ? t('accounting.credentialStored') : undefined}
                     className="flex-shrink-0 min-w-[140px] px-3 py-1.5 text-sm border border-slate-300 rounded-lg bg-white focus:ring-2 focus:ring-primary-500/20 focus:border-primary-500"
                   />
                 </div>
@@ -483,10 +511,10 @@ export const AccountingSettingsPanel = () => {
                 <div className="flex justify-end py-2">
                   <button
                     onClick={handleTestConnection}
-                    disabled={isTesting}
+                    disabled={isTesting || saveStatus === 'saving'}
                     className="px-4 py-2 text-sm font-medium text-white bg-primary-600 hover:bg-primary-700 rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                   >
-                    {isTesting ? '...' : t('accounting.testConnection')}
+                    {isTesting || saveStatus === 'saving' ? '...' : t('accounting.testConnection')}
                   </button>
                 </div>
               </>


### PR DESCRIPTION
Nilvera entegratörünün (PR #298) go-live ÖNCESİ düşmanca incelemesi (5 boyut × bağımsız doğrulama) **16 hata doğruladı, 0 çürütüldü**. Bu PR hepsini kapatıyor — sandbox creds geldiği gün aktivasyon pürüzsüz olsun diye.

## 🔴 Kritikler
1. **Hiçbir fatura senkronlanamıyordu (tüm sağlayıcılar):** SYNCING claim'inin `in: [null as any, …]` şekli Prisma'da ÇALIŞMA ZAMANI hatası (gerçek DB'ye karşı reprodüksiyon yapıldı) ve throw try/catch DIŞINDA → FAILED bile yazılmıyordu. → null kendi OR dalına alındı + şekli kilitleyen spec.
2. **Nilvera baseURL 24h kayboluyordu:** taze-adaptör + sıcak token cache → ilk push'tan sonra her push/cancel "apiUrl is not configured". → `setApiBase` + iki çağrı noktasında pin (Foriba paritesi) + settings PATCH'inde token-cache invalidation + regresyon spec'leri.
3. **Mükellef köprüsü şifreli `v1:` blob'u Bearer yapıyordu** → 401 → sessiz fallback → **tüm B2B alıcılar e-Arşiv'e** (GİB uyum ihlali). → decrypt routing'in üstüne alındı; köprü çözülmüş creds alıyor; EFATURA yönlendirme spec'i.

## 🟠 High/Medium
- FE hidrasyon: autosave'in `nilveraApiUrl` + tüm non-secret alanları silmesi düzeltildi (değerler artık görünür de).
- Signer politikası sağlayıcı-bazlı: Nilvera'ya global signer bağlanmıyor (server-side mühürlüyor); mock signer artık namespace-valid; `EBELGE_PROVIDER=mock` prod'da boot'u reddediyor.
- M4 swap "re-sync" ölü koddu → fiskal-güvenli açık davranış: başka sağlayıcıda kesilmiş belge asla yeniden kesilmez (dürüst warn log + spec).
- `nilveraApiUrl` https + `*.nilvera.com` doğrulaması (SSRF/anahtar-sızdırma hedefiydi).
- Test Connection artık debounced autosave'i flush edip öyle probe ediyor (bayat-creds testi bitti).

## 🟡 Low
- Secret DTO alanlarında `""` = değişmedi (silme değil); kayıtlı-credential placeholder'ları (5 locale); nilveraHint alan-bazlı bölündü; decrypt hataları artık loglanıyor.

## Doğrulama
- Backend `tsc` 0 · accounting suite **157 yeşil** (yeni claim-shape / fiscal-safe-swap / Nilvera bridge+pin spec'leri dahil)
- FE `tsc` 0 · settings page **6/6** · i18n keys **25/25** + parity ✓ + value-drift ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)