### PR TITLE
fix(analytics): camera ingest hardening + CV telemetry retention

### DIFF
--- a/backend/prisma/migrations/20260715150000_occupancy_read_index/down.sql
+++ b/backend/prisma/migrations/20260715150000_occupancy_read_index/down.sql
@@ -1,0 +1,3 @@
+-- Rollback for occupancy_read_index: drops exactly the index the up added.
+
+DROP INDEX IF EXISTS "occupancy_records_tenantId_branchId_timestamp_idx";

--- a/backend/prisma/migrations/20260715150000_occupancy_read_index/migration.sql
+++ b/backend/prisma/migrations/20260715150000_occupancy_read_index/migration.sql
@@ -1,0 +1,8 @@
+-- Composite read index for the heatmap/occupancy queries, which filter by
+-- (tenantId, branchId, timestamp range). The existing (tenantId, timestamp)
+-- and (tenantId, branchId) indexes force a filter step on multi-branch
+-- tenants; this covers the exact access path — and the nightly retention
+-- sweep's timestamp-cutoff subquery. Idempotent; reversible via down.sql.
+
+CREATE INDEX IF NOT EXISTS "occupancy_records_tenantId_branchId_timestamp_idx"
+  ON "occupancy_records"("tenantId", "branchId", "timestamp");

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -2784,6 +2784,9 @@ model OccupancyRecord {
   @@index([trackingId, timestamp])
   @@index([state])
   @@index([tenantId, branchId])
+  // Heatmap read path filters (tenantId, branchId, timestamp range); also
+  // serves the nightly retention sweep's cutoff subquery.
+  @@index([tenantId, branchId, timestamp])
   @@map("occupancy_records")
 }
 

--- a/backend/src/modules/analytics/analytics.module.ts
+++ b/backend/src/modules/analytics/analytics.module.ts
@@ -4,6 +4,7 @@ import { ConfigModule, ConfigService } from "@nestjs/config";
 import { PrismaModule } from "../../prisma/prisma.module";
 import { AnalyticsController } from "./analytics.controller";
 import { AnalyticsScheduler } from "./analytics.scheduler";
