### PR TITLE
fix(menu): product editor save/stock integrity, image order, drag guards

### DIFF
--- a/frontend/src/features/menu/menuApi.ts
+++ b/frontend/src/features/menu/menuApi.ts
@@ -342,8 +342,14 @@ export const useReorderCategories = () => {
           i18n.t("common:notifications.operationFailed"),
         ),
       );
+      // The per-category PATCH fan-out is non-atomic: on a partial failure the
+      // server holds a half-applied order, so the optimistic rollback above
+      // would LIE for the rest of the session (5-min staleTime, no focus
+      // refetch). Refetch to converge on the server's real order.
+      queryClient.invalidateQueries({ queryKey: categoriesKey });
     },
-    // NOTE: We intentionally do NOT invalidate queries here.
+    // NOTE: on success we intentionally do NOT invalidate — the optimistic
+    // cache already matches what the server accepted.
   });
 };
 
@@ -353,45 +359,31 @@ export const useReorderProducts = () => {
 
   return useMutation({
     mutationFn: async (orderedIds: string[]): Promise<void> => {
-      console.log("useReorderProducts mutation called with:", orderedIds);
       const updates = orderedIds.map((id, index) => ({
         id,
         displayOrder: index,
       }));
-      console.log("Sending updates:", updates);
-
-      const results = await Promise.all(
+      await Promise.all(
         updates.map(({ id, displayOrder }) =>
-          api
-            .patch(`/menu/products/${id}`, { displayOrder })
-            .then((res) => {
-              console.log(
-                `Product ${id} updated to displayOrder ${displayOrder}:`,
-                res.data,
-              );
-              return res;
-            })
-            .catch((err) => {
-              console.error(`Failed to update product ${id}:`, err);
-              throw err;
-            }),
+          api.patch(`/menu/products/${id}`, { displayOrder }),
         ),
       );
-      console.log("All updates complete:", results);
     },
-    // Optimistic update - immediately update the cache
     onSuccess: () => {
       // Invalidate all product queries to refetch with new order
       queryClient.invalidateQueries({ queryKey: ["products"] });
     },
     onError: (error: any) => {
-      console.error("Reorder products error:", error);
       toast.error(
         getApiErrorMessage(
           error,
           i18n.t("common:notifications.operationFailed"),
         ),
       );
+      // The fan-out is non-atomic: some PATCHes may have landed before the
+      // failure. Refetch so the UI shows the server's real order instead of
+      // silently keeping a stale local one.
+      queryClient.invalidateQueries({ queryKey: ["products"] });
     },
   });
 };

--- a/frontend/src/pages/admin/ProductEditorPage.tsx
+++ b/frontend/src/pages/admin/ProductEditorPage.tsx
@@ -160,33 +160,60 @@ export default function ProductEditorPage() {
       name: fetchedProduct.name,
       description: fetchedProduct.description || "",
       ingredients: fetchedProduct.ingredients || "",
-      price: fetchedProduct.price,
+      // The detail endpoint serializes Prisma Decimal columns as STRINGS
+      // ("45.5"); register()'s valueAsNumber/setValueAs do not run on reset
+      // values, so without coercion the z.number() schema rejects every
+      // existing product at save time ("Expected number, received string").
+      price: Number(fetchedProduct.price),
       categoryId: fetchedProduct.categoryId,
-      currentStock: fetchedProduct.currentStock,
+      currentStock:
+        fetchedProduct.currentStock != null
+          ? Number(fetchedProduct.currentStock)
+          : undefined,
       image: fetchedProduct.image || "",
       imageIds: imgs.map((img) => img.id),
       isAvailable: fetchedProduct.isAvailable ?? true,
       stockTracked: fetchedProduct.stockTracked ?? false,
-      taxRate: fetchedProduct.taxRate ?? 10,
+      taxRate: fetchedProduct.taxRate != null ? Number(fetchedProduct.taxRate) : 10,
       productType: fetchedProduct.productType ?? "STANDARD",
-      campaignPrice: fetchedProduct.campaignPrice ?? null,
+      campaignPrice:
+        fetchedProduct.campaignPrice != null
+          ? Number(fetchedProduct.campaignPrice)
+          : null,
       campaignLabel: fetchedProduct.campaignLabel ?? null,
       campaignStartAt: isoToLocalInput(fetchedProduct.campaignStartAt),
       campaignEndAt: isoToLocalInput(fetchedProduct.campaignEndAt),
     });
   }, [fetchedProduct, product, productForm, t]);
 
