### PR TITLE
docs(marketing): consolidate market-expansion research under docs/marketing

### DIFF
--- a/docs/marketing/MARKET_EXPANSION_SCAN.md
+++ b/docs/marketing/MARKET_EXPANSION_SCAN.md
@@ -1,0 +1,181 @@
+# Next-Market Scan — "Fresh Fiscal Mandate = Forced Buying Event"
+
+> **Purpose.** Companion to `UZ_EXPANSION_BENCHMARK.md`. Answers: *which other countries look like
+> Uzbekistan* — a recent/imminent fiscal-receipt or e-invoice mandate that forces every restaurant to
+> buy compliant POS/fiscal software — **and** are cheap for us to reach by reusing our TR/EN/RU/AR/UZ
+> locales and the Uzbekistan CIS-style fiscal/payment build. 14 countries were researched in parallel
+> and each country's core mandate-recency fact was **adversarially verified** (2024–2026 primary
+> sources). Confidence + sources are in the run journal; key corrections are in §7.
+
+| Field | Value |
+|---|---|
+| Status | **DRAFT — strategy input** |
+| Created | 2026-07-15 |
+| Scored on | `mandate_freshness` × `UZ-code-reuse` (heaviest), + market + reachability, each 0–5 (total /20) |
+
+---
+
+## 1. The thesis — and the refinement verification forced
+
+**Your instinct is correct.** A newly-introduced fiscal-receipt / online-cash-register / e-invoice
+mandate is a **forced buying event**: by the compliance deadline *every* restaurant must acquire
+compliant POS/fiscal software, and the market is not yet saturated. That is exactly Uzbekistan's
+profile (fiscalization 2019–2020, UzQR 2026).
+
+**The refinement** (the reason this needed verification, not memory): most CIS and Balkan countries
+**already fiscalized in 2019–2022**, so their greenfield window has *closed* — they are now
+compliance-*refresh* markets (a displacement play against installed incumbents), not land-grabs. The
+truly *fresh* restaurant-forcing mandates are fewer than the headlines suggest, and — critically —
+**the freshest mandates and the highest UZ-code-reuse markets are mostly disjoint quadrants.** Only
+one country lands in both.
+
+```
+                 UZ CODE-REUSE  (CIS-OFD fiscalization + RU locale + wallet-QR)
+                 low ───────────────────────────────────────────────▶ high
+   fresh  ▲   Egypt ● (e-Receipt, huge, AR)          ◀── Kyrgyzstan ★ (both!)
+  MANDATE │   Jordan ● (JoFotara, AR/Turkey-UBL)
+ FRESHNESS│   Croatia ○ (EU refresh)                     Tajikistan ○ (weak enforce)
+          │   UAE ○ (B2C excluded)
+   stale  ▼   Saudi ○ (window closed) · Romania ○         Kazakhstan ◆ (2026 refresh, big)
+              Serbia ○ · Albania ○ · Armenia ○            Azerbaijan ◆ (mature, TR≈Azeri)
+              Georgia ✗ (captured monopoly)
+```
+
+---
+
+## 2. Recommendation — a barbell, with a clear first move
+
+**Best next pick after Uzbekistan → Kyrgyzstan.** It is the *only* target that maxes **both** heavy
+axes: `code_reuse 5` (essentially a locale+endpoint swap on the UZ build — same CIS/OFD online
+fiscalization, same state-endorsed **virtual/software cash-register** a cloud POS can register as, same
+state e-invoice pattern `esf.salyk.kg`, RU-locale drop-in, and **ELQR/MBANK/O!Dengi** wallets that
+mirror Payme/Click) **and** a live, verified, restaurant-specific forcing motion (the STS/ГНС 2024–2026
+enforcement campaign declaring the fiscal ККМ receipt the *only* valid document in cafés/restaurants;
+canteens de-exempted 14 Sep 2024; 2025 tax reform + a fresh Cabinet draft tightening ККМ). Its only
+knock — small market — is exactly why it's the right *first* step: it de-risks and validates the CIS
+expansion engine at the **lowest possible engineering cost** before committing the warm codebase to a
+bigger market.
+
+**Suggested sequence:**
+
+1. **Kyrgyzstan** — cheapest second deployment (~70–80% of the UZ build reused); proves the CIS playbook against a live restaurant-targeted enforcement campaign.
+2. **Kazakhstan** — same code family (engine still warm); the largest high-reuse market, entered on the **2026 switching window** (National Catalog/НКТ + NTIN receipt fields to small business by 1 Jul 2026; ESF expansion Jan 2026) as a **displacement** play, not a first-time buy.
+3. **Egypt** — pivot to MENA on the *freshest genuinely-forcing* mandate (penalty-backed B2C **e-Receipt** waves rolling through 2026); the UZ online-fiscalization module's `queue→sign→POST→QR` shape ports (new ETA adapter), and **AR locale already ships**.
+4. **Jordan** — extend the MENA beachhead cheaply: fresh **JoFotara** mandate (mandatory since 1 Apr 2025, no sector exemption); **AR+EN reuse**, and JoFotara's **UBL 2.1 reuses the Turkey/Nilvera UBL builder** we already wrote.
+
+**Why a barbell:** prosecute the **CIS-OFD family first (KG → KZ)** to amortize the UZ engine at near-
+zero marginal cost, **then cross into MENA (Egypt, Jordan)** where mandate-freshness is highest but
+reuse drops from "drop-in" to "same pattern, new adapter" and leans on the **AR locale + Turkey UBL
+builder** rather than the UZ CIS code.
+
+**Do not chase raw market size:** Saudi (market 5) and UAE (market 5) both **fail the forcing test at
+the restaurant-POS layer** — Saudi's window has closed; UAE explicitly **excludes B2C**.
+
+---
+
+## 3. Comparison table (all 14, ranked by fit total)
+
+| Country | Region | Fiscal-receipt mandate (system · since) | Restaurants? | Virtual reg.? | E-invoice (since) | Fresh forcing? | UZ reuse | Fit /20 | Tier |
+|---|---|---|---|---|---|---|---|---|---|
+| **Kyrgyzstan** | C. Asia | Online-ККМ (STS/Salyk) · Res.#193 **2022**, enforcement 2024–25 | yes | **yes** | ЭСФ `esf.salyk.kg` (live 2025) | **moderate ✓ live** | **5** | **15** | **1** |
+| **Egypt** | MENA | ETA **e-Receipt (B2C)** · waves **2023→2026** | yes | yes | ETA e-Invoice (2023) | **strong ✓ fresh** | 3 | 14 | 2 |
+| **Kazakhstan** | C. Asia | Online-KKM + ОФД · **2020**; NTIN/НКТ **Jul 2026** | yes | yes | IS ESF (2019; exp. 2026) | weak–mod (2026 refresh) | 4 | 13 | **1** |
+| **Jordan** | MENA | **JoFotara** (receipt-level) · mand. **1 Apr 2025** | yes | yes | JoFotara (2023→2025) | **strong ✓ fresh** | 2 | 13 | 2 |
+| UAE | MENA | **None** (no fiscal-device mandate) | no | no | e-Billing pilot Jul 2026 → **2027** | weak (B2C **excluded**) | 2 | 12 | 2 |
+| Azerbaijan | Turkic | NKA online + E-Kassa · **2019–21** | yes | yes | e-qaimə (2017) | weak (mature) | 3 | 11 | 2 |
+| Tajikistan | C. Asia | Online-KKM + virtual cashier · **~2022** | partial | yes | none confirmed | weak (soft enforce) | 4 | 11 | 2(watch) |
+| Saudi Arabia | MENA | ZATCA Fatoora Ph.2 · Wave 24 **30 Jun 2026** | yes | yes | Fatoora UBL 2.1 (2023) | weak (**closing**) | 2 | 11 | 3 |
+| Croatia | EU | Fiscalization 2.0 · **1 Jan 2026** (base 2013) | yes | yes | EN 16931 (Jan 2026) | moderate (refresh) | 3 | 11 | 3 |
+| Georgia | Caucasus | Control cash registers · ~2010; **reform 1 Jan 2027** | yes | — | rs.ge e-invoice (~2011) | fresh but **captured** | 2 | 10 | **avoid** |
+| Serbia | Balkans | SUF fiscalization · **1 May 2022** | yes | yes | SEF (B2B 2023) | weak (absorbed) | 3 | 10 | 3 |
+| Romania | EU | Hardware AMEF + ANAF · 2021; **QR 2026** | yes | no | e-Factura B2C **Jan 2025** (dine-in <€100 **exempt**) | weak–mod | 1 | 10 | 3 |
+| Armenia | Caucasus | HDM · mature; VCR **optional** (Art.380.1) | yes | yes(opt) | SRC e-invoice (2016) | weak (no window) | 3 | 9 | 3 |
+| Albania | Balkans | Fiscalization (Law 87/2019) · **B2C Sep 2021** | yes | yes | Central Invoice Platform (2021) | weak (window passed) | 2 | 8 | 3 |
+
+---
+
+## 4. Tier 1 — go soon
+
+- **Kyrgyzstan** — the decisive pick (see §2). Near-identical to the UZ build; live restaurant-targeted
+  enforcement; small market is a *feature* for a first, cheap validation. New work: ГНС/Salyk +
+  `esf.salyk.kg` endpoints, ELQR wallet adapter, KGS formatting, optional Kyrgyz locale.
+- **Kazakhstan** — the biggest high-reuse prize; enter right after KG while the code is warm. Freshness
+  is the weak spot (fiscalized 2019–20), but the **2026 refresh** (НКТ/NTIN + ESF expansion) opens a
+  switching window to ride against incumbents (Webkassa/reKassa/iiko/rKeeper). New work: **Kaspi/Halyk**
+  wallet adapters, IS ESF XML + СНТ, НКТ/NTIN receipt fields, Kazakh locale.
+
+## 5. Tier 2 — watch / opportunistic
+
+- **Egypt** — freshest genuinely-forcing mandate + huge market; **AR ships**. Frictions: reachability
+  hard, and forcing is **list-by-list / district-by-district** (ETA taxpayer annexes), so GTM tracks
+  wave lists, not one cliff. Medium reuse (new ETA JSON/e-seal adapter; same fiscalization *shape*).
+- **Jordan** — fresh, hard, restaurant-covering; **AR+EN reuse** and **JoFotara UBL 2.1 reuses the
+  Turkey/Nilvera UBL builder**. Tier 2 (not 1) because the reuse is against the *Turkey e-Belge* asset,
+  not the UZ CIS build, and the sharpest first wave has passed — the live opportunity is the 2026
+  SME/small-F&B tail.
+- **Tajikistan** — maximum CIS-OFD reuse (single state FDO, virtual cashier, RU locale, Korti Milli/Alif
+  ≈ Payme/Click), but **weak enforcement / no crisp restaurant deadline**. Framework just re-issued
+  (Res. 638, Nov 2025); real catalyst = 1 Sep 2026 e-wallet/QR transaction tax. **Watch; enter if
+  enforcement sharpens.**
+- **Azerbaijan** — **best locale fit on the board** (TR ≈ Azerbaijani + RU + EN) and same architectural
+  pattern, but the mandate is **mature/absorbed** (freshness 1). A relationship/affinity market to seed
+  opportunistically, not a mandate-driven push.
+- **UAE** — large + fresh e-invoicing rollout, **but B2C is explicitly excluded (Decision 244)** and
+  there is **no fiscal cash-register mandate** — a restaurant's consumer POS faces no forcing event.
+  **Monitor only** for a future B2C phase; AR/EN/RU make it cheap to activate if one is announced.
+
+## 6. Tier 3 / avoid
+
+- **Saudi Arabia** — biggest market + maximally-forcing, restaurant-covering mandate, **but the window
+  has essentially closed** (Wave 24 threshold SAR 375k = the VAT-registration floor, deadline 30 Jun
+  2026, no Wave 25; incumbents captured the spike). Low UZ reuse. Only a residual sub-375k tail.
+- **Croatia** — Fiscalization 2.0 is real and imminent (1 Jan 2026), but restaurants have fiscalized
+  since **2013** (~100% penetration) — a refresh, forced spend flows to e-invoicing intermediaries;
+  zero locale/currency reuse (FINA certs, OIB, EUR). Not worth the EU-cert + new-locale lift.
+- **Serbia / Romania / Albania / Armenia** — genuine mandates but **windows already fired** (Serbia
+  2022, Albania 2021, Armenia's "fresh" VCR is *optional*, Romania's dine-in **<€100 is exempt** and
+  the backbone is pre-existing hardware). Low reuse + net-new locale/currency. Disconfirm the thesis.
+- **Georgia — AVOID despite a fresh mandate.** A real imminent forcing event exists (universal
+  register live 1 Jan 2027, old devices dead 1 May 2028, restaurants in scope) — **but supply and
+  servicing of the registers is centralized under a single government-appointed vendor**. The
+  forced-buying window is a **state monopoly a foreign POS SaaS cannot sell into.** Unreachable at the
+  point of forcing.
+
+## 7. What verification changed (honesty log)
+
+- **Georgia** — freshness *up* (real 2027 reform) but **reachability collapses** (captured monopoly).
+- **UAE** — fresh e-invoicing **excludes B2C**; no fiscal-register mandate → no restaurant forcing.
+- **Romania** — dine-in **<€100 exempt** from e-Factura; fiscal backbone is pre-existing hardware.
+- **Armenia** — the "fresh" Virtual Cash Register is **optional** (Art. 380.1), not a mandate.
+- **Saudi** — maximally forcing but **window closed** (Wave 24 passed, no Wave 25).
+- **Kazakhstan** — the fresh 2026 item (NTIN/National Catalog) is goods-**marking** for traded retail
+  products; its bite on a restaurant's prepared-meal lines is **narrower** than a restaurant-specific
+  forcing event — don't overstate it.
+- **Egypt** — "real-time" overstated (up-to-24h transmission); the "50k fine" is unconfirmed; forcing
+  is incremental list-by-list, not one all-restaurants deadline.
+- **Tajikistan** — mechanism confirmed but cited Res. 432 was superseded by **Res. 638 (Nov 2025)**;
+  enforcement weak, catalyst (1 Sep 2026 QR tax) still a pilot.
+
+## 8. Engineering reuse note
+
+- **CIS-OFD family (KG, KZ, TJ, and UZ):** ~70–80% of the Uzbekistan build ports — the OFD/virtual-
+  register fiscalization *shape*, RU locale, wallet-QR adapter pattern, XML e-invoice module. New work
+  per country = tax-authority endpoints + local wallet adapters + receipt-catalog fields + local
+  currency/locale. **This is the cheap lane — prosecute it first.**
+- **MENA (Egypt, Jordan, Saudi, UAE):** the UZ *CIS code* does **not** drop in, but (a) the **AR locale
+  ships**, and (b) UBL-based clearance systems (JoFotara, ZATCA, UAE PINT) **reuse the Turkey/Nilvera
+  shared UBL builder**, and (c) the fiscalization *pipeline shape* (queue → sign → POST → store fiscal
+  id/QR → offline buffer) is the same abstraction. Medium reuse, higher market freshness.
+- **Carry-over lesson from the UZ program:** every new-country fiscal adapter is a **cross-language
+  contract** (receipt schema, signing, wallet callback) — verify both sides against the *live*
+  tax-authority sandbox, and ship **INERT until credentials are set**, exactly like the Nilvera/UZ
+  adapters. Treat the virtual/software-register regime (what a cloud POS legally targets) as
+  still-maturing in KG/TJ → gate go-live behind a real per-country sandbox e2e.
+
+## 9. Method & sources
+
+14 country agents (EN/RU/AR + local-language search of tax-authority portals, Big-4 / VATupdate /
+EDICOM country guides, reputable local news), each adversarially fact-checked on its core
+mandate-recency claim, then a portfolio strategist ranked the two thesis-heavy axes. Full per-country
+sources + verification verdicts are in the workflow journal. Items in §7 are the corrections that
+survived verification — treat them as the load-bearing caveats.

