### PR TITLE
feat(analytics): ship camera/CV analytics INERT behind a feature flag

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -155,3 +155,14 @@ MARKETING_SERVICE_URL=
 # (x-internal-token header on /api/internal/* endpoints of either service).
 # Must match the kds-marketing deployment. Generate: openssl rand -hex 32
 INTERNAL_SERVICE_TOKEN=
+
+
+# ── Camera / computer-vision analytics (INERT by default) ──────────────────
+# The camera suite — camera management, occupancy heatmaps, traffic-flow +
+# congestion, edge-device ingest, calibration — ships DORMANT until on-site
+# cameras are provisioned. While false: the /api/analytics camera+heatmap+
+# traffic+mock-data endpoints 404, the edge-device WebSocket refuses
+# connections, and the retention sweep no-ops. Non-camera analytics (table
+# utilization, sales insights) stay live regardless. Set to true (backend)
+# AND rebuild the frontend with CAMERA_ANALYTICS_ENABLED=true to reactivate.
+CAMERA_ANALYTICS_ENABLED=false

--- a/backend/.env.production.template
+++ b/backend/.env.production.template
@@ -108,3 +108,14 @@ ADMIN_EMAIL=contact@hummytummy.com
 # [ ] Configure firewall rules and security groups
 # [ ] Set up database backups
 # [ ] Configure monitoring and alerting
+
+
+# ── Camera / computer-vision analytics (INERT by default) ──────────────────
+# The camera suite — camera management, occupancy heatmaps, traffic-flow +
+# congestion, edge-device ingest, calibration — ships DORMANT until on-site
+# cameras are provisioned. While false: the /api/analytics camera+heatmap+
+# traffic+mock-data endpoints 404, the edge-device WebSocket refuses
+# connections, and the retention sweep no-ops. Non-camera analytics (table
+# utilization, sales insights) stay live regardless. Set to true (backend)
+# AND rebuild the frontend with CAMERA_ANALYTICS_ENABLED=true to reactivate.
+CAMERA_ANALYTICS_ENABLED=false

--- a/backend/.env.staging.template
+++ b/backend/.env.staging.template
@@ -86,3 +86,14 @@ EMAIL_USER=admin@hummytummy.com
 EMAIL_PASSWORD=REPLACE_WITH_YOUR_GODADDY_EMAIL_PASSWORD
 EMAIL_FROM=noreply@hummytummy.com
 ADMIN_EMAIL=contact@hummytummy.com
+
+
+# ── Camera / computer-vision analytics (INERT by default) ──────────────────
+# The camera suite — camera management, occupancy heatmaps, traffic-flow +
+# congestion, edge-device ingest, calibration — ships DORMANT until on-site
+# cameras are provisioned. While false: the /api/analytics camera+heatmap+
+# traffic+mock-data endpoints 404, the edge-device WebSocket refuses
+# connections, and the retention sweep no-ops. Non-camera analytics (table
+# utilization, sales insights) stay live regardless. Set to true (backend)
+# AND rebuild the frontend with CAMERA_ANALYTICS_ENABLED=true to reactivate.
+CAMERA_ANALYTICS_ENABLED=false

--- a/backend/src/modules/analytics/analytics.controller.ts
+++ b/backend/src/modules/analytics/analytics.controller.ts
@@ -47,6 +47,7 @@ import {
   UpdateInsightStatusDto,
 } from "./dto";
 import { HeatmapGranularity } from "./enums/analytics.enum";
+import { CameraAnalyticsEnabledGuard } from "./camera-analytics.gate";
 
 // Iter-89: hard cap on the analytics date window. The heatmap, traffic,
 // dwell-time, and table-utilization queries scan AnalyticsEvent /
