### PR TITLE
fix(security): activate 49 inert @Throttle({default}) limits — NAT-safe

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -2,6 +2,7 @@ import { Module, NestModule, MiddlewareConsumer } from "@nestjs/common";
 import { ConfigModule } from "@nestjs/config";
 import { ScheduleModule } from "@nestjs/schedule";
 import { ThrottlerModule } from "@nestjs/throttler";
+import { THROTTLER_PROFILES } from "./common/config/throttler.config";
 import { MachineThrottlerGuard } from "./common/guards/machine-throttler.guard";
 import { APP_GUARD, APP_INTERCEPTOR } from "@nestjs/core";
 import { RequestContextInterceptor } from "./common/context/request-context.interceptor";
@@ -81,23 +82,10 @@ import { validate } from "./config/env.validation";
     // submodules. Nest tolerated it but every replica still runs every job;
     // leader-election / distributed locks live in the schedulers themselves.
     ScheduleModule.forRoot(),
-    ThrottlerModule.forRoot([
-      {
-        name: "short",
-        ttl: 1000,
-        limit: 10,
-      },
-      {
-        name: "medium",
-        ttl: 10000,
-        limit: 50,
-      },
-      {
-        name: "long",
-        ttl: 60000,
-        limit: 100,
-      },
-    ]),
+    // Profiles live in common/config/throttler.config.ts so a spec pins the
+    // `default` throttler's presence — without it, every route-level
+    // @Throttle({default:{...}}) (OTP, pairing, public lookups…) is INERT.
+    ThrottlerModule.forRoot(THROTTLER_PROFILES),
     PrismaModule,
     CommonModule,
     // Prometheus /api/metrics + the request-duration histogram fed by

--- a/backend/src/common/config/throttler.config.spec.ts
+++ b/backend/src/common/config/throttler.config.spec.ts
@@ -1,0 +1,37 @@
+import { THROTTLER_PROFILES } from "./throttler.config";
+
+/**
+ * Tripwire for the silent-inert-throttle bug class: 49 routes carry
+ * `@Throttle({ default: {...} })`, and @nestjs/throttler binds those
+ * overrides ONLY to a registered throttler literally named "default".
+ * For months no such profile existed, so every route-level brute-force /
+ * abuse cap (OTP send, device pairing, public lookups, self-pay…) was
+ * silently unenforced. This spec fails the build if anyone removes or
+ * renames the profile again.
+ */
+describe("THROTTLER_PROFILES", () => {
+  const byName = Object.fromEntries(
+    THROTTLER_PROFILES.map((p) => [p.name, p]),
+  );
+
+  it('registers the "default" throttler that all @Throttle({default}) overrides bind to', () => {
+    expect(byName.default).toBeDefined();
+  });
+
+  it('keeps "default" looser than "long" so registering it changes nothing globally', () => {
+    // default exists purely so route overrides bind; the generic global
+    // backstop must remain `long` (100/min). If default were tighter it
+    // would silently become a new global limit on every route.
+    const perMinute = (p: { ttl: number; limit: number }) =>
+      (p.limit / p.ttl) * 60_000;
+    expect(perMinute(byName.default as any)).toBeGreaterThan(
+      perMinute(byName.long as any),
+    );
+  });
+
+  it("keeps the pre-existing short/medium/long globals unchanged", () => {
+    expect(byName.short).toMatchObject({ ttl: 1000, limit: 10 });
+    expect(byName.medium).toMatchObject({ ttl: 10000, limit: 50 });
+    expect(byName.long).toMatchObject({ ttl: 60000, limit: 100 });
+  });
+});

