### PR TITLE
fix(delivery): pre-launch hardening — block POS double-fiş + auto-reject stale approvals

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -166,3 +166,12 @@ INTERNAL_SERVICE_TOKEN=
 # utilization, sales insights) stay live regardless. Set to true (backend)
 # AND rebuild the frontend with CAMERA_ANALYTICS_ENABLED=true to reactivate.
 CAMERA_ANALYTICS_ENABLED=false
+
+# ── Delivery-platform order moderation ─────────────────────────────────
+# Minutes a marketplace order (Yemeksepeti/Getir/Trendyol/Migros) may sit in
+# PENDING_APPROVAL before DeliveryApprovalTimeoutScheduler auto-rejects it:
+# the platform is told to cancel, so the customer gets a fast refund instead
+# of a ghost order that will never be cooked. Read per-tick (a change takes
+# effect without a restart). Default 15. Set to 0 to disable auto-reject
+# entirely (manual moderation only).
+DELIVERY_APPROVAL_TIMEOUT_MINUTES=15

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -175,3 +175,11 @@ CAMERA_ANALYTICS_ENABLED=false
 # effect without a restart). Default 15. Set to 0 to disable auto-reject
 # entirely (manual moderation only).
 DELIVERY_APPROVAL_TIMEOUT_MINUTES=15
+
+# Milliseconds the auto-accept outbound call may run INLINE inside the webhook
+# ack path before it is deferred to the RetryScheduler. Keeps the webhook 200
+# within the platform's ack window even when the platform accept (or a token
+# refresh) is slow; the deferred accept is retried out-of-band. Read per-tick.
+# Default 2500. Lower = safer ack window but more accepts deferred (≤1 retry
+# tick of extra latency); higher = more accepts confirmed synchronously.
+DELIVERY_AUTOACCEPT_INLINE_BUDGET_MS=2500

--- a/backend/src/modules/accounting/services/sales-invoice.service.spec.ts
+++ b/backend/src/modules/accounting/services/sales-invoice.service.spec.ts
@@ -297,6 +297,70 @@ describe("SalesInvoiceService.createFromOrder delivery reconciliation (CONCERN B
     );
     expect(Math.round(lineTotalSum * 100) / 100).toBe(invoice.totalAmount);
   });
