### PR TITLE
fix(infra): leak-proof advisory locks (pg_try_advisory_xact_lock) + tokenHash unique indexes

### DIFF
--- a/backend/prisma/migrations/20260715170000_tokenhash_unique_index/down.sql
+++ b/backend/prisma/migrations/20260715170000_tokenhash_unique_index/down.sql
@@ -1,0 +1,5 @@
+-- Rollback for tokenhash_unique_index: drops exactly the two indexes the up
+-- added. Safe no-op when already reverted.
+
+DROP INDEX IF EXISTS "devices_tokenHash_key";
+DROP INDEX IF EXISTS "local_bridge_agents_tokenHash_key";

--- a/backend/prisma/migrations/20260715170000_tokenhash_unique_index/migration.sql
+++ b/backend/prisma/migrations/20260715170000_tokenhash_unique_index/migration.sql
@@ -1,0 +1,11 @@
+-- Unique index on the rotating bearer-token hashes. Every device/bridge auth
+-- is a lookup by tokenHash; without an index it was a sequential scan per
+-- request, and nothing enforced one-token-one-row. sha256 values cannot
+-- realistically collide; Postgres treats NULLs as distinct, so the many
+-- unprovisioned rows (tokenHash NULL) are unaffected. Idempotent; reversible.
+
+CREATE UNIQUE INDEX IF NOT EXISTS "devices_tokenHash_key"
+  ON "devices"("tokenHash");
+
+CREATE UNIQUE INDEX IF NOT EXISTS "local_bridge_agents_tokenHash_key"
+  ON "local_bridge_agents"("tokenHash");

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -4897,7 +4897,10 @@ model Device {
   pairCodeExpiresAt DateTime?
   // Rotating bearer token (sha256 hashed) issued post-pair. Refreshed via
   // /devices/:id/token/refresh. Never store the raw token at rest.
-  tokenHash         String?
+  // @unique: every device auth is a lookup by tokenHash — without the index
+  // it was a seq scan per request, and nothing guaranteed one-token-one-device
+  // (PG unique treats NULLs as distinct, so unprovisioned rows are fine).
+  tokenHash         String?           @unique
   tokenExpiresAt    DateTime?
   // Free-form provisioning config — e.g. printer width, kitchen station id.
   config            Json?
@@ -4981,7 +4984,9 @@ model LocalBridgeAgent {
   // Hashed at rest (sha256); never raw.
   provisioningTokenHash String?
   // Rotating bearer token (sha256 hashed) post-claim.
-  tokenHash             String?
+  // @unique: same rationale as Device.tokenHash — indexed auth lookup +
+  // one-token-one-agent guarantee (NULLs distinct).
+  tokenHash             String?   @unique
   tokenExpiresAt        DateTime?
   hostname              String?
   os                    String?

--- a/backend/src/common/scheduling/advisory-lock.spec.ts
+++ b/backend/src/common/scheduling/advisory-lock.spec.ts
@@ -3,34 +3,39 @@ import { withAdvisoryLock } from "./advisory-lock";
 import { PrismaService } from "../../prisma/prisma.service";
 
 /**
- * Long-tail spec for the Postgres advisory-lock cron coordinator. Load-
- * bearing contracts: the winning replica (lock acquired) runs the body and
- * always unlocks afterwards; a losing replica (lock held elsewhere) skips
- * the body entirely; the unlock still fires if the body throws.
+ * Long-tail spec for the Postgres advisory-lock cron coordinator, v2
+ * mechanism: ONE interactive transaction acquires pg_try_advisory_xact_lock
+ * and holds it while run() executes — the lock releases at commit/rollback,
+ * so there is NO unlock statement a pooled connection could misroute (the v1
+ * leak: try_lock and unlock landed on different sessions → unlock no-op →
+ * that job's cron never ran again).
  */
 describe("withAdvisoryLock", () => {
   function makePrisma(locked: boolean) {
     const queryRawUnsafe = jest.fn((sql: string) => {
-      if (sql.includes("pg_try_advisory_lock")) {
+      if (sql.includes("pg_try_advisory_xact_lock")) {
         return Promise.resolve([{ locked }]);
       }
       return Promise.resolve([]);
     });
-    return { $queryRawUnsafe: queryRawUnsafe } as unknown as PrismaService & {
+    const prisma: any = { $queryRawUnsafe: queryRawUnsafe };
+    // The helper only touches tx.$queryRawUnsafe — hand it the same mock.
+    prisma.$transaction = jest.fn(async (cb: any, _opts: any) => cb(prisma));
+    return prisma as PrismaService & {
       $queryRawUnsafe: jest.Mock;
+      $transaction: jest.Mock;
     };
   }
 
-  it("runs the body and unlocks when the lock is acquired", async () => {
+  it("runs the body inside the lock-holding transaction when acquired", async () => {
     const prisma = makePrisma(true);
     const run = jest.fn().mockResolvedValue(undefined);
     await withAdvisoryLock(prisma, "job-a", run);
     expect(run).toHaveBeenCalledTimes(1);
-    const calls = (prisma.$queryRawUnsafe as jest.Mock).mock.calls.map(
-      (c) => c[0],
-    );
-    expect(calls.some((s: string) => s.includes("pg_advisory_unlock"))).toBe(
-      true,
+    // xact lock only — no unlock statement exists to misroute.
+    expect(prisma.$queryRawUnsafe).toHaveBeenCalledTimes(1);
+    expect(prisma.$queryRawUnsafe.mock.calls[0][0]).toContain(
+      "pg_try_advisory_xact_lock",
     );
   });
 
@@ -41,38 +46,41 @@ describe("withAdvisoryLock", () => {
     await withAdvisoryLock(prisma, "job-b", run, logger);
     expect(run).not.toHaveBeenCalled();
     expect(logger.debug).toHaveBeenCalled();
-    // never reaches the unlock statement
-    const calls = (prisma.$queryRawUnsafe as jest.Mock).mock.calls.map(
-      (c) => c[0],
-    );
-    expect(calls.some((s: string) => s.includes("pg_advisory_unlock"))).toBe(
-      false,
-    );
   });
 
-  it("releases the lock even when the body throws", async () => {
+  it("propagates a body throw (rollback still releases the xact lock)", async () => {
     const prisma = makePrisma(true);
     const run = jest.fn().mockRejectedValue(new Error("boom"));
     await expect(withAdvisoryLock(prisma, "job-c", run)).rejects.toThrow(
       "boom",
-    );
-    const calls = (prisma.$queryRawUnsafe as jest.Mock).mock.calls.map(
-      (c) => c[0],
-    );
-    expect(calls.some((s: string) => s.includes("pg_advisory_unlock"))).toBe(
-      true,
     );
   });
 
   it("derives the same lock id for the same job name (stable hash)", async () => {
     const p1 = makePrisma(true);
     const p2 = makePrisma(true);
-    await withAdvisoryLock(p1, "same-job", jest.fn().mockResolvedValue(undefined));
-    await withAdvisoryLock(p2, "same-job", jest.fn().mockResolvedValue(undefined));
+    await withAdvisoryLock(
+      p1,
+      "same-job",
+      jest.fn().mockResolvedValue(undefined),
+    );
+    await withAdvisoryLock(
+      p2,
+      "same-job",
+      jest.fn().mockResolvedValue(undefined),
+    );
     const lockSql = (p: typeof p1) =>
       (p.$queryRawUnsafe as jest.Mock).mock.calls
         .map((c) => c[0])
-        .find((s: string) => s.includes("pg_try_advisory_lock"));
+        .find((s: string) => s.includes("pg_try_advisory_xact_lock"));
     expect(lockSql(p1)).toBe(lockSql(p2));
+  });
+
+  it("holds the lock with generous transaction timeouts (expiry mid-run would re-open the duplicate-run window)", async () => {
+    const prisma = makePrisma(true);
+    await withAdvisoryLock(prisma, "job-t", async () => undefined);
+    const opts = prisma.$transaction.mock.calls[0][1];
+    expect(opts.timeout).toBe(30 * 60_000);
+    expect(opts.maxWait).toBe(10_000);
   });
 });

--- a/backend/src/common/scheduling/advisory-lock.ts
+++ b/backend/src/common/scheduling/advisory-lock.ts
@@ -8,9 +8,26 @@ import { PrismaService } from "../../prisma/prisma.service";
  * Under multi-replica deploy, every replica fires its @Cron decorators on
  * the same wall-clock tick — without coordination they all do duplicate
  * work (and in some cases double-charge / double-emit / double-update).
- * `pg_try_advisory_lock` is a per-session, transient, contention-free
- * primitive that returns true exactly once per id: the winning replica
- * proceeds, the losers silently skip.
+ * The winning replica proceeds, the losers silently skip.
+ *
+ * MECHANISM (v2 — leak-proof): a single interactive transaction acquires
+ * `pg_try_advisory_xact_lock` and holds it while `run()` executes; the lock
+ * releases automatically at commit/rollback. The previous implementation
+ * issued try_lock and unlock as two SEPARATE pooled queries — advisory
+ * SESSION locks belong to the connection that took them, so whenever the
+ * pool handed the unlock to a different connection it was a silent no-op,
+ * the lock stayed held by an idle pooled session ~forever, and every later
+ * tick of that job saw locked=false → the cron silently stalled until that
+ * one connection happened to close. The xact variant cannot leak: there is
+ * no unlock call to route to the wrong session, and a crashed process
+ * releases at rollback.
+ *
+ * The transaction performs no reads/writes itself — it is purely the lock
+ * holder (run()'s own queries use the normal pooled client), so it pins one
+ * pool connection (idle-in-transaction) for the duration of the job. The
+ * timeout is a safety valve for a wedged job; it is deliberately generous
+ * because expiry RELEASES the lock while an in-flight run() keeps executing
+ * detached — i.e. the very duplicate-run the lock exists to prevent.
  *
  * The id is derived from the job name with DJB2 (stable across runs), so
  * the same job string yields the same lock across replicas. Lock collisions
@@ -22,22 +39,25 @@ export async function withAdvisoryLock(
   jobName: string,
   run: () => Promise<void>,
   logger?: Logger,
+  opts?: { timeoutMs?: number; maxWaitMs?: number },
 ): Promise<void> {
   const lockId = djb2(jobName);
-  const acquired = await prisma.$queryRawUnsafe<{ locked: boolean }[]>(
-    `SELECT pg_try_advisory_lock(${lockId}) AS locked`,
+  await prisma.$transaction(
+    async (tx) => {
+      const acquired = await tx.$queryRawUnsafe<{ locked: boolean }[]>(
+        `SELECT pg_try_advisory_xact_lock(${lockId}) AS locked`,
+      );
+      if (!acquired?.[0]?.locked) {
+        logger?.debug(`skip ${jobName}: advisory lock held by another replica`);
+        return;
+      }
+      await run();
+    },
+    {
+      maxWait: opts?.maxWaitMs ?? 10_000,
+      timeout: opts?.timeoutMs ?? 30 * 60_000,
+    },
   );
-  if (!acquired[0]?.locked) {
-    logger?.debug(`skip ${jobName}: advisory lock held by another replica`);
-    return;
-  }
-  try {
-    await run();
-  } finally {
-    // Release explicitly — Postgres also releases at session end, but
-    // long-lived connection pools mean "session end" is hours away.
-    await prisma.$queryRawUnsafe(`SELECT pg_advisory_unlock(${lockId})`);
-  }
 }
 
 /** Deterministic 32-bit hash. Stable for the same input across processes. */

--- a/backend/src/modules/analytics/services/analytics-retention.service.spec.ts
+++ b/backend/src/modules/analytics/services/analytics-retention.service.spec.ts
@@ -15,8 +15,9 @@ describe("AnalyticsRetentionService", () => {
     delete process.env.ANALYTICS_OCCUPANCY_RETENTION_DAYS;
     delete process.env.ANALYTICS_TRAFFIC_RETENTION_DAYS;
     prisma = {
-      // withAdvisoryLock: grant by default (two raw queries: lock + unlock)
+      // withAdvisoryLock v2: xact lock inside a $transaction; grant by default
       $queryRawUnsafe: jest.fn().mockResolvedValue([{ locked: true }]),
+      $transaction: jest.fn(async (cb: any) => cb(prisma)),
       $executeRawUnsafe: jest.fn().mockResolvedValue(0),
       analyticsHeatmapCache: {
         deleteMany: jest.fn().mockResolvedValue({ count: 0 }),

--- a/backend/src/modules/customer-orders/services/customer-self-pay.service.spec.ts
+++ b/backend/src/modules/customer-orders/services/customer-self-pay.service.spec.ts
@@ -252,11 +252,15 @@ describe("CustomerSelfPayService (characterization)", () => {
     it("transitions PENDING+expired rows to EXPIRED under advisory lock", async () => {
       (prisma.$queryRawUnsafe as unknown as jest.Mock).mockImplementation(
         (sql: string) => {
-          if (sql.includes("pg_try_advisory_lock")) {
+          if (sql.includes("pg_try_advisory")) {
             return Promise.resolve([{ locked: true }]);
           }
           return Promise.resolve([]);
         },
+      );
+      (prisma.$transaction as unknown as jest.Mock).mockImplementation(
+        async (cb: any) =>
+          typeof cb === "function" ? cb(prisma) : Promise.all(cb),
       );
       (prisma.pendingSelfPayment.updateMany as any).mockResolvedValue({
         count: 3,
@@ -278,7 +282,7 @@ describe("CustomerSelfPayService (characterization)", () => {
     it("skips the sweep when the advisory lock is held by another replica", async () => {
       (prisma.$queryRawUnsafe as unknown as jest.Mock).mockImplementation(
         (sql: string) => {
-          if (sql.includes("pg_try_advisory_lock")) {
+          if (sql.includes("pg_try_advisory")) {
             return Promise.resolve([{ locked: false }]);
           }
           return Promise.resolve([]);

--- a/backend/src/modules/customer-orders/services/self-pay-recovery.service.spec.ts
+++ b/backend/src/modules/customer-orders/services/self-pay-recovery.service.spec.ts
@@ -180,10 +180,14 @@ describe("self-pay inquiry-recovery (sweep-3 #4)", () => {
     let svc: SelfPayRecoveryService;
 
     beforeEach(() => {
-      // Advisory lock acquired.
+      // Advisory lock acquired (v2: xact lock inside a $transaction).
       (prisma.$queryRawUnsafe as unknown as jest.Mock).mockResolvedValue([
         { locked: true },
       ]);
+      (prisma.$transaction as unknown as jest.Mock).mockImplementation(
+        async (cb: any) => (typeof cb === "function" ? cb(prisma) : Promise.all(cb)),
+      );
+
       paytr = { inquiryStatus: jest.fn() };
       webhook = { handleWebhookSuccess: jest.fn().mockResolvedValue(undefined) };
       svc = new SelfPayRecoveryService(

--- a/backend/src/modules/customers/customer-session.service.spec.ts
+++ b/backend/src/modules/customers/customer-session.service.spec.ts
@@ -70,6 +70,10 @@ describe('CustomerSessionService (iter-77 cleanup + cap)', () => {
       // release. Stub to return the locked=true row Postgres would
       // emit for `SELECT pg_try_advisory_lock(...) AS locked`.
       (prisma.$queryRawUnsafe as any).mockResolvedValue([{ locked: true }]);
+      (prisma.$transaction as any).mockImplementation(async (cb: any) =>
+      typeof cb === "function" ? cb(prisma) : Promise.all(cb),
+    );
+
       (prisma.customerSession.updateMany as any).mockResolvedValue({ count: 2 });
       (prisma.customerSession.deleteMany as any).mockResolvedValue({ count: 3 });
 

--- a/backend/src/modules/delivery-platforms/schedulers/delivery-reconciliation.scheduler.spec.ts
+++ b/backend/src/modules/delivery-platforms/schedulers/delivery-reconciliation.scheduler.spec.ts
@@ -13,6 +13,10 @@ describe('DeliveryReconciliationScheduler', () => {
 
   beforeEach(() => {
     prisma = mockPrismaClient();
+    (prisma.$transaction as any).mockImplementation(async (cb: any) =>
+      typeof cb === "function" ? cb(prisma) : Promise.all(cb),
+    );
+
     reconciliationService = {
       reconcile: jest
         .fn()
@@ -28,7 +32,7 @@ describe('DeliveryReconciliationScheduler', () => {
     let lockQueried = false;
     let unlockQueried = false;
     (prisma.$queryRawUnsafe as any).mockImplementation(async (sql: string) => {
-      if (sql.includes('pg_try_advisory_lock')) {
+      if (sql.includes('pg_try_advisory')) {
         lockQueried = true;
         return [{ locked: true }];
       }
@@ -42,13 +46,14 @@ describe('DeliveryReconciliationScheduler', () => {
     await svc.runReconciliation();
 
     expect(lockQueried).toBe(true);
-    expect(unlockQueried).toBe(true);
+    // v2 lock: xact variant releases at commit — no unlock statement exists.
+    expect(unlockQueried).toBe(false);
     expect(reconciliationService.reconcile).toHaveBeenCalledTimes(1);
   });
 
   it('skips the pass when the advisory lock is held by another replica', async () => {
     (prisma.$queryRawUnsafe as any).mockImplementation(async (sql: string) => {
-      if (sql.includes('pg_try_advisory_lock')) return [{ locked: false }];
+      if (sql.includes('pg_try_advisory')) return [{ locked: false }];
       return [];
     });
 
@@ -59,7 +64,7 @@ describe('DeliveryReconciliationScheduler', () => {
 
   it('swallows a reconciliation failure so the tick never crashes', async () => {
     (prisma.$queryRawUnsafe as any).mockImplementation(async (sql: string) => {
-      if (sql.includes('pg_try_advisory_lock')) return [{ locked: true }];
+      if (sql.includes('pg_try_advisory')) return [{ locked: true }];
       return [];
     });
     reconciliationService.reconcile.mockRejectedValueOnce(new Error('db blip'));

--- a/backend/src/modules/delivery-platforms/schedulers/retry.scheduler.spec.ts
+++ b/backend/src/modules/delivery-platforms/schedulers/retry.scheduler.spec.ts
@@ -21,6 +21,10 @@ describe('RetryScheduler (iter-40)', () => {
 
   beforeEach(() => {
     prisma = mockPrismaClient();
+    (prisma.$transaction as any).mockImplementation(async (cb: any) =>
+      typeof cb === "function" ? cb(prisma) : Promise.all(cb),
+    );
+
     logService = {
       getFailedOperations: jest.fn().mockResolvedValue([]),
       markRetrySuccess: jest.fn().mockResolvedValue(undefined),
@@ -40,13 +44,13 @@ describe('RetryScheduler (iter-40)', () => {
   });
 
   it('acquires a pg advisory lock before processing (cross-replica safety)', async () => {
-    // withAdvisoryLock invokes $queryRawUnsafe with pg_try_advisory_lock.
+    // withAdvisoryLock invokes $queryRawUnsafe with pg_try_advisory.
     // Stub to return locked=true so the inner runRetries fires; then
     // assert the lock query was issued at all.
     let lockQueried = false;
     let unlockQueried = false;
     (prisma.$queryRawUnsafe as any).mockImplementation(async (sql: string) => {
-      if (sql.includes('pg_try_advisory_lock')) {
+      if (sql.includes('pg_try_advisory')) {
         lockQueried = true;
         return [{ locked: true }];
       }
@@ -60,14 +64,16 @@ describe('RetryScheduler (iter-40)', () => {
     await svc.retryFailedOperations();
 
     expect(lockQueried).toBe(true);
-    expect(unlockQueried).toBe(true);
+    // v2 lock: pg_try_advisory_xact_lock releases at commit — no unlock
+    // statement exists (the old two-query pattern leaked on pooled conns).
+    expect(unlockQueried).toBe(false);
     expect(logService.getFailedOperations).toHaveBeenCalled();
   });
 
   it('SKIPS the retry loop when another replica holds the lock', async () => {
     // Simulate the loser case: lock query returns locked=false.
     (prisma.$queryRawUnsafe as any).mockImplementation(async (sql: string) => {
-      if (sql.includes('pg_try_advisory_lock')) return [{ locked: false }];
+      if (sql.includes('pg_try_advisory')) return [{ locked: false }];
       return [];
     });
 
@@ -86,7 +92,7 @@ describe('RetryScheduler (iter-40)', () => {
     // First tick: lock acquired, getFailedOperations hangs on the
     // inFlight promise so the tick stays "running".
     (prisma.$queryRawUnsafe as any).mockImplementation(async (sql: string) => {
-      if (sql.includes('pg_try_advisory_lock')) return [{ locked: true }];
+      if (sql.includes('pg_try_advisory')) return [{ locked: true }];
       return [];
     });
     logService.getFailedOperations.mockReturnValue(inFlight.then(() => []));
@@ -109,7 +115,7 @@ describe('RetryScheduler (iter-40)', () => {
 
   it('scopes order lookup by op.tenantId (defence-in-depth)', async () => {
     (prisma.$queryRawUnsafe as any).mockImplementation(async (sql: string) => {
-      if (sql.includes('pg_try_advisory_lock')) return [{ locked: true }];
+      if (sql.includes('pg_try_advisory')) return [{ locked: true }];
       return [];
     });
     logService.getFailedOperations.mockResolvedValue([

--- a/backend/src/modules/demo/demo.service.spec.ts
+++ b/backend/src/modules/demo/demo.service.spec.ts
@@ -30,6 +30,9 @@ describe('DemoService', () => {
     // guard). Grant it by default so the body runs; a dedicated test overrides
     // this to assert the lock actually gates the destructive wipe.
     (prisma.$queryRawUnsafe as jest.Mock).mockResolvedValue([{ locked: true }]);
+    (prisma.$transaction as any).mockImplementation(async (cb: any) =>
+      typeof cb === "function" ? cb(prisma) : Promise.all(cb),
+    );
   });
 
   it('short-circuits to the existing demo admin without re-seeding', async () => {
@@ -145,7 +148,8 @@ describe('DemoService', () => {
   it('resetDemoData is a no-op before the demo tenant exists', async () => {
     (prisma.tenant.findFirst as jest.Mock).mockResolvedValue(null);
     await service.resetDemoData();
-    expect(prisma.$transaction).not.toHaveBeenCalled();
+    // v2 advisory lock itself opens a $transaction, so assert on the
+    // destructive writes instead of the transaction wrapper.
     expect(prisma.order.deleteMany).not.toHaveBeenCalled();
   });
 
@@ -153,8 +157,9 @@ describe('DemoService', () => {
     // Another replica already holds the lock this tick.
     (prisma.$queryRawUnsafe as jest.Mock).mockResolvedValue([{ locked: false }]);
     await service.resetDemoData();
-    // The body never ran: no tenant lookup, no wipe.
+    // The body never ran: no tenant lookup, no wipe. ($transaction itself
+    // fires once as the v2 lock holder — assert on the body's calls.)
     expect(prisma.tenant.findFirst).not.toHaveBeenCalled();
-    expect(prisma.$transaction).not.toHaveBeenCalled();
+    expect(prisma.order.deleteMany).not.toHaveBeenCalled();
   });
 });

--- a/backend/src/modules/device-mesh/device-mesh.scheduler.spec.ts
+++ b/backend/src/modules/device-mesh/device-mesh.scheduler.spec.ts
@@ -12,13 +12,17 @@ import { LocalBridgeService } from "../local-bridge/local-bridge.service";
  */
 describe("DeviceMeshScheduler.sweep", () => {
   function makePrismaWithLock() {
-    return {
+    const prisma: any = {
       $queryRawUnsafe: jest.fn((sql: string) =>
-        sql.includes("pg_try_advisory_lock")
+        sql.includes("pg_try_advisory")
           ? Promise.resolve([{ locked: true }])
           : Promise.resolve([]),
       ),
-    } as unknown as PrismaService;
+    };
+    prisma.$transaction = jest.fn(async (cb: any) =>
+      typeof cb === "function" ? cb(prisma) : Promise.all(cb),
+    );
+    return prisma as PrismaService;
   }
 
   it("runs all three sweeps when the advisory lock is held", async () => {
@@ -57,9 +61,11 @@ describe("DeviceMeshScheduler.sweep", () => {
   });
 
   it("skips the sweeps when another replica holds the lock", async () => {
-    const prisma = {
+    const denied: any = {
       $queryRawUnsafe: jest.fn(() => Promise.resolve([{ locked: false }])),
-    } as unknown as PrismaService;
+    };
+    denied.$transaction = jest.fn(async (cb: any) => cb(denied));
+    const prisma = denied as unknown as PrismaService;
     const devices = { sweepStale: jest.fn() } as unknown as DeviceService;
     const sched = new DeviceMeshScheduler(
       prisma,

--- a/backend/src/modules/menu/services/product-3d.service.spec.ts
+++ b/backend/src/modules/menu/services/product-3d.service.spec.ts
@@ -46,6 +46,10 @@ describe("Product3dService", () => {
     // pollPendingModels now runs under a Postgres advisory lock (multi-replica
     // guard). Grant it by default so the poll body runs.
     (prisma.$queryRawUnsafe as any).mockResolvedValue([{ locked: true }]);
+    (prisma.$transaction as any).mockImplementation(async (cb: any) =>
+      typeof cb === "function" ? cb(prisma) : Promise.all(cb),
+    );
+
     (prisma.product.update as any).mockImplementation(
       async ({ data }: any) => ({
         id: "p1",

--- a/backend/src/modules/payment-terminal/payment-terminal.provisioning.spec.ts
+++ b/backend/src/modules/payment-terminal/payment-terminal.provisioning.spec.ts
@@ -23,6 +23,10 @@ describe("PaymentTerminalService (provisioning + activation gate)", () => {
     // recoverApprovedUnrecorded now runs under a Postgres advisory lock
     // (multi-replica guard). Grant it so the recovery body runs.
     (prisma.$queryRawUnsafe as any).mockResolvedValue([{ locked: true }]);
+    (prisma.$transaction as any).mockImplementation(async (cb: any) =>
+      typeof cb === "function" ? cb(prisma) : Promise.all(cb),
+    );
+
     const registry = new PaymentTerminalProviderRegistry();
     registry.register(new SimulatorTerminalProvider());
     registry.register(new Gmp3CardTerminalProvider(registry));


### PR DESCRIPTION
Closes the two remaining deferred infra findings from the June device-mesh review (both re-flagged by this month's architecture audit).

## 1. Advisory-lock pool leak — any of ~17 crons could silently stall
v1 issued `pg_try_advisory_lock` and `pg_advisory_unlock` as **two separate pooled queries**. Advisory session locks belong to the acquiring connection; when the pool routed the unlock elsewhere it silently no-op'd, the lock stayed held by an idle pooled session, and every later tick of that job skipped. Affected: subscription scheduler (×10 crons), z-reports, stock alerts, delivery polling/reconciliation, media/3D pollers, device-mesh sweep, retention sweep…

v2: one interactive transaction acquires `pg_try_advisory_xact_lock` and holds it while `run()` executes — releases at commit/rollback, no unlock statement exists to misroute, crash-safe. The tx is a pure lock holder (work queries stay on the normal pooled client); 30-min timeout is deliberate (expiry mid-run would re-open the duplicate-run window). Same signature — drop-in for all 17 call sites.

## 2. `tokenHash` unique indexes (reversible migration)
Every device/bridge auth did a **sequential scan** on `devices`/`local_bridge_agents` (no index on tokenHash) with no one-token-one-row guarantee. NULLs are distinct → unprovisioned rows unaffected.

## Verification
Backend 4,689 tests green (advisory-lock spec rewritten for the v2 contract + 11 scheduler specs rewired), `tsc` clean, lint 0 errors. No FE surface.