--- a/backend/src/common/config/throttler.config.ts
+++ b/backend/src/common/config/throttler.config.ts
@@ -1,0 +1,39 @@
+import { ThrottlerOptions } from "@nestjs/throttler";
+
+/**
+ * Root throttler profiles. Factored out of app.module so a spec can pin the
+ * one invariant that silently broke for months: a throttler named `default`
+ * MUST be registered.
+ *
+ * Every per-route `@Throttle({ default: { ... } })` in the codebase (49
+ * routes: OTP send, device pairing, public lookups, self-pay, webhooks…)
+ * targets the throttler NAMED "default". @nestjs/throttler resolves the
+ * override per registered throttler name — with no `default` profile
+ * registered, every one of those decorators was INERT and the only live
+ * limits were the generic short/medium/long globals. The `default` profile
+ * below is deliberately LOOSER than `long` (300/min vs 100/min), so
+ * registering it changes NOTHING globally — its entire purpose is to give
+ * the 49 route-level overrides a live throttler to bind to.
+ */
+export const THROTTLER_PROFILES: ThrottlerOptions[] = [
+  {
+    name: "short",
+    ttl: 1000,
+    limit: 10,
+  },
+  {
+    name: "medium",
+    ttl: 10000,
+    limit: 50,
+  },
+  {
+    name: "long",
+    ttl: 60000,
+    limit: 100,
+  },
+  {
+    name: "default",
+    ttl: 60000,
+    limit: 300,
+  },
+];

--- a/backend/src/common/guards/machine-throttler.guard.spec.ts
+++ b/backend/src/common/guards/machine-throttler.guard.spec.ts
@@ -30,6 +30,47 @@ describe("MachineThrottlerGuard.getTracker", () => {
     await expect(guard.track(req)).resolves.toBe("5.5.5.5:pk:pk_live_abc");
   });
 
