### PR TITLE
fix(security): AAD context-binding for at-rest secrets; bind camera streamUrl to tenant

### DIFF
--- a/backend/src/common/helpers/encryption.helper.spec.ts
+++ b/backend/src/common/helpers/encryption.helper.spec.ts
@@ -49,4 +49,45 @@ describe('encryption.helper', () => {
   it('decryptString returns legacy plaintext unchanged when v1 prefix missing', () => {
     expect(decryptString('legacy-plain-token')).toBe('legacy-plain-token');
   });
+
+  describe('v2 context binding (AAD)', () => {
+    const CTX = 'camera:streamUrl:tenant-A';
+
+    it('encryptString with a context emits v2 and round-trips with the same context', () => {
+      const blob = encryptString('rtsp://u:p@cam', CTX);
+      expect(blob.startsWith('v2:')).toBe(true);
+      expect(decryptString(blob, CTX)).toBe('rtsp://u:p@cam');
+    });
+
+    it('REJECTS a v2 blob decrypted with a DIFFERENT context (cross-tenant substitution)', () => {
+      // The exact attack: tenant A's ciphertext pasted into tenant B's row.
+      const stolen = encryptString('rtsp://u:p@cam', 'camera:streamUrl:tenant-A');
+      expect(() =>
+        decryptString(stolen, 'camera:streamUrl:tenant-B'),
+      ).toThrow(DecryptionError);
+    });
+
+    it('REJECTS a v2 blob decrypted with NO context', () => {
+      const blob = encryptString('secret', CTX);
+      expect(() => decryptString(blob)).toThrow(DecryptionError);
+    });
+
+    it('ignores a passed context for a legacy v1 blob (backwards compatible — existing rows keep working)', () => {
+      const legacy = encryptString('old-token'); // v1, written before binding
+      expect(legacy.startsWith('v1:')).toBe(true);
+      // A read site that now passes context must still decrypt the old row.
+      expect(decryptString(legacy, CTX)).toBe('old-token');
+    });
+
+    it('encryptJson/decryptJson bind context symmetrically and reject a mismatch', () => {
+      const enc = encryptJson({ token: 'abc' }, CTX);
+      expect(enc.v).toBe(2);
+      expect(decryptJson(enc, CTX)).toEqual({ token: 'abc' });
+      expect(() => decryptJson(enc, 'wrong-ctx')).toThrow(DecryptionError);
+      // Legacy JSON payload (no v) decrypts with context ignored.
+      const legacy = encryptJson({ token: 'xyz' });
+      expect((legacy as any).v).toBeUndefined();
+      expect(decryptJson(legacy, CTX)).toEqual({ token: 'xyz' });
+    });
+  });
 });