+import { AnalyticsRetentionService } from "./services/analytics-retention.service";
 import { AnalyticsGateway } from "./gateways/analytics.gateway";
 import {
   MockDataGeneratorService,
@@ -43,6 +44,7 @@ import {
     CameraService,
     AnalyticsGateway,
     AnalyticsScheduler,
+    AnalyticsRetentionService,
   ],
   exports: [
     MockDataGeneratorService,

--- a/backend/src/modules/analytics/dto/edge-device/edge-device.dto.ts
+++ b/backend/src/modules/analytics/dto/edge-device/edge-device.dto.ts
@@ -9,6 +9,7 @@ import {
   Min,
   Max,
   IsObject,
+  ArrayMaxSize,
 } from "class-validator";
 import { Type } from "class-transformer";
 import { EmptyStringToNumber } from "../../../../common/dto/transforms";
@@ -113,6 +114,12 @@ export class EdgeOccupancyDataDto {
   timestamp: string;
 
   @IsArray()
+  // A frame's detections = people visible to ONE camera — a real restaurant
+  // frame carries tens, not hundreds. The cap bounds the per-message
+  // createMany fan-out (each row is a DB insert on the pool the money
+  // transactions share); an oversized payload is a misbehaving/hostile
+  // device, not data.
+  @ArrayMaxSize(200)
   @ValidateNested({ each: true })
   @Type(() => DetectionDto)
   detections: DetectionDto[];

--- a/backend/src/modules/analytics/gateways/analytics.gateway.ts
+++ b/backend/src/modules/analytics/gateways/analytics.gateway.ts
@@ -65,6 +65,15 @@ export class AnalyticsGateway
 
   private readonly logger = new Logger(AnalyticsGateway.name);
 
+  /** Per-socket occupancy-ingest floor: max 1 accepted frame / 200ms (5/s).
+      The edge pipeline targets ~1fps; the floor bounds a misconfigured or
+      hostile device's write pressure on the shared Prisma pool. */
+  static readonly MIN_INGEST_INTERVAL_MS = 200;
+  /** How long the camera→branch resolution cached at edge:register stays
+      fresh before the ingest path re-reads it (camera moved to another
+      branch converges within this window without a reconnect). */
+  static readonly CAMERA_BRANCH_TTL_MS = 5 * 60 * 1000;
+
   // Track connected edge devices keyed by `${tenantId}:${deviceId}` so
   // two tenants with the same device id don't evict each other.
   private connectedDevices: Map<string, EdgeDeviceConnection> = new Map();
@@ -215,6 +224,26 @@ export class AnalyticsGateway
       client.data.deviceId = payload.deviceId;
       client.data.cameraId = payload.cameraId;
 
+      // Resolve the camera's branch ONCE at registration instead of once
+      // per occupancy frame (the ingest path runs at fps × cameras — a DB
+      // lookup per frame was pure hot-path waste). Cached on the socket
+      // with a TTL; the ingest refreshes it when stale so moving a camera
+      // to another branch converges within minutes, not reconnects.
+      if (payload.cameraId) {
+        const camera = await this.prisma.camera.findFirst({
+          where: { id: payload.cameraId, tenantId },
+          select: { branchId: true },
+        });
+        if (!camera) {
+          this.logger.warn(
+            `Edge device ${payload.deviceId} registration rejected: camera ${payload.cameraId} not found for tenant`,
+          );
+          return { success: false, error: "Camera not found for tenant" };
+        }
+        client.data.cameraBranchId = camera.branchId;
+        client.data.cameraBranchFetchedAt = Date.now();
+      }
+
       this.connectedDevices.set(
         this.deviceKey(payload.tenantId, payload.deviceId),
         {
@@ -356,23 +385,53 @@ export class AnalyticsGateway
         return { success: false, error: "Camera mismatch" };
       }
 
+      // Per-socket ingest floor: at most one accepted frame per 200ms
+      // (5/s). The edge device is configured around ~1fps; anything
+      // hammering faster is misconfigured or hostile, and every accepted
+      // frame costs inserts on the SAME Prisma pool the money
+      // transactions use. Dropped frames are cheap for the caller to
+      // retry-next-tick and are counted, not logged per-hit.
+      const now = Date.now();
+      const lastAccepted: number = client.data.lastOccupancyAcceptedAt ?? 0;
+      if (now - lastAccepted < AnalyticsGateway.MIN_INGEST_INTERVAL_MS) {
+        client.data.occupancyDropCount =
+          (client.data.occupancyDropCount ?? 0) + 1;
+        if (client.data.occupancyDropCount % 100 === 1) {
+          this.logger.warn(
+            `Rate-limiting occupancy ingest from ${client.id} (camera=${payload.cameraId}, dropped=${client.data.occupancyDropCount})`,
+          );
+        }
+        return { success: false, error: "Rate limited" };
+      }
+      client.data.lastOccupancyAcceptedAt = now;
+
       const timestamp = new Date(payload.timestamp);
 
       // Store occupancy records
       if (payload.detections.length > 0) {
-        // v3.0.0 — load the source camera's branchId once and propagate
-        // it to both the OccupancyRecord rows and the TrafficFlowRecord
-        // aggregation. OccupancyRecord/TrafficFlowRecord both now require
-        // branchId (NOT NULL, Restrict), and the source-of-truth for the
-        // branch is the camera entity, not the edge device JWT.
-        const camera = await this.prisma.camera.findFirst({
-          where: { id: payload.cameraId, tenantId },
-          select: { branchId: true },
-        });
-        if (!camera) {
-          return { success: false, error: "Camera not found for tenant" };
+        // v3.0.0 — OccupancyRecord/TrafficFlowRecord require branchId
+        // (NOT NULL, Restrict) and the source-of-truth for the branch is
+        // the camera entity, not the edge device JWT. The branch is
+        // resolved at edge:register and cached on the socket; refresh it
+        // here when the TTL lapses so a camera moved between branches
+        // converges without a reconnect.
+        let branchId: string | undefined = client.data.cameraBranchId;
+        const fetchedAt: number = client.data.cameraBranchFetchedAt ?? 0;
+        if (
+          !branchId ||
+          now - fetchedAt > AnalyticsGateway.CAMERA_BRANCH_TTL_MS
+        ) {
+          const camera = await this.prisma.camera.findFirst({
+            where: { id: payload.cameraId, tenantId },
+            select: { branchId: true },
+          });
+          if (!camera) {
+            return { success: false, error: "Camera not found for tenant" };
+          }
+          branchId = camera.branchId;
+          client.data.cameraBranchId = branchId;
+          client.data.cameraBranchFetchedAt = now;
         }
-        const branchId = camera.branchId;
 
         await this.prisma.occupancyRecord.createMany({
           data: payload.detections.map((detection) => ({

--- a/backend/src/modules/analytics/services/analytics-retention.service.spec.ts
+++ b/backend/src/modules/analytics/services/analytics-retention.service.spec.ts
@@ -1,0 +1,93 @@
+import { AnalyticsRetentionService } from "./analytics-retention.service";
+
+/**
+ * Nightly CV-telemetry retention sweep. Pins the money-relevant behaviors:
+ * batched deletes stop at the first short batch, the per-run cap bounds a
+ * huge backlog, the sweep only runs under the advisory lock, and cutoffs
+ * honor the env-tunable retention windows.
+ */
+describe("AnalyticsRetentionService", () => {
+  let prisma: any;
+  let svc: AnalyticsRetentionService;
+
+  beforeEach(() => {
+    jest.restoreAllMocks();
+    delete process.env.ANALYTICS_OCCUPANCY_RETENTION_DAYS;
+    delete process.env.ANALYTICS_TRAFFIC_RETENTION_DAYS;
+    prisma = {
+      // withAdvisoryLock: grant by default (two raw queries: lock + unlock)
+      $queryRawUnsafe: jest.fn().mockResolvedValue([{ locked: true }]),
+      $executeRawUnsafe: jest.fn().mockResolvedValue(0),
+      analyticsHeatmapCache: {
+        deleteMany: jest.fn().mockResolvedValue({ count: 0 }),
+      },
+    };
+    svc = new AnalyticsRetentionService(prisma);
+  });
+
+  it("deletes in batches and stops at the first short batch", async () => {
+    // occupancy: full batch (5000) then short (120) → 2 calls; traffic: 0 → 1 call
+    (prisma.$executeRawUnsafe as jest.Mock)
+      .mockResolvedValueOnce(5000)
+      .mockResolvedValueOnce(120)
+      .mockResolvedValueOnce(0);
+    await svc.sweep();
+    const tables = (prisma.$executeRawUnsafe as jest.Mock).mock.calls.map(
+      (c: any[]) => c[0],
+    );
+    expect(tables.filter((q: string) => q.includes("occupancy_records"))).toHaveLength(2);
+    expect(tables.filter((q: string) => q.includes("traffic_flow_records"))).toHaveLength(1);
+  });
+
+  it("caps a huge backlog at MAX_BATCHES_PER_RUN per table", async () => {
+    (prisma.$executeRawUnsafe as jest.Mock).mockResolvedValue(5000); // never short
+    await svc.sweep();
+    const occCalls = (prisma.$executeRawUnsafe as jest.Mock).mock.calls.filter(
+      (c: any[]) => c[0].includes("occupancy_records"),
+    );
+    expect(occCalls).toHaveLength(40);
+  });
+
+  it("does nothing when the advisory lock is held elsewhere", async () => {
+    (prisma.$queryRawUnsafe as jest.Mock).mockResolvedValue([
+      { locked: false },
+    ]);
+    await svc.sweep();
+    expect(prisma.$executeRawUnsafe).not.toHaveBeenCalled();
+    expect(prisma.analyticsHeatmapCache.deleteMany).not.toHaveBeenCalled();
+  });
+
+  it("honors env-tunable retention windows in the cutoff params", async () => {
+    process.env.ANALYTICS_OCCUPANCY_RETENTION_DAYS = "7";
+    const before = Date.now();
+    await svc.sweep();
+    const occCall = (prisma.$executeRawUnsafe as jest.Mock).mock.calls.find(
+      (c: any[]) => c[0].includes("occupancy_records"),
+    );
+    const cutoff: Date = occCall[1];
+    const expected = before - 7 * 24 * 60 * 60 * 1000;
+    expect(Math.abs(cutoff.getTime() - expected)).toBeLessThan(60_000);
+  });
+
+  it("purges expired heatmap-cache rows", async () => {
+    (prisma.analyticsHeatmapCache.deleteMany as jest.Mock).mockResolvedValue({
+      count: 3,
+    });
+    await svc.sweep();
+    const where = (prisma.analyticsHeatmapCache.deleteMany as jest.Mock).mock
+      .calls[0][0].where;
+    expect(where.expiresAt.lt).toBeInstanceOf(Date);
+  });
+
+  it("ignores a malformed retention env (falls back to the default)", async () => {
+    process.env.ANALYTICS_OCCUPANCY_RETENTION_DAYS = "banana";
+    const before = Date.now();
+    await svc.sweep();
+    const occCall = (prisma.$executeRawUnsafe as jest.Mock).mock.calls.find(
+      (c: any[]) => c[0].includes("occupancy_records"),
+    );
+    const cutoff: Date = occCall[1];
+    const expected = before - 30 * 24 * 60 * 60 * 1000;
+    expect(Math.abs(cutoff.getTime() - expected)).toBeLessThan(60_000);
+  });
+});

--- a/backend/src/modules/analytics/services/analytics-retention.service.ts
+++ b/backend/src/modules/analytics/services/analytics-retention.service.ts
@@ -1,0 +1,101 @@
+import { Injectable, Logger } from "@nestjs/common";
+import { Cron } from "@nestjs/schedule";
+import { PrismaService } from "../../../prisma/prisma.service";
+import { withAdvisoryLock } from "../../../common/scheduling/advisory-lock";
+
+/**
+ * Nightly retention sweep for the camera-CV telemetry tables. The edge
+ * ingest appends occupancy rows at fps × cameras × tenants — the only axis
+ * in this product that grows faster than orders — and until this service
+ * NOTHING pruned them in production (only the dev mock generator deleted
+ * rows). Unbounded telemetry on the same Postgres that holds money data is
+ * a disk-pressure incident waiting for the hardware go-live.
+ *
+ * Retention windows (env-tunable):
+ *  - occupancy_records:    ANALYTICS_OCCUPANCY_RETENTION_DAYS (default 30)
+ *  - traffic_flow_records: ANALYTICS_TRAFFIC_RETENTION_DAYS  (default 90)
+ *  - analytics heatmap cache: expired rows (validUntil in the past)
+ *
+ * Deletes run in fixed-size batches with a per-run batch cap so a huge
+ * backlog can't hold long row locks or bloat one transaction; the next
+ * night's run continues where this one stopped. Advisory-locked so only
+ * one replica sweeps; the deletes are idempotent anyway.
+ */
+@Injectable()
+export class AnalyticsRetentionService {
+  private readonly logger = new Logger(AnalyticsRetentionService.name);
+
+  private static readonly BATCH_SIZE = 5000;
+  private static readonly MAX_BATCHES_PER_RUN = 40; // ≤200k rows/table/night
+
+  constructor(private readonly prisma: PrismaService) {}
+
+  private retentionDays(envKey: string, fallback: number): number {
+    const raw = Number(process.env[envKey]);
+    return Number.isFinite(raw) && raw > 0 ? raw : fallback;
+  }
+
+  @Cron("40 3 * * *")
+  async sweep(): Promise<void> {
+    await withAdvisoryLock(
+      this.prisma,
+      "analytics.retention-sweep",
+      async () => {
+        const occupancyDays = this.retentionDays(
+          "ANALYTICS_OCCUPANCY_RETENTION_DAYS",
+          30,
+        );
+        const trafficDays = this.retentionDays(
+          "ANALYTICS_TRAFFIC_RETENTION_DAYS",
+          90,
+        );
+
+        const occupancy = await this.pruneBatched(
+          "occupancy_records",
+          "timestamp",
+          new Date(Date.now() - occupancyDays * 24 * 60 * 60 * 1000),
+        );
+        const traffic = await this.pruneBatched(
+          "traffic_flow_records",
+          "hourBucket",
+          new Date(Date.now() - trafficDays * 24 * 60 * 60 * 1000),
+        );
+        // Heatmap cache rows carry their own expiry; the write path purges
+        // per-tenant, this catches tenants that stopped writing.
+        const cache = await this.prisma.analyticsHeatmapCache.deleteMany({
+          where: { expiresAt: { lt: new Date() } },
+        });
+
+        if (occupancy + traffic + cache.count > 0) {
+          this.logger.log(
+            `Retention sweep: occupancy=${occupancy} traffic=${traffic} expiredCache=${cache.count} rows pruned`,
+          );
+        }
+      },
+    );
+  }
+
+  /** Batched delete by an indexed timestamp column. The column name comes
+      from the two hardcoded call sites above — never user input. */
+  private async pruneBatched(
+    table: "occupancy_records" | "traffic_flow_records",
+    column: "timestamp" | "hourBucket",
+    cutoff: Date,
+  ): Promise<number> {
+    let total = 0;
+    for (let i = 0; i < AnalyticsRetentionService.MAX_BATCHES_PER_RUN; i++) {
+      const deleted: number = await this.prisma.$executeRawUnsafe(
+        `DELETE FROM "${table}" WHERE "id" IN (SELECT "id" FROM "${table}" WHERE "${column}" < $1 LIMIT ${AnalyticsRetentionService.BATCH_SIZE})`,
+        cutoff,
+      );
+      total += deleted;
+      if (deleted < AnalyticsRetentionService.BATCH_SIZE) break;
+    }
+    if (total === AnalyticsRetentionService.MAX_BATCHES_PER_RUN * 5000) {
+      this.logger.warn(
+        `Retention sweep hit the per-run cap on ${table} — backlog continues tomorrow`,
+      );
+    }
+    return total;
+  }
+}


### PR DESCRIPTION
Closes the four producer-side findings deferred by the June heatmap review — the camera ingest was flagged again by this month's infra audit as the system's only unbounded-growth axis (fps × cameras × tenants) sharing the Prisma pool with money transactions.

## Changes
| Finding | Fix |
|---|---|
| DB lookup per frame | camera→branch resolved at `edge:register` (unknown camera rejected there), cached on the socket, 5-min TTL refresh |
| No ingest rate bound | per-socket floor: max 1 accepted frame/200ms; drops counted, logged every 100th |
| Unbounded detections array | `@ArrayMaxSize(200)` (gateway ValidationPipe enforces) |
| No retention — tables grew forever | nightly 03:40 advisory-locked sweep: occupancy 30d, traffic-flow 90d (env-tunable), batched deletes (5000×40 cap/run) + expired heatmap-cache purge |
| Missing read index | reversible migration: `(tenantId, branchId, timestamp)` on `occupancy_records` |

## Verification
Backend 4,688 tests green (+6 retention specs: batch stop, per-run cap, lock-skip, env cutoffs, cache purge, malformed env), `tsc` clean, `lint:ci` 0 errors. No FE surface.