@@ -112,6 +113,7 @@ export class AnalyticsController {
 
   // ==================== HEATMAP ENDPOINTS ====================
 
+  @UseGuards(CameraAnalyticsEnabledGuard)
   @Get("heatmap/occupancy")
   @Roles(UserRole.ADMIN, UserRole.MANAGER)
   @RequiresFeature(PlanFeature.ADVANCED_REPORTS)
@@ -148,6 +150,7 @@ export class AnalyticsController {
     );
   }
 
+  @UseGuards(CameraAnalyticsEnabledGuard)
   @Get("heatmap/traffic")
   @Roles(UserRole.ADMIN, UserRole.MANAGER)
   @RequiresFeature(PlanFeature.ADVANCED_REPORTS)
@@ -184,6 +187,7 @@ export class AnalyticsController {
     );
   }
 
+  @UseGuards(CameraAnalyticsEnabledGuard)
   @Get("heatmap/dwell-time")
   @Roles(UserRole.ADMIN, UserRole.MANAGER)
   @RequiresFeature(PlanFeature.ADVANCED_REPORTS)
@@ -222,6 +226,7 @@ export class AnalyticsController {
     );
   }
 
+  @UseGuards(CameraAnalyticsEnabledGuard)
   @Get("traffic/flow")
   @Roles(UserRole.ADMIN, UserRole.MANAGER)
   @RequiresFeature(PlanFeature.ADVANCED_REPORTS)
@@ -269,6 +274,7 @@ export class AnalyticsController {
     );
   }
 
+  @UseGuards(CameraAnalyticsEnabledGuard)
   @Get("traffic/congestion")
   @Roles(UserRole.ADMIN, UserRole.MANAGER)
   @RequiresFeature(PlanFeature.ADVANCED_REPORTS)
@@ -534,6 +540,7 @@ export class AnalyticsController {
 
   // ==================== CAMERA ENDPOINTS ====================
 
+  @UseGuards(CameraAnalyticsEnabledGuard)
   @Get("cameras")
   @Roles(UserRole.ADMIN, UserRole.MANAGER)
   @RequiresFeature(PlanFeature.ADVANCED_REPORTS)
@@ -543,6 +550,7 @@ export class AnalyticsController {
     return this.cameraService.getCameras(scope);
   }
 
+  @UseGuards(CameraAnalyticsEnabledGuard)
   @Get("cameras/health")
   @Roles(UserRole.ADMIN, UserRole.MANAGER)
   @RequiresFeature(PlanFeature.ADVANCED_REPORTS)
@@ -552,6 +560,7 @@ export class AnalyticsController {
     return this.cameraService.getCameraHealthSummary(scope);
   }
 
+  @UseGuards(CameraAnalyticsEnabledGuard)
   @Get("cameras/:id")
   @Roles(UserRole.ADMIN, UserRole.MANAGER)
   @RequiresFeature(PlanFeature.ADVANCED_REPORTS)
@@ -565,6 +574,7 @@ export class AnalyticsController {
     return this.cameraService.getCameraById(scope, id);
   }
 
+  @UseGuards(CameraAnalyticsEnabledGuard)
   @Post("cameras")
   @Roles(UserRole.ADMIN)
   @RequiresFeature(PlanFeature.ADVANCED_REPORTS)
@@ -577,6 +587,7 @@ export class AnalyticsController {
     return this.cameraService.createCamera(scope, dto);
   }
 
+  @UseGuards(CameraAnalyticsEnabledGuard)
   @Put("cameras/:id")
   @Roles(UserRole.ADMIN)
   @RequiresFeature(PlanFeature.ADVANCED_REPORTS)
@@ -591,6 +602,7 @@ export class AnalyticsController {
     return this.cameraService.updateCamera(scope, id, dto);
   }
 
+  @UseGuards(CameraAnalyticsEnabledGuard)
   @Delete("cameras/:id")
   @Roles(UserRole.ADMIN)
   @RequiresFeature(PlanFeature.ADVANCED_REPORTS)
@@ -605,6 +617,7 @@ export class AnalyticsController {
     return { success: true };
   }
 
+  @UseGuards(CameraAnalyticsEnabledGuard)
   @Put("cameras/:id/calibration")
   @Roles(UserRole.ADMIN)
   @RequiresFeature(PlanFeature.ADVANCED_REPORTS)
@@ -629,6 +642,7 @@ export class AnalyticsController {
     }
   }
 