--- a/backend/src/common/helpers/encryption.helper.ts
+++ b/backend/src/common/helpers/encryption.helper.ts
@@ -7,17 +7,32 @@ import {
 
 /**
  * AES-256-GCM envelope encryption for sensitive at-rest data (delivery
- * platform API keys, access tokens, future secrets). The master key
- * comes from the ENCRYPTION_MASTER_KEY env var — minimum 32 bytes; we
- * hash it to 32 bytes deterministically so operators can provide any
- * string and still land on a valid AES-256 key.
+ * platform API keys, access tokens, camera stream URLs, future secrets).
+ * The master key comes from the ENCRYPTION_MASTER_KEY env var — minimum
+ * 32 bytes; we hash it to 32 bytes deterministically so operators can
+ * provide any string and still land on a valid AES-256 key.
  *
- * Format on disk: `{ ciphertext, iv, authTag }`, all base64url.
+ * Format on disk: `{ ciphertext, iv, authTag }`, all base64url; the
+ * compact string form is `v1:iv:authTag:ciphertext`.
+ *
+ * CONTEXT BINDING (v2): a plain GCM tag proves a ciphertext hasn't been
+ * *altered*, but not that it belongs where it sits — an attacker with DB
+ * write access could paste tenant A's encrypted camera URL / token into
+ * tenant B's row and the tag still verifies (same master key, no
+ * provenance). Passing a `context` binds the ciphertext to that string as
+ * AAD (Additional Authenticated Data): decrypting with a different context
+ * fails the tag, so a moved blob is rejected. This mirrors the KMS
+ * provider's AAD binding. Backwards-compatible: no context → v1 (unchanged
+ * on disk); v1 blobs decrypt with the context IGNORED, so existing rows
+ * keep working and upgrade to v2 on their next write. `v` discriminates the
+ * structured form; the `v2:` prefix discriminates the string form.
  */
 export interface EncryptedPayload {
   ciphertext: string;
   iv: string;
   authTag: string;
+  /** 2 = AAD/context-bound. Absent/1 = legacy, no context. */
+  v?: 2;
 }
 
 /**
@@ -48,25 +63,34 @@ function requireMasterKey(): Buffer {
   return createHash("sha256").update(raw, "utf8").digest();
 }
 
-export function encryptJson(value: unknown): EncryptedPayload {
+export function encryptJson(
+  value: unknown,
+  context?: string,
+): EncryptedPayload {
   const key = requireMasterKey();
   const iv = randomBytes(12); // GCM standard nonce size
   const cipher = createCipheriv("aes-256-gcm", key, iv);
+  if (context) cipher.setAAD(Buffer.from(context, "utf8"));
   const plaintext = Buffer.from(JSON.stringify(value), "utf8");
   const encrypted = Buffer.concat([cipher.update(plaintext), cipher.final()]);
   return {
     ciphertext: encrypted.toString("base64url"),
     iv: iv.toString("base64url"),
     authTag: cipher.getAuthTag().toString("base64url"),
+    ...(context ? { v: 2 as const } : {}),
   };
 }
 
-export function decryptJson<T = unknown>(payload: EncryptedPayload): T {
+export function decryptJson<T = unknown>(
+  payload: EncryptedPayload,
+  context?: string,
+): T {
   const key = requireMasterKey();
 
   // Any of the steps below can throw on corrupted / tampered ciphertext:
   // - `setAuthTag` with wrong length bytes
-  // - `decipher.final()` when GCM auth tag doesn't match (tampered payload)
+  // - `decipher.final()` when GCM auth tag doesn't match (tampered payload,
+  //   OR a v2 blob decrypted with the wrong/absent context → rejected)
   // - `JSON.parse` if the decrypted bytes aren't valid JSON (key rotated
   //   without re-encrypting, or the column was written by a different
   //   codepath). One unhandled throw used to kill the whole request with
@@ -77,11 +101,15 @@ export function decryptJson<T = unknown>(payload: EncryptedPayload): T {
     const authTag = Buffer.from(payload.authTag, "base64url");
     const ciphertext = Buffer.from(payload.ciphertext, "base64url");
     const decipher = createDecipheriv("aes-256-gcm", key, iv);
+    // Only v2 blobs are context-bound. A legacy v1 blob (no `v`) MUST decrypt
+    // with the context ignored so pre-existing rows keep working; a v2 blob
+    // MUST bind the caller's context so a moved ciphertext fails the tag.
+    if (payload.v === 2) decipher.setAAD(Buffer.from(context ?? "", "utf8"));
     decipher.setAuthTag(authTag);
     plaintext = Buffer.concat([decipher.update(ciphertext), decipher.final()]);
   } catch (cause) {
     throw new DecryptionError(
-      "Failed to decrypt payload (corrupted ciphertext, wrong key, or tampered auth tag)",
+      "Failed to decrypt payload (corrupted ciphertext, wrong key, tampered auth tag, or context mismatch)",
       cause,
     );
   }
@@ -103,15 +131,19 @@ export function isEncryptedPayload(value: unknown): value is EncryptedPayload {
   );
 }
 
-export function encryptString(value: string): string {
+export function encryptString(value: string, context?: string): string {
   // Convenience wrapper that returns a single compact string so it fits
-  // into existing TEXT columns (accessToken) without a schema change.
-  const payload = encryptJson(value);
-  return `v1:${payload.iv}:${payload.authTag}:${payload.ciphertext}`;
+  // into existing TEXT columns (accessToken, streamUrl) without a schema
+  // change. `v2:` marks a context-bound blob; `v1:` stays context-free.
+  const payload = encryptJson(value, context);
+  const version = context ? "v2" : "v1";
+  return `${version}:${payload.iv}:${payload.authTag}:${payload.ciphertext}`;
 }
 
-export function decryptString(blob: string): string {
-  if (!blob.startsWith("v1:")) {
+export function decryptString(blob: string, context?: string): string {
+  const isV1 = blob.startsWith("v1:");
+  const isV2 = blob.startsWith("v2:");
+  if (!isV1 && !isV2) {
     // Legacy plaintext — accept during migration but flag once per process
     // so the operator notices unencrypted rows still in the DB.
     warnPlaintextFallback();
@@ -119,14 +151,19 @@ export function decryptString(blob: string): string {
   }
   const parts = blob.split(":");
   if (parts.length !== 4) {
-    // Defensive: a malformed `v1:` blob would otherwise feed undefined values
-    // into Buffer.from() and surface as a cryptic crypto stack trace.
+    // Defensive: a malformed versioned blob would otherwise feed undefined
+    // values into Buffer.from() and surface as a cryptic crypto stack trace.
     throw new DecryptionError(
       `Malformed encrypted blob: expected 4 colon-separated parts, got ${parts.length}`,
     );
   }
   const [, iv, authTag, ciphertext] = parts;
-  return decryptJson<string>({ iv, authTag, ciphertext });
+  // A v1 blob decrypts with the context ignored (legacy rows predate
+  // binding); a v2 blob binds the caller's context as AAD.
+  return decryptJson<string>(
+    { iv, authTag, ciphertext, ...(isV2 ? { v: 2 as const } : {}) },
+    isV2 ? context : undefined,
+  );
 }
 
 let _plaintextWarned = false;

--- a/backend/src/modules/analytics/gateways/analytics.gateway.ts
+++ b/backend/src/modules/analytics/gateways/analytics.gateway.ts
@@ -32,6 +32,7 @@ import {
   PersonState,
 } from "../dto/edge-device";
 import { decryptString } from "../../../common/helpers/encryption.helper";
+import { cameraStreamContext } from "../services/camera.service";
 
 interface EdgeDeviceConnection {
   socketId: string;
@@ -726,7 +727,9 @@ export class AnalyticsGateway
       // decrypted here. The admin-facing API path already does this in
       // camera.service.ts; forgetting it here previously broke camera
       // analytics end-to-end.
-      cameraUrl: camera.streamUrl ? decryptString(camera.streamUrl) : "",
+      cameraUrl: camera.streamUrl
+        ? decryptString(camera.streamUrl, cameraStreamContext(tenantId))
+        : "",
       calibration: camera.calibrationData as EdgeDeviceConfigDto["calibration"],
     };
   }

--- a/backend/src/modules/analytics/services/camera.service.ts
+++ b/backend/src/modules/analytics/services/camera.service.ts
@@ -15,6 +15,17 @@ import {
 import { BranchScope, branchScope } from "../../../common/scoping/branch-scope";
 
 /**
+ * AAD context that binds a camera streamUrl ciphertext to its owning tenant,
+ * so a moved blob (another tenant's row, pasted in by a DB-write attacker)
+ * fails GCM auth on decrypt. Write and every read MUST use this same helper
+ * — an asymmetric context would make v2 rows undecryptable. Exported so the
+ * analytics gateway's edge-config path binds identically.
+ */
+export function cameraStreamContext(tenantId: string): string {
+  return `camera:streamUrl:${tenantId}`;
+}
+
+/**
  * Replace `user:pass` in an RTSP/ONVIF URL with `***:***` so responses
  * to the tenant admin UI don't leak NVR credentials. The plaintext
  * still lives (encrypted) on disk for the edge device to use.
@@ -83,9 +94,11 @@ export class CameraService {
         branchId: edgeDevice.branchId,
         name: dto.name,
         description: dto.description,
-        // Encrypted at rest; the edge device's config fetch decrypts on
-        // the fly. Only the redacted form flows back to the admin UI.
-        streamUrl: encryptString(dto.streamUrl),
+        // Encrypted at rest, context-bound to this tenant so a DB-write
+        // attacker can't paste another tenant's camera-URL ciphertext into
+        // this row (v2 AAD binding). The edge device's config fetch decrypts
+        // on the fly. Only the redacted form flows back to the admin UI.
+        streamUrl: encryptString(dto.streamUrl, cameraStreamContext(tenantId)),
         streamType: dto.streamType || "RTSP",
         rotationY: dto.rotationY ?? 0,
         fov: dto.fov ?? 90,
@@ -183,7 +196,10 @@ export class CameraService {
         ...(dto.name !== undefined && { name: dto.name }),
         ...(dto.description !== undefined && { description: dto.description }),
         ...(dto.streamUrl !== undefined && {
-          streamUrl: encryptString(dto.streamUrl),
+          streamUrl: encryptString(
+            dto.streamUrl,
+            cameraStreamContext(tenantId),
+          ),
         }),
         ...(dto.streamType !== undefined && { streamType: dto.streamType }),
         ...(dto.status !== undefined && { status: dto.status }),
@@ -368,6 +384,7 @@ export class CameraService {
 
   private mapToResponseDto(camera: {
     id: string;
+    tenantId: string;
     name: string;
     description: string | null;
     streamUrl: string;
@@ -381,9 +398,12 @@ export class CameraService {
     createdAt: Date;
     updatedAt: Date;
   }): CameraResponseDto {
-    // The stored streamUrl is encrypted (AES-GCM). We decrypt so we
-    // can build the redacted form but never return the plaintext.
-    const decrypted = camera.streamUrl ? decryptString(camera.streamUrl) : "";
+    // The stored streamUrl is encrypted (AES-GCM), context-bound to the
+    // tenant (v2). We decrypt so we can build the redacted form but never
+    // return the plaintext. v1 legacy rows decrypt with the context ignored.
+    const decrypted = camera.streamUrl
+      ? decryptString(camera.streamUrl, cameraStreamContext(camera.tenantId))
+      : "";
     return {
       id: camera.id,
       name: camera.name,
@@ -408,7 +428,7 @@ export class CameraService {
    * actually needs to reach the device. Never call from user-facing
    * endpoints.
    */
-  decryptStreamUrl(encrypted: string): string {
-    return decryptString(encrypted);
+  decryptStreamUrl(encrypted: string, tenantId: string): string {
+    return decryptString(encrypted, cameraStreamContext(tenantId));
   }
 }


### PR DESCRIPTION
`encryption.helper` (AES-256-GCM) bound **no context**, so its GCM tag proved a ciphertext was *unaltered* but not that it *belonged where it sat*. A DB-write attacker could paste tenant A's encrypted camera URL / delivery token / PayTR credential into tenant B's row and the tag still verified (same master key, zero provenance). KMS already binds context via AAD; this helper didn't.

## Helper — backwards-compatible, opt-in
`encryptJson/encryptString/decryptJson/decryptString` gain an optional `context` bound as GCM **AAD**. With context → **v2** (`v:2` / `v2:` prefix); without → **v1, byte-identical to before**. A v1 blob decrypts with the context **ignored**, so every existing row keeps working and upgrades to v2 on its next write — **no migration, no format break**. Specs pin both the attack (v2 + wrong/absent context → `DecryptionError`) and the compat guarantee (v1 + context → still decrypts).

## Wired this pass: camera streamUrl
The clearest, lowest-money-risk, fully-symmetric call site. One exported `cameraStreamContext(tenantId)` is used at the write (create/update) **and every read** (`mapToResponseDto`, `decryptStreamUrl`, the gateway edge-config path) so contexts can't drift. Closes the cross-tenant substitution vector — otherwise tenant B could be made to connect to tenant A's NVR feed.

## Deliberately deferred (documented)
PayTR recurring token, delivery credentials/token, accounting settings, integrations config — money-critical with cross-module write/read symmetry where a context mismatch silently breaks recurring charges / sync. The helper now makes each a mechanical follow-up. (This is the "not a drive-by" scope the June review flagged; the primitive lands safely now, the risky money-path wiring is separate.)

## Verification
Backend 4,703 green (+6 context specs incl. the substitution attack + v1 backwards-compat), `tsc` clean, lint 0 errors. Real-DB e2e gate covers camera write→read round-trip. Existing prod camera rows are v1 → decrypt with context ignored (no prod break).