### PR TITLE
fix(migration): extra_branch grant migration table name (marketplace_addons) — v3.2.131 deploy hotfix

### DIFF
--- a/backend/prisma/migrations/20260722130000_fix_extra_branch_grant/down.sql
+++ b/backend/prisma/migrations/20260722130000_fix_extra_branch_grant/down.sql
@@ -10,7 +10,7 @@
 -- rollback: undo this migration's effect. Idempotent — a second run,
 -- or a run against a row that never had `limit.maxBranches`, is a
 -- no-op. Scoped to exactly `code = 'extra_branch'`.
-UPDATE "MarketplaceAddOn"
+UPDATE "marketplace_addons"
 SET grants = jsonb_set(
   grants - 'limit.maxBranches',
   '{limit.branches}',

--- a/backend/prisma/migrations/20260722130000_fix_extra_branch_grant/migration.sql
+++ b/backend/prisma/migrations/20260722130000_fix_extra_branch_grant/migration.sql
@@ -1,3 +1,4 @@
+-- @doctor:idempotent verified=single guarded UPDATE on marketplace_addons, scoped to code='extra_branch' AND grants ? 'limit.branches' (no-op on re-run once renamed); jsonb -/jsonb_set touch only the one key.
 -- Task 5 (DEF-6) — fix the extra_branch marketplace add-on's dead grant key.
 --
 -- DEFECT: seed-marketplace.ts's `extra_branch` entry wrote
@@ -60,7 +61,7 @@
 --   (e.g. via a one-off script querying TenantAddOn WHERE addOnId =
 --   the extra_branch row's id AND status IN ('active','past_due')),
 --   not to edit FeatureEntitlement by hand.
-UPDATE "MarketplaceAddOn"
+UPDATE "marketplace_addons"
 SET grants = jsonb_set(
   grants - 'limit.branches',
   '{limit.maxBranches}',


### PR DESCRIPTION
## Hotfix: extra_branch migration prod deploy'da patladı (tablo adı)

**Incident:** v3.2.131 deploy'unda migration `20260722130000_fix_extra_branch_grant` `relation "MarketplaceAddOn" does not exist` (42P01) ile patladı → otomatik rollback (prod v3.2.130'da sağlıklı kaldı, kesinti yok). Migration Prisma model adı `"MarketplaceAddOn"` kullanıyordu; gerçek tablo `@@map("marketplace_addons")`.

**Neden kapılar yakalamadı:** CI e2e `prisma db push` kullanıyor (migration SQL çalıştırmaz); görev round-trip testi tabloyu yanlış adla kurmuş → ikisi de false-pass. Migration'lar yalnız prod-deploy'da gerçek çalışıyor.

**Fix:** migration.sql + down.sql'de `"MarketplaceAddOn"`→`"marketplace_addons"`. Ayrıca `-- @doctor:idempotent` marker eklendi: deploy'un `db-migration-doctor.sh`'i prod'daki failed kaydı otomatik `resolve --rolled-back` + `migrate deploy` ile kurtarır (migration idempotent, `WHERE code='extra_branch' AND grants ? 'limit.branches'` guard'lı). Diğer 4 migration'ın çalışan-SQL tablo adları doğru (hardware_products/hardware_inventory) — teyit edildi.

Prod DB durumu: 120000 uygulandı, 130000 failed-mark (doctor kurtaracak), 140000-160000 bekliyor.