--- a/docs/marketing/README.md
+++ b/docs/marketing/README.md
@@ -1,0 +1,50 @@
+# Pazar Araştırmaları — Genişleme & Rekabet
+
+Bu klasör, **yeni pazarlara açılma** (market expansion) ve **rekabet** analizi araştırmalarını tek yerde
+toplar. Her benchmark, paralel **çok-ajanlı web araştırması + iddia-iddia çürütücü doğrulama** ile
+üretildi; kaynaklar ve güven-seviyeleri her belgenin içinde satır satır işaretlidir. İleride incelemek
+ve genişletmek için buradadır — kaybolmasın.
+
+> Not: Ülke benchmark'ları **İngilizce** yazıldı (Türk geliştirme ekibi + yerel ülke-partneri ortak dili);
+> bu index ve rakip-parite envanteri Türkçe. Durumlar plandır — **hiçbiri kod değildir**, uygulama
+> kullanıcı onayına bağlıdır.
+
+## İçindekiler
+
+| Belge | Konu | Durum | Dil |
+|---|---|---|---|
+| [MARKET_EXPANSION_SCAN.md](./MARKET_EXPANSION_SCAN.md) | **14 ülke** "taze fiskal-fiş zorunluluğu = zorunlu satın alma anı" taraması; puanlı/tier'li sıralama; **Kırgızistan = UZ'den sonra en iyi ilk hamle**; barbell strateji (KG→KZ→Mısır→Ürdün) | 📋 Strateji girdisi | EN |
+| [uzbekistan/UZ_EXPANSION_BENCHMARK.md](./uzbekistan/UZ_EXPANSION_BENCHMARK.md) | **Özbekistan** tam-sistem entegrasyon benchmark'ı: fiskalizasyon (OFD/UzQR), yerel ödeme (Payme/Click/Uzum), e-fatura (ЭСФ), veri-yerelleştirme, UZS/dil; dosya-seviyesi kod haritası + scorecard | 📋 DRAFT (review bekliyor) | EN |
+| [kyrgyzstan/KG_EXPANSION_BENCHMARK.md](./kyrgyzstan/KG_EXPANSION_BENCHMARK.md) | **Kırgızistan** benchmark'ı (**UZ'den delta**): ФПО (POS=fiskal yazılım), çift vergi НДС+НсП, ELQR tek-QR, ЭСФ bearer-token, veri-yerelleştirme YOK, Kırgızca-Kiril locale; reuse haritası + scorecard | 📋 DRAFT (review bekliyor) | EN |
+| [adisyo-parity-inventory.md](./adisyo-parity-inventory.md) | **adisyo** rakip-paritesi: tüm sayfa/modül taksonomisi + HummyTummy'nin gerçekten sunabildiği her şeyin durumu | 📋 Envanter | TR |
+
+## Kilit stratejik sonuç (tarama özeti)
+
+Tez doğru: **yeni çıkan bir fiş/fiskalizasyon zorunluluğu = "zorunlu satın alma anı"**. Ama doğrulama
+gösterdi ki çoğu CIS/Balkan penceresi 2019–2022'de **kapandı** (refresh pazarı). *Taze-mandate × UZ-kod-
+tekrarı* ekseninde **sadece Kırgızistan iki kadranda birden**. Önerilen sıra (barbell):
+
+1. **Kırgızistan** — en ucuz ikinci deployment (~%70-80 UZ kod-tekrarı), canlı ГНС restoran-icra motoru
+2. **Kazakistan** — aynı kod ailesi, 2026 refresh penceresi, en büyük yüksek-tekrar pazar
+3. **Mısır** — en taze zorunlu B2C e-fiş, AR locale hazır (orta tekrar)
+4. **Ürdün** — JoFotara 2025-04 zorunlu, AR+EN + Türkiye/Nilvera UBL builder tekrarı
+
+**Kaçın/dikkat:** Gürcistan (2027 taze ama tek-devlet-tedarikçi tekeli), Suudi (pencere kapandı), BAE
+(B2C hariç, fiş-mandate yok), Romanya (dine-in <€100 muaf). Detay için `MARKET_EXPANSION_SCAN.md`.
+
+## Durum lejantı & açık kalemler
+
+- 📋 = plan/araştırma (kod yok). Uygulama kullanıcı onayına bağlı.
+- **UZ benchmark:** kararlar kilitli (ayrı ülke-içi region + yerel partner/reseller + full-parity MVP).
+- **KG benchmark:** fiscal/ödeme/hukuk boyutlarının çürütücü-doğrulama pass'i session-limit'te kesildi →
+  belgede **⚠** ile işaretli; go-live öncesi yeniden doğrulanmalı.
+- Sıradaki mantıklı adım: **Kazakistan benchmark'ı** (barbell #2) veya KG'nin en zor parçası **НсП çift-
+  vergi rayı** için implementasyon planı.
+
+## Yöntem
+
+Belgeler; fiskalizasyon/ödeme/e-fatura/hukuk/currency/pazar boyutlarında paralel araştırma ajanları
+(EN/RU/UZ/KY/AR birincil kaynaklar: tax-authority portalları, sağlayıcı geliştirici dokümanları, Big-4/
+VATupdate ülke kılavuzları, yerel medya) + yüksek-riskli iddiaların çürütücü doğrulaması ile üretildi.
+Ham bulgular ve kaynak URL'leri belgelerin gövdesindeki tablolarda; güven-seviyeleri (high/medium/low)
+satır bazında işaretli.