+
+  // A marketplace/delivery-platform order (source set) is fiscalized BY the
+  // platform — it issues the customer's e-Arşiv and owns the money rail
+  // (delivery Orders never create Payment rows). A KDS invoice on top would be
+  // a SECOND fiscal document for revenue the platform already invoiced. The
+  // POS payment rail already blocks these (payment-validator); createFromOrder
+  // is a separate, manual admin entry point (POST from-order/:orderId) that
+  // must refuse them too.
+  it("REFUSES a marketplace order (source set — the platform already fiscalized it)", async () => {
+    (prisma.order.findFirst as any).mockResolvedValue({
+      id: "order-mp",
+      tenantId: "t1",
+      source: "YEMEKSEPETI",
+      externalOrderId: "ext-1",
+      customerName: "Marketplace Co",
+      customerPhone: null,
+      totalAmount: 100,
+      discount: 0,
+      finalAmount: 100,
+      payments: [{ method: "DIGITAL" }],
+      salesInvoices: [],
+      orderItems: [
+        {
+          id: "oi-1",
+          quantity: 1,
+          subtotal: 100,
+          taxRate: 10,
+          product: { name: "Burger" },
+        },
+      ],
+    });
+
+    await expect(svc.createFromOrder("order-mp", "t1")).rejects.toThrow(
+      "fiscalized by the platform",
+    );
+  });
+
+  it("still self-invoices a restaurant's OWN delivery (source null)", async () => {
+    // Own-delivery (type=DELIVERY, source=null) is NOT a marketplace order — it
+    // must stay invoiceable here (regression guard so the source check doesn't
+    // over-block the restaurant's own courier revenue).
+    (prisma.order.findFirst as any).mockResolvedValue({
+      id: "order-own",
+      tenantId: "t1",
+      source: null,
+      totalAmount: 100,
+      discount: 0,
+      finalAmount: 100,
+      payments: [{ method: "CASH" }],
+      salesInvoices: [],
+      orderItems: [
+        {
+          id: "oi-1",
+          quantity: 1,
+          subtotal: 100,
+          taxRate: 10,
+          product: { name: "Pizza" },
+        },
+      ],
+    });
+
+    const invoice: any = await svc.createFromOrder("order-own", "t1");
+    expect(invoice.totalAmount).toBe(100);
+  });
 });
 
 /**

--- a/backend/src/modules/accounting/services/sales-invoice.service.ts
+++ b/backend/src/modules/accounting/services/sales-invoice.service.ts
@@ -78,6 +78,23 @@ export class SalesInvoiceService {
     });
 
     if (!order) throw new NotFoundException("Paid order not found");
+
+    // Marketplace/delivery-platform orders are fiscalized BY the platform: the
+    // platform issues the customer's e-Arşiv/e-Fatura and owns the money rail
+    // (delivery Orders never create Payment rows — see delivery-order.service).
+    // Cutting a KDS invoice here would be a SECOND fiscal document for revenue
+    // the platform already invoiced. The POS payment rail already refuses these
+    // (payment-validator.assertOrderPayable); createFromOrder is a separate,
+    // manual admin entry point (POST from-order/:orderId, @Roles ADMIN/MANAGER)
+    // that must refuse them too. Gate on `source` (the marketplace:
+    // YEMEKSEPETI/GETIR/TRENDYOL/MIGROS), NOT `type` — a restaurant's OWN
+    // delivery (type=DELIVERY, source=null) is still self-invoiced here.
+    if (order.source != null && order.source.trim() !== "") {
+      throw new BadRequestException(
+        "This is a marketplace/delivery-platform order — it is fiscalized by the platform and cannot be invoiced through the POS.",
+      );
+    }
+
     if (order.salesInvoices.length > 0) {
       throw new BadRequestException("Invoice already exists for this order");
     }

--- a/backend/src/modules/delivery-platforms/delivery-platforms.module.ts
+++ b/backend/src/modules/delivery-platforms/delivery-platforms.module.ts
@@ -41,6 +41,7 @@ import { OrderPollingScheduler } from "./schedulers/order-polling.scheduler";
 import { TokenRefreshScheduler } from "./schedulers/token-refresh.scheduler";
 import { RetryScheduler } from "./schedulers/retry.scheduler";
 import { DeliveryReconciliationScheduler } from "./schedulers/delivery-reconciliation.scheduler";
+import { DeliveryApprovalTimeoutScheduler } from "./schedulers/delivery-approval-timeout.scheduler";
 
 // Guards
 import { WebhookAuthGuard } from "./guards/webhook-auth.guard";
@@ -83,6 +84,7 @@ import { WebhookAuthGuard } from "./guards/webhook-auth.guard";
     TokenRefreshScheduler,
     RetryScheduler,
     DeliveryReconciliationScheduler,
+    DeliveryApprovalTimeoutScheduler,
 
     // Guards
     WebhookAuthGuard,

--- a/backend/src/modules/delivery-platforms/schedulers/delivery-approval-timeout.scheduler.spec.ts
+++ b/backend/src/modules/delivery-platforms/schedulers/delivery-approval-timeout.scheduler.spec.ts
@@ -1,0 +1,178 @@
+import { DeliveryApprovalTimeoutScheduler } from "./delivery-approval-timeout.scheduler";
+import { DeliveryModerationService } from "../services/delivery-moderation.service";
+import { OrderStatus } from "../../../common/constants/order-status.enum";
+import { mockPrismaClient } from "../../../common/test/prisma-mock.service";
+
+/**
+ * Spec for the PENDING_APPROVAL auto-reject cron. A delivery order that no
+ * operator approves within DELIVERY_APPROVAL_TIMEOUT_MINUTES (default 15) is
+ * auto-rejected — pushed back to the platform (cancel) so the customer gets a
+ * fast refund instead of waiting on a ghost order. Load-bearing contracts:
+ *   - reuses DeliveryModerationService.rejectOrder (platform push + audit +
+ *     idempotency), never re-implements the reject
+ *   - race guard: never cancels an order the operator accepted between the
+ *     query snapshot and the reject
+ *   - env escape hatch: 0 disables the tick entirely
+ *   - the advisory lock + isRunning shell prevents cross-replica / re-entrant
+ *     double-reject
+ */
+describe("DeliveryApprovalTimeoutScheduler", () => {
+  const ENV_KEY = "DELIVERY_APPROVAL_TIMEOUT_MINUTES";
+  const ORIGINAL = process.env[ENV_KEY];
+
+  afterEach(() => {
+    if (ORIGINAL === undefined) delete process.env[ENV_KEY];
+    else process.env[ENV_KEY] = ORIGINAL;
+    jest.restoreAllMocks();
+  });
+
+  function make({
+    locked = true,
+    stale = [] as any[],
+    statusById = {} as Record<string, string>,
+  } = {}) {
+    const prisma = mockPrismaClient();
+    // v2 withAdvisoryLock holds the lock inside a $transaction that runs the
+    // callback; the mock invokes it with the same client (tx === prisma), and
+    // pg_try_advisory_xact_lock returns { locked } to gate the work.
+    (prisma.$transaction as any).mockImplementation(async (cb: any) =>
+      typeof cb === "function" ? cb(prisma) : Promise.all(cb),
+    );
+    (prisma.$queryRawUnsafe as any).mockImplementation(async (sql: string) =>
+      sql.includes("pg_try_advisory") ? [{ locked }] : [],
+    );
+    (prisma.order.findMany as any).mockResolvedValue(stale);
+    (prisma.order.findUnique as any).mockImplementation(
+      async ({ where: { id } }: any) => ({
+        status: statusById[id] ?? OrderStatus.PENDING_APPROVAL,
+      }),
+    );
+
+    const moderation = {
+      rejectOrder: jest.fn().mockResolvedValue({}),
+    } as unknown as DeliveryModerationService;
+
+    const sched = new DeliveryApprovalTimeoutScheduler(
+      prisma as any,
+      moderation,
+    );
+    return { sched, prisma, moderation };
+  }
+
+  it("auto-rejects a stale PENDING_APPROVAL delivery order via moderation", async () => {
+    process.env[ENV_KEY] = "15";
+    const { sched, moderation } = make({
+      stale: [
+        { id: "o1", tenantId: "t1", source: "YEMEKSEPETI", externalOrderId: "x1" },
+      ],
+    });
+
+    await sched.rejectStaleApprovals();
+
+    expect(moderation.rejectOrder).toHaveBeenCalledWith(
+      "t1",
+      "o1",
+      expect.stringContaining("otomatik iptal"),
+    );
+  });
+
+  it("queries with a createdAt cutoff derived from the env threshold", async () => {
+    process.env[ENV_KEY] = "20";
+    const { sched, prisma } = make({ stale: [] });
+
+    const before = Date.now();
+    await sched.rejectStaleApprovals();
+
+    const arg = (prisma.order.findMany as jest.Mock).mock.calls[0][0];
+    const cutoff = arg.where.createdAt.lt as Date;
+    const expected = before - 20 * 60_000;
+    expect(Math.abs(cutoff.getTime() - expected)).toBeLessThan(5_000);
+    expect(arg.where.status).toBe(OrderStatus.PENDING_APPROVAL);
+    expect(arg.where.requiresApproval).toBe(true);
+  });
+
+  it("is disabled when the threshold is 0 (no query, no reject)", async () => {
+    process.env[ENV_KEY] = "0";
+    const { sched, prisma, moderation } = make({
+      stale: [{ id: "o1", tenantId: "t1", source: "GETIR", externalOrderId: "x" }],
+    });
+
+    await sched.rejectStaleApprovals();
+
+    expect(prisma.order.findMany).not.toHaveBeenCalled();
+    expect(moderation.rejectOrder).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the 15-min default when the env var is missing/garbage", async () => {
+    process.env[ENV_KEY] = "not-a-number";
+    const { sched, prisma } = make({ stale: [] });
+
+    const before = Date.now();
+    await sched.rejectStaleApprovals();
+
+    const arg = (prisma.order.findMany as jest.Mock).mock.calls[0][0];
+    const cutoff = arg.where.createdAt.lt as Date;
+    const expected = before - 15 * 60_000;
+    expect(Math.abs(cutoff.getTime() - expected)).toBeLessThan(5_000);
+  });
+
+  it("does NOT reject an order the operator accepted after the query snapshot (race guard)", async () => {
+    process.env[ENV_KEY] = "15";
+    const { sched, moderation } = make({
+      stale: [
+        { id: "o1", tenantId: "t1", source: "GETIR", externalOrderId: "x1" },
+      ],
+      statusById: { o1: OrderStatus.PENDING }, // re-check sees it's now accepted
+    });
+
+    await sched.rejectStaleApprovals();
+
+    expect(moderation.rejectOrder).not.toHaveBeenCalled();
+  });
+
+  it("continues after a reject failure (one bad order does not block the rest)", async () => {
+    process.env[ENV_KEY] = "15";
+    const { sched, moderation } = make({
+      stale: [
+        { id: "bad", tenantId: "t1", source: "TRENDYOL", externalOrderId: "xa" },
+        { id: "good", tenantId: "t1", source: "TRENDYOL", externalOrderId: "xb" },
+      ],
+    });
+    (moderation.rejectOrder as jest.Mock)
+      .mockRejectedValueOnce(new Error("platform 500"))
+      .mockResolvedValueOnce({});
+
+    await sched.rejectStaleApprovals();
+
+    expect(moderation.rejectOrder).toHaveBeenCalledTimes(2);
+    expect(moderation.rejectOrder).toHaveBeenNthCalledWith(
+      2,
+      "t1",
+      "good",
+      expect.any(String),
+    );
+  });
+
+  it("skips work when another replica holds the advisory lock", async () => {
+    process.env[ENV_KEY] = "15";
+    const { sched, prisma, moderation } = make({
+      locked: false,
+      stale: [{ id: "o1", tenantId: "t1", source: "GETIR", externalOrderId: "x" }],
+    });
+
+    await sched.rejectStaleApprovals();
+
+    expect(prisma.order.findMany).not.toHaveBeenCalled();
+    expect(moderation.rejectOrder).not.toHaveBeenCalled();
+  });
+
+  it("skips a re-entrant tick while one is already in flight", async () => {
+    process.env[ENV_KEY] = "15";
+    const { sched, prisma } = make({ stale: [] });
+    (sched as unknown as { isRunning: boolean }).isRunning = true;
+
+    await sched.rejectStaleApprovals();
+
+    expect(prisma.order.findMany).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/modules/delivery-platforms/schedulers/delivery-approval-timeout.scheduler.ts
+++ b/backend/src/modules/delivery-platforms/schedulers/delivery-approval-timeout.scheduler.ts
@@ -1,0 +1,149 @@
+import { Injectable, Logger } from "@nestjs/common";
+import { Interval } from "@nestjs/schedule";
+import { PrismaService } from "../../../prisma/prisma.service";
+import { DeliveryModerationService } from "../services/delivery-moderation.service";
+import { OrderStatus } from "../../../common/constants/order-status.enum";
+import { withAdvisoryLock } from "../../../common/scheduling/advisory-lock";
+
+/**
+ * Minutes a delivery order may sit in PENDING_APPROVAL before it is auto-
+ * rejected. Overridable per deploy via DELIVERY_APPROVAL_TIMEOUT_MINUTES; set
+ * to 0 to disable the sweep entirely.
+ */
+export const DEFAULT_APPROVAL_TIMEOUT_MINUTES = 15;
+
+/** Bound the work per tick so a backlog burst can't monopolise a replica. */
+const MAX_PER_TICK = 100;
+
+/**
+ * Auto-rejects delivery-platform orders that no operator has approved within
+ * the timeout window.
+ *
+ * An order lands in PENDING_APPROVAL only when something needs human judgment:
+ * the config has autoAccept=false, an item is unmapped, or the platform total
+ * doesn't reconcile (see DeliveryOrderService.processIncomingOrder). Left
+ * unattended it's a ghost order — the customer waits on food that will never
+ * be made and the platform can't settle. Auto-*accepting* it would push a
+ * possibly-wrong basket (no recipe → no stock deduction, or a bad total) into
+ * the kitchen unreviewed, so the safe default is to REJECT: the platform is
+ * told to cancel (customer gets a fast refund) and the internal Order moves to
+ * CANCELLED.
+ *
+ * We reuse DeliveryModerationService.rejectOrder verbatim — it owns the
+ * platform-first contract (never fabricate platform success), the audit log,
+ * the circuit-breaker bump, and reject idempotency. This cron only decides
+ * WHICH orders are stale and hands each to that method.
+ */
+@Injectable()
+export class DeliveryApprovalTimeoutScheduler {
+  private readonly logger = new Logger(DeliveryApprovalTimeoutScheduler.name);
+  // Same-pod overlap guard: the advisory lock coordinates across replicas but
+  // doesn't help if a single pod's tick overruns the 60s interval.
+  private isRunning = false;
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly moderation: DeliveryModerationService,
+  ) {}
+
+  @Interval(60_000) // every minute
+  async rejectStaleApprovals(): Promise<void> {
+    const minutes = this.thresholdMinutes();
+    if (minutes <= 0) {
+      // Escape hatch: DELIVERY_APPROVAL_TIMEOUT_MINUTES=0 disables auto-reject
+      // (e.g. a tenant that insists on manual-only moderation). Bail before we
+      // even touch the DB / advisory lock.
+      return;
+    }
+    if (this.isRunning) {
+      this.logger.debug(
+        "Previous approval-timeout tick still running, skipping",
+      );
+      return;
+    }
+    this.isRunning = true;
+    try {
+      await withAdvisoryLock(
+        this.prisma,
+        "delivery-approval-timeout",
+        () => this.runOnce(minutes),
+        this.logger,
+      );
+    } finally {
+      this.isRunning = false;
+    }
+  }
+
+  private async runOnce(minutes: number): Promise<void> {
+    const cutoff = new Date(Date.now() - minutes * 60_000);
+    const stale = await this.prisma.order.findMany({
+      where: {
+        status: OrderStatus.PENDING_APPROVAL,
+        requiresApproval: true,
+        // Delivery-platform orders only — a restaurant's own PENDING_APPROVAL
+        // (source null) is never auto-rejected by this cron.
+        source: { not: null },
+        externalOrderId: { not: null },
+        createdAt: { lt: cutoff },
+      },
+      select: { id: true, tenantId: true, source: true, createdAt: true },
+      take: MAX_PER_TICK,
+      orderBy: { createdAt: "asc" }, // oldest ghosts first
+    });
+    if (stale.length === 0) return;
+
+    const reason = `Sipariş ${minutes} dakika içinde onaylanmadı — otomatik iptal edildi`;
+    let rejected = 0;
+    for (const order of stale) {
+      try {
+        // Race guard: an operator may have Accepted this order (→ PENDING,
+        // requiresApproval=false) between the findMany snapshot above and now.
+        // rejectOrder would still reject a PENDING order, so re-read and skip
+        // anything no longer sitting in PENDING_APPROVAL. (A sub-millisecond
+        // TOCTOU vs rejectOrder's own re-resolve remains, but at a 15-minute
+        // horizon with 60s ticks it's negligible.)
+        const fresh = await this.prisma.order.findUnique({
+          where: { id: order.id },
+          select: { status: true },
+        });
+        if (!fresh || fresh.status !== OrderStatus.PENDING_APPROVAL) {
+          continue;
+        }
+
+        await this.moderation.rejectOrder(order.tenantId, order.id, reason);
+        rejected += 1;
+      } catch (error: any) {
+        // One platform/HTTP failure must not block the rest of the backlog.
+        // moderation.rejectOrder has already logged the failure and bumped the
+        // circuit breaker; we just move on to the next stale order.
+        this.logger.warn(
+          `Auto-reject failed for ${order.source} order ${order.id} (tenant ${order.tenantId}): ${error?.message ?? error}`,
+        );
+      }
+    }
+
+    if (rejected > 0) {
+      this.logger.log(
+        `Auto-rejected ${rejected}/${stale.length} delivery order(s) unapproved for >${minutes} min`,
+      );
+    }
+  }
+
+  /**
+   * Resolve the timeout window from the environment, defaulting to
+   * DEFAULT_APPROVAL_TIMEOUT_MINUTES. A missing, empty, non-numeric, or
+   * negative value falls back to the default; 0 is honoured as "disabled".
+   * Read per-tick so an ops change takes effect without a restart.
+   */
+  private thresholdMinutes(): number {
+    const raw = process.env.DELIVERY_APPROVAL_TIMEOUT_MINUTES;
+    if (raw === undefined || raw.trim() === "") {
+      return DEFAULT_APPROVAL_TIMEOUT_MINUTES;
+    }
+    const n = Number(raw);
+    if (!Number.isFinite(n) || n < 0) {
+      return DEFAULT_APPROVAL_TIMEOUT_MINUTES;
+    }
+    return Math.floor(n);
+  }
+}

--- a/backend/src/modules/delivery-platforms/services/delivery-order.service.spec.ts
+++ b/backend/src/modules/delivery-platforms/services/delivery-order.service.spec.ts
@@ -29,6 +29,7 @@ describe('DeliveryOrderService (iter-39)', () => {
     logService = {
       log: jest.fn().mockResolvedValue(undefined),
       scrubPii: jest.fn((x: any) => x),
+      markRetrySuccess: jest.fn().mockResolvedValue(undefined),
     };
     authService = { ensureValidToken: jest.fn() };
     configService = { recordError: jest.fn().mockResolvedValue({}) };
@@ -190,6 +191,119 @@ describe('DeliveryOrderService (iter-39)', () => {
 
     expect(adapterMock.acceptOrder).not.toHaveBeenCalled();
     expect(configService.recordError).not.toHaveBeenCalled();
+  });
+
+  // ── Auto-accept ack-first inline budget ─────────────────────────────────
+  // The outbound accept must NOT hold the webhook 200 past the platform's ack
+  // window. It runs inline with a short budget; over budget it is deferred to
+  // the RetryScheduler (which re-dispatches the identical acceptOrder), and the
+  // still-running attempt is reconciled so the scheduler never double-accepts.
+  describe('auto-accept ack-first inline budget', () => {
+    const BUDGET_ENV = 'DELIVERY_AUTOACCEPT_INLINE_BUDGET_MS';
+    afterEach(() => {
+      delete process.env[BUDGET_ENV];
+    });
+
+    function wireAutoAccept(acceptImpl: () => Promise<void>) {
+      (prisma.deliveryPlatformConfig.findUnique as any).mockResolvedValue({
+        id: 'cfg-1',
+        isEnabled: true,
+        autoAccept: true,
+      });
+      (prisma.branch.findFirst as any).mockResolvedValue({ id: 'br-1' });
+      (prisma.$transaction as any).mockImplementation(async (cb: any) =>
+        cb({
+          order: {
+            findFirst: jest.fn().mockResolvedValue(null),
+            create: jest
+              .fn()
+              .mockResolvedValue({ id: 'ord-1', tenantId: 't1', branchId: 'br-1' }),
+          },
+          menuItemMapping: { findMany: jest.fn().mockResolvedValue([]) },
+          deliveryPlatformConfig: { findUnique: jest.fn() },
+        }),
+      );
+      authService.ensureValidToken.mockResolvedValue({ id: 'cfg-1' });
+      adapterFactory.getAdapter.mockReturnValue({
+        acceptOrder: jest.fn(acceptImpl),
+      });
+    }
+
+    const deferredLog = () =>
+      (logService.log as jest.Mock).mock.calls.find(
+        ([e]: any[]) =>
+          e.success === false &&
+          typeof e.error === 'string' &&
+          e.error.includes('deferred'),
+      );
+
+    it('defers to the RetryScheduler when the accept exceeds the inline budget', async () => {
+      process.env[BUDGET_ENV] = '5';
+      // Accept takes far longer than the 5ms budget.
+      wireAutoAccept(() => new Promise<void>((res) => setTimeout(res, 120)));
+      (logService.log as jest.Mock).mockResolvedValue({ id: 'log-defer' });
+
+      await svc.processIncomingOrder('t1', normalizedOrder);
+
+      const call = deferredLog();
+      expect(call).toBeTruthy();
+      expect(call[0].nextRetryAt).toBeInstanceOf(Date);
+      // Ack-first: the order still reaches KDS immediately, not gated on accept.
+      expect(kdsGateway.emitNewOrder).toHaveBeenCalled();
+    });
+
+    it('reconciles a LATE-successful deferred accept so the scheduler will not double-accept', async () => {
+      process.env[BUDGET_ENV] = '5';
+      let resolveAccept!: () => void;
+      wireAutoAccept(
+        () => new Promise<void>((res) => (resolveAccept = () => res())),
+      );
+      (logService.log as jest.Mock).mockResolvedValue({ id: 'log-defer' });
+
+      await svc.processIncomingOrder('t1', normalizedOrder);
+      expect(deferredLog()).toBeTruthy();
+      // Not reconciled yet — the accept is still in flight.
+      expect(logService.markRetrySuccess).not.toHaveBeenCalled();
+
+      resolveAccept();
+      await new Promise((r) => setTimeout(r, 15)); // let the continuation run
+
+      // The deferred ORDER_ACCEPTED row is marked done so the RetryScheduler
+      // skips it (no second platform accept).
+      expect(logService.markRetrySuccess).toHaveBeenCalledWith('log-defer');
+    });
+
+    it('trips the circuit breaker when a deferred accept LATER fails', async () => {
+      process.env[BUDGET_ENV] = '5';
+      let rejectAccept!: (e: any) => void;
+      wireAutoAccept(
+        () => new Promise<void>((_res, rej) => (rejectAccept = rej)),
+      );
+      (logService.log as jest.Mock).mockResolvedValue({ id: 'log-defer' });
+
+      await svc.processIncomingOrder('t1', normalizedOrder);
+      expect(configService.recordError).not.toHaveBeenCalled();
+
+      rejectAccept(new Error('platform 503'));
+      await new Promise((r) => setTimeout(r, 15));
+
+      expect(configService.recordError).toHaveBeenCalledWith(
+        'cfg-1',
+        expect.stringContaining('accept_order:'),
+      );
+    });
+
+    it('keeps the fast happy path inline (success, no defer) within budget', async () => {
+      // Default budget (no env) — an instant accept resolves inline: no
+      // deferred row, no markRetrySuccess, no recordError.
+      wireAutoAccept(() => Promise.resolve());
+
+      await svc.processIncomingOrder('t1', normalizedOrder);
+
+      expect(deferredLog()).toBeFalsy();
+      expect(logService.markRetrySuccess).not.toHaveBeenCalled();
+      expect(configService.recordError).not.toHaveBeenCalled();
+    });
   });
 
   // ── Auto-print kitchen ticket ───────────────────────────────────────────

--- a/backend/src/modules/delivery-platforms/services/delivery-order.service.ts
+++ b/backend/src/modules/delivery-platforms/services/delivery-order.service.ts
@@ -284,29 +284,92 @@ export class DeliveryOrderService {
       return null;
     }
 
-    // 5. If autoAccept, also accept on the platform side. Config +
-    // autoAccept were resolved once before the txn (iter-39) — same
-    // snapshot drove both `requiresApproval` and this branch.
+    // 5. If autoAccept, also accept on the platform side — but BOUNDED so a
+    // slow/degraded platform can't hold the webhook 200 past the platform's
+    // ack window (a blown ack triggers redelivery / marks the integration
+    // unhealthy). Config + autoAccept were resolved once before the txn
+    // (iter-39). The accept runs inline with a short budget; if it exceeds
+    // that we stop blocking the response and hand the accept to the
+    // RetryScheduler, which re-dispatches the identical adapter.acceptOrder
+    // from an ORDER_ACCEPTED log row. Ack-first: the platform's prompt 200
+    // matters more than confirming the accept synchronously.
     if (autoAccept && config) {
-      try {
-        const freshConfig = await this.authService.ensureValidToken(config.id);
-        if (freshConfig) {
+      const budgetMs = this.autoAcceptInlineBudgetMs();
+      const TIMEOUT = Symbol("ack-budget");
+
+      // Wrapped so it NEVER rejects: once we stop awaiting it (timeout branch)
+      // a late rejection would otherwise be an unhandled promise rejection.
+      const acceptPromise: Promise<
+        { kind: "ok" } | { kind: "error"; error: string } | { kind: "skip" }
+      > = (async () => {
+        try {
+          const freshConfig = await this.authService.ensureValidToken(
+            config.id,
+          );
+          if (!freshConfig) return { kind: "skip" as const };
           const adapter = this.adapterFactory.getAdapter(platform);
           await adapter.acceptOrder(freshConfig, externalOrderId);
-
-          await this.logService.log({
-            tenantId,
-            platform,
-            direction: PlatformLogDirection.OUTBOUND,
-            action: PlatformLogAction.ORDER_ACCEPTED,
-            orderId: createdOrder.id,
-            externalId: externalOrderId,
-            success: true,
-          });
+          return { kind: "ok" as const };
+        } catch (error: any) {
+          return {
+            kind: "error" as const,
+            error: error?.message ?? String(error),
+          };
         }
-      } catch (error: any) {
+      })();
+
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      const raced = await Promise.race([
+        acceptPromise,
+        new Promise<typeof TIMEOUT>((resolve) => {
+          timer = setTimeout(() => resolve(TIMEOUT), budgetMs);
+        }),
+      ]);
+      if (timer) clearTimeout(timer);
+
+      if (raced === TIMEOUT) {
+        // Over budget → defer. Enqueue an ORDER_ACCEPTED retry row the
+        // RetryScheduler drains on its next tick (nextRetryAt = now), then
+        // reconcile the still-running attempt: a late success marks the row
+        // done so the scheduler doesn't double-accept; a late failure trips
+        // the circuit breaker (same accounting the inline error path does).
+        const pending = await this.logService.log({
+          tenantId,
+          platform,
+          direction: PlatformLogDirection.OUTBOUND,
+          action: PlatformLogAction.ORDER_ACCEPTED,
+          orderId: createdOrder.id,
+          externalId: externalOrderId,
+          success: false,
+          error: "deferred: exceeded inline ack budget (ack-first)",
+          nextRetryAt: new Date(),
+        });
+        void acceptPromise
+          .then(async (result) => {
+            if (result.kind === "ok" && pending?.id) {
+              await this.logService
+                .markRetrySuccess(pending.id)
+                .catch(() => undefined);
+            } else if (result.kind === "error") {
+              await this.configService
+                .recordError(config.id, `accept_order: ${result.error}`)
+                .catch(() => undefined);
+            }
+          })
+          .catch(() => undefined);
+      } else if (raced.kind === "ok") {
+        await this.logService.log({
+          tenantId,
+          platform,
+          direction: PlatformLogDirection.OUTBOUND,
+          action: PlatformLogAction.ORDER_ACCEPTED,
+          orderId: createdOrder.id,
+          externalId: externalOrderId,
+          success: true,
+        });
+      } else if (raced.kind === "error") {
         this.logger.error(
-          `Failed to auto-accept order ${externalOrderId} on ${platform}: ${error.message}`,
+          `Failed to auto-accept order ${externalOrderId} on ${platform}: ${raced.error}`,
         );
         await this.logService.log({
           tenantId,
@@ -316,19 +379,21 @@ export class DeliveryOrderService {
           orderId: createdOrder.id,
           externalId: externalOrderId,
           success: false,
-          error: error.message,
+          error: raced.error,
           nextRetryAt: new Date(Date.now() + 30_000),
         });
 
-        // Circuit-breaker parity with iter-38 (menu/status sync). A
-        // platform whose acceptOrder endpoint is permanently broken
-        // (wrong API version, dropped credentials) would otherwise
-        // loop forever — every webhook bumps the retry queue but the
-        // config never auto-disables at CIRCUIT_BREAKER_THRESHOLD.
+        // Circuit-breaker parity with iter-38 (menu/status sync). A platform
+        // whose acceptOrder endpoint is permanently broken (wrong API version,
+        // dropped credentials) would otherwise loop forever — every webhook
+        // bumps the retry queue but the config never auto-disables at
+        // CIRCUIT_BREAKER_THRESHOLD.
         await this.configService
-          .recordError(config.id, `accept_order: ${error.message}`)
+          .recordError(config.id, `accept_order: ${raced.error}`)
           .catch((e) => this.logger.warn(`recordError failed: ${e.message}`));
       }
+      // raced.kind === "skip": no valid token this tick — do nothing (a later
+      // webhook/poll or the token-refresh cron reconciles), same as before.
     }
 
     // 6. Emit via KDS WebSocket
@@ -504,6 +569,22 @@ export class DeliveryOrderService {
       .join("\n");
 
     return { validItems, unmappedItems, totalsMismatch, orderNotes };
+  }
+
+  /**
+   * Inline budget (ms) the auto-accept outbound call may spend inside the
+   * webhook ack path before it is deferred to the RetryScheduler. Keeps the
+   * webhook 200 well within the platform's ack window even when the accept (or
+   * a token refresh it triggers) is slow. Env-overridable via
+   * DELIVERY_AUTOACCEPT_INLINE_BUDGET_MS (read per-call so an ops change takes
+   * effect without a restart); default 2500ms. A missing/garbage/non-positive
+   * value falls back to the default.
+   */
+  private autoAcceptInlineBudgetMs(): number {
+    const raw = process.env.DELIVERY_AUTOACCEPT_INLINE_BUDGET_MS;
+    const n = raw === undefined || raw.trim() === "" ? NaN : Number(raw);
+    if (!Number.isFinite(n) || n <= 0) return 2500;
+    return Math.floor(n);
   }
 
   /**

--- a/backend/src/modules/orders/services/payment-validator.service.spec.ts
+++ b/backend/src/modules/orders/services/payment-validator.service.spec.ts
@@ -84,6 +84,42 @@ describe("PaymentValidator", () => {
         }),
       ).toThrow("Order is already paid");
     });
+
+    // Marketplace/delivery-platform orders are settled BY the platform —
+    // they never create a Payment row (the platform owns the money rail).
+    // Taking a POS payment on one would double-charge the customer AND fire
+    // a SECOND fiscal document (e-Arşiv + ÖKC) on top of the platform's own.
+    // Guard on `source` (the marketplace), NOT `type`: a restaurant's OWN
+    // delivery (type=DELIVERY, source=null) is still POS-payable at the door.
+    it("rejects a marketplace order (source set — settled by the platform)", () => {
+      expect(() =>
+        v.assertOrderPayable({
+          status: OrderStatus.SERVED,
+          requiresApproval: false,
+          source: "YEMEKSEPETI",
+        }),
+      ).toThrow("settled by the platform");
+    });
+
+    it("throws BadRequestException (type) for a marketplace order", () => {
+      expect(() =>
+        v.assertOrderPayable({
+          status: OrderStatus.SERVED,
+          requiresApproval: false,
+          source: "TRENDYOL",
+        }),
+      ).toThrow(BadRequestException);
+    });
+
+    it("does NOT block an internal/POS order (source null)", () => {
+      expect(() =>
+        v.assertOrderPayable({
+          status: OrderStatus.SERVED,
+          requiresApproval: false,
+          source: null,
+        }),
+      ).not.toThrow();
+    });
   });
 
   describe("validateSplitTotal", () => {

--- a/backend/src/modules/orders/services/payment-validator.service.ts
+++ b/backend/src/modules/orders/services/payment-validator.service.ts
@@ -34,6 +34,7 @@ export class PaymentValidator {
    * order is confirmed to exist, BEFORE any payment row is written or
    * the self-pay intent is consulted. Throws the exact BadRequestException
    * messages the inline code threw, in the same order:
+   *   0. marketplace `source` set (settled by the platform — never POS-payable)
    *   1. already PAID
    *   2. CANCELLED
    *   3. requiresApproval && PENDING_APPROVAL
@@ -41,7 +42,22 @@ export class PaymentValidator {
   assertOrderPayable(order: {
     status: string;
     requiresApproval: boolean;
+    source?: string | null;
   }): void {
+    // Marketplace/delivery-platform orders are settled BY the platform: they
+    // never create a Payment row (the platform owns the money rail — see
+    // delivery-order.service). Taking a POS payment on one would double-charge
+    // the customer AND fire a SECOND fiscal document (e-Arşiv/e-Fatura + ÖKC
+    // receipt) on top of the platform's own. Gate on `source` (the marketplace:
+    // YEMEKSEPETI/GETIR/TRENDYOL/MIGROS), NOT `type` — a restaurant's OWN
+    // delivery (type=DELIVERY, source=null) is still POS-payable at the door.
+    // Checked FIRST so the marketplace message surfaces regardless of status.
+    if (order.source != null && order.source.trim() !== "") {
+      throw new BadRequestException(
+        "This is a marketplace/delivery-platform order — it is settled by the platform and cannot be paid through the POS.",
+      );
+    }
+
     // Check if order is already paid (inside transaction to prevent race condition)
     if (order.status === OrderStatus.PAID) {
       throw new BadRequestException("Order is already paid");


### PR DESCRIPTION
Pre-launch hardening for the delivery-platforms flow, mapped from a live trace + an adversarially-verified 6-area gap audit of how marketplace orders (Yemeksepeti/Getir/Trendyol/Migros) move through the system. All fixes are self-contained, TDD'd, and green on current `main`.

## 1. Block POS payment on marketplace/delivery orders (`465b65a1`)
Delivery orders are settled **by the platform** — they never create a Payment row. Nothing stopped a POS payment on one, which would **double-charge the customer AND fire a second fiscal document**. `PaymentValidator.assertOrderPayable` now refuses `source`-set orders (checked first). Gated on `source`, not `type` — a restaurant's OWN delivery stays POS-payable.

## 2. Auto-reject stale PENDING_APPROVAL orders (`3164443f`)
An unapproved order is a **ghost order** (customer waits forever, platform can't settle). New `DeliveryApprovalTimeoutScheduler` — a 1-min cron that auto-**rejects** delivery orders past `DELIVERY_APPROVAL_TIMEOUT_MINUTES` (default 15, per-tick, 0 disables). Reuses `rejectOrder` (platform-first push + audit + idempotency); race guard re-reads status before rejecting; advisory lock + `isRunning`; bounded 100/tick.

## 3. Refuse KDS invoice on marketplace/delivery orders (`6740374e`)
`SalesInvoiceService.createFromOrder` loaded the order with **no `source` filter** → a marketplace order manually flipped to PAID + passed to the manual invoice path could cut a KDS e-belge **on top of** the platform's own — a duplicate fiscalization. Same guard as #1 on the sibling manual path. Own-delivery (incl. its "Teslimat / Diğer" reconcile row) unaffected.

## 4. Bound the auto-accept in the webhook ack path — ack-first (`537a75f9`)
`processIncomingOrder` awaited `adapter.acceptOrder` **inline before the webhook 200**, so a slow platform (10s HTTP timeout + retries + possible token refresh) could hold the response tens of seconds past the platform's ack window → redelivery / unhealthy flag. Now bounded by `DELIVERY_AUTOACCEPT_INLINE_BUDGET_MS` (default 2500ms): within budget behaves exactly as before; over budget it stops blocking the 200 and enqueues an `ORDER_ACCEPTED` row the existing RetryScheduler drains. The still-running attempt is reconciled — late success marks the row done (no double-accept), late failure trips the breaker. Same real `acceptOrder`, just deferred — no fabricated call.

## Testing
TDD throughout: 3 payment-validator + 8 scheduler + 2 sales-invoice + 4 ack-first tests. Green on current `main`: delivery-platforms **306/306**, sales-invoice **28/28**, payment-validator. `tsc --noEmit` clean.

## Verified-but-deferred (out of scope — blocked on external inputs, per the gap audit)
Not honestly code-completable now (each would need a fabricated platform API/field or a business decision the codebase's honesty contract forbids):
- **prep-time → platform**: no verified per-platform ETA request field exists anywhere in code/docs.
- **sandbox hosts + `TODO(trendyol-binding)`**: need each provider's non-public sandbox host / a captured prod webhook body.
- **Getir/Migros refund/amendment**: need the real poll-order-updates endpoint shapes (only pollNewOrders exists).
- **e-belge komisyon side**: a TR-tax decision (must the restaurant self-issue on marketplace commission/share revenue?).

