### PR TITLE
fix(deploy): migration-doctor failed-migration parse (v3.2.132 recovery)

### DIFF
--- a/scripts/db-migration-doctor.sh
+++ b/scripts/db-migration-doctor.sh
@@ -178,11 +178,22 @@ if echo "$status_out" | grep -qi "drift detected"; then
   exit 1
 fi
 
-# Failed migration in DB. The format Prisma prints is:
-#   The `<name>` migration started at <timestamp> failed
-failed_names=$(echo "$status_out" \
-  | grep -oE 'The `[0-9A-Za-z_]+` migration started' \
-  | sed -E 's/The `([^`]+)` migration started/\1/' \
+# Failed migration in DB. Prisma's `migrate status` wording is version-
+# dependent, so match every shape we've seen instead of a single one:
+#   - Older: "The `<name>` migration started at <timestamp> failed"
+#   - Newer: "Following migration have failed:" then the name, plus the
+#     always-printed remediation hints
+#     `prisma migrate resolve --rolled-back "<name>"` /
+#     `... --applied "<name>"`. The resolve-hint lines carry the exact
+#     migration name verbatim on EVERY affected version, so parsing them
+#     is the robust cross-version signal. (v3.2.131 incident: the old
+#     single-pattern parse silently missed a real failed migration on the
+#     installed Prisma, so the doctor reported "state clean" and the
+#     follow-on `migrate deploy` died with P3009.)
+failed_names=$(printf '%s\n' "$status_out" \
+  | grep -oE 'The `[0-9A-Za-z_]+` migration started|migrate resolve --(rolled-back|applied) "[0-9A-Za-z_]+"' \
+  | sed -E 's/^The `([^`]+)` migration started$/\1/; s/^migrate resolve --(rolled-back|applied) "([^"]+)"$/\2/' \
+  | grep -E '^[0-9]' \
   | sort -u || true)
 
 failed_count=$(printf '%s\n' "$failed_names" | grep -c . || true)


### PR DESCRIPTION
## Hotfix: migration-doctor failed-migration'ı tespit edemiyor (parse bug)

**Incident devamı (v3.2.132):** #324 migration tablo-adını düzeltti ama re-deploy YİNE patladı — `scripts/db-migration-doctor.sh` prod'daki failed `130000` kaydını göremedi ("Migration state clean" dedi), sonraki `migrate deploy` P3009 verdi.

**Kök neden:** doctor'ın `failed_names` regex'i yalnız ESKİ Prisma formatını (`The \`<name>\` migration started at ... failed`) arıyordu; kurulu sürüm "Following migration have failed:" + `resolve --rolled-back "<name>"` ipuçları basıyor → parse boş döndü → failed_count=0 → auto-recovery atlandı.

**Fix:** parse'ı her iki formatı da kapsayacak şekilde genişlet — özellikle her sürümde birebir migration adı taşıyan `migrate resolve --(rolled-back|applied) "<name>"` ipucu satırlarını da yakala. Gerçek prod çıktısına + eski formata karşı doğrulandı (backward-compat korundu). Bu düzeltmeyle re-deploy'da doctor failed `130000`'i görür, `@doctor:idempotent` marker'ıyla otomatik `resolve --rolled-back` + `migrate deploy` yapar → düzeltilmiş migration + bekleyen 3'ü uygulanır.
