### PR TITLE
fix(pos): charge the live order amount; never release a table with an open balance

### DIFF
--- a/frontend/src/components/pos/PaymentModal.tsx
+++ b/frontend/src/components/pos/PaymentModal.tsx
@@ -49,6 +49,7 @@ const PaymentModal = ({
     handleSubmit,
     watch,
     control,
+    reset,
     formState: { errors },
   } = useForm<PaymentFormData>({
     resolver: zodResolver(paymentSchema),
@@ -70,6 +71,15 @@ const PaymentModal = ({
   useEffect(() => {
     if (!isOpen || !isCash) setTenderedRaw('');
   }, [isOpen, isCash]);
+
+  // The modal stays permanently mounted (POSPage only toggles isOpen), so the
+  // form would otherwise carry the previous sale's customerPhone/transactionId/
+  // method into the next payment. Reset to the declared defaults on the OPEN
+  // transition only — keyed on isOpen alone so it can never clobber values
+  // mid-payment.
+  useEffect(() => {
+    if (isOpen) reset();
+  }, [isOpen, reset]);
 
   const changeDue = useMemo(
     () => computeChangeDue(total, tendered),

--- a/frontend/src/pages/pos/POSPage.tsx
+++ b/frontend/src/pages/pos/POSPage.tsx
@@ -214,6 +214,24 @@ const POSPage = () => {
     return tableOrders.find((o) => o.id === currentOrderId) || null;
   }, [currentOrderId, tableOrders]);
 
+  // Live payable amounts. `currentOrderAmount`/`payingOrderAmount` are
+  // snapshots captured when the order was created/loaded or when "collect
+  // payment" was tapped; a socket-driven `tableOrders` refetch (another
+  // cashier adding items, a QR top-up) never re-synced them, so the modal
+  // could charge a stale-low total — the backend accepts any amount ≤
+  // remaining and records a silent PARTIAL payment. Resolve against the
+  // freshest server row at render, falling back to the snapshot only while
+  // the live row isn't loaded. finalAmount may serialize as a string
+  // (Prisma Decimal) → Number().
+  const liveCurrentOrderAmount = currentOrder
+    ? Number(currentOrder.finalAmount)
+    : currentOrderAmount;
+  const livePayingOrderAmount = useMemo(() => {
+    if (!payingOrderId) return payingOrderAmount;
+    const live = tableOrders?.find((o) => o.id === payingOrderId);
+    return live ? Number(live.finalAmount) : payingOrderAmount;
+  }, [payingOrderId, payingOrderAmount, tableOrders]);
+
   // Payment eligibility calculation for two-step checkout. The gate logic
   // (order-type + dine-in requireServed) is the pure computeCanProceedToPayment
   // in posCart.ts; kept inside a useMemo so referential identity is unchanged.
@@ -565,7 +583,7 @@ const POSPage = () => {
         setIsPaymentModalOpen(false);
         setPayingOrderId(null);
         setPayingOrderAmount(null);
-        const hasRemainingOrders = hasRemainingUnpaidOrders(freshOrders, target.orderId);
+        const hasRemainingOrders = hasRemainingUnpaidOrders(freshOrders);
         if (!hasRemainingOrders && selectedTable) {
           updateTableStatus({ id: selectedTable.id, status: TableStatus.AVAILABLE });
         }
@@ -631,9 +649,9 @@ const POSPage = () => {
     // (currentOrderId). Returns null (and we bail) when nothing is chargeable.
     const target = resolvePaymentTarget({
       payingOrderId,
-      payingOrderAmount,
+      payingOrderAmount: livePayingOrderAmount,
       currentOrderId,
-      currentOrderAmount,
+      currentOrderAmount: liveCurrentOrderAmount,
     });
     if (!target) return;
     const orderIdToPay = target.orderId;
@@ -695,8 +713,11 @@ const POSPage = () => {
           setPayingOrderAmount(null);
 
           // Always check for remaining unpaid orders before marking table as
-          // available (the documented stale-snapshot race guard).
-          const hasRemainingOrders = hasRemainingUnpaidOrders(freshOrders, orderIdToPay);
+          // available (the documented stale-snapshot race guard). The just-paid
+          // order is NOT excluded: fully paid ⇒ it already dropped out of the
+          // refetched status-filtered list; still present ⇒ partial payment,
+          // which must block the release.
+          const hasRemainingOrders = hasRemainingUnpaidOrders(freshOrders);
 
           if (wasExistingOrderPayment) {
             // For existing order payments (READY/SERVED), only mark available if no remaining orders
@@ -1219,7 +1240,7 @@ const POSPage = () => {
           setPayingOrderId(null);
           setPayingOrderAmount(null);
         }}
-        total={payingOrderAmount ?? currentOrderAmount ?? total}
+        total={livePayingOrderAmount ?? liveCurrentOrderAmount ?? total}
         onConfirm={handlePaymentConfirm}
         isLoading={isCreatingPayment}
       />

--- a/frontend/src/pages/pos/posCart.test.ts
+++ b/frontend/src/pages/pos/posCart.test.ts
@@ -324,42 +324,42 @@ describe('resolvePaymentTarget', () => {
 const ord = (id: string, status: OrderStatus): Pick<Order, 'id' | 'status'> => ({ id, status });
 
 describe('hasRemainingUnpaidOrders', () => {
-  it('is false when the only order is the one just paid', () => {
-    expect(hasRemainingUnpaidOrders([ord('o-1', OrderStatus.PENDING)], 'o-1')).toBe(false);
+  it('is false when the refetched list is empty (fully-paid order already dropped out)', () => {
+    expect(hasRemainingUnpaidOrders([])).toBe(false);
+  });
+
+  it('is true when the just-paid order is STILL present (partial payment) — table must not be freed', () => {
+    // The old excluded-id parameter hid exactly this: a stale-low charge
+    // records a PARTIAL payment, the order stays in the status-filtered
+    // refetch, and the table would have been released with an open balance.
+    expect(hasRemainingUnpaidOrders([ord('o-1', OrderStatus.SERVED)])).toBe(true);
   });
 
   it('is true when another unpaid order remains on the table', () => {
     expect(
-      hasRemainingUnpaidOrders(
-        [ord('o-1', OrderStatus.PAID), ord('o-2', OrderStatus.PENDING)],
-        'o-1',
-      ),
+      hasRemainingUnpaidOrders([
+        ord('o-1', OrderStatus.PAID),
+        ord('o-2', OrderStatus.PENDING),
+      ]),
     ).toBe(true);
   });
 
   it('ignores PAID and CANCELLED orders (table can still be freed)', () => {
     expect(
-      hasRemainingUnpaidOrders(
-        [
-          ord('o-1', OrderStatus.PAID),
-          ord('o-2', OrderStatus.PAID),
-          ord('o-3', OrderStatus.CANCELLED),
-        ],
-        'o-1',
-      ),
+      hasRemainingUnpaidOrders([
+        ord('o-1', OrderStatus.PAID),
+        ord('o-2', OrderStatus.PAID),
+        ord('o-3', OrderStatus.CANCELLED),
+      ]),
     ).toBe(false);
-  });
-
-  it('is false for an empty order list', () => {
-    expect(hasRemainingUnpaidOrders([], 'o-1')).toBe(false);
   });
 
   it('counts a SERVED/READY sibling order as still unpaid', () => {
     expect(
-      hasRemainingUnpaidOrders(
-        [ord('o-1', OrderStatus.PAID), ord('o-2', OrderStatus.SERVED)],
-        'o-1',
-      ),
+      hasRemainingUnpaidOrders([
+        ord('o-1', OrderStatus.PAID),
+        ord('o-2', OrderStatus.READY),
+      ]),
     ).toBe(true);
   });
 });

--- a/frontend/src/pages/pos/posCart.ts
+++ b/frontend/src/pages/pos/posCart.ts
@@ -238,20 +238,20 @@ export function resolvePaymentTarget(args: {
 }
 
 /**
- * Whether any unpaid order remains on the table after `paidOrderId` is
- * settled — the guard that decides if the table can be freed to AVAILABLE.
- * Excludes the just-paid order, PAID orders, and CANCELLED orders. Must run
- * against freshly-refetched orders (a stale snapshot could free a table that
- * still has an unpaid bill — the documented race this guards). Pure
- * extraction of the `remainingOrders` filter (~L626-633).
+ * Whether any unpaid order remains on the table after a payment settles —
+ * the guard that decides if the table can be freed to AVAILABLE. Must run
+ * against freshly-refetched, status-filtered orders (a stale snapshot could
+ * free a table that still has an unpaid bill — the documented race this
+ * guards). The refetched list is authoritative as-is: a fully paid order has
+ * already dropped out of it, while a PARTIALLY paid one remains and must
+ * block the release — the old excluded-`paidOrderId` parameter hid exactly
+ * that case, freeing the table with an open balance.
  */
 export function hasRemainingUnpaidOrders(
-  orders: Pick<Order, 'id' | 'status'>[],
-  paidOrderId: string,
+  orders: Pick<Order, 'status'>[],
 ): boolean {
   return orders.some(
     (order) =>
-      order.id !== paidOrderId &&
       order.status !== OrderStatus.PAID &&
       order.status !== OrderStatus.CANCELLED,
   );


### PR DESCRIPTION
Review loop tick 4 — two money-grade findings from the POS modal review:

1. **Stale amount snapshot → silent partial payment + table freed with an open balance.** The payment modal charged `currentOrderAmount`, a snapshot taken at order create/load and never re-synced by socket refetches — if another terminal added items, confirming charged the OLD total, which the backend records as a partial payment. The post-payment release guard then EXCLUDED the just-paid order by id from `hasRemainingUnpaidOrders`, so the table flipped AVAILABLE with an unpaid balance. Now: the modal (and the terminal-charge path) resolves the amount from the live `tableOrders` row at render time, and the release guard trusts the refetched list with no exclusion — a partially-paid order keeps the table occupied. posCart tests re-pinned: the old "just-paid ⇒ release" case was exactly the hazard and is now inverted.
2. **PaymentModal carried the previous sale's customerPhone/transactionId/method into the next sale** (permanently mounted form, only tender reset) — payments could be attributed to the previous customer's phone. The form now fully resets on the open transition.

Verification: 144 POS tests green (posCart suite rewritten for the new guard), tsc clean, eslint clean.