-  const buildSubmitData = (data: ProductFormData) => {
+  const buildSubmitData = (data: ProductFormData, opts?: { forUpdate?: boolean }) => {
     const { image, campaignStartAt, campaignEndAt, ...rest } = data;
     const productType = data.productType ?? "STANDARD";
     const cp =
       data.campaignPrice != null && Number(data.campaignPrice) > 0
         ? Number(data.campaignPrice)
         : null;
+    // Live stock is decremented by POS sales while the editor is open, so an
+    // update must not round-trip the page-load snapshot: send currentStock /
+    // isAvailable only when the operator actually edited them, and treat a
+    // cleared stock field as "don't change", never as 0.
+    const dirty = productForm.formState.dirtyFields;
+    const stockPatch = opts?.forUpdate
+      ? {
+          ...(dirty.currentStock && data.currentStock != null
+            ? { currentStock: Number(data.currentStock) }
+            : {}),
+          ...(dirty.isAvailable ? { isAvailable: data.isAvailable } : {}),
+        }
+      : { currentStock: data.currentStock != null ? Number(data.currentStock) : 0 };
+    if (opts?.forUpdate) {
+      delete (rest as Partial<ProductFormData>).currentStock;
+      delete (rest as Partial<ProductFormData>).isAvailable;
+    }
     return {
       ...rest,
+      ...stockPatch,
       price: Number(data.price),
-      currentStock: data.currentStock ? Number(data.currentStock) : 0,
       taxRate: data.taxRate != null ? Number(data.taxRate) : 10,
       imageIds: productImages.map((img) => img.id),
       productType,
@@ -233,7 +260,7 @@ export default function ProductEditorPage() {
       try {
         await updateProduct({
           id: product.id,
-          data: buildSubmitData(productForm.getValues()),
+          data: buildSubmitData(productForm.getValues(), { forUpdate: true }),
         });
         await persistModifiers(product.id);
         return product.id;
@@ -264,14 +291,23 @@ export default function ProductEditorPage() {
   };
 
   const onSubmit = async (data: ProductFormData) => {
-    const submitData = buildSubmitData(data);
     try {
       if (product?.id) {
-        await updateProduct({ id: product.id, data: submitData });
+        await updateProduct({
+          id: product.id,
+          data: buildSubmitData(data, { forUpdate: true }),
+        });
         await persistModifiers(product.id);
       } else {
-        const created = (await createProduct(submitData)) as Product;
-        if (created?.id) await persistModifiers(created.id);
+        const created = (await createProduct(buildSubmitData(data))) as Product;
+        if (created?.id) {
+          // Adopt the created row IMMEDIATELY: if persistModifiers fails below,
+          // the next Save must run the update path — re-running create would
+          // silently duplicate the product.
+          setProduct(created);
+          navigate(`/admin/menu/products/${created.id}/edit`, { replace: true });
+          await persistModifiers(created.id);
+        }
       }
       toast.success(t("menu.itemSaved", "Ürün kaydedildi"));
       navigate("/admin/menu");
@@ -599,6 +635,7 @@ export default function ProductEditorPage() {
                   label={t("menu.campaignPrice", "Kampanya fiyatı (₺)")}
                   type="number"
                   step="0.01"
+                  error={productForm.formState.errors.campaignPrice?.message}
                   {...productForm.register("campaignPrice", {
                     setValueAs: (v) =>
                       v === "" || v === null ? null : Number(v),
@@ -671,7 +708,18 @@ export default function ProductEditorPage() {
         isOpen={imageLibraryOpen}
         onClose={() => setImageLibraryOpen(false)}
         onSelectImages={(images) => {
-          setProductImages(images);
+          // Preserve the existing attachment order — images[0] is the primary
+          // photo on QR/POS. The library lists newest-first, so replacing the
+          // array wholesale would silently promote the newest upload to
+          // primary; instead keep still-selected images in place and append
+          // the newly added ones.
+          setProductImages((prev) => {
+            const selectedById = new Map(images.map((img) => [img.id, img]));
+            const kept = prev.filter((img) => selectedById.has(img.id));
+            const keptIds = new Set(kept.map((img) => img.id));
+            const added = images.filter((img) => !keptIds.has(img.id));
+            return [...kept, ...added];
+          });
           setImageLibraryOpen(false);
         }}
         selectedImageIds={productImages.map((img) => img.id)}

--- a/frontend/src/pages/admin/menuManagement/MenuTab.tsx
+++ b/frontend/src/pages/admin/menuManagement/MenuTab.tsx
@@ -103,41 +103,33 @@ const MenuTab = ({
 
   // Drag & Drop handler
   const handleDragEnd = useCallback((result: DropResult) => {
-    const { source, destination, type, draggableId } = result;
+    const { source, destination, type } = result;
 
-    console.log('handleDragEnd called:', { source, destination, type, draggableId });
-
-    if (!destination) {
-      console.log('No destination, returning');
-      return;
-    }
+    if (!destination) return;
     if (source.index === destination.index && source.droppableId === destination.droppableId) {
-      console.log('Same position, returning');
       return;
     }
 
     if (type === 'CATEGORY') {
-      console.log('Reordering categories');
       const reordered = reorder(sortedCategories, source.index, destination.index);
       reorderCategories(reordered.map(c => c.id));
     } else if (type === 'PRODUCT') {
+      // Cross-category drops are not a supported move: the payload below only
+      // reorders the SOURCE category, so accepting one would scramble that
+      // category's order while the product visibly snaps back. Bail instead.
+      if (source.droppableId !== destination.droppableId) return;
+
       // droppableId is "products-{categoryId}"
       const categoryId = source.droppableId.replace('products-', '');
-      console.log('Reordering products in category:', categoryId);
       const categoryProducts = productsByCategory[categoryId] || [];
-      console.log('Category products:', categoryProducts.map(p => ({ id: p.id, name: p.name, displayOrder: p.displayOrder })));
 
       const sortedCategoryProducts = [...categoryProducts].sort((a, b) => {
         const orderA = a.displayOrder ?? 0;
         const orderB = b.displayOrder ?? 0;
         return orderA - orderB;
       });
-      console.log('Sorted products before reorder:', sortedCategoryProducts.map(p => p.name));
 
       const reordered = reorder(sortedCategoryProducts, source.index, destination.index);
-      console.log('Reordered products:', reordered.map(p => p.name));
-      console.log('Sending IDs to API:', reordered.map(p => p.id));
-
       reorderProducts(reordered.map(p => p.id));
     }
   }, [sortedCategories, productsByCategory, reorderCategories, reorderProducts]);


### PR DESCRIPTION
Adversarial review pass over the admin menu-management frontend (review loop tick 1). Six confirmed defects fixed:

1. **Editing any existing product was validation-blocked**: the detail endpoint serializes Prisma Decimal columns as strings; form reset() bypasses register() coercion, so saving an existing product failed z.number() with a raw "Expected number, received string" (and silently, when only campaignPrice failed — that input had no error binding). AI Studio actions bailed the same way. Hydration now coerces; campaignPrice binds its error.
2. **Save clobbered live stock**: updates round-tripped the page-load currentStock/isAvailable snapshot (overwriting POS-decremented stock → oversell risk) and turned a cleared stock field into 0. Both now sent only when dirty; cleared = unchanged.
3. **Image library confirm silently changed the primary photo** (newest-first library order replaced the attachment order). Existing order preserved, new picks appended.
4. **Cross-category product drops** were visually accepted but scrambled the source category's order without moving the product. Now rejected.
5. **Duplicate product on partial create failure** (modifier-assign rejection left the page in create mode). The created row is adopted before modifiers persist.
6. Reorder fan-outs now refetch on error (half-applied server order was hidden behind the optimistic cache for the whole session); drag-path debug console.logs removed.

Verification: 93 admin+product component tests and 26 menu tests green, tsc clean, eslint clean.
