### PR TITLE
fix(deploy): blue-green hardening — 24 verified findings (fixes #299 before merge)

### DIFF
--- a/.github/workflows/release-deploy.yml
+++ b/.github/workflows/release-deploy.yml
@@ -65,13 +65,24 @@ jobs:
           # every healthy production as "down".
           ssh -n root@${{ env.SERVER_HOST }} 'bash -s' <<'PROBE'
             set -euo pipefail
+            # Colour-aware: under blue-green the active backend may be on green's
+            # loopback port (3010), not blue's 3000. Read the state file the
+            # deploy script writes; default to 3000 for the legacy/pre-adoption
+            # single stack. Probe both as a fallback so a mid-migration box or a
+            # missing state file still passes when either colour is healthy.
+            active=blue
+            [ -f /var/lib/kds-deploy/active-color-prod ] && \
+              active="$(. /var/lib/kds-deploy/active-color-prod 2>/dev/null; echo "${ACTIVE_COLOR:-blue}")"
+            [ "$active" = green ] && port=3010 || port=3000
             attempt=1
             while [ $attempt -le 3 ]; do
-              if curl -fsS --max-time 10 http://localhost:3000/api/health > /dev/null; then
-                echo "Production /api/health (loopback) is healthy."
+              if curl -fsS --max-time 10 "http://localhost:${port}/api/health" > /dev/null \
+                 || curl -fsS --max-time 10 http://localhost:3000/api/health > /dev/null \
+                 || curl -fsS --max-time 10 http://localhost:3010/api/health > /dev/null; then
+                echo "Production /api/health (loopback, active=${active}) is healthy."
                 exit 0
               fi
-              echo "Attempt $attempt: backend not responding on localhost, retrying in 10s..."
+              echo "Attempt $attempt: backend not responding on localhost (tried ${port}/3000/3010), retrying in 10s..."
               attempt=$((attempt + 1))
               sleep 10
             done
@@ -488,12 +499,24 @@ jobs:
             'mv /root/kds/.env.production.new /root/kds/.env.production'
 
       - name: Run deploy.sh on the server
+        id: deploy
         env:
           VERSION: ${{ needs.build.outputs.version }}
           GHCR_USER: ${{ github.actor }}
           GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Mapped through env: (NOT inlined into the remote root shell string)
+          # so an attacker-influenceable variable value can never break out of
+          # the quoting and run as root@prod — same hardening the tag step uses.
+          PROD_BLUEGREEN: ${{ vars.PROD_BLUEGREEN }}
         run: |
           set -euo pipefail
+          # Decide the deploy command HERE, on the runner, from the env var —
+          # the value never reaches the remote shell parser.
+          if [ "${PROD_BLUEGREEN:-}" = 'true' ]; then
+            DEPLOY_CMD='./scripts/deploy-blue-green.sh prod'
+          else
+            DEPLOY_CMD='./scripts/deploy.sh prod'
+          fi
           # Single SSH session, set -euo pipefail at the top so any
           # failed line aborts immediately. The previous workflow used
           # a heredoc without set -e and silently continued on
@@ -507,7 +530,7 @@ jobs:
               git stash --include-untracked --quiet || true
               # --force on --tags overwrites any local tag the deploy
               # box rewrote during earlier manual debugging. Without
-              # --force, fetch dies with "would clobber existing tag"
+              # --force, fetch dies with 'would clobber existing tag'
               # and the whole deploy is aborted.
               git fetch --all --tags --force
               git reset --hard ${VERSION}
@@ -515,13 +538,9 @@ jobs:
               export GHCR_TOKEN='${GHCR_TOKEN}'
               # Zero-downtime blue-green once vars.PROD_BLUEGREEN=true — set that
               # repo variable ONLY after the one-time server prep in
-              # docs/deploy/blue-green-runbook.md §2-3. Until then this defaults
+              # docs/deploy/blue-green-runbook.md §2-4. Until then this defaults
               # to the legacy in-place deploy, so merging changes nothing.
-              if [ '${{ vars.PROD_BLUEGREEN }}' = 'true' ]; then
-                ./scripts/deploy-blue-green.sh prod ${VERSION}
-              else
-                ./scripts/deploy.sh prod ${VERSION}
-              fi
+              ${DEPLOY_CMD} ${VERSION}
             "
 
       # Post-deploy public probe lives in scripts/deploy.sh
@@ -572,25 +591,42 @@ jobs:
           '
 
       - name: Rollback on failure
-        if: failure()
+        # ONLY when the DEPLOY step itself failed — not for a later step (SSL
+        # guard / perf smoke), which must never flip prod traffic. Scoped to
+        # steps.deploy so an unrelated post-deploy failure can't trigger a
+        # traffic change.
+        if: failure() && steps.deploy.conclusion == 'failure'
         env:
           VERSION: ${{ needs.build.outputs.version }}
+          PROD_BLUEGREEN: ${{ vars.PROD_BLUEGREEN }}
         run: |
-          # Re-sync before invoking deploy.sh — if the deploy step
-          # crashed before its own reset, scripts/deploy.sh may not be
-          # present on disk in the version we're rolling back to.
-          ssh -o ServerAliveInterval=15 root@${{ env.SERVER_HOST }} "
-            set -euo pipefail
-            cd /root/kds
-            git stash --include-untracked --quiet || true
-            git fetch --all --tags --force
-            git reset --hard ${VERSION}
-            if [ '${{ vars.PROD_BLUEGREEN }}' = 'true' ]; then
-              ./scripts/deploy-blue-green.sh prod rollback
-            else
+          set -euo pipefail
+          if [ "${PROD_BLUEGREEN:-}" = 'true' ]; then
+            # The blue-green script ALREADY self-handles failure: a pre-flip
+            # failure tears down the un-promoted colour (active untouched); a
+            # post-flip failure reverts nginx to the active colour AND rewrites
+            # state. Re-invoking `rollback` here would boot the OTHER colour and
+            # flip onto it — turning a safely-contained failure into an outage.
+            # So we only LOG status; a real rollback is a deliberate manual call.
+            ssh -o ServerAliveInterval=15 root@${{ env.SERVER_HOST }} '
+              set -euo pipefail
+              cd /root/kds
+              echo "::warning::blue-green deploy failed; script self-reverted. Current status:"
+              ./scripts/deploy-blue-green.sh prod status || true
+            '
+          else
+            # Legacy path: deploy.sh owns its own rollback. Re-sync first — if the
+            # deploy step crashed before its own reset, the script may not be on
+            # disk at the version we roll back to.
+            ssh -o ServerAliveInterval=15 root@${{ env.SERVER_HOST }} "
+              set -euo pipefail
+              cd /root/kds
+              git stash --include-untracked --quiet || true
+              git fetch --all --tags --force
+              git reset --hard ${VERSION}
               ./scripts/deploy.sh prod-rollback
-            fi
-          "
+            "
+          fi
 
       - name: Cleanup workspace
         if: always()

--- a/docker-compose.color.yml
+++ b/docker-compose.color.yml
@@ -28,7 +28,7 @@ services:
       - .env.production
     # Pinned to the immutable :vX.Y.Z tag by the deploy script (IMAGE_TAG),
     # NOT the movable :current pointer — each colour runs an exact version.
-    image: ghcr.io/mtarikucar/kds/backend:${IMAGE_TAG:-current}
+    image: ghcr.io/mtarikucar/kds/backend:${IMAGE_TAG:?IMAGE_TAG must be set by the deploy script (never boot the movable :current tag)}
     container_name: kds_backend_${COLOR:?COLOR must be set (blue|green)}
     restart: always
     environment:
@@ -90,7 +90,7 @@ services:
   frontend:
     env_file:
       - .env.production
-    image: ghcr.io/mtarikucar/kds/frontend:${IMAGE_TAG:-current}
+    image: ghcr.io/mtarikucar/kds/frontend:${IMAGE_TAG:?IMAGE_TAG must be set by the deploy script (never boot the movable :current tag)}
     container_name: kds_frontend_${COLOR:?COLOR must be set (blue|green)}
     restart: always
     ports:

--- a/docs/deploy/blue-green-runbook.md
+++ b/docs/deploy/blue-green-runbook.md
@@ -21,11 +21,11 @@
 | `scripts/deploy-blue-green.sh` | The cutover engine: `prod <vX.Y.Z>` / `prod rollback` / `prod status` |
 | `docs/deploy/blue-green-runbook.md` | This file |
 
-The zero-downtime health gate is **`/healthz/ready`** — it already exists in the
-backend (`app.controller.ts`) and returns **503** when Postgres or Redis is down
-(`app.service.getHealth()` → `status:"degraded"`), so it is a *safe* cutover
-gate. `/api/health` (always-200, used by the Docker healthcheck + legacy deploy)
-is intentionally left alone.
+The zero-downtime health gate is **`/api/healthz/ready`** — it already exists in
+the backend (`app.controller.ts`, served under the global `api` prefix) and
+returns **503** when Postgres or Redis is down (`app.service.getHealth()` →
+`status:"degraded"`), so it is a *safe* cutover gate. `/api/health` (always-200,
+used by the Docker healthcheck + legacy deploy) is intentionally left alone.
 
 ---
 
@@ -72,48 +72,74 @@ docker volume create kds_redis_data
 docker volume create kds_invoice_storage
 docker volume create kds_uploads_storage
 
-# 3. Stop the app tier ONLY (keep DB/redis running to take a fresh backup first)
-#    Take a backup BEFORE any volume move:
+# 3. Take a backup BEFORE any volume move:
 ./scripts/backup-database.sh prod   # or the deploy.sh backup path
 
-# 4. Bring the whole legacy prod stack down (brief maintenance window — the ONLY
-#    downtime in the entire migration; steady-state deploys after this are 0s):
-docker compose -p kds-prod --env-file .env.production -f docker-compose.prod.yml down
+# 4. Stop ONLY the services blue-green replaces (backend/frontend/postgres/redis).
+#    KEEP landing/developer/help running under the legacy project so those three
+#    public surfaces (hummytummy.com/landing, developer./help.hummytummy.com) do
+#    NOT go dark — blue-green only models backend+frontend. (See "Known gap"
+#    below: those three need their own deploy path before you rely on CI for them.)
+#    This stop/rm — not a full `down` — is the ONLY downtime in the migration.
+docker compose -p kds-prod --env-file .env.production -f docker-compose.prod.yml \
+  rm -sf backend frontend postgres redis
 
-# 5. Copy data from the old project volumes into the new external volumes:
+# 5. Copy data from the old project volumes into the new external volumes.
+#    set -e + per-pair source check + real failure on cp error (a silent partial
+#    copy here would let an EMPTY database be promoted as prod):
+set -e
 for pair in \
   "kds-prod_postgres_data:kds_postgres_data" \
   "kds-prod_redis_data:kds_redis_data" \
   "kds-prod_invoice_storage:kds_invoice_storage" \
   "kds-prod_uploads_storage:kds_uploads_storage"; do
   src="${pair%%:*}"; dst="${pair##*:}"
+  docker volume inspect "$src" >/dev/null     # typo/missing-source guard (no -v auto-create)
   docker run --rm -v "$src":/from -v "$dst":/to alpine \
-    sh -c 'cp -a /from/. /to/ && echo copied $src -> $dst'
+    sh -c 'cp -a /from/. /to/' && echo "copied $src -> $dst" \
+    || { echo "COPY FAILED: $src -> $dst"; exit 1; }
 done
 
-# 6. Start the shared data layer on the new volumes:
+# 6. VERIFY the postgres volume actually holds the migrated cluster BEFORE boot
+#    (the deploy script also enforces this via ALLOW_EMPTY_DATA guard):
+docker run --rm -v kds_postgres_data:/d alpine test -f /d/PG_VERSION \
+  && echo "postgres volume populated ✓" || { echo "EMPTY postgres volume — copy failed"; exit 1; }
+
+# 7. Start the shared data layer on the new volumes:
 docker compose -p kds-data --env-file .env.production -f docker-compose.data.yml up -d
 docker compose -p kds-data -f docker-compose.data.yml ps   # postgres+redis healthy?
 ```
 
 > The old `kds-prod_*` volumes are left intact as a rollback safety net; delete
-> them only after blue-green is proven for a few days.
+> them only after blue-green is proven for a few days. **Do NOT** re-run the
+> legacy `deploy.sh prod` while blue-green is live — its `kds-prod` postgres uses
+> the same `container_name` and would collide (the blue-green script's
+> `assert_no_legacy_stack` guard aborts if legacy app containers reappear).
 
 ---
 
 ## §3 — nginx wiring (the traffic switch)
 
+> ⚠️ **NOT** `/etc/nginx/conf.d/` — the stock nginx.conf globs
+> `include /etc/nginx/conf.d/*.conf;`, and both colour fragments declare the same
+> `upstream kds_backend`/`kds_frontend`, so globbing them makes `nginx -t` fail
+> with **"duplicate upstream"** and the flip can never validate. Install them in a
+> dedicated dir nginx does NOT auto-glob, included exactly once by the vhost.
+
 ```bash
-# Place the upstream fragments where nginx will include them:
-cp ops/nginx/upstream-blue.conf ops/nginx/upstream-green.conf /etc/nginx/conf.d/
+# Place the upstream fragments in a NON-globbed dir:
+mkdir -p /etc/nginx/kds-upstreams
+cp ops/nginx/upstream-blue.conf ops/nginx/upstream-green.conf /etc/nginx/kds-upstreams/
 # Start on blue (matches legacy ports 3000/8080):
-ln -sfn /etc/nginx/conf.d/upstream-blue.conf /etc/nginx/conf.d/kds-upstream-active.conf
+ln -sfn /etc/nginx/kds-upstreams/upstream-blue.conf /etc/nginx/kds-upstreams/kds-upstream-active.conf
+# Confirm nothing else pulls these in (must print 0):
+nginx -T 2>/dev/null | grep -c 'upstream kds_backend' | grep -qx 1 || echo "check: kds_backend must be defined exactly once after the vhost include"
 ```
 
 Then patch the **prod vhost** (`hummytummy.com` server block — verify against the
 `nginx -T` capture from §1). Add at the top of the file (outside `server{}`):
 ```nginx
-include /etc/nginx/conf.d/kds-upstream-active.conf;
+include /etc/nginx/kds-upstreams/kds-upstream-active.conf;
 ```
 and change the hardcoded targets:
 ```
@@ -137,10 +163,19 @@ After §2/§3 the site is served by **blue** (which took over the legacy 3000/80
 via the data-layer + a first colour boot). To bring blue up explicitly:
 
 ```bash
-# Boot blue (backend 3000 / frontend 8080) against the shared data layer:
-IMAGE_TAG=current docker compose -p kds-prod-blue \
+# Boot blue against the shared data layer at an EXPLICIT version (the current
+# live tag, e.g. the latest vX.Y.Z — NOT the movable ":current" pointer, which
+# the blue-green script never advances). docker-compose.color.yml now REQUIRES
+# IMAGE_TAG to be set (fails loudly if unset), so a stale image can't sneak in.
+IMAGE_TAG=vX.Y.Z docker compose -p kds-prod-blue \
   --env-file .env.production --env-file ops/deploy/color.blue.env \
   -f docker-compose.color.yml up -d
+
+# Seed the state file so the first CI deploy knows blue is active + its version
+# (the script reads VERSION_blue to pin a future rollback):
+sudo mkdir -p /var/lib/kds-deploy
+printf 'ACTIVE_COLOR=blue\nPREVIOUS_COLOR=\nVERSION_blue=vX.Y.Z\n' \
+  | sudo tee /var/lib/kds-deploy/active-color-prod
 
 scripts/deploy-blue-green.sh prod status    # confirm active=blue, nginx=blue
 ```
@@ -160,8 +195,16 @@ verified on the box, set ONE repo variable:
 > **New variable:** `PROD_BLUEGREEN` = `true`
 
 Every `vX.Y.Z` tag then runs `scripts/deploy-blue-green.sh` (deploy + rollback);
-unset/any-other value keeps the legacy `scripts/deploy.sh` path. Revert any time
-by deleting the variable — no code change, no redeploy.
+unset/any-other value keeps the legacy `scripts/deploy.sh` path.
+
+> ⚠️ **The "revert by deleting the variable" escape hatch only holds BEFORE §2.**
+> After the §2 data migration the legacy `deploy.sh` path can no longer run (its
+> `kds-prod` postgres collides on `container_name` with the live `kds-data`
+> stack, and it points at the frozen pre-migration `kds-prod_*` volumes). So set
+> `PROD_BLUEGREEN=true` as the LAST step of the §2–§4 maintenance session, and
+> treat a real revert as an explicit procedure (down `kds-data`+colours,
+> reverse-copy the volumes back, restore the nginx vhost proxy_pass targets),
+> not a one-variable toggle.
 
 Staging's target host is likewise the repo variable `STAGING_SERVER_HOST` (unset
 → current shared box; set to Server-2's IP → staging deploys there, §7).
@@ -184,9 +227,14 @@ never affected); after the flip a failing smoke auto-reverts the symlink.
 ```bash
 scripts/deploy-blue-green.sh prod rollback
 ```
-Brings the previous colour back (if stopped), health-gates it, flips the nginx
-symlink back, reloads — **sub-second**, no container recreate, no image retag, no
-DB change. State (`ACTIVE_COLOR`/`PREVIOUS_COLOR`) is persisted at
+Re-boots the previous colour at the **exact version it last ran** — the script
+records `VERSION_blue`/`VERSION_green` in the state file and pins `IMAGE_TAG` to
+`PREVIOUS`'s recorded tag (pulling it first), then health-gates + flips the nginx
+symlink back and reloads. It is NOT a "no-recreate" flip: the retired colour was
+removed after the drain, so rollback recreates it from the pinned image (a few
+seconds, not sub-second). It **dies loudly** if no version is recorded rather
+than silently booting the movable `:current` tag. State
+(`ACTIVE_COLOR`/`PREVIOUS_COLOR`/`VERSION_*`) is persisted at
 `/var/lib/kds-deploy/active-color-prod` so rollback works days later.
 
 **DB is not rolled back** — migrations are expand-only/backward-compatible, so
@@ -228,9 +276,25 @@ running by you.
 
 ---
 
+## Known gaps (address before full CI adoption)
+
+- **landing / developer / help are NOT in blue-green.** `docker-compose.color.yml`
+  models only backend+frontend. §2 keeps the three portals running under the
+  legacy `kds-prod` project (so they don't go dark), but they then have **no CI
+  deploy path** — a future release won't update them. Before flipping
+  `PROD_BLUEGREEN=true` permanently, give them a home: either a small always-on
+  `docker-compose.portals.yml` (project `kds-portals`, on `kds_bluegreen`) that
+  `deploy-blue-green.sh` pulls+ups each release, or add them to the colour compose
+  with their own ports + nginx upstreams. `public_smoke()` should then also probe
+  `hummytummy.com/landing`, `developer.hummytummy.com/tr`, `help.hummytummy.com/tr`.
+- **Monitoring reconcile** (`deploy.sh bring_up_monitoring`, Prometheus/Grafana on
+  the prod app network) is not ported — repoint `ops/monitoring` at the
+  `kds_bluegreen` network and update scrape targets to the `kds_backend_blue/green`
+  container names before relying on alerting under blue-green.
+
 ## Risk register (all mitigated in the script, listed for reviewers)
 
-- **/api/health always-200** → we gate on **`/healthz/ready`** (503-aware). ✔
+- **/api/health always-200** → we gate on **`/api/healthz/ready`** (503-aware). ✔
 - **Shared volumes** → `external: true` on invoice/uploads; a cross-colour upload
   test is a required §4 acceptance check.
 - **socket.io drop on cutover** → `stop_grace_period: 60s` + a 60s drain window so
@@ -242,4 +306,20 @@ running by you.
 - **Inactive colour internet-exposed** → colour ports bind `127.0.0.1` only.
 - **Script stops both colours** → hard guard: the old colour is retired ONLY after
   state is persisted AND nginx is *confirmed* resolved onto the new colour
-  (`readlink -f` check); an ERR trap reverts the symlink on post-flip failure.
+  (`readlink -f` check). Every gate failure routes through `cleanup_and_exit`
+  (not bare `die`, which would bypass the ERR trap): pre-flip it tears down the
+  un-promoted colour; post-flip it reverts the nginx symlink to ACTIVE **and**
+  rewrites the state file so disk state and the live symlink can never disagree. ✔
+- **Migrations never applied to the new colour** → `migrate_in_color` runs
+  `prisma migrate deploy` INSIDE the freshly-booted target (whose image contains
+  the new migrations) before the health gate, expand-only. ✔
+- **Rollback boots a stale image** → per-colour version recorded in state; rollback
+  pins `IMAGE_TAG` to it (and `docker-compose.color.yml` requires `IMAGE_TAG`, no
+  `:current` fallback). ✔
+- **Empty data volume promoted as prod** → `ensure_data_layer` refuses to boot
+  unless `kds_postgres_data` holds an initialised cluster (`PG_VERSION`). ✔
+- **Duplicate `upstream` in globbed conf.d** → fragments live in the non-globbed
+  `/etc/nginx/kds-upstreams/`, included once by the vhost. ✔
+- **CI auto-rollback flips prod onto a broken/stale colour** → the workflow only
+  runs rollback when the deploy STEP failed, and for blue-green it only LOGS
+  status (the script already self-reverts) instead of re-flipping. ✔

--- a/scripts/deploy-blue-green.sh
+++ b/scripts/deploy-blue-green.sh
@@ -12,8 +12,9 @@
 #
 # postgres/redis + invoice/uploads volumes are SHARED (docker-compose.data.yml,
 # external volumes) and never recreated. Migrations are expand-only and run in
-# the CURRENTLY LIVE backend before the new colour boots, so both colours
-# tolerate one schema during overlap.
+# the freshly-booted NEW colour (its image contains the new migration files)
+# BEFORE the nginx flip, so the still-serving old colour tolerates the expanded
+# schema during the overlap window.
 #
 # USAGE (run on the prod host as the deploy user, cwd = repo root /root/kds):
 #   scripts/deploy-blue-green.sh prod <vX.Y.Z>     # deploy that version, cut over
@@ -37,7 +38,11 @@ COLOR_COMPOSE="${COLOR_COMPOSE:-$REPO_DIR/docker-compose.color.yml}"
 DATA_COMPOSE="${DATA_COMPOSE:-$REPO_DIR/docker-compose.data.yml}"
 # The host-nginx symlink that the vhost `include`s, and the dir holding the
 # upstream-blue.conf / upstream-green.conf it points at (see runbook §3).
-NGINX_UPSTREAM_LINK="${NGINX_UPSTREAM_LINK:-/etc/nginx/conf.d/kds-upstream-active.conf}"
+# MUST live OUTSIDE the stock `include /etc/nginx/conf.d/*.conf;` glob — both
+# colour fragments declare the same `upstream kds_backend`/`kds_frontend`, so if
+# the glob loaded them nginx -t would fail with "duplicate upstream" and the
+# flip could never validate. A dedicated dir is included exactly once by the vhost.
+NGINX_UPSTREAM_LINK="${NGINX_UPSTREAM_LINK:-/etc/nginx/kds-upstreams/kds-upstream-active.conf}"
 NGINX_UPSTREAM_DIR="${NGINX_UPSTREAM_DIR:-$(dirname "$NGINX_UPSTREAM_LINK")}"
 PUBLIC_URL="${PUBLIC_URL:-https://hummytummy.com}"
 HEALTH_BUDGET_SEC="${HEALTH_BUDGET_SEC:-300}"
@@ -68,8 +73,10 @@ read_active_color() {
     # shellcheck disable=SC1090
     ( set +u; . "$ACTIVE_FILE"; echo "${ACTIVE_COLOR:-blue}" )
   else
-    # First run: assume the legacy stack is serving on blue ports (3000/8080),
-    # so the first blue-green deploy targets green and cuts over with no downtime.
+    # No state file yet — this is the first deploy after §4's manual blue boot,
+    # so blue is active and the first flip targets green. (The script does NOT
+    # cut over directly from the legacy stack; §2 retires legacy first, enforced
+    # by assert_no_legacy_stack.)
     echo blue
   fi
 }
@@ -77,9 +84,53 @@ read_previous_color() {
   [[ -f "$ACTIVE_FILE" ]] || { echo ""; return; }
   ( set +u; . "$ACTIVE_FILE"; echo "${PREVIOUS_COLOR:-}" )
 }
-write_active_color() { # <active> <previous>
+read_color_version() { # <color> — the image tag last deployed to that colour
+  [[ -f "$ACTIVE_FILE" ]] || { echo ""; return; }
+  ( set +u; . "$ACTIVE_FILE"; local c="$1"; eval "echo \"\${VERSION_${c}:-}\"" )
+}
+write_active_color() { # <active> <previous> [active_version]
+  # Persist the per-colour image tag alongside the colours so `rollback` can
+  # re-boot the previous colour at the EXACT version it ran — not the movable
+  # ":current" tag (which this script never advances, so it would resurrect a
+  # stale/legacy image). The active colour's version updates; the other colour
+  # keeps whatever it last ran.
   mkdir -p "$STATE_DIR"
-  { echo "ACTIVE_COLOR=$1"; echo "PREVIOUS_COLOR=$2"; echo "UPDATED_AT=$(date -u +%FT%TZ)"; } > "$ACTIVE_FILE"
+  local active="$1" prev="$2" av="${3:-$(read_color_version "$1")}"
+  local pv; pv="$(read_color_version "$prev")"
+  {
+    echo "ACTIVE_COLOR=$active"
+    echo "PREVIOUS_COLOR=$prev"
+    echo "VERSION_${active}=$av"
+    [[ -n "$prev" ]] && echo "VERSION_${prev}=$pv"
+    echo "UPDATED_AT=$(date -u +%FT%TZ)"
+  } > "$ACTIVE_FILE"
+}
+
+# Authenticate to GHCR for private image pulls, mirroring scripts/deploy.sh.
+# CI exports GHCR_USER/GHCR_TOKEN into this SSH session; a manual run on the box
+# without creds clears any stale (revoked GITHUB_TOKEN) cache so anonymous pulls
+# of public packages still work.
+ghcr_login() {
+  if [[ -n "${GHCR_USER:-}" && -n "${GHCR_TOKEN:-}" ]]; then
+    log "docker login ghcr.io as ${GHCR_USER}"
+    echo "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_USER" --password-stdin >/dev/null
+  else
+    warn "no GHCR_USER/GHCR_TOKEN — clearing any stale ghcr.io cred (anonymous pull)"
+    docker logout ghcr.io >/dev/null 2>&1 || true
+  fi
+}
+
+# Abort cleanly if the box still runs the LEGACY single-stack (project kds-prod).
+# The data plane reuses container_name kds_postgres_prod/kds_redis_prod, so
+# starting blue-green while legacy is up would collide; §2 must retire legacy
+# first. Fail loud with a pointer instead of a raw "name already in use".
+assert_no_legacy_stack() {
+  local legacy
+  legacy="$(docker ps -a --filter 'label=com.docker.compose.project=kds-prod' \
+              --format '{{.Names}}' 2>/dev/null | tr '\n' ' ')"
+  if [[ -n "${legacy// /}" ]]; then
+    die "legacy kds-prod containers still present ($legacy) — complete blue-green-runbook §2 (retire the legacy stack) before deploying blue-green"
+  fi
 }
 
 dc_color() { # <color> <compose args...>
@@ -90,12 +141,16 @@ dc_color() { # <color> <compose args...>
     -f "$COLOR_COMPOSE" "$@"
 }
 
-wait_until_ready() { # <color> — poll /healthz/ready (503-aware) N consecutive times
+wait_until_ready() { # <color> — poll /api/healthz/ready (503-aware) N consecutive times
+  # The route is served UNDER the global "api" prefix (backend main.ts calls
+  # setGlobalPrefix("api") with no exclude), so it lives at /api/healthz/ready
+  # — NOT /healthz/ready. Probing the un-prefixed path 404s forever and every
+  # deploy would fail the gate before the flip.
   local color="$1" port; port="$(backend_port "$color")"
   local deadline=$(( SECONDS + HEALTH_BUDGET_SEC )) hits=0
-  log "health-gating $color backend on http://127.0.0.1:${port}/healthz/ready (need ${READY_CONSECUTIVE} consecutive, budget ${HEALTH_BUDGET_SEC}s)"
+  log "health-gating $color backend on http://127.0.0.1:${port}/api/healthz/ready (need ${READY_CONSECUTIVE} consecutive, budget ${HEALTH_BUDGET_SEC}s)"
   while (( SECONDS < deadline )); do
-    if curl -fsS -m 5 "http://127.0.0.1:${port}/healthz/ready" >/dev/null 2>&1; then
+    if curl -fsS -m 5 "http://127.0.0.1:${port}/api/healthz/ready" >/dev/null 2>&1; then
       hits=$(( hits + 1 ))
       (( hits >= READY_CONSECUTIVE )) && { log "$color READY (${hits}/${READY_CONSECUTIVE})"; return 0; }
     else
@@ -119,17 +174,25 @@ probe_frontend() { # <color>
 
 nginx_point_to() { # <color> — atomically flip the upstream symlink + graceful reload
   local color="$1" src="$NGINX_UPSTREAM_DIR/upstream-${color}.conf"
-  [[ -f "$src" ]] || die "upstream conf missing on host: $src (see runbook §3)"
+  # return (not die) so a caller wrapped in gate()/on the deploy path runs the
+  # recovery handler instead of exiting raw.
+  [[ -f "$src" ]] || { err "upstream conf missing on host: $src (see runbook §3)"; return 1; }
+  # Snapshot the current target so a failed nginx -t can be truly reverted —
+  # otherwise the on-disk symlink is left pointing at an unvalidated config and
+  # the next unrelated reload (certbot/logrotate/reboot) detonates it.
+  local prev; prev="$(readlink "$NGINX_UPSTREAM_LINK" 2>/dev/null || true)"
   log "flipping nginx upstream → $color ($src)"
   ln -sfn "$src" "$NGINX_UPSTREAM_LINK"
-  if ! nginx -t 2>/dev/null; then
-    err "nginx -t FAILED after pointing to $color — reverting symlink"
+  if ! nginx -t; then
+    err "nginx -t FAILED after pointing to $color — restoring previous symlink ($prev)"
+    if [[ -n "$prev" ]]; then ln -sfn "$prev" "$NGINX_UPSTREAM_LINK"; else rm -f "$NGINX_UPSTREAM_LINK"; fi
+    nginx -t >/dev/null 2>&1 || err "even the RESTORED nginx config fails -t — pre-existing breakage; do NOT reload nginx until fixed (disk restored to ${prev:-<none>})"
     return 1
   fi
   systemctl reload nginx
   # Confirm the symlink really resolves to the colour we intended (guard for
   # the 'never stop old colour until nginx is proven on new' invariant).
-  [[ "$(readlink -f "$NGINX_UPSTREAM_LINK")" == "$(readlink -f "$src")" ]] || die "post-reload symlink does not resolve to $color"
+  [[ "$(readlink -f "$NGINX_UPSTREAM_LINK")" == "$(readlink -f "$src")" ]] || { err "post-reload symlink does not resolve to $color"; return 1; }
   log "nginx reloaded; active upstream = $color"
 }
 
@@ -142,20 +205,40 @@ public_smoke() {
 }
 
 ensure_data_layer() {
+  # DATA-LOSS GUARD: the shared postgres volume is created empty in runbook §2
+  # and filled by a manual copy. If that copy was skipped/partial, postgres
+  # would initdb a FRESH cluster on the empty volume, the connectivity-only
+  # health gate would PASS, and an EMPTY database would be promoted as prod.
+  # Refuse to start the data layer unless the volume already holds an
+  # initialised cluster (PG_VERSION present). First-ever bootstrap can override
+  # with ALLOW_EMPTY_DATA=1 (e.g. a brand-new staging box).
+  if [[ "${ALLOW_EMPTY_DATA:-0}" != "1" ]]; then
+    if ! docker run --rm -v kds_postgres_data:/d alpine test -f /d/PG_VERSION >/dev/null 2>&1; then
+      die "shared postgres volume kds_postgres_data is EMPTY (no PG_VERSION) — the §2 data copy is missing/incomplete; refusing to boot an empty database as prod. Set ALLOW_EMPTY_DATA=1 ONLY for a first-time bootstrap."
+    fi
+  fi
   log "ensuring shared data layer (postgres+redis) is up"
   docker compose -p kds-data --env-file "$ENV_FILE" -f "$DATA_COMPOSE" up -d
 }
 
-run_expand_migrations() { # run prisma migrate deploy in the CURRENTLY LIVE backend
-  local live="kds_backend_$(read_active_color)"
-  if docker inspect -f '{{.State.Running}}' "$live" >/dev/null 2>&1 && \
-     [[ "$(docker inspect -f '{{.State.Running}}' "$live")" == "true" ]]; then
-    log "running expand-only migrations in live backend ($live)"
-    docker exec "$live" npx --no-install prisma migrate deploy
-  else
-    warn "no running live backend ($live) — deferring migrations to the new colour after boot"
-    DEFER_MIGRATIONS=1
-  fi
+# AUTHORITATIVE migration pass — runs inside the freshly-booted NEW colour,
+# whose image actually CONTAINS this release's migration files. (The old live
+# container runs the previous image and physically lacks the new migrations, so
+# an exec there is a no-op for anything new — that was the bug. The backend
+# image CMD is `node dist/main`, no boot-time migrate.) Expand-only discipline
+# keeps this safe: migrations land while the OLD colour still serves, before the
+# nginx flip, and the old code tolerates the expanded schema.
+migrate_in_color() { # <color>
+  local c="$1" cont="kds_backend_${c}" deadline=$(( SECONDS + 90 ))
+  log "waiting for $cont to accept exec, then applying prisma migrate deploy"
+  while (( SECONDS < deadline )); do
+    if docker exec "$cont" true >/dev/null 2>&1; then
+      docker exec "$cont" npx --no-install prisma migrate deploy
+      return 0
+    fi
+    sleep 3
+  done
+  return 1
 }
 
 # ── status ───────────────────────────────────────────────────────────────────
@@ -171,14 +254,23 @@ fi
 if [[ "$ACTION" == "rollback" ]]; then
   prev="$(read_previous_color)"; active="$(read_active_color)"
   [[ -n "$prev" ]] || die "no PREVIOUS_COLOR recorded in $ACTIVE_FILE — nothing to roll back to"
-  log "ROLLBACK: $active → $prev"
-  # Bring the previous colour back if it was stopped, then flip.
+  # Re-boot the previous colour at the EXACT version it last ran. Without this
+  # IMAGE_TAG pin, docker-compose.color.yml would fall back to :current (which
+  # this script never advances → a stale/legacy image), silently rolling prod
+  # onto the wrong code.
+  prev_version="$(read_color_version "$prev")"
+  [[ -n "$prev_version" ]] || die "no recorded VERSION for $prev in $ACTIVE_FILE — cannot pin the rollback image; roll back manually with an explicit tag"
+  log "ROLLBACK: $active → $prev (pinned image $prev_version)"
+  ghcr_login
+  export IMAGE_TAG="$prev_version"
+  docker pull "ghcr.io/mtarikucar/kds/backend:${prev_version}"
+  docker pull "ghcr.io/mtarikucar/kds/frontend:${prev_version}"
   dc_color "$prev" up -d
   wait_until_ready "$prev" || die "previous colour $prev did not become ready — aborting rollback"
   nginx_point_to "$prev"
   public_smoke || warn "post-rollback public smoke imperfect — inspect manually"
-  write_active_color "$prev" "$active"
-  log "rollback complete — active colour is now $prev"
+  write_active_color "$prev" "$active" "$prev_version"
+  log "rollback complete — active colour is now $prev ($prev_version)"
   exit 0
 fi
 
@@ -189,21 +281,26 @@ export IMAGE_TAG="$VERSION"
 
 ACTIVE="$(read_active_color)"
 TARGET="$(other_color "$ACTIVE")"
-DEFER_MIGRATIONS=0
 log "active=$ACTIVE  target=$TARGET  version=$VERSION"
 
-# ERR trap: anything failing BEFORE the flip tears down the un-promoted target;
-# the live ACTIVE colour is never touched, so users see zero impact.
+# Recovery handler shared by the ERR trap AND every explicit gate failure. Bare
+# `X || die` on the left of `||` does NOT fire the ERR trap and `die`'s exit
+# does not either, so gate failures MUST call this directly — otherwise the
+# advertised teardown/revert is dead code. On post-flip failure it reverts nginx
+# to ACTIVE and, critically, persists state so the file can never disagree with
+# the live symlink (a stale file would turn the NEXT deploy into a live-colour
+# recreate outage).
 FLIPPED=0
-on_err() {
-  local code=$?
-  err "deploy failed (exit $code)"
+cleanup_and_exit() {
+  local code="${1:-1}"
+  err "deploy aborting (code $code)"
   if [[ "$FLIPPED" -eq 0 ]]; then
     warn "tearing down un-promoted $TARGET (active $ACTIVE untouched → zero user impact)"
     dc_color "$TARGET" down --remove-orphans 2>/dev/null || true
   else
     err "failure occurred AFTER nginx flip — reverting traffic to $ACTIVE"
     if nginx_point_to "$ACTIVE"; then
+      write_active_color "$ACTIVE" "$TARGET" "$(read_color_version "$ACTIVE")"
       warn "traffic reverted to $ACTIVE; leaving $TARGET up for inspection"
     else
       err "AUTOMATIC REVERT FAILED — manual intervention required (symlink=$NGINX_UPSTREAM_LINK)"
@@ -211,40 +308,42 @@ on_err() {
   fi
   exit "$code"
 }
-trap on_err ERR
+trap 'cleanup_and_exit $?' ERR
+# Route explicit gate failures through the same recovery instead of bare `die`.
+gate() { "$@" || { err "gate failed: $*"; cleanup_and_exit 1; }; }
 
+assert_no_legacy_stack
 ensure_data_layer
+ghcr_login
 
 log "pulling immutable images :$VERSION"
-docker pull "ghcr.io/mtarikucar/kds/backend:${VERSION}"
-docker pull "ghcr.io/mtarikucar/kds/frontend:${VERSION}"
-
-run_expand_migrations
+gate docker pull "ghcr.io/mtarikucar/kds/backend:${VERSION}"
+gate docker pull "ghcr.io/mtarikucar/kds/frontend:${VERSION}"
 
 log "booting $TARGET colour on backend $(backend_port "$TARGET") / frontend $(frontend_port "$TARGET")"
-dc_color "$TARGET" up -d
+gate dc_color "$TARGET" up -d
 
-if [[ "${DEFER_MIGRATIONS}" -eq 1 ]]; then
-  log "running deferred migrations in the freshly-booted $TARGET backend"
-  # brief wait for the container process to accept exec
-  sleep 10
-  docker exec "kds_backend_${TARGET}" npx --no-install prisma migrate deploy
-fi
+# Authoritative migrate INSIDE the new colour (its image has the new migrations)
+# BEFORE the health gate + flip — expand-only, so the still-serving old colour
+# tolerates the expanded schema.
+gate migrate_in_color "$TARGET"
 
-wait_until_ready "$TARGET" || die "$TARGET failed /healthz/ready within ${HEALTH_BUDGET_SEC}s — not cutting over"
-probe_socketio "$TARGET" || die "$TARGET socket.io handshake failed — not cutting over"
-probe_frontend "$TARGET" || die "$TARGET frontend not serving — not cutting over"
+gate wait_until_ready "$TARGET"
+gate probe_socketio "$TARGET"
+gate probe_frontend "$TARGET"
 
 # ── CUTOVER ──────────────────────────────────────────────────────────────────
-nginx_point_to "$TARGET"
+gate nginx_point_to "$TARGET"
 FLIPPED=1
 
-# Post-flip confirmation against the public edge; failure triggers on_err revert.
-public_smoke || die "post-flip public smoke failed"
+# Record state IMMEDIATELY after the confirmed flip so the state file always
+# matches the live nginx symlink (before the post-flip smoke, which — on
+# failure — reverts nginx AND rewrites state back to ACTIVE via cleanup_and_exit).
+write_active_color "$TARGET" "$ACTIVE" "$VERSION"
 
-# Only NOW is it safe to record state + retire the old colour (risk-#10 guard:
-# nginx is proven reloaded onto TARGET and state is persisted before any stop).
-write_active_color "$TARGET" "$ACTIVE"
+# Post-flip confirmation against the public edge; failure reverts to ACTIVE.
+gate public_smoke
+
 trap - ERR   # cutover succeeded; a drain-window hiccup must not trigger a revert
 
 log "cutover to $TARGET succeeded; draining $ACTIVE for ${DRAIN_SECONDS}s so websocket clients reconnect"


### PR DESCRIPTION
Merge-öncesi düşmanca inceleme (#299 blue-green deploy) **24 hata doğruladı (7 kritik)** — mevcut haliyle ilk gerçek deploy'da patlar, prod'u indirebilir. Bu PR hepsini **#299'un üstüne** düzeltir; merge edilince #299 kararlı/mergeable olur.

## 🔴 Kritik (deploy fiilen çalışmıyordu)
- **Sağlık kontrolü yanlış path** `/healthz/ready` → gerçek `/api/healthz/ready` (`setGlobalPrefix("api")`). Her deploy flip'ten önce başarısız oluyordu.
- **Migration'lar yeni renge uygulanmıyordu** — ESKİ imajın container'ında koşuyordu (yeni dosyalar orada yok). `migrate_in_color`: yeni renkte, sağlık kapısından önce, expand-only.
- **CI ön-kontrolü hep `:3000`** — green aktifken kimse yok → 2. deploy kilitleniyor. Renk-farkında yaptım.
- **GHCR login yok** — private pull reddediliyordu. `ghcr_login()` eklendi.
- **Rollback bayat `:current` + CI her hatada rollback** — sağlıklı prod'u bozuk/bayat renge flip'liyordu. Renk-başına VERSION state'e yazılıyor, rollback `IMAGE_TAG`'i pinliyor; compose `IMAGE_TAG` zorunlu; CI rollback yalnız deploy-step patlarsa + blue-green'de sadece status logluyor.
- **`|| die` ERR trap'i baypaslıyordu** → flip-sonrası oto-revert ölü koddu. `cleanup_and_exit` + `gate()` ile tüm geçitler handler'dan geçiyor; state flip'ten hemen sonra + revert'te yazılıyor.

## 🟠 Yüksek
- `nginx_point_to` "revert ediyorum" deyip etmiyordu → snapshot + gerçek geri-al + `nginx -t` tanısı.
- Boş external volume tüm kapıları geçiyordu → `PG_VERSION` guard + runbook §2 kopya döngüsü sertleştirildi.
- Legacy-stack çakışması ("additive/istediğin an dön" yanlıştı) → `assert_no_legacy_stack` preflight; §2 landing/developer/help'i ayakta tutuyor; §5 revert iddiası düzeltildi.
- Globlanan `conf.d`'de duplicate `upstream` → non-globbed `/etc/nginx/kds-upstreams/`.

## 🟡 Düşük
- `vars.PROD_BLUEGREEN` root SSH string'ine gömülüydü (injection) → `env:` üzerinden runner'da değerlendiriliyor.

## 📄 Doküman
Runbook baştan sona dürüstleştirildi (health path, §2–§6, risk register) + **"Known gaps"**: landing/developer/help + monitoring henüz blue-green topolojisinde DEĞİL — tam adopsiyon öncesi deploy yolu gerekiyor.

## ⚠️ Doğrulama sınırı
**Sadece statik doğrulandı** (`bash -n`, YAML parse) — deploy altyapısı gerçek kutu olmadan çalıştırılamaz. `PROD_BLUEGREEN=true` yapmadan önce **staging dry-run şart**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)