### PR TITLE
fix(security): key throttling on CF-Connecting-IP — per-IP limits were inert in prod

### DIFF
--- a/backend/src/common/guards/machine-throttler.guard.spec.ts
+++ b/backend/src/common/guards/machine-throttler.guard.spec.ts
@@ -86,6 +86,27 @@ describe("MachineThrottlerGuard.getTracker", () => {
     expect(k2.startsWith("9.9.9.9:")).toBe(true);
   });
 
+  it("prefers CF-Connecting-IP over req.ip (req.ip is the rotating CF edge behind the double proxy hop)", async () => {
+    const req = {
+      headers: { "cf-connecting-ip": "9.9.9.9" },
+      ip: "172.16.0.5", // nginx/CF-edge peer — must NOT be the key
+      ips: ["104.28.1.1"], // rotating CF edge
+    };
+    await expect(guard.track(req)).resolves.toBe("9.9.9.9");
+  });
+
+  it("two requests from the same real client stay in ONE bucket even as the CF edge (req.ip) rotates", async () => {
+    const a = await guard.track({
+      headers: { "cf-connecting-ip": "9.9.9.9" },
+      ip: "104.28.1.1",
+    });
+    const b = await guard.track({
+      headers: { "cf-connecting-ip": "9.9.9.9" },
+      ip: "104.28.9.9", // different CF edge, same real client
+    });
+    expect(a).toBe(b);
+  });
+
   it("falls back to client IP when no machine principal header is present", async () => {
     await expect(guard.track({ headers: {}, ip: "9.9.9.9" })).resolves.toBe(
       "9.9.9.9",

--- a/backend/src/common/guards/machine-throttler.guard.ts
+++ b/backend/src/common/guards/machine-throttler.guard.ts
@@ -16,13 +16,42 @@ import { ThrottlerGuard } from "@nestjs/throttler";
  *    a sha256 prefix of the token (the raw token is entirely secret, so it
  *    is hashed before becoming a bucket key; stable per device/bridge).
  *  - `X-Partner-Key: <keyId>` → `pk:<keyId>`.
- *  - otherwise the client IP (default behavior, preserving X-Forwarded-For
- *    handling via req.ips when trust proxy is configured).
+ *  - otherwise the client IP, resolved via CF-Connecting-IP behind
+ *    Cloudflare (see clientIp() — req.ip alone rotates per request behind
+ *    the CF+nginx double hop, which silently disables all throttling).
  */
 @Injectable()
 export class MachineThrottlerGuard extends ThrottlerGuard {
+  /**
+   * Resolve the true client IP behind Cloudflare → nginx → app.
+   *
+   * `req.ip` / `req.ips` depend on Express `trust proxy`, which is set to a
+   * fixed hop count (default 1). Prod sits behind TWO proxy hops (Cloudflare
+   * edge + nginx), so with one trusted hop `req.ip` resolves to the nginx-
+   * appended entry's predecessor — the Cloudflare EDGE ip, which ROTATES per
+   * request. That silently defeats per-IP throttling entirely: every request
+   * lands in a fresh bucket, so no global OR route-level limit ever
+   * accumulates (this is why the reservation 3/min lookup never 429'd in
+   * prod even after the default-profile fix).
+   *
+   * `CF-Connecting-IP` is Cloudflare's canonical true-client-IP header:
+   * Cloudflare always sets it and OVERWRITES any client-supplied value, so
+   * for a Cloudflare-fronted origin it is the correct, stable throttle key.
+   * We prefer it when present and fall back to req.ips/req.ip for
+   * dev/direct/non-Cloudflare deployments. (An attacker who bypasses
+   * Cloudflare to hit the origin directly could spoof it — but the same is
+   * already true of the X-Forwarded-For that req.ips trusts, so this is no
+   * weaker, and strictly correct when actually behind Cloudflare. Locking
+   * the origin to Cloudflare ingress is a separate infra concern.)
+   */
+  private clientIp(req: Record<string, any>): string {
+    const cf = req?.headers?.["cf-connecting-ip"];
+    if (typeof cf === "string" && cf.length > 0) return cf;
+    return req?.ips?.length ? req.ips[0] : req?.ip;
+  }
+
   protected async getTracker(req: Record<string, any>): Promise<string> {
-    const ip = req?.ips?.length ? req.ips[0] : req?.ip;
+    const ip = this.clientIp(req);
     // SECURITY: the throttler runs BEFORE the auth guards, so the principal id
     // here is UNVERIFIED (attacker-suppliable). If we keyed on it alone, an
     // attacker could rotate a fresh fake prefix per request and escape IP


### PR DESCRIPTION
**Live prod probe caught this:** after #307 activated the `default` throttler profile, I tested the 3/min public reservation-lookup route in prod — and it *still* never 429'd, even under 12 parallel requests. Neither did the 10/sec `short` global. So **all rate limiting was effectively off in production**, not just the route overrides.

## Root cause
Topology is **Cloudflare → nginx → backend = two proxy hops**, but Express `trust proxy` defaults to `1`. With one trusted hop, `req.ip` resolves to the **Cloudflare edge IP, which rotates per request** → every request gets a fresh per-IP bucket → no limit (global or route) ever accumulates.

## Fix
`MachineThrottlerGuard.getTracker` resolves the client IP via Cloudflare's canonical **`CF-Connecting-IP`** header (CF always sets it and overwrites any client value for a fronted origin), falling back to `req.ips`/`req.ip` for dev/direct/non-CF. No weaker than the `X-Forwarded-For` that `req.ips` already trusted; stable behind CF so buckets finally accumulate.

## Verification
- Post-deploy prod probe: reservation 3/min route now returns **429 on the 4th rapid hit** (was 400/never).
- Backend 4,698 green (+2 CF-IP tracker specs proving the rotating-edge case collapses to one bucket), `tsc` clean, lint 0 errors.