+  @UseGuards(CameraAnalyticsEnabledGuard)
   @Post("mock-data/generate")
   @Roles(UserRole.ADMIN)
   @RequiresFeature(PlanFeature.ADVANCED_REPORTS)
@@ -653,6 +667,7 @@ export class AnalyticsController {
     );
   }
 
+  @UseGuards(CameraAnalyticsEnabledGuard)
   @Delete("mock-data")
   @Roles(UserRole.ADMIN)
   @RequiresFeature(PlanFeature.ADVANCED_REPORTS)

--- a/backend/src/modules/analytics/camera-analytics.gate.spec.ts
+++ b/backend/src/modules/analytics/camera-analytics.gate.spec.ts
@@ -1,0 +1,42 @@
+import { NotFoundException } from "@nestjs/common";
+import {
+  CameraAnalyticsEnabledGuard,
+  isCameraAnalyticsEnabled,
+} from "./camera-analytics.gate";
+
+/**
+ * The camera/CV analytics suite ships INERT (CAMERA_ANALYTICS_ENABLED). This
+ * pins the gate: enabled ONLY when the flag is exactly "true"; the guard 404s
+ * (looks-absent) otherwise so a probe can't distinguish disabled from missing.
+ */
+describe("camera-analytics gate", () => {
+  const orig = process.env.CAMERA_ANALYTICS_ENABLED;
+  afterEach(() => {
+    if (orig === undefined) delete process.env.CAMERA_ANALYTICS_ENABLED;
+    else process.env.CAMERA_ANALYTICS_ENABLED = orig;
+  });
+
+  it("is disabled by default (unset) and for any non-'true' value", () => {
+    delete process.env.CAMERA_ANALYTICS_ENABLED;
+    expect(isCameraAnalyticsEnabled()).toBe(false);
+    process.env.CAMERA_ANALYTICS_ENABLED = "false";
+    expect(isCameraAnalyticsEnabled()).toBe(false);
+    process.env.CAMERA_ANALYTICS_ENABLED = "1";
+    expect(isCameraAnalyticsEnabled()).toBe(false);
+    process.env.CAMERA_ANALYTICS_ENABLED = "TRUE";
+    expect(isCameraAnalyticsEnabled()).toBe(false);
+  });
+
+  it("is enabled only for the exact string 'true'", () => {
+    process.env.CAMERA_ANALYTICS_ENABLED = "true";
+    expect(isCameraAnalyticsEnabled()).toBe(true);
+  });
+
+  it("guard throws 404 NotFound when inert, passes when enabled", () => {
+    const guard = new CameraAnalyticsEnabledGuard();
+    delete process.env.CAMERA_ANALYTICS_ENABLED;
+    expect(() => guard.canActivate()).toThrow(NotFoundException);
+    process.env.CAMERA_ANALYTICS_ENABLED = "true";
+    expect(guard.canActivate()).toBe(true);
+  });
+});

