### PR TITLE
feat(menu): atomic batch reorder endpoints for categories and products

### DIFF
--- a/backend/src/modules/menu/controllers/categories.controller.spec.ts
+++ b/backend/src/modules/menu/controllers/categories.controller.spec.ts
@@ -18,6 +18,7 @@ describe('CategoriesController', () => {
       findOne: jest.fn().mockResolvedValue({ id: 'c1' }),
       update: jest.fn().mockResolvedValue({ id: 'c1' }),
       remove: jest.fn().mockResolvedValue({ id: 'c1' }),
+      reorder: jest.fn().mockResolvedValue([]),
     };
     ctrl = new CategoriesController(svc as any);
   });
@@ -52,5 +53,10 @@ describe('CategoriesController', () => {
   it('remove forwards id + tenantId', () => {
     ctrl.remove('c1', req as any);
     expect(svc.remove).toHaveBeenCalledWith('c1', 't1');
+  });
+
+  it('reorder forwards orderedIds (from dto) + tenantId', () => {
+    ctrl.reorder({ orderedIds: ['c2', 'c1'] } as any, req as any);
+    expect(svc.reorder).toHaveBeenCalledWith(['c2', 'c1'], 't1');
   });
 });

--- a/backend/src/modules/menu/controllers/categories.controller.ts
+++ b/backend/src/modules/menu/controllers/categories.controller.ts
@@ -20,6 +20,7 @@ import {
 import { CategoriesService } from "../services/categories.service";
 import { CreateCategoryDto } from "../dto/create-category.dto";
 import { UpdateCategoryDto } from "../dto/update-category.dto";
+import { ReorderMenuDto } from "../dto/reorder-menu.dto";
 import { ListQueryDto } from "../../../common/dto/list-query.dto";
 import { JwtAuthGuard } from "../../auth/guards/jwt-auth.guard";
 import { RolesGuard } from "../../auth/guards/roles.guard";
@@ -77,6 +78,21 @@ export class CategoriesController {
   @ApiResponse({ status: 404, description: "Category not found" })
   findOne(@Param("id") id: string, @Request() req) {
     return this.categoriesService.findOne(id, req.tenantId);
+  }
+
+  // ROUTE ORDER: must stay ABOVE @Patch(":id") — Nest matches routes in
+  // declaration order, so a later "reorder" literal would be swallowed as
+  // :id="reorder" and 404 in the update handler.
+  @Patch("reorder")
+  @Roles(UserRole.ADMIN, UserRole.MANAGER)
+  @ApiOperation({
+    summary: "Reorder categories in one atomic batch (ADMIN, MANAGER)",
+  })
+  @ApiResponse({ status: 200, description: "Categories reordered" })
+  @ApiResponse({ status: 400, description: "Invalid category IDs" })
+  @ApiResponse({ status: 403, description: "Insufficient permissions" })
+  reorder(@Body() reorderDto: ReorderMenuDto, @Request() req) {
+    return this.categoriesService.reorder(reorderDto.orderedIds, req.tenantId);
   }
 
   @Patch(":id")

--- a/backend/src/modules/menu/controllers/menu-reorder.routing.spec.ts
+++ b/backend/src/modules/menu/controllers/menu-reorder.routing.spec.ts
@@ -1,0 +1,162 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  INestApplication,
+  Injectable,
+  ValidationPipe,
+} from "@nestjs/common";
+import { Test } from "@nestjs/testing";
+import request from "supertest";
+import { CategoriesController } from "./categories.controller";
+import { ProductsController } from "./products.controller";
+import { CategoriesService } from "../services/categories.service";
+import { ProductsService } from "../services/products.service";
+import { JwtAuthGuard } from "../../auth/guards/jwt-auth.guard";
+import { RolesGuard } from "../../auth/guards/roles.guard";
+import { TenantGuard } from "../../auth/guards/tenant.guard";
+import { PlanFeatureGuard } from "../../subscriptions/guards/plan-feature.guard";
+
+/**
+ * HTTP-level routing spec for the batch reorder endpoints, run through a real
+ * Nest app (services mocked, guards stubbed) — the same in-unit-gate supertest
+ * pattern as branch-scope.behavior.spec.ts. It pins the ROUTE-ORDER footgun:
+ * Nest matches routes in declaration order, so @Patch("reorder") must be
+ * declared BEFORE @Patch(":id") or the literal path is swallowed as
+ * :id="reorder" and dispatched to the update handler. A pure
+ * controller-instance spec cannot see that; only real routing can.
+ * Also exercises the ReorderMenuDto validation (empty / duplicate ids → 400).
+ */
+
+@Injectable()
+class StubTenantGuard implements CanActivate {
+  canActivate(ctx: ExecutionContext): boolean {
+    ctx.switchToHttp().getRequest().tenantId = "t1";
+    return true;
+  }
+}
+
+const passGuard = { canActivate: () => true };
+
+describe("menu reorder routing (real HTTP)", () => {
+  let app: INestApplication;
+  let categoriesSvc: Record<string, jest.Mock>;
+  let productsSvc: Record<string, jest.Mock>;
+
+  beforeAll(async () => {
+    categoriesSvc = {
+      reorder: jest.fn().mockResolvedValue([]),
+      update: jest.fn().mockResolvedValue({ id: "c1" }),
+    };
+    productsSvc = {
+      reorderProducts: jest.fn().mockResolvedValue([]),
+      update: jest.fn().mockResolvedValue({ id: "p1" }),
+    };
+
+    const moduleRef = await Test.createTestingModule({
+      controllers: [CategoriesController, ProductsController],
+      providers: [
+        { provide: CategoriesService, useValue: categoriesSvc },
+        { provide: ProductsService, useValue: productsSvc },
+      ],
+    })
+      .overrideGuard(JwtAuthGuard)
+      .useValue(passGuard)
+      .overrideGuard(TenantGuard)
+      .useClass(StubTenantGuard)
+      .overrideGuard(RolesGuard)
+      .useValue(passGuard)
+      .overrideGuard(PlanFeatureGuard)
+      .useValue(passGuard)
+      .compile();
+
+    app = moduleRef.createNestApplication();
+    // Mirror main.ts's pipe exactly so the DTO validation is exercised for real.
+    app.useGlobalPipes(
+      new ValidationPipe({
+        whitelist: true,
+        transform: true,
+        forbidNonWhitelisted: false,
+        transformOptions: { enableImplicitConversion: true },
+      }),
+    );
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("PATCH /menu/categories/reorder hits the batch handler, NOT update(':id')", async () => {
+    await request(app.getHttpServer())
+      .patch("/menu/categories/reorder")
+      .send({ orderedIds: ["c2", "c1"] })
+      .expect(200);
+
+    expect(categoriesSvc.reorder).toHaveBeenCalledWith(["c2", "c1"], "t1");
+    expect(categoriesSvc.update).not.toHaveBeenCalled();
+  });
+
+  it("PATCH /menu/categories/:id still reaches the update handler", async () => {
+    await request(app.getHttpServer())
+      .patch("/menu/categories/c-123")
+      .send({ name: "Renamed" })
+      .expect(200);
+
+    expect(categoriesSvc.update).toHaveBeenCalledWith(
+      "c-123",
+      expect.objectContaining({ name: "Renamed" }),
+      "t1",
+    );
+    expect(categoriesSvc.reorder).not.toHaveBeenCalled();
+  });
+
+  it("PATCH /menu/products/reorder hits the batch handler, NOT update(':id')", async () => {
+    await request(app.getHttpServer())
+      .patch("/menu/products/reorder")
+      .send({ orderedIds: ["p2", "p1"] })
+      .expect(200);
+
+    expect(productsSvc.reorderProducts).toHaveBeenCalledWith(
+      ["p2", "p1"],
+      "t1",
+    );
+    expect(productsSvc.update).not.toHaveBeenCalled();
+  });
+
+  it("PATCH /menu/products/:id still reaches the update handler", async () => {
+    await request(app.getHttpServer())
+      .patch("/menu/products/p-9")
+      .send({ price: 9.5 })
+      .expect(200);
+
+    expect(productsSvc.update).toHaveBeenCalledWith(
+      "p-9",
+      expect.objectContaining({ price: 9.5 }),
+      "t1",
+    );
+    expect(productsSvc.reorderProducts).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["missing orderedIds", {}],
+    ["empty orderedIds", { orderedIds: [] }],
+    ["duplicate ids", { orderedIds: ["a", "a"] }],
+    ["non-string entries", { orderedIds: [1, 2] }],
+  ])("rejects %s with 400 before the service runs", async (_label, body) => {
+    await request(app.getHttpServer())
+      .patch("/menu/categories/reorder")
+      .send(body)
+      .expect(400);
+    await request(app.getHttpServer())
+      .patch("/menu/products/reorder")
+      .send(body)
+      .expect(400);
+
+    expect(categoriesSvc.reorder).not.toHaveBeenCalled();
+    expect(productsSvc.reorderProducts).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/modules/menu/controllers/products.controller.spec.ts
+++ b/backend/src/modules/menu/controllers/products.controller.spec.ts
@@ -20,6 +20,7 @@ describe("ProductsController", () => {
       remove: jest.fn().mockResolvedValue({ id: "p1" }),
       updateStock: jest.fn().mockResolvedValue({ id: "p1" }),
       getProductImages: jest.fn().mockResolvedValue([]),
+      reorderProducts: jest.fn().mockResolvedValue([]),
       reorderProductImages: jest.fn().mockResolvedValue([]),
       removeImageFromProduct: jest.fn().mockResolvedValue({ id: "p1" }),
     };
@@ -98,6 +99,11 @@ describe("ProductsController", () => {
   it("getProductImages forwards id + tenantId", () => {
     ctrl.getProductImages("p1", req as any);
     expect(svc.getProductImages).toHaveBeenCalledWith("p1", "t1");
+  });
+
+  it("reorderProducts forwards orderedIds (from dto) + tenantId", () => {
+    ctrl.reorderProducts({ orderedIds: ["p2", "p1"] } as any, req as any);
+    expect(svc.reorderProducts).toHaveBeenCalledWith(["p2", "p1"], "t1");
   });
 
   it("reorderImages forwards id, imageIds (from @Body), tenantId", () => {

--- a/backend/src/modules/menu/controllers/products.controller.ts
+++ b/backend/src/modules/menu/controllers/products.controller.ts
@@ -20,6 +20,7 @@ import {
 import { ProductsService } from "../services/products.service";
 import { CreateProductDto } from "../dto/create-product.dto";
 import { UpdateProductDto } from "../dto/update-product.dto";
+import { ReorderMenuDto } from "../dto/reorder-menu.dto";
 import { ListQueryDto } from "../../../common/dto/list-query.dto";
 import { JwtAuthGuard } from "../../auth/guards/jwt-auth.guard";
 import { RolesGuard } from "../../auth/guards/roles.guard";
@@ -103,6 +104,28 @@ export class ProductsController {
   @ApiResponse({ status: 404, description: "Product not found" })
   findOne(@Param("id") id: string, @Request() req) {
     return this.productsService.findOne(id, req.tenantId);
+  }
+
+  // ROUTE ORDER: must stay ABOVE @Patch(":id") — Nest matches routes in
+  // declaration order, so a later "reorder" literal would be swallowed as
+  // :id="reorder" and 404 in the update handler.
+  @Patch("reorder")
+  @Roles(UserRole.ADMIN, UserRole.MANAGER)
+  @ApiOperation({
+    summary:
+      "Reorder products of one category in one atomic batch (ADMIN, MANAGER)",
+  })
+  @ApiResponse({ status: 200, description: "Products reordered" })
+  @ApiResponse({
+    status: 400,
+    description: "Invalid product IDs or ids span multiple categories",
+  })
+  @ApiResponse({ status: 403, description: "Insufficient permissions" })
+  reorderProducts(@Body() reorderDto: ReorderMenuDto, @Request() req) {
+    return this.productsService.reorderProducts(
+      reorderDto.orderedIds,
+      req.tenantId,
+    );
   }
 
   @Patch(":id")

--- a/backend/src/modules/menu/dto/reorder-menu.dto.ts
+++ b/backend/src/modules/menu/dto/reorder-menu.dto.ts
@@ -1,0 +1,29 @@
+import { ApiProperty } from "@nestjs/swagger";
+import {
+  ArrayMaxSize,
+  ArrayNotEmpty,
+  ArrayUnique,
+  IsArray,
+  IsString,
+} from "class-validator";
+
+/**
+ * Batch reorder payload shared by PATCH /menu/categories/reorder and
+ * PATCH /menu/products/reorder. The server applies displayOrder = array
+ * index inside ONE transaction, replacing the old per-row PATCH fan-out
+ * that could leave a half-applied order on partial failure.
+ */
+export class ReorderMenuDto {
+  @ApiProperty({
+    example: ["b6a4…", "0f21…"],
+    type: [String],
+    description:
+      "Ids in their new display order — displayOrder becomes the array index",
+  })
+  @IsArray()
+  @ArrayNotEmpty()
+  @ArrayUnique()
+  @ArrayMaxSize(1000)
+  @IsString({ each: true })
+  orderedIds: string[];
+}

--- a/backend/src/modules/menu/services/categories.service.spec.ts
+++ b/backend/src/modules/menu/services/categories.service.spec.ts
@@ -1,4 +1,4 @@
-import { ConflictException, NotFoundException } from '@nestjs/common';
+import { BadRequestException, ConflictException, NotFoundException } from '@nestjs/common';
 import { Prisma } from '@prisma/client';
 import { CategoriesService } from './categories.service';
 import { mockPrismaClient, MockPrismaClient } from '../../../common/test/prisma-mock.service';
@@ -164,6 +164,71 @@ describe('CategoriesService', () => {
       expect(call.take).toBeUndefined();
       expect(call.skip).toBeUndefined();
       expect(result.map((c: any) => c.id)).toEqual(['a', 'b', 'c']);
+    });
+  });
+
+  // -- Batch reorder: atomic displayOrder = array index ----------------
+
+  describe('reorder', () => {
+    beforeEach(() => {
+      // Interactive tx forwards onto the same deep mock so the assertions
+      // below see the writes the service issued inside the transaction.
+      (prisma.$transaction as any).mockImplementation(async (work: any) =>
+        work(prisma),
+      );
+      (prisma.category.updateMany as any).mockResolvedValue({ count: 1 });
+    });
+
+    it('applies displayOrder = array index for every id inside ONE transaction', async () => {
+      (prisma.category.findMany as any)
+        // 1st call: in-tx bulk ownership check.
+        .mockResolvedValueOnce([{ id: 'c3' }, { id: 'c1' }, { id: 'c2' }])
+        // 2nd call: post-tx findAll re-read.
+        .mockResolvedValueOnce([]);
+
+      await svc.reorder(['c3', 'c1', 'c2'], 't1');
+
+      expect((prisma.$transaction as any).mock.calls.length).toBe(1);
+      const writes = (prisma.category.updateMany as any).mock.calls.map(
+        (c: any[]) => c[0],
+      );
+      expect(writes).toEqual([
+        { where: { id: 'c3', tenantId: 't1' }, data: { displayOrder: 0 } },
+        { where: { id: 'c1', tenantId: 't1' }, data: { displayOrder: 1 } },
+        { where: { id: 'c2', tenantId: 't1' }, data: { displayOrder: 2 } },
+      ]);
+    });
+
+    it('rejects a foreign-tenant / unknown id before ANY write (tx rolls back)', async () => {
+      // Ownership check only finds c1 — c-foreign is another tenant's row.
+      (prisma.category.findMany as any).mockResolvedValueOnce([{ id: 'c1' }]);
+
+      await expect(svc.reorder(['c1', 'c-foreign'], 't1')).rejects.toThrow(
+        BadRequestException,
+      );
+      expect((prisma.category.updateMany as any).mock.calls.length).toBe(0);
+    });
+
+    it('rejects empty and duplicate id lists without touching the DB', async () => {
+      await expect(svc.reorder([], 't1')).rejects.toThrow(BadRequestException);
+      await expect(svc.reorder(['c1', 'c1'], 't1')).rejects.toThrow(
+        BadRequestException,
+      );
+      expect((prisma.$transaction as any).mock.calls.length).toBe(0);
+    });
+
+    it('aborts the batch when a row vanishes between check and write', async () => {
+      (prisma.category.findMany as any).mockResolvedValueOnce([
+        { id: 'c1' },
+        { id: 'c2' },
+      ]);
+      (prisma.category.updateMany as any)
+        .mockResolvedValueOnce({ count: 1 })
+        .mockResolvedValueOnce({ count: 0 });
+
+      await expect(svc.reorder(['c1', 'c2'], 't1')).rejects.toThrow(
+        BadRequestException,
+      );
     });
   });
 });

--- a/backend/src/modules/menu/services/categories.service.ts
+++ b/backend/src/modules/menu/services/categories.service.ts
@@ -1,4 +1,5 @@
 import {
+  BadRequestException,
   Injectable,
   NotFoundException,
   ConflictException,
@@ -89,6 +90,53 @@ export class CategoriesService {
     // miss the constraint. Same pattern iter-9 closed across tables/
     // suppliers/stock-categories.
     return this.prisma.category.findFirstOrThrow({ where: { id, tenantId } });
+  }
+
+  /**
+   * Atomic batch reorder: displayOrder = array index, applied inside ONE
+   * transaction so a partial failure can never leave a half-applied order
+   * (the failure mode of the old per-category PATCH fan-out). Ownership is
+   * validated INSIDE the transaction; any invalid id rolls everything back.
+   */
+  async reorder(orderedIds: string[], tenantId: string) {
+    // The DTO already enforces non-empty/unique — re-check cheaply so a
+    // future internal caller that bypasses the pipe can't half-apply junk.
+    if (!orderedIds || orderedIds.length === 0) {
+      throw new BadRequestException("orderedIds must not be empty");
+    }
+    if (new Set(orderedIds).size !== orderedIds.length) {
+      throw new BadRequestException("orderedIds must not contain duplicates");
+    }
+
+    await this.prisma.$transaction(async (tx) => {
+      // Bulk ownership check (same shape as the product-image reorder's
+      // bulk verify): one round-trip catches both "wrong tenant" and
+      // "id doesn't exist".
+      const owned = await tx.category.findMany({
+        where: { id: { in: orderedIds }, tenantId },
+        select: { id: true },
+      });
+      if (owned.length !== orderedIds.length) {
+        const foundSet = new Set(owned.map((o) => o.id));
+        const missing = orderedIds.filter((id) => !foundSet.has(id));
+        throw new BadRequestException(
+          `Category(ies) not found or do not belong to your tenant: ${missing.join(", ")}`,
+        );
+      }
+      for (const [index, id] of orderedIds.entries()) {
+        // Compound WHERE — IDOR guard (B41-B45 pattern). count===0 means the
+        // row vanished between the check and the write; abort the whole tx.
+        const claim = await tx.category.updateMany({
+          where: { id, tenantId },
+          data: { displayOrder: index },
+        });
+        if (claim.count === 0) {
+          throw new BadRequestException(`Category with ID ${id} not found`);
+        }
+      }
+    });
+
+    return this.findAll(tenantId);
   }
 
   async remove(id: string, tenantId: string) {

--- a/backend/src/modules/menu/services/products.crud.service.spec.ts
+++ b/backend/src/modules/menu/services/products.crud.service.spec.ts
@@ -419,4 +419,95 @@ describe("ProductsService — create/update/remove/transform", () => {
       expect(uploadService.deleteProductImage).not.toHaveBeenCalled();
     });
   });
+
+  // -- reorderProducts: atomic displayOrder = array index --------------
+
+  describe("reorderProducts", () => {
+    beforeEach(() => {
+      // Interactive tx forwards onto the same deep mock so the assertions
+      // below see the writes the service issued inside the transaction.
+      (prisma.$transaction as any).mockImplementation(async (work: any) =>
+        work(prisma),
+      );
+      (prisma.product.updateMany as any).mockResolvedValue({ count: 1 });
+    });
+
+    it("applies displayOrder = array index for every id inside ONE transaction", async () => {
+      (prisma.product.findMany as any)
+        // 1st call: in-tx bulk ownership + same-category check.
+        .mockResolvedValueOnce([
+          { id: "p3", categoryId: "cat-1" },
+          { id: "p1", categoryId: "cat-1" },
+          { id: "p2", categoryId: "cat-1" },
+        ])
+        // 2nd call: post-tx findAll(tenantId, categoryId) re-read.
+        .mockResolvedValueOnce([]);
+
+      await svc.reorderProducts(["p3", "p1", "p2"], TENANT);
+
+      expect((prisma.$transaction as any).mock.calls.length).toBe(1);
+      const writes = (prisma.product.updateMany as any).mock.calls.map(
+        (c: any[]) => c[0],
+      );
+      expect(writes).toEqual([
+        { where: { id: "p3", tenantId: TENANT }, data: { displayOrder: 0 } },
+        { where: { id: "p1", tenantId: TENANT }, data: { displayOrder: 1 } },
+        { where: { id: "p2", tenantId: TENANT }, data: { displayOrder: 2 } },
+      ]);
+      // The post-tx re-read is scoped to the affected category.
+      const reread = (prisma.product.findMany as any).mock.calls[1][0];
+      expect(reread.where).toMatchObject({
+        tenantId: TENANT,
+        categoryId: "cat-1",
+      });
+    });
+
+    it("rejects a foreign-tenant / unknown id before ANY write (tx rolls back)", async () => {
+      // Ownership check only finds p1 — p-foreign is another tenant's row.
+      (prisma.product.findMany as any).mockResolvedValueOnce([
+        { id: "p1", categoryId: "cat-1" },
+      ]);
+
+      await expect(
+        svc.reorderProducts(["p1", "p-foreign"], TENANT),
+      ).rejects.toThrow(BadRequestException);
+      expect((prisma.product.updateMany as any).mock.calls.length).toBe(0);
+    });
+
+    it("rejects ids spanning two categories before ANY write", async () => {
+      (prisma.product.findMany as any).mockResolvedValueOnce([
+        { id: "p1", categoryId: "cat-1" },
+        { id: "p2", categoryId: "cat-2" },
+      ]);
+
+      await expect(svc.reorderProducts(["p1", "p2"], TENANT)).rejects.toThrow(
+        "All products in a reorder must belong to the same category",
+      );
+      expect((prisma.product.updateMany as any).mock.calls.length).toBe(0);
+    });
+
+    it("rejects empty and duplicate id lists without touching the DB", async () => {
+      await expect(svc.reorderProducts([], TENANT)).rejects.toThrow(
+        BadRequestException,
+      );
+      await expect(svc.reorderProducts(["p1", "p1"], TENANT)).rejects.toThrow(
+        BadRequestException,
+      );
+      expect((prisma.$transaction as any).mock.calls.length).toBe(0);
+    });
+
+    it("aborts the batch when a row vanishes between check and write", async () => {
+      (prisma.product.findMany as any).mockResolvedValueOnce([
+        { id: "p1", categoryId: "cat-1" },
+        { id: "p2", categoryId: "cat-1" },
+      ]);
+      (prisma.product.updateMany as any)
+        .mockResolvedValueOnce({ count: 1 })
+        .mockResolvedValueOnce({ count: 0 });
+
+      await expect(svc.reorderProducts(["p1", "p2"], TENANT)).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+  });
 });

--- a/backend/src/modules/menu/services/products.service.ts
+++ b/backend/src/modules/menu/services/products.service.ts
@@ -598,6 +598,65 @@ export class ProductsService {
     return this.findOne(id, tenantId);
   }
 
+  /**
+   * Atomic batch reorder of products WITHIN one category: displayOrder =
+   * array index, applied inside ONE transaction so a partial failure can
+   * never leave a half-applied order (the failure mode of the old
+   * per-product PATCH fan-out). The admin drag UI only reorders inside a
+   * single category droppable, so a payload spanning two categories is a
+   * client bug — rejected rather than silently scrambling both lists.
+   */
+  async reorderProducts(orderedIds: string[], tenantId: string) {
+    // The DTO already enforces non-empty/unique — re-check cheaply so a
+    // future internal caller that bypasses the pipe can't half-apply junk.
+    if (!orderedIds || orderedIds.length === 0) {
+      throw new BadRequestException("orderedIds must not be empty");
+    }
+    if (new Set(orderedIds).size !== orderedIds.length) {
+      throw new BadRequestException("orderedIds must not contain duplicates");
+    }
+
+    let categoryId = "";
+    await this.prisma.$transaction(async (tx) => {
+      // Bulk ownership check (same shape as attachImagesToProduct's bulk
+      // verify): one round-trip catches both "wrong tenant" and
+      // "id doesn't exist".
+      const owned = await tx.product.findMany({
+        where: { id: { in: orderedIds }, tenantId },
+        select: { id: true, categoryId: true },
+      });
+      if (owned.length !== orderedIds.length) {
+        const foundSet = new Set(owned.map((o) => o.id));
+        const missing = orderedIds.filter((id) => !foundSet.has(id));
+        throw new BadRequestException(
+          `Product(s) not found or do not belong to your tenant: ${missing.join(", ")}`,
+        );
+      }
+      const categoryIds = new Set(owned.map((p) => p.categoryId));
+      if (categoryIds.size > 1) {
+        throw new BadRequestException(
+          "All products in a reorder must belong to the same category",
+        );
+      }
+      categoryId = owned[0].categoryId;
+      for (const [index, id] of orderedIds.entries()) {
+        // Compound WHERE — IDOR guard (B41-B45 pattern). count===0 means the
+        // row vanished between the check and the write; abort the whole tx.
+        const claim = await tx.product.updateMany({
+          where: { id, tenantId },
+          data: { displayOrder: index },
+        });
+        if (claim.count === 0) {
+          throw new BadRequestException(`Product with ID ${id} not found`);
+        }
+      }
+    });
+
+    // Fresh, campaign-decorated list of the affected category (mirrors the
+    // image reorder returning getProductImages).
+    return this.findAll(tenantId, categoryId);
+  }
+
   // Image management methods
   private async attachImagesToProduct(
     productId: string,

--- a/frontend/src/features/menu/menuApi.test.tsx
+++ b/frontend/src/features/menu/menuApi.test.tsx
@@ -6,11 +6,14 @@ import type { Category } from '../../types';
 
 /**
  * Specs for menuApi's reorder mutations — the only hooks here with real
- * logic beyond pass-through CRUD. useReorderCategories does an optimistic
- * cache rewrite in onMutate (remap each category's displayOrder to its
- * index in the new id order, leaving unknown ids untouched) and rolls the
- * snapshot back on error. We deep-mock the axios-ish `api` and the toast,
- * and assert the exact PATCH payloads + cache transitions.
+ * logic beyond pass-through CRUD. Both hooks now issue a SINGLE atomic
+ * batch PATCH (/menu/{categories,products}/reorder with { orderedIds })
+ * instead of the old non-atomic per-row fan-out. useReorderCategories does
+ * an optimistic cache rewrite in onMutate (remap each category's
+ * displayOrder to its index in the new id order, leaving unknown ids
+ * untouched) and rolls the snapshot back on error; useReorderProducts
+ * invalidates on success AND on error. We deep-mock the axios-ish `api`
+ * and the toast, and assert the exact PATCH payload + cache transitions.
  */
 
 const patchMock = vi.fn();
@@ -24,7 +27,7 @@ vi.mock('sonner', () => ({ toast: { error: (...a: unknown[]) => toastErrorMock(.
 vi.mock('../../i18n/config', () => ({ default: { t: (k: string) => k } }));
 
 import { useBranchScopeStore } from '../../store/branchScopeStore';
-import { useReorderCategories } from './menuApi';
+import { useReorderCategories, useReorderProducts } from './menuApi';
 
 function wrapper(client: QueryClient) {
   return ({ children }: { children: ReactNode }) => (
@@ -47,7 +50,7 @@ beforeEach(() => {
 });
 
 describe('useReorderCategories — mutationFn payloads', () => {
-  it('PATCHes each category with its new index as displayOrder', async () => {
+  it('sends ONE atomic batch PATCH with the full ordered id list', async () => {
     patchMock.mockResolvedValue({ data: {} });
     const client = new QueryClient();
     const { result } = renderHook(() => useReorderCategories(), {
@@ -58,10 +61,12 @@ describe('useReorderCategories — mutationFn payloads', () => {
       await result.current.mutateAsync(['c3', 'c1', 'c2']);
     });
 
-    expect(patchMock).toHaveBeenCalledTimes(3);
-    expect(patchMock).toHaveBeenCalledWith('/menu/categories/c3', { displayOrder: 0 });
-    expect(patchMock).toHaveBeenCalledWith('/menu/categories/c1', { displayOrder: 1 });
-    expect(patchMock).toHaveBeenCalledWith('/menu/categories/c2', { displayOrder: 2 });
+    // Single batch call — NOT a per-category fan-out (that shape was
+    // non-atomic: a partial failure left a half-applied order server-side).
+    expect(patchMock).toHaveBeenCalledTimes(1);
+    expect(patchMock).toHaveBeenCalledWith('/menu/categories/reorder', {
+      orderedIds: ['c3', 'c1', 'c2'],
+    });
   });
 });
 
@@ -131,5 +136,61 @@ describe('useReorderCategories — error rollback', () => {
     expect(after.find((c) => c.id === 'c2')!.displayOrder).toBe(1);
     expect(after.find((c) => c.id === 'c1')!.displayOrder).toBe(0);
     expect(toastErrorMock).toHaveBeenCalledWith('boom');
+  });
+
+  it('invalidates the branch-keyed categories query on error (converge on server order)', async () => {
+    patchMock.mockRejectedValue({ isAxiosError: true, response: { data: { message: 'boom' } } });
+    const client = new QueryClient();
+    const invalidateSpy = vi.spyOn(client, 'invalidateQueries');
+    client.setQueryData(['categories', 'b-1'], [cat('c1', 0), cat('c2', 1)]);
+
+    const { result } = renderHook(() => useReorderCategories(), {
+      wrapper: wrapper(client),
+    });
+    await act(async () => {
+      await result.current.mutateAsync(['c2', 'c1']).catch(() => undefined);
+    });
+
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['categories', 'b-1'] });
+  });
+});
+
+describe('useReorderProducts — single batch call + invalidation', () => {
+  it('sends ONE atomic batch PATCH and invalidates products on success', async () => {
+    patchMock.mockResolvedValue({ data: {} });
+    const client = new QueryClient();
+    const invalidateSpy = vi.spyOn(client, 'invalidateQueries');
+    const { result } = renderHook(() => useReorderProducts(), {
+      wrapper: wrapper(client),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync(['p2', 'p3', 'p1']);
+    });
+
+    // Single batch call — NOT a per-product fan-out (that shape was
+    // non-atomic: a partial failure left a half-applied order server-side).
+    expect(patchMock).toHaveBeenCalledTimes(1);
+    expect(patchMock).toHaveBeenCalledWith('/menu/products/reorder', {
+      orderedIds: ['p2', 'p3', 'p1'],
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['products'] });
+  });
+
+  it('surfaces a toast and still invalidates products on error', async () => {
+    patchMock.mockRejectedValue({ isAxiosError: true, response: { data: { message: 'nope' } } });
+    const client = new QueryClient();
+    const invalidateSpy = vi.spyOn(client, 'invalidateQueries');
+    const { result } = renderHook(() => useReorderProducts(), {
+      wrapper: wrapper(client),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync(['p1', 'p2']).catch(() => undefined);
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(toastErrorMock).toHaveBeenCalledWith('nope');
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['products'] });
   });
 });

--- a/frontend/src/features/menu/menuApi.ts
+++ b/frontend/src/features/menu/menuApi.ts
@@ -303,15 +303,10 @@ export const useReorderCategories = () => {
 
   return useMutation({
     mutationFn: async (orderedIds: string[]): Promise<void> => {
-      const updates = orderedIds.map((id, index) => ({
-        id,
-        displayOrder: index,
-      }));
-      await Promise.all(
-        updates.map(({ id, displayOrder }) =>
-          api.patch(`/menu/categories/${id}`, { displayOrder }),
-        ),
-      );
+      // Single atomic batch — the server applies displayOrder = array index
+      // inside ONE transaction, so a failure can never leave a half-applied
+      // order (the old per-category PATCH fan-out could).
+      await api.patch("/menu/categories/reorder", { orderedIds });
     },
     // Optimistic update - immediately update the cache
     onMutate: async (orderedIds: string[]) => {
@@ -342,10 +337,10 @@ export const useReorderCategories = () => {
           i18n.t("common:notifications.operationFailed"),
         ),
       );
-      // The per-category PATCH fan-out is non-atomic: on a partial failure the
-      // server holds a half-applied order, so the optimistic rollback above
-      // would LIE for the rest of the session (5-min staleTime, no focus
-      // refetch). Refetch to converge on the server's real order.
+      // The batch endpoint is atomic (nothing half-applies), but the rollback
+      // above restores a pre-drag snapshot that may itself be stale (5-min
+      // staleTime, no focus refetch). Refetch to converge on the server's
+      // real order.
       queryClient.invalidateQueries({ queryKey: categoriesKey });
     },
     // NOTE: on success we intentionally do NOT invalidate — the optimistic
@@ -359,15 +354,12 @@ export const useReorderProducts = () => {
 
   return useMutation({
     mutationFn: async (orderedIds: string[]): Promise<void> => {
-      const updates = orderedIds.map((id, index) => ({
-        id,
-        displayOrder: index,
-      }));
-      await Promise.all(
-        updates.map(({ id, displayOrder }) =>
-          api.patch(`/menu/products/${id}`, { displayOrder }),
-        ),
-      );
+      // Single atomic batch — the server applies displayOrder = array index
+      // inside ONE transaction and requires every id to sit in ONE category
+      // (the drag UI only reorders within a category droppable), so a failure
+      // can never leave a half-applied order (the old per-product PATCH
+      // fan-out could).
+      await api.patch("/menu/products/reorder", { orderedIds });
     },
     onSuccess: () => {
       // Invalidate all product queries to refetch with new order
@@ -380,9 +372,9 @@ export const useReorderProducts = () => {
           i18n.t("common:notifications.operationFailed"),
         ),
       );
-      // The fan-out is non-atomic: some PATCHes may have landed before the
-      // failure. Refetch so the UI shows the server's real order instead of
-      // silently keeping a stale local one.
+      // The batch endpoint is atomic, but the list shown locally may be stale.
+      // Refetch so the UI shows the server's real order instead of silently
+      // keeping a stale local one.
       queryClient.invalidateQueries({ queryKey: ["products"] });
     },
   });


### PR DESCRIPTION
Review loop tick 3 — closes the last confirmed menu-module finding: drag-and-drop reordering fanned out N parallel per-row PATCHes, so a partial failure (429/network) left the server with a half-applied order.

- New `PATCH /menu/categories/reorder` and `PATCH /menu/products/reorder` (mirroring the existing images-reorder pattern): `{ orderedIds }` DTO (non-empty, unique, ≤1000), bulk tenant-ownership verification (products additionally must all share one category), `displayOrder = index` applied inside a single transaction with row-vanished abort. Declared above `:id` routes (route-order pinned by a supertest spec).
- Frontend hooks now send one batch call; optimistic update/rollback and invalidation semantics preserved exactly.
- Tests: backend 169 (routing spec proves `/reorder` isn't swallowed by `:id`; tx write-shape, foreign-tenant, cross-category, mid-batch-vanish cases), frontend 40 (single-call + invalidation assertions). Both tsc clean.
