### PR TITLE
fix(security): CSV formula-injection defence in the shared toCsv serializer

### DIFF
--- a/backend/src/common/utils/csv.util.spec.ts
+++ b/backend/src/common/utils/csv.util.spec.ts
@@ -22,4 +22,34 @@ describe('toCsv', () => {
   it('renders null/undefined as empty cells', () => {
     expect(toCsv(['a', 'b'], [[null, undefined]])).toBe('a,b\n,');
   });
+
+  describe('formula-injection defence', () => {
+    it("prefixes a string cell starting with a formula char (= + - @) with a quote", () => {
+      const csv = toCsv(
+        ['name'],
+        [['=HYPERLINK("http://evil","x")'], ['+1+1'], ['-cmd'], ['@SUM(A1)']],
+      );
+      // Each dangerous string is prefixed with ' → then RFC-quoted because it
+      // now contains a comma/quote (the HYPERLINK one) or stays bare.
+      const lines = csv.split('\n');
+      expect(lines[1]).toBe(`"'=HYPERLINK(""http://evil"",""x"")"`);
+      expect(lines[2]).toBe(`'+1+1`);
+      expect(lines[3]).toBe(`'-cmd`);
+      expect(lines[4]).toBe(`'@SUM(A1)`);
+    });
+
+    it('leaves a NEGATIVE NUMBER untouched (must not become text)', () => {
+      // Regression guard: an over/short of -50 is a number, not an injection.
+      const csv = toCsv(['overShort'], [[-50]]);
+      expect(csv).toBe('overShort\n-50');
+    });
+
+    it('does not prefix a benign string that merely contains a formula char later', () => {
+      expect(toCsv(['x'], [['a=b']])).toBe('x\na=b');
+    });
+
+    it('quotes a cell containing a lone carriage return', () => {
+      expect(toCsv(['x'], [['a\rb']])).toBe('x\n"a\rb"');
+    });
+  });
 });

--- a/backend/src/common/utils/csv.util.ts
+++ b/backend/src/common/utils/csv.util.ts
@@ -1,16 +1,30 @@
 /**
  * Minimal RFC-4180 CSV serializer for report/accountant exports. A cell is
- * quoted only when it contains a comma, double-quote or newline; embedded
+ * quoted only when it contains a comma, double-quote, CR or newline; embedded
  * quotes are doubled. null/undefined render as empty cells.
+ *
+ * CSV/formula-injection defence: a cell whose first character is = + - @ (or a
+ * leading tab/CR) is executed as a FORMULA by Excel/Sheets/LibreOffice the
+ * moment the export is opened — so a STRING cell carrying user-controlled text
+ * (a product/category/cashier name like `=HYPERLINK("http://evil","x")`) would
+ * run on the accountant's machine. Such string cells are prefixed with a single
+ * quote to force text. NUMBER cells are left untouched: they can't carry an
+ * injection payload, and prefixing would wrongly turn a legitimate negative
+ * value (e.g. an over/short of -50) into text. Matches the escaper in
+ * personnel attendance + superadmin audit exports.
  */
 export function toCsv(
   headers: string[],
   rows: Array<Array<string | number | null | undefined>>,
 ): string {
   const esc = (v: string | number | null | undefined): string => {
-    const s = v == null ? "" : String(v);
-    return /[",\n]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s;
+    if (v == null) return "";
+    const isNumber = typeof v === "number";
+    let s = String(v);
+    if (!isNumber && /^[=+\-@\t\r]/.test(s)) s = `'${s}`;
+    return /[",\n\r]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s;
   };
+  // Headers are static literals but escape them too for uniformity.
   const lines = [headers.map(esc).join(",")];
   for (const row of rows) {
     lines.push(row.map(esc).join(","));


### PR DESCRIPTION
The shared `common/utils/csv.util` `toCsv()` was RFC-4180 correct but had **no formula-injection guard**: a cell whose first char is `= + - @` (or tab/CR) executes as a **formula** when the CSV is opened in Excel/Sheets/LibreOffice — e.g. a product/category/cashier name like `=HYPERLINK("http://evil","x")` runs on the accountant's machine. Its two siblings already defend against this (personnel attendance export, superadmin audit export); `toCsv` was the unhardened odd one out, and it's the reusable serializer future exports reach for.

## Fix (at the reusable layer)
A **string** cell starting with a formula char is prefixed with a single quote (force-text), matching the sibling escapers. **Number** cells are deliberately untouched — they can't carry a payload, and prefixing would wrongly turn a legitimate negative value (a cash over/short of `-50`) into text. Also adds CR to the RFC quoting set.

## Exploitability today
The two current callers (reports sales CSV, cash-drawer session CSV) emit only numeric/date/id columns, so weren't exploitable yet — but the defence belongs at the shared util so it covers them and every future caller by construction (defence-in-depth + consistency with the two hardened siblings).

## Verification
Backend 4,707 green (+4 `csv.util` specs: the HYPERLINK attack across `=/+/-/@`, the negative-number regression guard, benign-`=`-later, lone-CR quoting), `tsc` clean, lint 0 errors. No FE surface.