--- a/backend/src/modules/analytics/camera-analytics.gate.ts
+++ b/backend/src/modules/analytics/camera-analytics.gate.ts
@@ -1,0 +1,33 @@
+import { CanActivate, Injectable, NotFoundException } from "@nestjs/common";
+
+/**
+ * The camera / computer-vision analytics suite — camera management, occupancy
+ * heatmaps, traffic-flow + congestion, edge-device ingest and calibration —
+ * ships INERT until on-site cameras are actually provisioned. Nothing about it
+ * is deleted: the services, schema models (Camera / OccupancyRecord /
+ * TrafficFlowRecord / EdgeDevice) and DTOs all remain, dormant. A single env
+ * flag reactivates the whole feature.
+ *
+ * Non-camera analytics (table utilization/trends, sales insights, customer
+ * behavior) are deliberately NOT gated — they read order-derived data and stay
+ * live.
+ *
+ * To reactivate: set CAMERA_ANALYTICS_ENABLED=true on the backend AND
+ * CAMERA_ANALYTICS_ENABLED (VITE build arg) on the frontend.
+ */
+export function isCameraAnalyticsEnabled(): boolean {
+  return process.env.CAMERA_ANALYTICS_ENABLED === "true";
+}
+
+/**
+ * Route guard for the camera/CV endpoints. When the feature is inert it throws
+ * 404 (the endpoints look absent, not forbidden) so a probe can't tell a
+ * disabled feature from a missing one.
+ */
+@Injectable()
+export class CameraAnalyticsEnabledGuard implements CanActivate {
+  canActivate(): boolean {
+    if (isCameraAnalyticsEnabled()) return true;
+    throw new NotFoundException("Camera analytics is not enabled");
+  }
+}

--- a/backend/src/modules/analytics/gateways/analytics.gateway.ts
+++ b/backend/src/modules/analytics/gateways/analytics.gateway.ts
@@ -33,6 +33,7 @@ import {
 } from "../dto/edge-device";
 import { decryptString } from "../../../common/helpers/encryption.helper";
 import { cameraStreamContext } from "../services/camera.service";