--- a/docs/marketing/kyrgyzstan/KG_EXPANSION_BENCHMARK.md
+++ b/docs/marketing/kyrgyzstan/KG_EXPANSION_BENCHMARK.md
@@ -1,0 +1,283 @@
+# Kyrgyzstan Expansion — Full-System Integration Benchmark (delta from Uzbekistan)
+
+> **Purpose.** The single source of truth + scorecard for launching the KDS restaurant POS/KDS platform
+> in **Kyrgyzstan**, the recommended *first market after Uzbekistan* (see `MARKET_EXPANSION_SCAN.md`).
+> Written as a **delta from the Uzbekistan build** (`../uzbekistan/UZ_EXPANSION_BENCHMARK.md`): the
+> architecture, adapter/registry seams, and `Tenant.region` policy layer are shared; this doc records
+> what **carries over** vs what is **new/different** for KG. Grounded in 7 parallel research agents
+> (RU/KY/EN primary sources) with adversarial fact-verification.
+>
+> **Verification status (honest):** the e-invoice, delivery/SMS, currency/i18n and market/competition
+> dimensions completed their adversarial-verify pass. The **fiscal/tax, payments, and legal/residency**
+> verify pass was cut short by a session limit — their findings are high-confidence and primary-sourced
+> but marked **⚠ verify** where a claim is load-bearing. Re-run the verify pass before go-live.
+
+| Field | Value |
+|---|---|
+| Status | **DRAFT — awaiting review** |
+| Created | 2026-07-15 |
+| Sequence | Market **#2** after Uzbekistan (highest UZ-code-reuse × live restaurant-forcing motion) |
+| Deployment | **No separate in-country region required** — KG has **no data-localization law** (see WS4); KG tenants can run on the existing multi-tenant stack via the `region` seam. *Simpler than UZ.* |
+| Legal model | Local partner **ОсОО** (LLC) reseller; **ФПО-operator** route is the strategic fiscal gate |
+| Codebase baseline | prod v3.2.125 · shared adapter/registry architecture; `Tenant.region` seam introduced by the UZ program |
+
+---
+
+## 1. Executive summary — the deltas that matter
+
+Kyrgyzstan is the **cheapest possible second deployment** (~70–80% of the UZ build reuses) *and* has a
+**live, restaurant-specific forcing motion**. But it is not a copy of Uzbekistan — seven differences
+drive the plan:
+
+1. **ФПО = your POS *becomes* the fiscal channel (blocker AND entry door).** Under the ФПО pilot
+   (Cabinet order №767-т of 08.09.2025 + ГНС order №510 of 11.09.2025), restaurants/bars **>100 m²** in
+   Bishkek/Osh/Jalal-Abad **must run "fiscal software"** — the POS/accounting system itself —
+   integrated with a **state-issued smart-card fiscal module** and transmitting **directly to ИС ГНС**,
+   and (from 1 Feb 2026) uploading **monthly deep operational data**: per-check lines with
+   waiter/table/service-%/discount, purchases, write-offs, inventory, even payroll. This is a
+   **tailor-made door for a restaurant SaaS** (a foreign vendor operates through a local *оператор
+   ФПО*). ⚠ **The pilot is a *Temporary Regulation* expiring 31 Jul 2026** (expanded to chain fast-food
+   by disp. №136-т of 05.03.2026); ГНС reports +60% tax receipts → continuation likely but **not yet
+   permanent** — confirm status.
+2. **Dual tax on every receipt breaks the single-`taxRate` model.** A KG restaurant receipt carries
+   **two** taxes per line — **НДС 12%** *and* **налог с продаж (НсП)** — with НсП rate driven by tax
+   regime × VAT status × region × payment form. The UZ money engine has one VAT rail; **KG needs a
+   second per-line tax rail + regime-aware rate resolution** (schema + pricing-calculator change).
+3. **Payments are *easier* than UZ: one national QR (ELQR) reaches everyone.** ELQR (NBKR standard,
+   operated by МПЦ/Elcart, live 2022) makes **one merchant QR payable from ~20 banks + 14 payment orgs
+   via 32–34 apps** (MBANK, O!Dengi, Optima24, …). **One aggregator integration (Finik)** replaces the
+   3+ per-wallet adapters UZ needed. Finik even embeds an online-KKM → **payment and fiscal are fused**;
+   design them together to avoid double receipts.
+4. **e-Invoice (ЭСФ) is *simpler* than UZ — no client-side signing.** Single government system
+   (`esf.salyk.kg`), **no licensed-operator market**. Programmatic access is a **taxpayer-issued bearer
+   "access token"** (`cabinet.salyk.kg` → Токены доступа) scoped to an accredited aggregator → **the
+   server acts unattended, no per-document E-IMZO key ceremony** (the UZ blocker vanishes). One live
+   aggregator: **Tumar App**. But B2C is **not** fully exempt like UZ Art.47 — a VAT-payer restaurant
+   must file **one consolidated monthly ЭСФ** over KKM sales (new scheduled job).
+5. **No data-localization law → no separate in-country region needed.** Neither the old Law 58 nor the
+   new **Digital Code** (No. 178, in force 6 Feb 2026) requires KG servers; database registration was
+   **abolished**. **Existing hosting stays** (opposite of the UZ separate-region decision). *Caveat:* a
+   **DPIA is mandatory for the camera-occupancy feature** (Digital Code Art. 82).
+6. **Kyrgyz (Cyrillic) locale is a *legal* requirement.** Constitutional Law No. 140 (2023, amended
+   2025): software UI sold in KG **must have a Kyrgyz interface**; receipts/menus/price-lists Kyrgyz +
+   optional Russian (**Russian-alone is not sufficient**). We ship `ru` but **no `ky`** — and Kyrgyz is
+   **Cyrillic**, so the `uz` (Latin) set gives nothing to reuse. New locale required.
+7. **Competition is Russian heavyweights + a free bank KKM.** Incumbents are **R-Keeper, iiko, Poster**
+   (per the ГНС ФПО-operator registry), and **MBANK MKassa gives a free software-KKM + POS**. Compete on
+   **restaurant workflow value (KDS, floor plan, combos, delivery)**, not on fiscal compliance alone.
+
+**Bottom line:** engineering is ~**M/L** (less than UZ — no residency infra, one payment adapter, no
+client-side signing, no IKPU catalog), but with **two genuinely new subsystems**: the **НсП second-tax
+rail** and the **ФПО operational-data-upload reporting** track. The commercial gate is a **ФПО-operator
+agreement with ГНС** via the local partner.
+
+---
+
+## 2. Market & commercial case
+
+| Signal | Value | Source/conf. |
+|---|---|---|
+| Population | **7.28M** (Bishkek 1.32M) | Нацстатком, high |
+| HoReCa count (proxy) | **~3,440 Bishkek + 885 Osh** catering points (2GIS, +53–57% in 2024) | verified; official series stale (2015: 4,120) |
+| Restaurant sector revenue | **13.2 bn KGS (2024), +58% y/y**; tourism +45% (2025) | high |
+| KKM installed base | 71k (2023) → 118k (2024) → **~131k (2025)** | high |
+| Fiscal-forcing window | **LIVE** — ФПО pilot for catering (Sep 2025), expanded to chains (Mar 2026); ⚠ pilot **expires 31 Jul 2026**, extension likely-unconfirmed | verified (partially-correct: time-boxed) |
+| Receipt lottery | ⚠ "Требуй чек" was a **2023 one-time** campaign, now **dormant** (site dead) — do **not** market against a live lottery | verified |
+| QR payments boom | H1 2025: **167M QR payments, 274.9 bn KGS** (12–20× y/y); MBANK >3M users | NBKR, high |
+| **Competition** | **R-Keeper, iiko, Poster** (+ Paloma365, EvoResto, Dodo IS, 1С); **MBANK MKassa = free KKM+POS** | verified from ГНС registry |
+| Price anchor | Poster KG **$14–54/mo** + $19/extra terminal; MKassa **$0** bare fiscal | high |
+| Channel | Dealer/franchise + **bank/telco bundling** (MBANK, Beeline); entry ≈ become/partner with a **ФПО operator** (ГНС interaction agreement) | high |
+
+**Positioning:** above the free-KKM commodity floor, on **workflow depth** (KDS/floor-plan/combos/
+delivery/analytics) — exactly the data the ФПО regime now *requires* restaurants to report, which we
+already hold. Turkish origin + the UZ Elcart–HUMO/CIS knowledge is a sales asset.
+
+---
+
+## 3. Verified fact base (KG-specific)
+
+### 3.1 Fiscalization & tax  ⚠ *verify pass pending (session limit) — primary-sourced, high-confidence*
+| Fact | Value | Conf. |
+|---|---|---|
+| VAT (НДС) | **12%**; VAT-registration threshold 30M KGS / 12 mo | high |
+| **Sales tax (НсП)** — 2nd receipt tax | VAT payers **1%** (trade/prod) / **2%** (other incl. catering); VAT-exempt 2–3%; mobile 5%. Cashless-0% incentive **expired 1 Jan 2023** | high ⚠ |
+| Both taxes per line on receipt | ФФД tag 1003 = 1006 НДС + 1007 НсП; each item (1059) carries its own НДС+НсП rate codes | high |
+| Unified tax (единый налог) — catering | Bishkek/Osh **6% cash / 4% cashless**; rest **4% cash / 2% cashless** (Tax Code art. 423) | high ⚠ |
+| Fiscal data architecture | **Dual channel** — direct to ГНС **and/or** via **~6 accredited OFDs** (Нур Телеком/O!, Альфа/MegaCom, Скай Мобайл/Beeline, Telemedia…) — unlike UZ's single OFD | high |
+| Software/virtual KKM | Legal; state cloud ФМ; commercial software-KKM APIs: **eKassa** (~500 KGS/mo/KKM), O!Kassa, MegaKassa, WebKassa, SMARTUCHET | high |
+| **ФПО pilot** | POS-as-fiscal-software for restaurants **>100 m²** (Bishkek/Osh/Jalal-Abad), + monthly operational-data upload from 1 Feb 2026; **Temporary Regulation → 31 Jul 2026** | high (⚠ end-date/permanence) |
+| Per-line catalog code | **No UZ-IKPU-style universal code**; tag 1162 conditional (ТН ВЭД/ГКЭД/EAN/GS1 DataMatrix); marking codes (alcohol/tobacco/dairy — Текшер) on receipts since 1 Apr 2024 | high |
+| Wire format | ФФД Приказ №440 — **binary TLV** (Russia-style tags); relevant only at wire-level (commercial APIs abstract it) | high |
+| Receipt QR | Verify at `kkm.gov.kg` / app "Проверка чеков ГНС КР"; exact QR URL params not published | medium |
+| Offline | Real-time except outage (buffering); paper бланки backup; clock drift ≤5 min | high |
+
+### 3.2 Payments  ⚠ *verify pass pending — primary-sourced*
+| Fact | Value | Conf. |
+|---|---|---|
+| **ELQR** | Single interoperable national QR (NBKR, operator МПЦ/Elcart, live 2022); one QR ← ~20 banks + 14 payment orgs, 32–34 apps | high |
+| Integration path | Not direct with МПЦ; via a participant. Best-documented: **Finik** (QuickPay) — API-key auth, static/dynamic QR, webhooks, refunds, split, Visa PayFac, SDKs, **built-in online-KKM**. Fallback: **Freedom Pay KG** (`docs.freedompay.kz`). **MBANK MKassa** / **O!Dengi** = partnership-gated, no public docs | high |
+| Cashless mandate | **From 1 Jan 2026** businesses must accept cashless (cards/e-money/national QR); **personal/third-party QR for business banned** (fines) — cash not abolished | high ⚠ |
+| Elsom | **Dead** (merged into KICB app, Feb 2025) | high |
+| Card scheme | **Elcart** via МПЦ (+ Visa/MC acquiring ~1.5–2.5%); **Elcart–HUMO bridge** = UZ knowledge asset | high |
+| Wire minor units | **UNCONFIRMED** — ELQR payload is decimal som; **do not assume Payme ×100**; per-adapter `wireUnit` config, confirm at onboarding | low |
+
+### 3.3 e-Invoice (ЭСФ)  ✅ *verified*
+| Fact | Value | Conf. |
+|---|---|---|
+| System | Single govt IS ЭСФ (`esf.salyk.kg`, test `testesf.salyk.kg`), ГНС/Салык Сервис; **no operator market** | high |
+| Mandatory | All VAT payers since 1 Jul 2020; **issue within 5 working days** (since 1 May 2025, Res. #146) | high ✓ |
+| B2C rule | **Not** UZ-Art.47 full exemption — VAT-payer restaurant files **one consolidated monthly ЭСФ** over KKM sales (buyer «ККМ», ИНН = 14×`9`) within **10 working days** after month-end | high ✓ |
+| Programmatic access | **Taxpayer bearer "access token"** (`cabinet.salyk.kg` → Токены доступа), scoped to accredited aggregator, 30d–1y; live aggregator **Tumar App** (REST). No public govt REST docs (XML/XLSX batch) | high |
+| **Signing** | **Server acts unattended via the aggregator token — no per-document E-IMZO ceremony** (UZ blocker gone). Cloud ЭЦП exists (Инфоком/KYZMAT) but **no public per-document signing API** — do not architect around DSS | high |
+| ЭТТН (waybills) | Narrow — oil/alcohol/tobacco since 1 Jan 2025; restaurant relevance = **supplier-side alcohol only** | high |
+
+### 3.4 Delivery + SMS  ✅ *verified*
+| Fact | Value | Conf. |
+|---|---|---|
+| Delivery duopoly | **Glovo** (since Nov 2020; real **Partners API** — menu upload + order webhooks; `partner.integrationseu@glovoapp.com`) + **Yandex Eats** (Bishkek since 14 Mar 2024; acquired Namba Food Jul 2024; vendor API `yandex.ru/dev/eda-vendor`, **partner-hosted PULL** model). **Namba Food defunct** | high ✓ |
+| Yandex reuse | If a Yandex Eats adapter was built for UZ (same platform), it **carries over** — only KG credentials/currency differ | high ✓ |
+| SMS/OTP | **Nikita** (`smspro.nikita.kg`) default; JSON OTP API (`X-API-KEY`, `/api/otp/send`+`/verify`, idempotent `transaction_id`≤32); ~**1.24–1.45 KGS/SMS** | high ✓ |
+| Alpha-name | Register in cabinet + email `names@nikita.kg`; **up to 10 business days** national approval; no fee; contract for accounting/non-cash | high ✓ (corrected from "~1 day") |
+
+### 3.5 Legal / residency / language  ⚠ *verify pass pending — primary-sourced*
+| Fact | Value | Conf. |
+|---|---|---|
+| **Data localization** | **NONE** — neither Law 58 nor Digital Code (No. 178, in force 6 Feb 2026) requires KG servers; foreign hosting lawful (cross-border = consent/contract until DPA adequacy list published) | high |
+| DB registration | **Abolished** with the Digital Code | high |
+| DPIA | **Mandatory for systematic automated monitoring of public places (Art. 82) → camera-occupancy feature** | high |
+| **Language** | Constitutional Law No. 140 (2023, am. 2025): software UI **must have Kyrgyz**; receipts/menus/price-lists Kyrgyz + optional Russian (**Russian-alone insufficient**); fines 17,000 KGS/legal entity | high ⚠ |
+| Entity | ОсОО (LLC, no min capital, 2–7 day Minjust); единый налог **4–6%** services / 2% software dev | medium |
+| Royalty WHT | **10%** to Turkish licensor (Tax Code Art. 249(2)(3)); **Türkiye–KG DTT (1999) caps 10%** — apply via residency certificate | high |
+| Direct-sales VAT | **12% "Google-tax"** on cross-border SaaS (`vat.salyk.kg`) → **avoid via local partner** | high |
+| Currency control | **Liberal** — free repatriation, no capital controls | high |
+
+### 3.6 Currency / i18n / geo  ✅ *verified*
+| Fact | Value | Conf. |
+|---|---|---|
+| Currency | **KGS**, ISO 417, exponent 2; **tyiyn LIVE** (100/som) → store **integer tyiyn ×100** (UZ money core reuses) | high ✓ |
+| **Cash rounding** | Cash tenders round to **nearest 50 tyiyn** (Gov/NBKR 631/35/10, 2011); **non-cash NOT rounded** → new cash-rounding rail | high ✓ |
+| Display | `12 345,50 сом` (NBSP group, comma decimal, currency after); use **`сом`** (⃀ U+20C0 poor font support); use **`ru-KG`** explicitly | high ✓ |
+| **Language script** | Kyrgyz = **Cyrillic** (not Latin like `uz`) → **new `ky` translation set**; `ru`→`ru-KG` tag/symbol override | high |
+| Phone | **+996**, 9-digit NSN; libphonenumber region **KG** → PhoneInput/@NormalizePhone reuse (just enable KG) | high ✓ |
+| Timezone / geo | **Asia/Bishkek UTC+6, no DST**; 7 oblasts + Bishkek/Osh (⚠ watch Apr-2026 okrug reform) | high ✓ |
+
+---
+
+## 4. Architecture — the KG delta on the shared seam
+
+Reuse the `Tenant.region` seam from the UZ program; add `"KG"`. Because there is **no data-localization
+law**, KG tenants can run on the **existing multi-tenant stack** — **no separate region/DB/hosting
+workstream** (the single biggest UZ cost, gone). The region flag drives:
+
+```
+Tenant.region ("KG")
+  ├─▶ currency policy → KGS {minorUnits ×100, cashRounding: 50-tiyin, wireUnit: per-adapter, taxes:[НДС, НсП]}
+  ├─▶ i18n default    → ru-KG  (+ NEW ky Cyrillic locale, legally required)
+  ├─▶ TAX ENGINE      → NEW second per-line tax (НсП) + regime×VAT×region×payment-form rate resolution
+  ├─▶ fiscal registry → providerId "fiscal_kg_ofd" (software-KKM API)  OR  "fiscal_kg_fpo" (ФПО operator)
+  ├─▶ payments        → providerId "elqr_finik" (one adapter reaches all wallets)  [+ card acquiring]
+  ├─▶ e-invoice       → ЭСФ aggregator (Tumar / self-accredited), bearer-token unattended
+  ├─▶ delivery        → GLOVO (+ YANDEX_EATS, likely reused from UZ)
+  └─▶ SMS             → Nikita (per-tenant provider resolution)
+```
+
+**The one change that is NOT just a new adapter:** the **dual-tax (НсП) rail**. Everything else plugs
+into an existing seam; НсП touches the Prisma money model, `order-pricing.calculator`,
+`fiscal-line-builder`, receipt-snapshot, Z-report and analytics — plan it as a first-class WS.
+
+> **Reversible migrations:** the НсП column(s), region config, and any KG-specific fields ship as
+> reversible **up/down** pairs, backfilled and round-trip-verified, per repo rule.
+
+---
+
+## 5. What carries over vs new work (reuse map)
+
+| Area | ✅ Reuse from UZ build | 🆕 New / different for KG |
+|---|---|---|
+| Region seam | `Tenant.region` flag + per-region policy table | `region='KG'` config values |
+| Money core | integer minor-unit (tyiyn ×100), Decimal discipline | **cash-rounding to 50 tyiyn** (non-cash exact); **per-adapter `wireUnit`** (don't assume ×100) |
+| **Tax** | VAT-inclusive extraction, per-line `taxRate` | **SECOND per-line tax (НсП)** + regime×VAT×region×payment-form resolution — **schema + calculator change** |
+| Fiscal | `FiscalProvider` interface, registry, **INERT** pattern, shift/Z-report, refund-by-original idempotency, offline queue | KG driver (software-KKM API e.g. eKassa/Finik) **or become a ФПО operator**; **ФПО monthly operational-data upload subsystem**; dual-channel OFD/direct; ФФД TLV only at wire-level; **drop IKPU/MXIK entirely** |
+| Payments | wallet-adapter shape, charge-before-record, NON_RETRYABLE/NEEDS_REVIEW, PaymentTerminal | **ELQR via Finik/Freedom Pay** (1–2 adapters vs 3+); payment↔fiscal **fused** (avoid double receipts) |
+| e-Invoice | provider-adapter abstraction, INERT, outbox/retry/deadline-alerting, consolidated-invoice concept | **ЭСФ via ГНС bearer token** (Tumar or self-accredit); **unattended — no client-side signing** (UZ E-IMZO blocker gone); **monthly consolidated ЭСФ job** |
+| Delivery | delivery-platforms adapters, **Yandex Eats adapter** (if built for UZ) | **Glovo Partners API adapter** |
+| SMS | SMS provider abstraction, OTP flow | **Nikita** JSON-OTP adapter; alpha-name ops (~10 business days) |
+| Legal/infra | local-partner reseller playbook, royalty **10% WHT + DTT**, consent artifacts ~70% | **NO data-localization → no separate region/DB** (big saving); **DPIA for camera feature**; Digital-Code consent/DPIA artifacts |
+| i18n | `ru`→`ru-KG` tag/symbol override; phone infra (enable KG) | **`ky` Cyrillic locale — legal requirement** (uz Latin gives nothing) |
+| Geo | two-level admin hierarchy, single-tz no-DST model | Asia/Bishkek UTC+6; 7 oblasts + Bishkek/Osh seed |
+
+---
+
+## 6. Workstreams
+
+- **WS0 — Foundation delta (M):** `region='KG'`; KGS currency + **cash-rounding (50 tyiyn, cash-only)** + per-adapter `wireUnit`; `ru-KG`; phone KG; timezone Asia/Bishkek. *No residency/hosting WS.*
+- **WS1 — Dual-tax engine (L, new):** add **НсП** as a second per-line tax; regime×VAT×region×payment-form rate resolution; surface both tax lines on receipt/Z-report/analytics/ЭСФ. **Blocks correct money** — non-negotiable, breaks the carried-over single-`taxRate` assumption.
+- **WS2 — Fiscalization + ФПО (L):** KG fiscal adapter via a registered **software-KKM API** (fastest: eKassa/Finik) *or* pursue **ФПО-operator** status (ГНС interaction agreement) for >100 m² restaurants; **ФПО monthly operational-data upload** (per-check waiter/table/service%/discount, purchases, write-offs, inventory, payroll) — a reporting subsystem fed by data we already hold. Marking-code (Текшер) scan for alcohol/tobacco/dairy lines. INERT until credentials.
+- **WS3 — Payments ELQR (M):** **Finik** adapter (create-invoice → QR/deeplink → signed webhook → idempotent match → poll fallback); **fuse with fiscal** so Finik's embedded KKM doesn't double-fiscalize; encode the **1 Jan 2026 cashless-acceptance mandate + personal-QR ban** in onboarding. Freedom Pay KG as fallback; Elcart/Visa/MC acquiring optional.
+- **WS4 — e-Invoice ЭСФ (M):** ГНС **bearer-token** integration (contract **Tumar** or self-accredit as aggregator); **unattended signing** (no E-IMZO); **monthly consolidated ЭСФ** scheduled job (buyer «ККМ», 14×`9`, ≤10 working days); 5-working-day B2B rule.
+- **WS5 — Delivery + SMS (M):** **Glovo Partners API** adapter (new); **Yandex Eats** (reuse UZ adapter, KG credentials); **Nikita** SMS/OTP adapter + alpha-name ops.
+- **WS6 — Localization + legal (M):** **`ky` (Cyrillic) locale** (legal requirement) + bilingual KY/RU receipts; **DPIA** for camera-occupancy; Digital-Code consent artifacts; local **ОсОО** + reseller contract (10% WHT + DTT residency cert).
+
+---
+
+## 7. Sequenced roadmap
+
+```
+Phase A (partner, weeks) ── Local ОсОО + ФПО-operator agreement (ГНС) + ЭСФ aggregator (Tumar) +
+                            software-KKM/Finik contracts + Nikita alpha-name (~10 business days)
+        │  (master dependency — start now; lighter than UZ: no EDS-token ceremony, no PD-DB registration)
+        ▼
+Phase B (no creds) ── WS0 foundation + WS1 DUAL-TAX ENGINE + WS6 ky locale/DPIA   [start immediately]
+        ▼
+Phase C (creds-gated) ── WS2 fiscal/ФПО ── WS3 ELQR payments (fused) ── WS4 ЭСФ ── WS5 delivery/SMS
+        ▼
+Phase D ── Pilot go-live: 1 Bishkek restaurant, full day, ФПО-compliant, dual-tax-correct receipts
+```
+
+**Critical-path notes:** ФПО-operator agreement + software-KKM contract gate fiscal; **dual-tax (WS1)
+must land before any KG receipt** (money-correctness); Nikita alpha-name ~10 business days; **no
+data-residency, EDS-token, or PD-registration lead times** (all UZ blockers absent). ⚠ ФПО pilot legal
+basis expires **31 Jul 2026** — confirm the successor/permanent regime before committing the fiscal
+adapter shape.
+
+---
+
+## 8. Benchmark scorecard (go/no-go gates)
+
+| # | Workstream | Acceptance gate | Status |
+|---|---|---|---|
+| WS0 | Foundation | KG tenant: KGS `сом` 2-decimal, **cash rounds to 50 tyiyn (cash only)**, ru-KG, +996, Asia/Bishkek; no PayTR path | ☐ |
+| WS1 | Dual tax | Receipt/Z-report/ЭСФ show **both НДС 12% + НсП** per line; НсП rate correct per regime×VAT×region×payment-form | ☐ |
+| WS2 | Fiscal + ФПО | Real fiscal receipt verifiable in ГНС app; **ФПО monthly operational-data upload** validated; marking-code lines handled; INERT until certified | ☐ |
+| WS3 | Payments ELQR | Finik QR intent → verified webhook → refund; **no double fiscal receipt** (payment↔fiscal fused); cashless-mandate messaging | ☐ |
+| WS4 | e-Invoice ЭСФ | B2B ЭСФ via bearer token (unattended) in 5 wd; **consolidated monthly ЭСФ** job runs (buyer «ККМ») | ☐ |
+| WS5 | Delivery + SMS | Glovo Partners API live; Yandex Eats (reused) live; Nikita OTP with approved alpha-name | ☐ |
+| WS6 | Localization/legal | **ky Cyrillic UI + bilingual receipts**; DPIA filed for camera; ОсОО + reseller contract (WHT/DTT) | ☐ |
+| GO | Pilot | 1 Bishkek restaurant, full day: ФПО-compliant fiscalization + ELQR payments + dual-tax receipts + ЭСФ, zero money/tax defects | ☐ |
+
+---
+
+## 9. Open questions & risks
+
+**Open questions (owner):**
+1. **ФПО permanence** — does the pilot (expires 31 Jul 2026) become the permanent regime, and do we integrate as a **ФПО operator** (become one / partner) vs a **software-KKM API** (eKassa/Finik)? *This defines the fiscal adapter.* (Platform + Partner)
+2. **НсП rate matrix** — exact catering НсП + unified-tax rates by regime × VAT status × region × payment form, for 2026. ⚠ verify with a KG accountant. (Finance)
+3. **ЭСФ**: contract **Tumar** vs self-accredit as aggregator; token lifecycle (≤1y, rotation). (Platform + Partner)
+4. **Payment wire units** — confirm Finik/ELQR som-vs-tyiyn per adapter at onboarding (don't assume ×100). (Platform)
+5. **Payment↔fiscal fusion** — does Finik/MKassa's embedded KKM replace or duplicate our fiscal receipt? Define the boundary. (Platform)
+6. **Re-run the adversarial verify pass** on fiscal/tax, payments, legal (cut by session limit). (PM)
+
+**Top risks:**
+- **Dual-tax miss** → every KG receipt mis-taxed (money-correctness). *Mitigate:* WS1 before any KG order; exhaustive tax tests.
+- **ФПО pilot expiry / regime change** → adapter built to a lapsing spec. *Mitigate:* confirm permanence; keep the fiscal driver behind the existing abstraction.
+- **Double fiscal receipt** (payment embeds KKM). *Mitigate:* design WS2+WS3 together.
+- **Missing ky locale** → illegal + fines (17k KGS). *Mitigate:* WS6 before pilot; add ky to the i18n CI parity gate.
+- **Competition (R-Keeper/iiko/Poster + free MKassa)** → commodity squeeze. *Mitigate:* workflow-value positioning (KDS/floor/combo/delivery + the ФПО operational data we already produce).
+
+## 10. Method & confidence
+
+7 research agents (RU-first, then KY/EN; primary sources sti.gov.kg, cbd.minjust.gov.kg, nbkr.kg,
+provider docs, local media), framed as a delta from the UZ build. **e-invoice, delivery/SMS,
+currency/i18n, market/competition** completed adversarial verification; **fiscal/tax, payments,
+legal/residency** did not (session limit) — marked ⚠ and to be re-verified before go-live. Sources +
+verdicts are in the workflow journal.

--- a/docs/marketing/uzbekistan/UZ_EXPANSION_BENCHMARK.md
+++ b/docs/marketing/uzbekistan/UZ_EXPANSION_BENCHMARK.md
@@ -1,0 +1,536 @@
+# Uzbekistan Expansion — Full-System Integration Benchmark
+
+> **Purpose.** This document is the single source of truth and the *scorecard* ("benchmark")
+> for taking the KDS restaurant POS/KDS platform live in Uzbekistan. It is grounded in (a) an
+> adversarially fact-verified research pass on Uzbek fiscal/payment/e-invoice/legal/currency rules
+> (sources + confidence inline) and (b) a file-level map of the exact code seams that must change.
+> Treat the **Benchmark Scorecard** (§12) as the go/no-go gate: a workstream is "done" only when
+> its acceptance criteria pass.
+
+| Field | Value |
+|---|---|
+| Status | **DRAFT — awaiting review** |
+| Created | 2026-07-15 |
+| Owner (platform) | _TBD_ |
+| Owner (UZ partner / legal) | _TBD_ |
+| Locked decisions | 1) **Separate in-country UZ region** · 2) **Local partner / reseller** operating model · 3) **Full-parity MVP** (fiscal receipt + local payments + UZS/language + e-invoice) |
+| Codebase baseline | prod v3.2.117 · single-region (Turkey), TRY-locked, adapter/registry architecture already in place |
+
+---
+
+## 1. Executive summary
+
+The platform is **architecturally ready** for a new country: fiscal, online-payment, card-terminal
+and delivery integrations already sit behind provider **interfaces + registries** (adapters
+self-register by a free-form `providerId` string — no enum/migration to add one), and `uz` + `ru`
+locales already ship. The expansion is therefore **new adapters + a per-region policy layer + legal/
+ops setup**, not a rewrite.
+
+The hard part is **not the code seams — it is Uzbekistan's compliance surface and its lead-time
+dependencies**, which must be booked in parallel from day one:
+
+- **Fiscalization is mandatory and centralized.** Every cash/card settlement with the public must be
+  captured by a fiscal module and transmitted online to the **single state OFD** (SUE "Yangi
+  Texnologiyalar", `ofd.uz`/`ofd.soliq.uz`); the receipt carries a fiscal sign + a
+  `https://ofd.soliq.uz/check?...` QR. There is **no open self-serve fiscal API**; the exact
+  virtual-cash-register transport is the #1 open question.
+- **UzQR is already live and mandatory** (since **2026-07-01**, Decree PF-246; operator **MUNIS**,
+  0.65% merchant fee). Any UZ tenant operating a till without QR acceptance is in a fine-exposed
+  window **today**. This cannot be a post-MVP follow-up.
+- **Every menu line needs an IKPU/MXIK national catalog code** on both the fiscal receipt and the
+  e-invoice. The `Product` model has no such field — this is a mandatory data workstream that blocks
+  the first legal receipt.
+- **e-Invoices (ЭСФ) require an E-IMZO PKCS#7 signature whose private key lives on the client
+  device.** A cloud SaaS cannot sign unattended without either (a) delegating to a licensed operator
+  (Didox / Faktura.uz) or (b) custodying each tenant's key — an explicit architecture decision.
+- **Money is a 100× trap.** UZS displays with **0 decimals** but the wallet APIs (Payme, Uzum)
+  transact in **tiyin (amount × 100)**. The money layer is TRY/2-decimal today. A single minor-unit
+  policy must land before any amount crosses a payment or fiscal wire.
+- **Data-residency law was *narrowed* on 2026-03-27** (Law ZRU-1125): only **biometric, genetic and
+  telecom-user** data must stay in Uzbekistan; ordinary customer/staff data may now be offshore under
+  conditions. This *relaxes* the residency rationale — but the personnel module's **biometric
+  clock-in** data still hard-requires in-country storage, which validates the separate-region choice.
+- **The local legal entity is the master dependency.** Fiscal/KKM registration, ЭСФ-operator
+  onboarding, payment-merchant accounts, EDS token issuance, SMS alpha-name (legal-entity-only) and
+  the personal-data-DB registration **all** require the resident entity/partner to exist first.
+
+**Bottom line:** engineering is ~**L/XL across 8 workstreams**, but the critical path is set by
+partner/ops lead times (entity → EDS → merchant/OFD/operator certification → alpha-name), so those
+must start **now**, in parallel with the region/money/i18n platform foundation (which needs no
+external credentials).
+
+---
+
+## 2. Operating model & the three locked decisions
+
+### 2.1 Deployment — separate in-country UZ region
+One codebase, per-region configuration. A **new UZ deployment hosted in Uzbekistan** with its own DB
+and its own fiscal/payment stack, isolated from the Turkey region.
+
+- **Still the right call**, even though the 2026-03 law change means most data *could* be offshore:
+  it (a) trivially satisfies the **biometric** in-country requirement, (b) minimizes latency to UZ
+  fiscal/payment APIs, (c) isolates the blast radius from Turkey, and (d) aligns with the local
+  partner holding UZ infra/relationships.
+- **Note (honest):** a lighter *hybrid* (app shared, only biometric + regulated data in UZ) is now
+  *legally* permissible. We are **not** choosing it — but record it as a fallback if UZ ops cost is
+  prohibitive.
+
+### 2.2 Legal model — local partner / reseller
+A **UZ-resident partner** holds the fiscal registration, ЭСФ-operator client account, payment-merchant
+agreements, settlement bank account, EDS tokens and SMS alpha-name. We **license the platform** and
+**integrate to their credentials**. Implications:
+
+- The **partner (or the restaurant tenant) is the data controller/operator of record** and the
+  taxpayer; the platform is a processor/software supplier.
+- **Withholding tax:** royalties from the UZ entity to the platform vendor are **20% WHT** (Tax Code
+  Art. 353), reducible under the **Türkiye–Uzbekistan double-tax treaty** with a valid tax-residency
+  certificate. Build this into the reseller contract. _(confidence: high; treaty rate to confirm)_
+- Every provider credential is **per-tenant/per-partner**, stored **encrypted** (reuse the existing
+  `ENCRYPTION_MASTER_KEY` pattern) in `FiscalDeviceRecord.config` / `PaymentTerminalRecord.config`.
+
+### 2.3 Scope — full-parity MVP (phased by dependency)
+All four launch blockers are in scope: **fiscal receipt, local payments, UZS + language, e-invoice**.
+Because their lead times differ, they are **sequenced** (§11), not shipped simultaneously.
+
+---
+
+## 3. Verified regulatory & market fact base
+
+Confidence and primary sources per fact. **Verify items marked ⚠ against final Uzbek-language
+primary text before go-live.**
+
+### 3.1 Tax (QQS / VAT)
+| Fact | Value | Conf. | Source |
+|---|---|---|---|
+| Standard VAT (QQS) | **12%** (since 2023, frozen through 2028) | High | PwC UZ tax summary; gazeta.uz 2024-12-31 |
+| Voluntary simplified regime | **6%** for catering/trade/services, 2026-06-01 → 2029-12-31; **no input-VAT credit**, exempt from profit tax | High | spot.uz 2026-05-27/06-01; gazeta.uz 2026-05-26 |
+| Zero rate | **0%** for exports & defined list (Tax Code Ch. 36, Arts. 260–264) | High | lex.uz 4674893; nrm.uz |
+| Prices are **VAT-inclusive** (extract tax component) | matches existing `TaxCalculationService.extractTax()` | High | codebase |
+
+> **Decision needed:** does each restaurant tenant elect **12%** (standard, with input credit) or the
+> **6%** simplified regime? This drives the per-tenant tax rate. Default assumption: **12%**.
+
+### 3.2 Fiscalization (OFD / online-KKM / virtual cash register)
+| Fact | Value | Conf. | Source |
+|---|---|---|---|
+| OFD routing mandatory | Cash/card settlements with the public must transmit fiscal docs online to the state OFD | High | PKM No. **943** (23.11.2019); Decree **UP-5813** (06.09.2019); Tax Code **227-1** |
+| Single state OFD | SUE "**Yangi Texnologiyalar**" (Scientific-Information Center) under the State Tax Committee; `ofd.uz` / `ofd.soliq.uz`; fiscal module distributed **free** (no Russia-style competitive OFD market) | High | soliq.uz; norma.uz |
+| Receipt QR format | `https://ofd.soliq.uz/check?t=<TerminalID>&r=<ReceiptSeq>&c=<YYYYMMDDHHMMSS>&s=<FiscalSign>` (variant path `/epi`); **fiscal sign = `s`** | High | github abdullo211/fiscal_document; docs.bmms.uz; regos docs |
+| Software usable via hardware **online-KKM** or software **virtual cash register (virtualnaya kassa)** | either is legal; a cloud POS targets the **virtual register** | High | PKM 943 |
+| **IKPU / MXIK** catalog code per line | ⚠ Every fiscal-receipt line **and** ЭСФ line must carry a national catalog code (ИКПУ/MXIK) + package/unit + VAT attribute | Med (verify) | domain + critic; verify on soliq/lex |
+| **Exact virtual-register API contract** (transport/auth/schema, shift open-close, Z-report) | **UNVERIFIED — open question #1** | Low | — |
+
+### 3.3 Payments
+| Provider | What / flow | API | Conf. | Source |
+|---|---|---|---|---|
+| **Payme (Paycom)** | wallet/QR + Uzcard/HUMO; **provider-calls-merchant JSON-RPC 2.0** | `developer.help.paycom.uz`; methods `CheckPerformTransaction/CreateTransaction/PerformTransaction/CancelTransaction/CheckTransaction/GetStatement` + `SetFiscalData`; Basic auth `base64("Paycom:KEY")`; **amounts in tiyin** | High | developer.help.paycom.uz |
+| **Click** | wallet + **Click Pass** (customer-presented QR, merchant-scanned) | `docs.click.uz`; Shop API `Prepare`+`Complete` (md5 `sign_string`); Click Pass `POST api.click.uz/v2/merchant/click_pass/payment` (`otp_data`), auth `merchant_user_id:sha1(ts+secret_key):ts`; fiscalization supported | High | docs.click.uz |
+| **Uzum Bank** | S2S REST + webhooks (Checkout / Merchant API / FastPay / Dynamic QR) | `developer.uzumbank.uz`; ops `check/create/confirm/reverse/status`; Basic auth + `serviceId`; **tiyin** | High | developer.uzumbank.uz |
+| **UzQR (national)** | **MANDATORY since 2026-07-01** for all trade/service; static or dynamic QR interoperable across all bank apps + Humo/Uzcard | operator **MUNIS** (CBU interbank clearing); merchant fee **0.65%** (MUNIS 0.20%), buyer pays 0 | High | Decree **PF-246** (2025-12-10); CBU reg. Apr 2026; kun.uz/gazeta.uz Jun 2026 |
+| Market reality | Trio ≠ 90%. 2024 shares ≈ **Click 33% · Paynet 15% · Payme 12%**, Uzum lower. Underlying rails = **UzCard + HUMO**. **Paynet** is top-3 and omitted by the trio | High (refutes "90%") | kapital.uz / pulbek.uz (Humo 2024) |
+| Payment↔fiscal coupling | Payme `SetFiscalData` / Click fiscalization ⇒ wallet auth and fiscal-receipt data are **coupled**, legally required | High | provider docs |
+
+### 3.4 e-Invoice (ЭСФ / elektron hisob-faktura)
+| Fact | Value | Conf. | Source |
+|---|---|---|---|
+| Mandatory since | **2020-01-01** for VAT payers; buyer VAT offset **only** via electronic invoice | High | Cab. Decision **489** (2020-08-14) App.2 §10 |
+| No open government API | Integrate via a **licensed operator** (~27 operators; roaming via E-Faktura/`rouming.uz`) — Cab. Res. **522** (2019-06-25) | High | edicom; vatupdate; buxgalter |
+| Operator APIs (documented) | **Faktura.uz** (`api.faktura.uz/help`, Bearer via `/Token`; `ImportDocumentRegister`, `SignDocument`, `GetDocuments`, `SendDocument`, `VerifySignature`) · **Didox.uz** (`api-docs.didox.uz`; prod `api-partners.didox.uz`, test `testapi3.didox.uz`; `POST /v1/documents/{docId}/sign`, partner token) | High | api.faktura.uz/help; api-docs.didox.uz |
+| **EDS signature (E-IMZO)** | **PKCS#7 mandatory**; private key on **client device** (`.pfx` in `C:\DSKEYS` or ID-card/USB token); signed client-side via E-IMZO desktop app + CAPIWS loopback WS (`127.0.0.1`); **server cannot sign** without holding the tenant's key+PIN | High (port `64443` low-conf) | github qo0p/e-imzo-doc; crpt-turon |
+| Chek vs ЭСФ split | Tax Code **Art. 47**: no счёт-фактура to buyer when a KKM/virtual-cash **chek** is given for cash/individual-card retail; corporate-card sale → invoice on demand; seller still forms a **monthly one-sided consolidated ЭСФ** (⚠ whether required when cheki cover retail is **unsettled**) | High / Med | lex.uz; bss.uz; norma.uz |
+
+### 3.5 Legal / data residency / language
+| Fact | Value | Conf. | Source |
+|---|---|---|---|
+| Personal-data law | Law **ZRU-547** "On Personal Data" (2019-07-02) | High | dlapiper; cis-legislation |
+| **Localization NARROWED** | Law **ZRU-1125** (in force **2026-03-27**) rewrote Art. **27-1**: only **biometric, genetic, telecom-user** data must stay in-country; other data may be offshore if 3 conditions met — **info-security requirements + international-standards compliance + oversight by Uzbek state bodies remains possible** (⚠ **not** EU SCC/BCR/adequacy — don't design to GDPR shape) | High | gazeta.uz/kursiv 2026-03-27; Dentons 2026-03-31 |
+| Biometric exception | Personnel **face/fingerprint clock-in** data **must** be stored on UZ soil | High | kursiv.media 2026-03-27 |
+| PD-database registration | Register in State Register via **pd.gov.uz** (Personalization Agency, MoJ); **~15-day** review before processing | High | dlapiper; azizovpartners |
+| Penalties | Admin **Art. 46-2** (officials 50 BCV ≈ $1,250–1,400); repeat → criminal **Art. 141-2** (100–200 BCV, up to 3 yrs); website blocking + violators' register | High | gratanet; kun.uz; loc.gov |
+| Receipt/label language | **Uzbek (state language) mandatory** on receipts/price tags; may duplicate in Russian; **receipt mandatory on every sale** | High (article #s Med) | State Language Law; Consumer Protection Law **221-I** (1996-04-26) |
+
+### 3.6 Currency / i18n / geo
+| Fact | Value | Conf. | Source |
+|---|---|---|---|
+| Currency | **UZS**, ISO 4217 numeric **860**; minor unit **tiyin** (100/som, **defunct** in circulation) | High | iban.com; Mastercard ISO 4217 |
+| Display precision | **0 decimals** in practice (CLDR default is 2 → deliberate override); format `15 000 so'm` (space thousands, comma decimal, **currency word after**) | High | CLDR uz |
+| **Wire precision** | Payme/Uzum transact in **tiyin (×100)** — display ≠ wire | High | provider docs |
+| Language/script | Default **uz-Latn** (Latin mandate from 2023-01-01), **ru** strong alternate, **en** common; Cyrillic legacy-but-present | High | thediplomat; lex.uz |
+| Phone | **+998**, NSN **9 digits** (2-digit area/operator + 7 subscriber), E.164 12 digits, region **UZ** | High | ITU E.164; Wikipedia |
+| Timezone | **Asia/Tashkent**, UTC+5, **no DST** | High | timeanddate; IANA |
+
+---
+
+## 4. Target architecture — the per-region seam
+
+Today the app is **hard-wired to Turkey**: there is **no `region`/`country` flag** on `Tenant`/`Branch`
+(the `country`/`region` columns in schema are only on analytics models `PageView`/`Lead` and never
+touch tenant behavior). Currency, tax, phone, fiscal, delivery and SMS are all chosen by **hardcoded
+TR constants or the `currency === "TRY"` literal**.
+
+**The seam we introduce:** a single `Tenant.region` flag (`"TR" | "UZ"`) as the source of truth,
+threaded through the existing extension points:
+
+```
+Tenant.region ("UZ")
+      │
+      ├─▶ currency policy table  → UZS {taxRate 0.12, minorUnitDigits 0, wireMinorUnits 100, paymentProvider payme|click}
+      ├─▶ i18n default locale    → uz-Latn / ru (getInitialLanguage)
+      ├─▶ tax rate at write-time → Product.taxRate = 12 (QQS)   [column @default(10) is TR; set on create]
+      ├─▶ phone region           → @NormalizePhone("UZ") / PhoneInput defaultCountry
+      ├─▶ fiscal-core registry   → providerId "fiscal_uz_ofd"  (FiscalProvider, cloud-HTTP shape)
+      ├─▶ payments-core registry → providerId "payme"/"click"/"uzum"  (PaymentProvider)
+      ├─▶ payment-terminal reg.  → providerId "uz_qr" (in_process, activatable=false until certified)
+      ├─▶ delivery AdapterFactory→ UZUM_TEZKOR / YANDEX_EATS   (PlatformAdapter)
+      └─▶ SMS provider resolver  → Eskiz  (per-tenant, not process-global env)
+```
+
+**Adapter mechanics (verified from code):** all three provider subsystems (`fiscal-core`,
+`payments-core`, `payment-terminal`) use *interface + `Map` registry + adapters that self-register on
+`onModuleInit`*; `providerId` is a **free-form `String`** on every record (`FiscalDeviceRecord`,
+`PaymentTerminalRecord`, `FiscalReceipt`). **A new provider needs no enum and no migration** — only a
+new adapter class, an entry in the module's `providers[]`, and `registry.register(this)`. The façade
+dispatches by the **literal `providerId`**, so registering an adapter is *necessary but not
+sufficient*: the caller (`CheckoutIntentService`, self-pay, fiscal path) must **select** the UZ
+provider by region, or the adapter is never dispatched. _(Memory: registered-but-never-dispatched
+providers were deleted once — don't repeat that.)_
+
+> **Reversible migrations:** every schema change below (region column, money-column widening, new
+> UZ-specific columns, IKPU field) ships as a reversible **up/down** pair, backfilled and
+> round-trip-verified (up → down → up), per the repo rule. No up-only migrations.
+
+---
+
+## 5. Workstream WS0 — Platform foundation (region + money + i18n + tax + phone)
+
+**Needs no external credentials — start immediately, in parallel with legal setup.** Effort: **L**
+(money) + **XL** (region/i18n/tax/phone/delivery/SMS seams).
+
+### Code seams (verified files)
+- **Region flag:** add `Tenant.region String @default("TR")` (+ optional `country`, `defaultLocale`)
+  in `backend/prisma/schema.prisma`; reversible migration; backfill `'TR'`; set `region='UZ'`,
+  `currency='UZS'`, `timezone='Asia/Tashkent'` in `auth-provisioning.service` for UZ signups.
+- **Money / currency policy table (NEW):** central `Record<Currency, {taxRate, minorUnitDigits,
+  wireMinorUnitFactor, paymentProvider}>`. Replace the three TRY literals:
+  `quote.service.ts:241` (`currency === "TRY" ? TR_KDV_RATE : 0`), `billing.service.ts:79`
+  (`isTurkish`), `kdv.helper.ts` default.
+- **Currency allowlists (double-source!):** add `UZS` to **both** `frontend/src/hooks/useCurrency.ts`
+  (`SUPPORTED_CURRENCIES`, currently locked to `['TRY']`) **and**
+  `backend/src/common/constants/currencies.const.ts`, **plus** symbol maps in `lib/currency.ts` and
+  `z-reports/currency-symbols.ts`. Update the tests pinning `['TRY']`.
+- **Minor-unit formatting:** every hardcoded `minimumFractionDigits:2` / `toFixed(2)`
+  (`lib/currency.ts`, escpos `money()`, `invoice-pdf.service.ts`, receipt-snapshot `fmt()`) must
+  derive digits from the policy table (UZS = 0). **Two divergent formatter families exist**
+  (`useFormatCurrency`/Intl is correct; the manual family is not) — fix both or screens ≠ receipts.
+- **Tax:** `Product.taxRate`/`OrderItem.taxRate`/`SalesInvoiceItem.taxRate` all `@default(10)` (TR).
+  Column defaults can't be region-conditional → **write `taxRate=12` at product create/seed time** and
+  make the `?? 10` fallbacks region-aware (`combo-pricing.ts:203`, `fiscal-line-builder.ts`).
+- **Phone:** `@NormalizePhone("TR")` is a **static literal across ~14 DTOs**; add region→country
+  resolution and switch UZ call sites to `"UZ"`; `PhoneInput` `defaultCountry`/`buildCountryOptions`
+  → `'UZ'`.
+- **i18n default:** `getInitialLanguage()` (`frontend/src/i18n/config.ts`) is client-only; make it
+  prefer `uz`/`ru` for UZ tenants (deliver region/defaultLocale with the session). `uz` namespaces
+  are fully imported — **audit the 27 `uz/*.json` for translation completeness** ("wired" ≠
+  "translated").
+
+### ⚠ Money gotchas (money-correctness, not cosmetic)
+- **Tiyin ×100 wire policy:** display 0 decimals **but** Payme/Uzum wire tiyin. Define one
+  **conversion boundary** (store integer tiyin internally; convert at the adapter edge). Off-by-100×
+  is the classic UZ money bug.
+- **`Decimal(10,2)` overflow:** menu/order money caps at 99,999,999.99 — in UZS ≈ $8k. Catering or
+  monthly subscription totals in som can overflow → widen to `Decimal(14,2)` (reversible migration)
+  and store tiyin as integers where amounts cross wires.
+- **Non-TRY currency currently gets 0% tax** — shipping UZS without the tax-policy change **silently
+  under-taxes** UZ orders. Blocker.
+- **ESC/POS code page:** thermal builder encodes **CP857 (Turkish)** and maps `₺`→`T`; Uzbek
+  Latin/Cyrillic + `so'm` have no CP857 codepoint → **mojibake receipts**. Needs a code-page switch or
+  transliteration (see WS7).
+
+### Acceptance (benchmark)
+A UZS tenant, end-to-end: settings save UZS; menu prices render `0-decimal so'm`; order + receipt
+snapshot + Z-report + subscription invoice compute **12% QQS**; internal amounts are integer tiyin;
+PayTR-backed flows fail **cleanly** with a UZ-appropriate message; no Decimal overflow at catering
+magnitudes.
+
+---
+
+## 6. Workstream WS1 — Fiscalization (OFD virtual cash register) + IKPU/MXIK + UzQR
+
+**The #1 blocker. Legally you cannot operate a till without it, and UzQR is already overdue.**
+Effort: **L** (adapter) + **L** (IKPU data) + **M** (UzQR), gated on entity + OFD registration +
+API-contract discovery + certification.
+
+### 6.1 OFD fiscal adapter
+- **NEW** `backend/src/modules/fiscal-core/adapters/uz-ofd-fiscal-provider.ts` implementing
+  `FiscalProvider`, id `fiscal_uz_ofd`, capabilities `['receipt','cancel','z_report']`.
+- **Cloud-HTTP shape** (model on the stateless `EfaturaFiscalProvider` *structure*, **not** its refusal
+  behavior) — a UZ OFD is an online API, **not** a serial device on the local bridge, so do **not**
+  use `Gmp3FiscalProviderBase` (unless a physical fiscal module is later bridged). Omit mesh
+  `deviceId` (`FiscalService.registerDevice` allows it).
+- `issueReceipt`: build fiscal check from `req.lines` (**integer tiyin**), submit to the OFD/virtual-
+  register API keyed by `idempotencyKey`, return `fiscalNo` + attach the `ofd.soliq.uz/check?...` QR
+  into `raw`. Honor the **3-state** result — a synchronous cloud OFD returns **`issued`** (or
+  `failed`), never leaves it `queued` (that waits for a bridge ack that never comes).
+- Add to `fiscal-core.module.ts` `providers[]`; **ship INERT** (fail-closed with an actionable
+  message) until API key + certification; creds **encrypted** in `FiscalDeviceRecord.config`.
+- `fiscal-line-builder.ts` default `?? 10` is TR KDV → UZ lines must carry **explicit 12%**.
+
+> **OPEN QUESTION #1 (blocks this WS):** virtual-register software API vs certified hardware
+> online-KKM — and the exact transport/auth/message schema + shift open-close + Z-report to Yangi
+> Texnologiyalar/`ofd.uz`. **Resolve before coding the adapter body.** Likely fastest path: integrate
+> a local fiscal-module SDK / an OFD-certified middleware the partner already uses.
+
+### 6.2 IKPU / MXIK product classification (mandatory data workstream)
+- ⚠ Add an **IKPU/MXIK code** (+ package/unit code + VAT attribute) field to `Product` (reversible
+  migration) and to the fiscal-line + ЭСФ-line builders.
+- Build **code-assignment tooling** (admin UI + bulk mapping) and **source the catalog**; validate
+  codes against the tax catalog. **Blocks the first legal receipt** — every menu item needs a code.
+
+### 6.3 UzQR / MUNIS (already mandatory)
+- Integrate national **UzQR** acceptance (static + dynamic QR) via the **MUNIS** operating API;
+  handle the **0.65%** merchant fee/settlement. Model the POS-present flow as a `payment-terminal`
+  `uz_qr` provider (see WS2) **or** the payments-core QR mode.
+- **OPEN QUESTION #2:** MUNIS operating-regulation/API, credential issuance, exact fine amount.
+
+### Acceptance
+A UZ order issues a **real fiscal check** with a scannable `ofd.soliq.uz/check` QR that verifies in
+the Soliq app; each line carries a valid IKPU/MXIK; **UzQR** payment is accepted and fiscalized;
+cancel + Z-report/day-close work; adapter is fail-closed until certified.
+
+---
+
+## 7. Workstream WS2 — Local payments (Payme / Click / Uzum + UzQR) + fiscal coupling
+
+Effort: **L**, gated on merchant accounts (partner) + WS1 fiscal path.
+
+### Code seams
+- **NEW** `payments-core/adapters/payme-payment-provider.ts` (+ `click-`, `uzum-`) implementing
+  `PaymentProvider`, ids `payme`/`click`/`uzum`, modes `['online','qr']`. **Env-gated registration**
+  like `PaytrPaymentProvider` (register only if creds present).
+- `createIntent`: **do NOT copy PayTR's `req.currency !== 'TRY'` reject** — accept **UZS**; return
+  `clientAction {paymentUrl | qrPng | deeplink}`. `refund` → provider cancel/reverse.
+- `parseWebhook` / callback — **each provider differs, verify precisely, don't assume PayTR's HMAC:**
+  - **Payme** = server-to-server **JSON-RPC** the aggregator *calls into us* (`CheckPerformTransaction`
+    /`CreateTransaction`/`PerformTransaction`/`CancelTransaction`), HTTP **Basic** `base64("Paycom:KEY")`,
+    **tiyin** → likely needs a **dedicated controller route + small state machine**, verification in
+    the adapter.
+  - **Click** = `Prepare`/`Complete` with **md5 `sign_string`**; Click Pass = merchant-scanned
+    customer QR, `sha1(ts+secret)` auth.
+  - **Uzum** = `check/create/confirm/reverse/status`, Basic auth + `serviceId`, tiyin.
+- **Thread provider selection by region** into `CheckoutIntentService`/self-pay (TR→`paytr`,
+  UZ→`payme`/`click`) — the lone live caller passes the literal `'paytr'` today.
+- **Payment↔fiscal coupling (legal):** wire the payment adapter to the WS1 fiscal rail so the wallet
+  transaction carries the required fiscal data (Payme `SetFiscalData` / Click fiscalization). Not
+  optional.
+
+### Optional POS-present terminal
+- **NEW** `payment-terminal/providers/uz-qr-terminal.provider.ts` modeled on
+  `SoftPosTerminalProvider`: id `uz_qr`, `kind:'in_process'`, `activatable=false` (fail-closed) until
+  certified; `charge()` calls the aggregator/UzQR dynamic-QR endpoint, polls, maps
+  `APPROVED|DECLINED|TIMEOUT|ERROR`; **not** `fiscal_coupled` (the OFD rail issues the check).
+
+### Scope note
+- MVP payment set: **Payme + Click + Uzum + UzQR**. **Consider Paynet** (top-3, ~15%, omitted by the
+  trio) and confirm **UzCard/HUMO** acquiring/settlement/refund/reconciliation with the partner's bank.
+
+### Acceptance
+UZS payment via each enabled rail creates an intent, confirms via verified callback, refunds, and
+**attaches fiscal data**; provider is selected by tenant region; adapters register only with creds;
+no PayTR path is reachable for UZ.
+
+---
+
+## 8. Workstream WS3 — e-Invoice (ЭСФ) via licensed operator + E-IMZO signing
+
+Effort: **L–XL**, gated on operator contract (partner) + EDS tokens.
+
+- **Integrate a licensed operator** (Didox **or** Faktura.uz — pick one, on commercial terms) via its
+  documented REST API (Faktura: Bearer via `/Token`, `ImportDocumentRegister`/`SignDocument`; Didox:
+  partner token, `POST /v1/documents/{docId}/sign`). Do **not** build against the government portal
+  (no open third-party API).
+- **Signing architecture — DECISION REQUIRED (open question #3):**
+  - **(a) Operator-side signing** — delegate to Didox/Faktura if they support **unattended** signing
+    on the tenant's behalf (⚠ confirm — the E-IMZO key is client-side by design). *Preferred if
+    available* (no custodial key risk).
+  - **(b) Custodial signing** — store each tenant's `.pfx` + PIN server-side and generate the PKCS#7
+    ourselves (E-IMZO). Heavier security/compliance burden; only if (a) is impossible.
+- Implement the **chek↔ЭСФ split** (Tax Code Art. 47): no per-buyer invoice for cash/individual-card
+  retail; corporate-card → invoice on demand; **monthly one-sided consolidated ЭСФ** generation
+  (⚠ confirm whether required when cheki already cover retail — open item).
+- Build in the **Accounting module** (where e-documents already issue on order PAID for Turkey), region-gated.
+
+### Acceptance
+A B2B UZ order issues a valid EDS-signed ЭСФ via the operator that appears in `my.soliq.uz`; B2C cash
+sales correctly issue **only** a fiscal chek; consolidated monthly ЭСФ generated per the confirmed rule.
+
+---
+
+## 9. Workstream WS4 — In-country hosting, data residency & PD registration
+
+Effort: **L–XL** (infra), partner-gated (hosting + registration).
+
+- **Stand up the UZ region** in an **in-country** data center/cloud (partner-selected UZ hosting).
+  Own DB, own secrets, own fiscal/payment stack, isolated from Turkey.
+- **Biometric data split (hard requirement):** the personnel module captures **face/fingerprint
+  clock-in** (`clock-in.dto.ts`) — that biometric data **must** reside on UZ soil. Ensure the UZ
+  region stores it locally; never replicate it to Turkey. Genetic + telecom-user data likewise (n/a
+  here).
+- **Ordinary data** (names, phones, orders, payroll basics) *may* be offshore under the 3 statutory
+  conditions — but with a separate UZ region it's moot; keep it in UZ.
+- **Personal-data-database registration:** register the UZ personal-data DB via **pd.gov.uz**
+  (Personalization Agency); **~15-day** review **before** processing real UZ personal data. Blocks the
+  first live tenant → start early.
+- **Secrets hygiene:** a fresh region = fresh secrets. Do **not** reuse the Turkey secrets;
+  ⚠ resolve the outstanding public-repo leaked-secrets risk before/with standing up UZ prod
+  (see the existing security runbook).
+- ⚠ **Obtain and read the final Uzbek-language ZRU-1125 / Art. 27-1 text** to confirm the 3
+  cross-border conditions and registration exemptions — do **not** design the compliance layer on a
+  GDPR-shaped misread (open question #10).
+
+### Acceptance
+UZ prod runs in-country; biometric clock-in data provably stays in UZ; PD-DB registered; UZ secrets
+independent of TR; residency design signed off against primary law text.
+
+---
+
+## 10. Workstreams WS5–WS7
+
+### WS5 — Delivery + SMS/OTP + telephony (Effort: L)
+- **SMS/OTP:** NEW `EskizProvider implements SmsProvider` + case in
+  `SmsService.initializeProvider()`. **Selection is process-global env today** → make it
+  **per-tenant** (or run UZ as a separate deployment with `SMS_PROVIDER=eskiz`). Eskiz: JWT REST
+  `notify.eskiz.uz/api` (`/auth/login`→Bearer, `POST /message/sms/send`). **Alpha-name: 300k UZS
+  one-time, 1–2 month operator approval, legal-entities-only, one per company → start at kickoff**
+  (gates all OTP/customer-verification). Play Mobile as secondary (`send.smsxabar.uz/broker-api/send`,
+  Basic auth). ⚠ Eskiz text-moderation gate is uncertain — confirm.
+- **Delivery:** add `UZUM_TEZKOR` + `YANDEX_EATS` to the `DeliveryPlatform` enum, implement each
+  against `PlatformAdapter` (extend `base.adapter.ts`), add `AdapterFactory` switch cases, register in
+  `delivery-platforms.module.ts`; ship **INERT** until creds. **Wolt is dead** (exited 2026-03-05) —
+  not an adapter. Both remaining platforms are **partner-gated** (Yandex publishes readable docs at
+  `yandex.ru/dev/eda-vendor` but credentials are gated; Uzum Tezkor = Client ID+Secret+EndPoint).
+  **Decision:** direct adapters vs **middleware** (Delever / iiko / JOWi / r_keeper / REGOS).
+
+### WS6 — Legal entity / reseller / tax structure (Partner-led — the master dependency)
+- Stand up the **UZ-resident entity/partner** (data controller/operator of record, taxpayer).
+- **VAT registration** of the entity; decide **12% vs 6%** regime for the restaurant tenants **and**
+  the SaaS entity separately.
+- **Reseller/licensing contract** with **WHT (20%, treaty-reducible)** and currency-control terms;
+  obtain the **tax-residency certificate** for treaty relief.
+- Provision **EDS/E-IMZO tokens** (in-person, lead time), **fiscal-module/KKM registration**,
+  **payment-merchant accounts** (Payme/Click/Uzum/UzQR), **ЭСФ-operator client onboarding**.
+
+### WS7 — Localization of fiscal artifacts (Effort: M)
+- Guarantee **Uzbek (uz-Latn)** text on receipts/price tags/product names (legal); Russian optional
+  duplicate.
+- Solve the **ESC/POS CP857** problem (code-page switch or transliteration) so `so'm` + Uzbek glyphs
+  print correctly on thermal printers.
+- Ensure receipt-snapshot + escpos + invoice-pdf render UZS 0-decimal `so'm` and Uzbek strings.
+
+---
+
+## 11. Sequenced roadmap (dependency-ordered)
+
+```
+        ┌─────────────────────────────────────────────────────────────────────┐
+Phase A │ MASTER DEPENDENCY — Local entity/partner (WS6)                       │  (partner, weeks)
+START   │   → EDS tokens · fiscal/KKM registration · merchant accounts        │
+NOW     │   → ЭСФ-operator onboarding · SMS alpha-name · PD-DB registration   │
+        └───────────────┬─────────────────────────────────────────────────────┘
+                        │ (these gate everything; long lead times)
+   ┌────────────────────┴───────────────────┐
+   ▼ (no creds needed — parallel)            ▼ (creds-gated)
+┌────────────────────────────┐   ┌────────────────────────────────────────────┐
+│ Phase B — Platform          │   │ Phase C — Fiscal + IKPU + UzQR (WS1)        │
+│ foundation (WS0, WS4 infra, │   │  ⚠ overdue: UzQR mandatory since 2026-07-01 │
+│ WS7 localization)           │   │ Phase D — Payments (WS2)  ── coupled to C   │
+│  region · tiyin money ·     │   │ Phase E — ЭСФ (WS3)                          │
+│  UZS · i18n · tax12 · phone │   │ Phase F — Delivery + SMS (WS5)               │
+└────────────────────────────┘   └───────────────────┬────────────────────────┘
+                                                      ▼
+                                        ┌──────────────────────────────┐
+                                        │ Phase G — Pilot go-live       │
+                                        │  1st restaurant · compliance  │
+                                        │  sign-off · Benchmark §12 pass │
+                                        └──────────────────────────────┘
+```
+
+**Critical-path facts:**
+- **Local entity (WS6) blocks EDS, fiscal/KKM reg, merchant accounts, ЭСФ operator, alpha-name,
+  PD-DB reg** — start immediately.
+- **Alpha-name = 1–2 months** operator approval → start at kickoff or OTP onboarding slips.
+- **PD-DB registration = ~15 days** before any real UZ personal data in prod.
+- **IKPU/MXIK coding of the full menu** blocks the first fiscal receipt regardless of code readiness.
+- **Tiyin money refactor (WS0) must land before any amount crosses a fiscal/payment wire** —
+  foundational, not incremental.
+- **UzQR is already mandatory** — treat as Phase C, not a follow-up.
+
+---
+
+## 12. Benchmark scorecard (go/no-go gates)
+
+A workstream counts only when **all** its criteria pass. This table *is* the benchmark.
+
+| # | Workstream | Acceptance gate | Status |
+|---|---|---|---|
+| WS0 | Foundation | UZS tenant end-to-end: 0-decimal `so'm`, integer-tiyin internally, 12% QQS on order/receipt/Z-report/subscription, no Decimal overflow, PayTR flows fail cleanly | ☐ |
+| WS1 | Fiscal + IKPU + UzQR | Real fiscal chek w/ verifiable `ofd.soliq.uz/check` QR; every line has valid IKPU/MXIK; UzQR accepted + fiscalized; cancel + Z-report work; adapter fail-closed until certified | ☐ |
+| WS2 | Payments | Each rail (Payme/Click/Uzum/UzQR) creates intent, confirms via **verified** callback, refunds, **attaches fiscal data**; region-selected; env-gated | ☐ |
+| WS3 | e-Invoice ЭСФ | B2B order issues EDS-signed ЭСФ via operator (visible in my.soliq.uz); B2C issues chek only; consolidated monthly ЭСФ per confirmed rule | ☐ |
+| WS4 | Residency/hosting | UZ prod in-country; biometric clock-in provably UZ-only; PD-DB registered; UZ secrets independent; law text signed off | ☐ |
+| WS5 | Delivery + SMS | Eskiz OTP live w/ approved alpha-name; ≥1 delivery platform integrated (or middleware) and INERT-until-creds | ☐ |
+| WS6 | Legal/entity | Resident entity live; VAT regime chosen; reseller contract w/ WHT/treaty; EDS + merchant + operator + KKM + alpha-name + PD-DB all provisioned | ☐ |
+| WS7 | Localization | Uzbek receipts/price tags/product names print correctly (ESC/POS code-page solved); UZS 0-decimal `so'm` everywhere | ☐ |
+| GO | Pilot | One real restaurant runs a full day: fiscalized sales + UzQR + wallet payments + e-invoice (B2B) + compliant receipts, zero money/tax defects | ☐ |
+
+---
+
+## 13. Open questions & decisions required (owner + due)
+
+| # | Question | Owner | Blocks |
+|---|---|---|---|
+| 1 | Fiscal path: **virtual-register software API vs hardware online-KKM**, and its exact transport/auth/schema (shift, Z-report) to Yangi Texnologiyalar/`ofd.uz`? | Platform + Partner | WS1 |
+| 2 | **UzQR/MUNIS** operating-API, credential issuance, exact fine amount? | Partner | WS1/WS2 |
+| 3 | **ЭСФ signing**: operator-side unattended (Didox/Faktura — which, terms) vs custodial `.pfx`+PIN? | Platform + Legal | WS3 |
+| 4 | **IKPU/MXIK**: catalog source, per-item assignment UI, data migration — verify it is a hard blocker on lex.uz/soliq | Platform | WS1 |
+| 5 | **Data-residency architecture** confirmed (separate UZ DB) + biometric store location + UZ hosting provider | Infra + Partner | WS4 |
+| 6 | **Payment rails in MVP** (add Paynet? UzCard/HUMO acquiring via which bank?) + payment↔fiscal attach mechanism | Product + Partner | WS2 |
+| 7 | **Tax regime** per tenant: **12% standard vs 6% simplified**; entity VAT registration; WHT treaty-cert process | Legal | WS0/WS6 |
+| 8 | **Money policy**: single minor-unit boundary (store tiyin integer; convert at adapter edge) confirmed | Platform | WS0 |
+| 9 | **Delivery**: direct adapters vs middleware (Delever/iiko/JOWi/r_keeper/REGOS); onboarding timeline | Product + Partner | WS5 |
+| 10 | Read **final ZRU-1125 / Art. 27-1 Uzbek text** — confirm 3 conditions (not SCC/BCR) + registration exemptions | Legal | WS4 |
+| 11 | **Sandbox/certification lead times & costs** for OFD module, ЭСФ operator, EDS, alpha-name, each merchant — the real critical path | PM | all |
+
+---
+
+## 14. Risk register (top)
+
+| Risk | Impact | Mitigation |
+|---|---|---|
+| **UzQR already mandatory (2026-07-01 passed)** | Admin fines from day one | Prioritize UzQR into Phase C MVP; no live UZ tenant without it |
+| **Tiyin ×100 confusion** | Every txn off by 100× (money bug) | Single conversion boundary; integer-tiyin storage; adapter-edge conversion; exhaustive money tests |
+| **Non-TRY = 0% tax today** | Silent under-taxation of UZ orders | WS0 tax-policy table before any UZS order |
+| **Registered-but-undispatched provider** | UZ adapter never runs | Thread region→provider selection into every caller; integration test dispatch |
+| **E-IMZO client-side key** | Can't sign ЭСФ unattended | Prefer operator-side signing; custodial only as fallback w/ security review |
+| **Entity lead times serial** | Go-live compresses/slips | Start WS6 now; book all certifications/sandboxes early |
+| **ESC/POS CP857** | Mojibake Uzbek receipts (illegal) | Code-page/transliteration in WS7 before pilot |
+| **Multi-mirror config drift** (currency ×3+, phone ×14) | Partial rollout bugs | Enumerate every mirror + its test; per memory this is where drift hides |
+| **Decimal(10,2) overflow in UZS** | Failed large orders/invoices | Widen columns (reversible) + tiyin integers |
+| **Leaked-secrets risk into new region** | Compromise of fresh UZ prod | Resolve runbook before/with UZ prod; independent UZ secrets |
+
+---
+
+## 15. Appendix — method notes & source confidence
+
+- Facts above were produced by 6 parallel research agents (EN/RU/UZ sources) and **adversarially
+  verified** claim-by-claim; each row carries confidence + primary source. Items marked **⚠** are
+  explicitly *not fully settled* and must be confirmed against Uzbek-language primary text
+  (lex.uz / soliq / provider docs) before go-live.
+- **Under-verified (do before relying on them):** exact virtual-register/OFD machine API; UzQR/MUNIS
+  API + fine amount; whether operators sign ЭСФ unattended; IKPU/MXIK legal basis; the monthly
+  consolidated-ЭСФ requirement for retail; the precise Art. 27-1 cross-border conditions; Eskiz
+  content-moderation gate; real combined wallet market share (the "90%" claim was **refuted**).
+- **Codebase map** was produced by 3 agents reading the actual repo (`fiscal-core`, `payments-core`,
+  `payment-terminal`, currency/tax/phone/i18n/delivery/SMS seams); file paths and line references are
+  from prod v3.2.117.
+- **Migration rule:** every schema/seed change here is a reversible **up/down** pair, backfilled and
+  round-trip-verified, per repo policy.


### PR DESCRIPTION
Gathers all market-expansion / competitive research in one tracked place so it is easy to review later and does not get lost as untracked files.

## What's included

- **`MARKET_EXPANSION_SCAN.md`** — 14-country scan of the "fresh fiscal-receipt mandate = forced buying event" thesis. Each country's core mandate-recency claim was adversarially verified. Ranked tiers + suggested sequence (Kyrgyzstan -> Kazakhstan -> Egypt -> Jordan), and an honesty log of what verification weakened (Georgia's captured single-vendor monopoly, UAE excluding B2C, Romania's under-EUR100 dine-in exemption, Saudi's closed window).
- **`uzbekistan/UZ_EXPANSION_BENCHMARK.md`** — full-system integration benchmark: fiscalization (OFD, UzQR), local payments (Payme/Click/Uzum), e-invoice (ESF), data residency, UZS/language. Includes a file-level map of the code seams to change and a go/no-go scorecard.
- **`kyrgyzstan/KG_EXPANSION_BENCHMARK.md`** — Kyrgyzstan benchmark written as a delta from the Uzbekistan build: FPO (the POS itself becomes the fiscal software), dual tax (VAT + sales tax, which breaks the single tax-rate assumption), ELQR single national QR, ESF bearer-token unattended signing, no data-localization requirement, Kyrgyz (Cyrillic) locale.
- **`README.md`** — index of the folder, including the existing adisyo competitor-parity inventory.

## Notes

- Docs only. No code, schema, or config changes; nothing ships from this PR.
- Country benchmarks are in English (shared language for the dev team and local partners); the index is in Turkish.
- Statuses are DRAFT / plan — implementation stays user-gated.
- Known gap, flagged in the KG doc: the adversarial verify pass for its fiscal/payments/legal dimensions was cut short and is marked with a warning to re-verify before go-live.