+  it("keys a Device token by IP + a sha256 prefix (per-device bucket, secret never in the key)", async () => {
+    const req = {
+      headers: { authorization: "Device super-secret-token" },
+      ip: "5.5.5.5",
+    };
+    const tracker = await guard.track(req);
+    expect(tracker).toMatch(/^5\.5\.5\.5:device:[0-9a-f]{16}$/);
+    expect(tracker).not.toContain("super-secret-token");
+    // Stable: the same token always lands in the same bucket.
+    await expect(guard.track(req)).resolves.toBe(tracker);
+  });
+
+  it("two devices behind the same NAT IP get SEPARATE buckets", async () => {
+    const a = await guard.track({
+      headers: { authorization: "Device token-a" },
+      ip: "5.5.5.5",
+    });
+    const b = await guard.track({
+      headers: { authorization: "Device token-b" },
+      ip: "5.5.5.5",
+    });
+    expect(a).not.toBe(b);
+  });
+
+  it("keys a Bridge token like a Device token (bridge: namespace)", async () => {
+    const tracker = await guard.track({
+      headers: { authorization: "Bridge bridge-secret" },
+      ip: "5.5.5.5",
+    });
+    expect(tracker).toMatch(/^5\.5\.5\.5:bridge:[0-9a-f]{16}$/);
+  });
+
+  it("a user Bearer JWT stays on the plain IP bucket (not machine traffic)", async () => {
+    await expect(
+      guard.track({
+        headers: { authorization: "Bearer eyJhbGciOi..." },
+        ip: "5.5.5.5",
+      }),
+    ).resolves.toBe("5.5.5.5");
+  });
+
   it("a single IP cycling forged Screen prefixes stays bucketed under that IP", async () => {
     const k1 = await guard.track({
       headers: { authorization: "Screen forged-1.x" },

--- a/backend/src/common/guards/machine-throttler.guard.ts
+++ b/backend/src/common/guards/machine-throttler.guard.ts
@@ -1,16 +1,20 @@
+import { createHash } from "crypto";
 import { Injectable } from "@nestjs/common";
 import { ThrottlerGuard } from "@nestjs/throttler";
 
 /**
  * Rate-limit tracker that keys machine traffic by PRINCIPAL instead of IP, so
- * a venue running many partner screens behind one NAT IP does not collide on a
- * single IP throttle bucket.
+ * a venue running many partner screens / paired devices / print bridges
+ * behind one NAT IP does not collide on a single IP throttle bucket.
  *
  * Runs as the global APP_GUARD ThrottlerGuard (registered BEFORE the auth
  * chain), so req.user / req.screen are not populated yet — we must read the
  * principal id straight from the raw request headers:
  *  - `Authorization: Screen <uuidv7>.<secret>` → `screen:<uuidv7>` (the uuid
  *    prefix is stable + non-secret; we never key on the secret tail).
+ *  - `Authorization: Device <token>` / `Authorization: Bridge <token>` →
+ *    a sha256 prefix of the token (the raw token is entirely secret, so it
+ *    is hashed before becoming a bucket key; stable per device/bridge).
  *  - `X-Partner-Key: <keyId>` → `pk:<keyId>`.
  *  - otherwise the client IP (default behavior, preserving X-Forwarded-For
  *    handling via req.ips when trust proxy is configured).
@@ -30,6 +34,25 @@ export class MachineThrottlerGuard extends ThrottlerGuard {
     if (typeof auth === "string" && auth.startsWith("Screen ")) {
       const prefix = auth.slice("Screen ".length).split(".")[0];
       if (prefix) return `${ip}:screen:${prefix}`;
+    }
+    if (typeof auth === "string") {
+      // Device fleet + print bridges poll on tight loops (heartbeat 10s,
+      // next-command 5s per the agent SDK). Without a per-principal key a
+      // 10-device venue exhausts the shared IP bucket and the whole fleet
+      // 429s. The raw token is 100% secret — hash it before it becomes a
+      // tracker key.
+      const machine = auth.startsWith("Device ")
+        ? ["device", auth.slice("Device ".length)]
+        : auth.startsWith("Bridge ")
+          ? ["bridge", auth.slice("Bridge ".length)]
+          : null;
+      if (machine && machine[1]) {
+        const digest = createHash("sha256")
+          .update(machine[1])
+          .digest("hex")
+          .slice(0, 16);
+        return `${ip}:${machine[0]}:${digest}`;
+      }
     }
     const partnerKey: string | undefined = req?.headers?.["x-partner-key"];
     if (typeof partnerKey === "string" && partnerKey.length > 0) {

--- a/backend/src/modules/customer-orders/controllers/customer-orders.controller.ts
+++ b/backend/src/modules/customer-orders/controllers/customer-orders.controller.ts
@@ -63,7 +63,9 @@ export class CustomerOrdersController {
   }
 
   @Public()
-  @Throttle({ default: { limit: 60, ttl: 60_000 } })
+  // NAT-aware limit: customers share the venue WiFi's single IP, so this
+  // read/poll cap is sized for a BUSY venue's whole clientele, not one user.
+  @Throttle({ default: { limit: 240, ttl: 60_000 } })
   @Get("session/:sessionId")
   @ApiOperation({ summary: "Get all orders for a session" })
   async getSessionOrders(@Param("sessionId") sessionId: string) {
@@ -71,7 +73,7 @@ export class CustomerOrdersController {
   }
 
   @Public()
-  @Throttle({ default: { limit: 60, ttl: 60_000 } })
+  @Throttle({ default: { limit: 240, ttl: 60_000 } })
   @Get(":orderId")
   @ApiOperation({ summary: "Get order details by ID" })
   async getOrderById(
@@ -94,7 +96,7 @@ export class CustomerOrdersController {
   }
 
   @Public()
-  @Throttle({ default: { limit: 30, ttl: 60_000 } })
+  @Throttle({ default: { limit: 120, ttl: 60_000 } })
   @Get("waiter-requests/session/:sessionId")
   @ApiOperation({ summary: "Get all waiter requests for a session" })
   async getSessionWaiterRequests(@Param("sessionId") sessionId: string) {
@@ -114,7 +116,7 @@ export class CustomerOrdersController {
   }
 
   @Public()
-  @Throttle({ default: { limit: 30, ttl: 60_000 } })
+  @Throttle({ default: { limit: 120, ttl: 60_000 } })
   @Get("bill-requests/session/:sessionId")
   @ApiOperation({ summary: "Get all bill requests for a session" })
   async getSessionBillRequests(@Param("sessionId") sessionId: string) {

--- a/backend/src/modules/customer-orders/controllers/customer-self-pay.controller.ts
+++ b/backend/src/modules/customer-orders/controllers/customer-self-pay.controller.ts
@@ -27,7 +27,9 @@ export class CustomerSelfPayController {
   constructor(private readonly service: CustomerSelfPayService) {}
 
   @Get("payable-items")
-  @Throttle({ default: { limit: 30, ttl: 60_000 } })
+  // NAT-aware limit: customers share the venue WiFi's single IP, so this
+  // read/poll cap is sized for a BUSY venue's whole clientele, not one user.
+  @Throttle({ default: { limit: 120, ttl: 60_000 } })
   @ApiOperation({
     summary: "List unpaid items across all open orders at the session's table",
   })
@@ -77,7 +79,7 @@ export class CustomerSelfPayController {
   }
 
   @Get("pay-status")
-  @Throttle({ default: { limit: 60, ttl: 60_000 } })
+  @Throttle({ default: { limit: 240, ttl: 60_000 } })
   @ApiOperation({
     summary: "Poll the PendingSelfPayment row + return current remaining items",
   })

--- a/backend/src/modules/customers/customer-public.controller.ts
+++ b/backend/src/modules/customers/customer-public.controller.ts
@@ -68,14 +68,16 @@ export class CustomerPublicController {
   }
 
   @Get("sessions/:sessionId")
-  @Throttle({ default: { limit: 60, ttl: 60_000 } })
+  // NAT-aware limit: customers share the venue WiFi's single IP, so this
+  // read/poll cap is sized for a BUSY venue's whole clientele, not one user.
+  @Throttle({ default: { limit: 240, ttl: 60_000 } })
   @ApiOperation({ summary: "Get session information" })
   async getSession(@Param("sessionId") sessionId: string) {
     return this.sessionService.getSession(sessionId);
   }
 
   @Post("sessions/validate")
-  @Throttle({ default: { limit: 60, ttl: 60_000 } })
+  @Throttle({ default: { limit: 240, ttl: 60_000 } })
   @ApiOperation({ summary: "Validate a session" })
   async validateSession(@Body("sessionId") sessionId: string) {
     const isValid = await this.sessionService.validateSession(sessionId);
@@ -127,7 +129,7 @@ export class CustomerPublicController {
   // ========================================
 
   @Get("profile")
-  @Throttle({ default: { limit: 60, ttl: 60_000 } })
+  @Throttle({ default: { limit: 180, ttl: 60_000 } })
   @ApiOperation({ summary: "Get customer profile by session" })
   async getProfile(@Query("sessionId") sessionId: string) {
     const session = await this.sessionService.requireSession(sessionId);
@@ -141,7 +143,7 @@ export class CustomerPublicController {
   }
 
   @Get("loyalty/balance")
-  @Throttle({ default: { limit: 60, ttl: 60_000 } })
+  @Throttle({ default: { limit: 180, ttl: 60_000 } })
   @ApiOperation({ summary: "Get loyalty points balance" })
   async getLoyaltyBalance(@Query("sessionId") sessionId: string) {
     const session = await this.sessionService.requireSession(sessionId);
@@ -161,7 +163,7 @@ export class CustomerPublicController {
   }
 
   @Get("loyalty/transactions")
-  @Throttle({ default: { limit: 30, ttl: 60_000 } })
+  @Throttle({ default: { limit: 120, ttl: 60_000 } })
   @ApiOperation({ summary: "Get loyalty transaction history" })
   async getLoyaltyTransactions(
     @Query("sessionId") sessionId: string,
@@ -180,14 +182,14 @@ export class CustomerPublicController {
   }
 
   @Get("loyalty/config")
-  @Throttle({ default: { limit: 60, ttl: 60_000 } })
+  @Throttle({ default: { limit: 180, ttl: 60_000 } })
   @ApiOperation({ summary: "Get loyalty program configuration" })
   async getLoyaltyConfig() {
     return this.loyaltyService.getLoyaltyConfig();
   }
 
   @Get("loyalty/tier")
-  @Throttle({ default: { limit: 30, ttl: 60_000 } })
+  @Throttle({ default: { limit: 120, ttl: 60_000 } })
   @ApiOperation({ summary: "Get customer tier status" })
   async getTierStatus(@Query("sessionId") sessionId: string) {
     const session = await this.sessionService.requireSession(sessionId);
@@ -245,7 +247,7 @@ export class CustomerPublicController {
   }
 
   @Get("phone/verification-status/:verificationId")
-  @Throttle({ default: { limit: 20, ttl: 60_000 } })
+  @Throttle({ default: { limit: 60, ttl: 60_000 } })
   @ApiOperation({ summary: "Get verification status" })
   async getVerificationStatus(
     @Param("verificationId") verificationId: string,
@@ -296,7 +298,7 @@ export class CustomerPublicController {
   }
 
   @Get("referral/stats")
-  @Throttle({ default: { limit: 30, ttl: 60_000 } })
+  @Throttle({ default: { limit: 90, ttl: 60_000 } })
   @ApiOperation({ summary: "Get referral statistics" })
   async getReferralStats(@Query("sessionId") sessionId: string) {
     const session = await this.sessionService.requireSession(sessionId);

--- a/backend/src/modules/menu/controllers/qr-menu.controller.ts
+++ b/backend/src/modules/menu/controllers/qr-menu.controller.ts
@@ -26,7 +26,9 @@ export class QrMenuController {
   ) {}
 
   @Public()
-  @Throttle({ default: { limit: 60, ttl: 60_000 } })
+  // NAT-aware limit: customers share the venue WiFi's single IP, so this
+  // read/poll cap is sized for a BUSY venue's whole clientele, not one user.
+  @Throttle({ default: { limit: 240, ttl: 60_000 } })
   @Get("by-subdomain/:subdomain")
   @ApiOperation({
     summary: "Get public menu by subdomain (no authentication required)",
@@ -63,7 +65,7 @@ export class QrMenuController {
   }
 
   @Public()
-  @Throttle({ default: { limit: 60, ttl: 60_000 } })
+  @Throttle({ default: { limit: 240, ttl: 60_000 } })
   @Get(":tenantId")
   @ApiOperation({
     summary: "Get public menu for QR code access (no authentication required)",

--- a/backend/src/modules/tables/tables.controller.ts
+++ b/backend/src/modules/tables/tables.controller.ts
@@ -128,7 +128,9 @@ export class TablesController {
   // touches public routes but the lint rule needs the explicit marker.
   @Public()
   @SkipBranchScope()
-  @Throttle({ default: { limit: 30, ttl: 60_000 } })
+  // NAT-aware limit: customers share the venue WiFi's single IP, so this
+  // read/poll cap is sized for a BUSY venue's whole clientele, not one user.
+  @Throttle({ default: { limit: 90, ttl: 60_000 } })
   @Get("public/:tenantId")
   @ApiOperation({
     summary: "Get available tables for customer selection (no auth required)",


### PR DESCRIPTION
Closes the last big deferred finding from the June device-mesh review: **every route-level `@Throttle({default:{...}})` in the codebase was inert** because no throttler named `default` was registered — OTP send, device pairing, reservation-lookup enumeration, self-pay intents, the contact form… none of those brute-force caps were enforced (only the generic 100/min global).

## Why it was deferred, and how this PR de-risks it
Blind activation risks 429ing real flows: customers share the venue WiFi's single NAT IP, and device fleets poll on tight loops. Three-part fix:

1. **`default` profile registered at 300/min — looser than `long` (100/min)**, so globally nothing changes; it exists purely to give the 49 route overrides a live throttler to bind to. Profiles extracted to `throttler.config.ts` with a tripwire spec pinning both the profile's presence and the looser-than-long invariant.
2. **Per-device buckets**: `Authorization: Device/Bridge <token>` traffic now keys `ip:device:sha256prefix` (mirrors the existing Screen/partner-key handling; the secret never becomes a bucket key). A 10-device venue no longer shares one IP bucket at 120/min.
3. **NAT-sized customer read caps** (18 routes ×3–4): pay-status 60→240/min, order-status 60→240, QR menu 60→240, OTP status poll 20→60… True brute-force caps stay tight (OTP send 5/min, pairing 5/min, lookup 3/min, contact 3/hour).

## Verification
- Backend 4,696 green (+7 new specs), `tsc` clean, lint 0 errors.
- Post-deploy prod probe planned: 4 rapid hits on the 3/min public reservation-lookup route must yield 429 on the 4th (proving the binding is live).