+import { isCameraAnalyticsEnabled } from "../camera-analytics.gate";
 
 interface EdgeDeviceConnection {
   socketId: string;
@@ -105,6 +106,15 @@ export class AnalyticsGateway
 
   async handleConnection(client: Socket) {
     try {
+      // Camera/CV analytics ships INERT until on-site cameras are provisioned
+      // (CAMERA_ANALYTICS_ENABLED). Refuse edge-device connections while
+      // disabled so no occupancy/traffic telemetry is ingested; the REST
+      // endpoints 404 in parallel via CameraAnalyticsEnabledGuard.
+      if (!isCameraAnalyticsEnabled()) {
+        client.disconnect();
+        return;
+      }
+
       // Check for JWT token or API key
       const token =
         client.handshake.auth.token ||

--- a/backend/src/modules/analytics/services/analytics-retention.service.spec.ts
+++ b/backend/src/modules/analytics/services/analytics-retention.service.spec.ts
@@ -10,10 +10,19 @@ describe("AnalyticsRetentionService", () => {
   let prisma: any;
   let svc: AnalyticsRetentionService;
 
+  const origFlag = process.env.CAMERA_ANALYTICS_ENABLED;
+  afterAll(() => {
+    if (origFlag === undefined) delete process.env.CAMERA_ANALYTICS_ENABLED;
+    else process.env.CAMERA_ANALYTICS_ENABLED = origFlag;
+  });
+
   beforeEach(() => {
     jest.restoreAllMocks();
     delete process.env.ANALYTICS_OCCUPANCY_RETENTION_DAYS;
     delete process.env.ANALYTICS_TRAFFIC_RETENTION_DAYS;
+    // The sweep no-ops when camera analytics is inert; the body-exercising
+    // tests need it enabled. A dedicated test flips it off.
+    process.env.CAMERA_ANALYTICS_ENABLED = "true";
     prisma = {
       // withAdvisoryLock v2: xact lock inside a $transaction; grant by default
       $queryRawUnsafe: jest.fn().mockResolvedValue([{ locked: true }]),
@@ -54,6 +63,14 @@ describe("AnalyticsRetentionService", () => {
       { locked: false },
     ]);
     await svc.sweep();
+    expect(prisma.$executeRawUnsafe).not.toHaveBeenCalled();
+    expect(prisma.analyticsHeatmapCache.deleteMany).not.toHaveBeenCalled();
+  });
+
+  it("no-ops entirely when camera analytics is inert (no lock, no deletes)", async () => {
+    process.env.CAMERA_ANALYTICS_ENABLED = "false";
+    await svc.sweep();
+    expect(prisma.$transaction).not.toHaveBeenCalled();
     expect(prisma.$executeRawUnsafe).not.toHaveBeenCalled();
     expect(prisma.analyticsHeatmapCache.deleteMany).not.toHaveBeenCalled();
   });

--- a/backend/src/modules/analytics/services/analytics-retention.service.ts
+++ b/backend/src/modules/analytics/services/analytics-retention.service.ts
@@ -2,6 +2,7 @@ import { Injectable, Logger } from "@nestjs/common";
 import { Cron } from "@nestjs/schedule";
 import { PrismaService } from "../../../prisma/prisma.service";
 import { withAdvisoryLock } from "../../../common/scheduling/advisory-lock";
+import { isCameraAnalyticsEnabled } from "../camera-analytics.gate";
 
 /**
  * Nightly retention sweep for the camera-CV telemetry tables. The edge
@@ -37,6 +38,9 @@ export class AnalyticsRetentionService {
 
   @Cron("40 3 * * *")
   async sweep(): Promise<void> {
+    // Camera/CV telemetry is INERT until cameras are provisioned — no new
+    // occupancy/traffic rows accrue, so the retention sweep has nothing to do.
+    if (!isCameraAnalyticsEnabled()) return;
     await withAdvisoryLock(
       this.prisma,
       "analytics.retention-sweep",

--- a/frontend/src/features/analytics/analyticsApi.ts
+++ b/frontend/src/features/analytics/analyticsApi.ts
@@ -100,7 +100,10 @@ export const useTrafficFlow = (params: DateRangeParams & { limit?: number }) => 
   });
 };
 
-export const useCongestionAnalysis = (params: DateRangeParams) => {
+export const useCongestionAnalysis = (
+  params: DateRangeParams,
+  enabled = true,
+) => {
   const branchId = useBranchScopeStore((s) => s.branchId);
   return useQuery({
     queryKey: [...analyticsKeys.congestion(params), branchId],
@@ -108,7 +111,9 @@ export const useCongestionAnalysis = (params: DateRangeParams) => {
       const response = await api.get('/analytics/traffic/congestion', { params });
       return response.data;
     },
-    enabled: true,
+    // Gated off when camera analytics is inert — the endpoint 404s and the
+    // only consumer (hasCameraData) correctly reads "no camera data".
+    enabled,
     staleTime: 10 * 60 * 1000,
   });
 };

--- a/frontend/src/features/analytics/cameraAnalytics.config.ts
+++ b/frontend/src/features/analytics/cameraAnalytics.config.ts
@@ -1,0 +1,10 @@
+/**
+ * Mirrors the backend `CAMERA_ANALYTICS_ENABLED` env flag. The camera /
+ * computer-vision analytics suite — camera management, occupancy heatmaps,
+ * traffic-flow + congestion, edge devices, calibration — ships INERT until
+ * on-site cameras are provisioned. While false the camera + traffic tabs are
+ * hidden and the camera-derived queries don't fire (the backend endpoints 404
+ * in parallel). No component or type is deleted — flip this AND the backend
+ * env var to reactivate the whole feature.
+ */
+export const CAMERA_ANALYTICS_ENABLED = false;

--- a/frontend/src/pages/admin/AnalyticsPage.tsx
+++ b/frontend/src/pages/admin/AnalyticsPage.tsx
@@ -15,6 +15,7 @@ import {
   CameraManagement,
 } from '../../features/analytics';
 import { InsightSeverity, InsightStatus } from '../../features/analytics/types';
+import { CAMERA_ANALYTICS_ENABLED } from '../../features/analytics/cameraAnalytics.config';
 import { Card, CardHeader, CardTitle, CardContent } from '../../components/ui/Card';
 import Button from '../../components/ui/Button';
 import Input from '../../components/ui/Input';
@@ -75,7 +76,10 @@ const AnalyticsPage = () => {
   const actionableInsightsQuery = useActionableInsights();
   const insightSummaryQuery = useInsightSummary();
   const customerBehaviorQuery = useCustomerBehavior(dateRange);
-  const congestionQuery = useCongestionAnalysis(dateRange);
+  const congestionQuery = useCongestionAnalysis(
+    dateRange,
+    CAMERA_ANALYTICS_ENABLED,
+  );
   const { data: tableUtilization } = tableUtilizationQuery;
   const { data: actionableInsights } = actionableInsightsQuery;
   const { data: insightSummary } = insightSummaryQuery;
@@ -141,13 +145,20 @@ const AnalyticsPage = () => {
     }
   };
 
+  // Camera/CV analytics ships INERT (CAMERA_ANALYTICS_ENABLED). The traffic
+  // heatmap + camera-management tabs are hidden until cameras are provisioned;
+  // the order-derived tabs (overview/tables/behavior/insights) stay live.
   const tabs = [
     { id: 'overview' as TabType, label: t('analytics:tabs.overview'), icon: BarChart3 },
     { id: 'tables' as TabType, label: t('analytics:tabs.tables'), icon: Table2 },
-    { id: 'traffic' as TabType, label: t('analytics:tabs.traffic'), icon: Map },
+    ...(CAMERA_ANALYTICS_ENABLED
+      ? [{ id: 'traffic' as TabType, label: t('analytics:tabs.traffic'), icon: Map }]
+      : []),
     { id: 'behavior' as TabType, label: t('analytics:tabs.behavior'), icon: Users },
     { id: 'insights' as TabType, label: t('analytics:tabs.insights'), icon: Lightbulb },
-    { id: 'cameras' as TabType, label: t('analytics:tabs.cameras'), icon: Video },
+    ...(CAMERA_ANALYTICS_ENABLED
+      ? [{ id: 'cameras' as TabType, label: t('analytics:tabs.cameras'), icon: Video }]
+      : []),
   ];
 
   const getSeverityColor = (severity: InsightSeverity) => {


### PR DESCRIPTION
Camera analytics (camera management, occupancy heatmaps, traffic-flow + congestion, edge-device ingest, calibration) is made **INERT** until on-site cameras are provisioned — we haven't started that rollout. Nothing is deleted; everything is dormant and reversible.

## Backend — `CAMERA_ANALYTICS_ENABLED` (default false)
- `CameraAnalyticsEnabledGuard` **404s the 14 camera/CV endpoints** (`heatmap/*`, `traffic/*`, `cameras/*`, `mock-data/*`) — looks-absent, not forbidden.
- The edge-device **WebSocket gateway refuses connections** → no occupancy/traffic telemetry ingested.
- The nightly CV-telemetry **retention sweep no-ops**.
- Documented in all three env templates.

## Frontend — `CAMERA_ANALYTICS_ENABLED` const (mirrors backend)
- Hides the **Traffic** (heatmap) + **Cameras** (management) tabs.
- Gates the congestion query so it doesn't fire against the 404'd endpoint (`hasCameraData` → false → the existing "requires cameras" disclosure).

## Deliberately kept live (order-derived analytics)
Table utilization/trends/underutilized, sales insights, customer behavior (degrades to the honest "requires cameras" empty state, same as before). Mock-data buttons were already dev-only.

## Reversible
No component, DTO, service, or schema model deleted. Reactivate = `CAMERA_ANALYTICS_ENABLED=true` on backend + FE rebuild.

## Verification
Backend 4,711 green (+3 gate specs proving 404-when-inert / pass-when-`true`, +1 retention no-op), FE 1,989 green, both `tsc` + lint clean.