### PR TITLE
fix(pos): settle remaining due after partial payments; target cart lines by identity

### DIFF
--- a/frontend/src/components/pos/AwaitingPaymentSection.test.tsx
+++ b/frontend/src/components/pos/AwaitingPaymentSection.test.tsx
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { PaymentStatus, type Order, type Payment } from '../../types';
+
+/**
+ * Specs for AwaitingPaymentSection's settle-up math. The HIGH bug pinned
+ * here: after a partial/progressive payment the section charged the FULL
+ * finalAmount, which the backend rejects ("Payment amount exceeds
+ * remaining") — leaving the cashier with NO path to collect the true
+ * balance. The section must display and pass the REMAINING due
+ * (finalAmount − COMPLETED payments).
+ */
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('../../hooks/useFormatCurrency', () => ({
+  useFormatCurrency: () => (amount: number) => `₺${amount.toFixed(2)}`,
+}));
+
+import AwaitingPaymentSection from './AwaitingPaymentSection';
+
+const order = (over: Partial<Order>): Order =>
+  ({
+    id: 'o-1',
+    orderNumber: '1001',
+    finalAmount: 100,
+    createdAt: '2026-07-27T10:00:00Z',
+    items: [],
+    ...over,
+  } as Order);
+
+const payment = (
+  amount: number | string,
+  status: PaymentStatus = PaymentStatus.COMPLETED,
+): Payment => ({ id: `pay-${amount}-${status}`, amount, status } as unknown as Payment);
+
+describe('AwaitingPaymentSection — remaining-due settle-up', () => {
+  it('shows the full amount under "order total" and collects it when nothing is paid yet', () => {
+    const onCollectPayment = vi.fn();
+    render(
+      <AwaitingPaymentSection
+        orders={[order({ payments: [] })]}
+        onCollectPayment={onCollectPayment}
+      />,
+    );
+
+    expect(screen.getByText('awaitingPayment.orderTotal')).toBeTruthy();
+    expect(screen.queryByText('awaitingPayment.remainingDue')).toBeNull();
+    expect(screen.getByText('₺100.00')).toBeTruthy();
+
+    fireEvent.click(screen.getByText('awaitingPayment.collectPayment'));
+    expect(onCollectPayment).toHaveBeenCalledWith('o-1', 100);
+  });
+
+  it('shows and collects the REMAINING due after a partial payment (never the gross total)', () => {
+    const onCollectPayment = vi.fn();
+    render(
+      <AwaitingPaymentSection
+        orders={[
+          order({
+            // 60 completed counts; the refunded 40 must NOT (it would show
+            // remaining 0 and strand a live 40 balance).
+            payments: [payment(60), payment(40, PaymentStatus.REFUNDED)],
+          }),
+        ]}
+        onCollectPayment={onCollectPayment}
+      />,
+    );
+
+    expect(screen.getByText('awaitingPayment.remainingDue')).toBeTruthy();
+    expect(screen.getByText('₺40.00')).toBeTruthy();
+    // Gross total stays visible as struck-through context.
+    expect(screen.getByText('₺100.00')).toBeTruthy();
+
+    fireEvent.click(screen.getByText('awaitingPayment.collectPayment'));
+    expect(onCollectPayment).toHaveBeenCalledWith('o-1', 40);
+  });
+
+  it('coerces string Decimal serializations (finalAmount and payment amounts)', () => {
+    const onCollectPayment = vi.fn();
+    render(
+      <AwaitingPaymentSection
+        orders={[
+          order({
+            finalAmount: '100.00' as unknown as number,
+            payments: [payment('33.33'), payment('33.33')],
+          }),
+        ]}
+        onCollectPayment={onCollectPayment}
+      />,
+    );
+
+    expect(screen.getByText('₺33.34')).toBeTruthy();
+    fireEvent.click(screen.getByText('awaitingPayment.collectPayment'));
+    expect(onCollectPayment).toHaveBeenCalledWith('o-1', 33.34);
+  });
+});

--- a/frontend/src/components/pos/AwaitingPaymentSection.tsx
+++ b/frontend/src/components/pos/AwaitingPaymentSection.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { ChevronDown, ChevronUp, CreditCard, Clock } from 'lucide-react';
 import { Order } from '../../types';
 import { useFormatCurrency } from '../../hooks/useFormatCurrency';
+import { orderPaidAmount, orderRemainingDue } from '../../pages/pos/posCart';
 
 interface AwaitingPaymentSectionProps {
   orders: Order[];
@@ -50,6 +51,11 @@ const AwaitingPaymentSection = ({
       {isExpanded && (
         <div className="border-t border-amber-200 divide-y divide-amber-200">
           {orders.map((order) => {
+            // Charge the REMAINING due, not the gross finalAmount — after a
+            // partial/progressive payment the backend rejects anything above
+            // the remainder, which left the cashier with no settle-up path.
+            const remainingDue = orderRemainingDue(order);
+            const hasPartialPayment = orderPaidAmount(order) > 0;
             const itemCount =
               order.items?.length || order.orderItems?.length || 0;
             const itemsSummary =
@@ -83,17 +89,22 @@ const AwaitingPaymentSection = ({
                 <div className="flex items-center gap-3">
                   <div className="text-right">
                     <div className="text-xs text-slate-500">
-                      {t('awaitingPayment.orderTotal')}
+                      {hasPartialPayment
+                        ? t('awaitingPayment.remainingDue')
+                        : t('awaitingPayment.orderTotal')}
                     </div>
                     <div className="font-semibold text-slate-900">
-                      {formatPrice(Number(order.finalAmount))}
+                      {formatPrice(remainingDue)}
                     </div>
+                    {hasPartialPayment && (
+                      <div className="text-xs text-slate-400 line-through">
+                        {formatPrice(Number(order.finalAmount))}
+                      </div>
+                    )}
                   </div>
 
                   <button
-                    onClick={() =>
-                      onCollectPayment(order.id, Number(order.finalAmount))
-                    }
+                    onClick={() => onCollectPayment(order.id, remainingDue)}
                     className="px-3 py-1.5 bg-amber-600 hover:bg-amber-700 text-white text-sm font-medium rounded-lg transition-colors whitespace-nowrap"
                   >
                     {t('awaitingPayment.collectPayment')}

--- a/frontend/src/components/pos/OrderCart.tsx
+++ b/frontend/src/components/pos/OrderCart.tsx
@@ -6,7 +6,7 @@ import { Card, CardHeader, CardTitle, CardContent } from '../ui/Card';
 import Button from '../ui/Button';
 import Input from '../ui/Input';
 import { useFormatCurrency } from '../../hooks/useFormatCurrency';
-import { calculateItemTotal, calculateSubtotal } from '../../pages/pos/posCart';
+import { calculateItemTotal, calculateSubtotal, getCartLineId } from '../../pages/pos/posCart';
 import type { SelectedModifier } from './ProductOptionsModal';
 
 interface CartItem extends Product {
@@ -14,6 +14,7 @@ interface CartItem extends Product {
   notes?: string;
   modifiers?: SelectedModifier[];
   comboSelections?: ComboSelectionInput[];
+  lineId?: string;
 }
 
 interface OrderCartProps {
@@ -21,8 +22,11 @@ interface OrderCartProps {
   discount: number;
   customerName: string;
   orderNotes: string;
-  onUpdateQuantity: (productId: string, quantity: number) => void;
-  onRemoveItem: (productId: string) => void;
+  // Line ops address a LINE (product + modifiers + combo picks), not a bare
+  // product id — same-product lines with different modifiers must stay
+  // independently adjustable/removable.
+  onUpdateQuantity: (lineId: string, quantity: number) => void;
+  onRemoveItem: (lineId: string) => void;
   onUpdateDiscount: (discount: number) => void;
   onUpdateCustomerName: (name: string) => void;
   onUpdateOrderNotes: (notes: string) => void;
@@ -168,6 +172,7 @@ const OrderCart = ({
             {/* Cart Items - Scrollable area */}
             <div className="flex-1 min-h-0 overflow-y-auto p-4 space-y-2">
               {items.map((item) => {
+                const lineId = getCartLineId(item);
                 const lineModifiers = item.modifiers ?? [];
                 const lineTotal = calculateItemTotal(
                   Number(item.price),
@@ -176,7 +181,7 @@ const OrderCart = ({
                 );
                 return (
                 <div
-                  key={item.id}
+                  key={lineId}
                   className="flex items-center justify-between p-3 bg-slate-50/80 rounded-xl border border-slate-100"
                 >
                   <div className="flex-1 min-w-0">
@@ -221,7 +226,7 @@ const OrderCart = ({
                   <div className="flex items-center gap-2 ml-3">
                     <div className="flex items-center gap-1 bg-white rounded-lg border border-slate-200 p-0.5">
                       <button
-                        onClick={() => onUpdateQuantity(item.id, Math.max(1, item.quantity - 1))}
+                        onClick={() => onUpdateQuantity(lineId, Math.max(1, item.quantity - 1))}
                         className="p-1.5 rounded-md hover:bg-slate-100 transition-colors text-slate-600"
                       >
                         <Minus className="h-3.5 w-3.5" />
@@ -230,7 +235,7 @@ const OrderCart = ({
                         {item.quantity}
                       </span>
                       <button
-                        onClick={() => onUpdateQuantity(item.id, item.quantity + 1)}
+                        onClick={() => onUpdateQuantity(lineId, item.quantity + 1)}
                         className="p-1.5 rounded-md hover:bg-slate-100 transition-colors text-slate-600"
                       >
                         <Plus className="h-3.5 w-3.5" />
@@ -238,7 +243,7 @@ const OrderCart = ({
                     </div>
 
                     <button
-                      onClick={() => onRemoveItem(item.id)}
+                      onClick={() => onRemoveItem(lineId)}
                       className="p-1.5 rounded-lg text-slate-400 hover:text-red-600 hover:bg-red-50 transition-all"
                     >
                       <Trash2 className="h-4 w-4" />

--- a/frontend/src/i18n/locales/ar/pos.json
+++ b/frontend/src/i18n/locales/ar/pos.json
@@ -283,7 +283,8 @@
   "awaitingPayment": {
     "title": "بانتظار الدفع",
     "collectPayment": "تحصيل الدفع",
-    "orderTotal": "إجمالي الطلب"
+    "orderTotal": "إجمالي الطلب",
+    "remainingDue": "المبلغ المتبقي"
   },
   "dineInPaymentRequiresServed": "لا يمكن دفع طلبات تناول الطعام بالمطعم إلا بعد تقديمها",
   "dineInPaymentRequiresReadyOrServed": "لا يمكن دفع طلبات تناول الطعام بالمطعم إلا عندما تكون جاهزة أو مقدمة",

--- a/frontend/src/i18n/locales/en/pos.json
+++ b/frontend/src/i18n/locales/en/pos.json
@@ -188,7 +188,8 @@
   "awaitingPayment": {
     "title": "Awaiting Payment",
     "collectPayment": "Collect Payment",
-    "orderTotal": "Order Total"
+    "orderTotal": "Order Total",
+    "remainingDue": "Remaining Due"
   },
   "tableGrid": {
     "selected": "Selected",

--- a/frontend/src/i18n/locales/ru/pos.json
+++ b/frontend/src/i18n/locales/ru/pos.json
@@ -283,7 +283,8 @@
   "awaitingPayment": {
     "title": "Ожидание оплаты",
     "collectPayment": "Принять оплату",
-    "orderTotal": "Сумма заказа"
+    "orderTotal": "Сумма заказа",
+    "remainingDue": "Осталось оплатить"
   },
   "dineInPaymentRequiresServed": "Заказы в зале можно оплатить только после подачи блюд",
   "dineInPaymentRequiresReadyOrServed": "Заказы в зале можно оплатить только когда они готовы или поданы",

--- a/frontend/src/i18n/locales/tr/pos.json
+++ b/frontend/src/i18n/locales/tr/pos.json
@@ -188,7 +188,8 @@
   "awaitingPayment": {
     "title": "Ödeme Bekleyen",
     "collectPayment": "Ödeme Al",
-    "orderTotal": "Sipariş Toplamı"
+    "orderTotal": "Sipariş Toplamı",
+    "remainingDue": "Kalan Tutar"
   },
   "tableGrid": {
     "selected": "Seçili",

--- a/frontend/src/i18n/locales/uz/pos.json
+++ b/frontend/src/i18n/locales/uz/pos.json
@@ -283,7 +283,8 @@
   "awaitingPayment": {
     "title": "To'lov kutilmoqda",
     "collectPayment": "To'lovni qabul qilish",
-    "orderTotal": "Buyurtma jami"
+    "orderTotal": "Buyurtma jami",
+    "remainingDue": "Qolgan summa"
   },
   "dineInPaymentRequiresServed": "Zalda buyurtmalar uchun to'lov faqat taom uzatilgandan so'ng amalga oshiriladi",
   "dineInPaymentRequiresReadyOrServed": "Zalda buyurtmalar uchun to'lov faqat tayyor yoki uzatilgan holatda amalga oshiriladi",

--- a/frontend/src/pages/pos/POSPage.tsx
+++ b/frontend/src/pages/pos/POSPage.tsx
@@ -38,6 +38,11 @@ import {
   resolvePaymentTarget,
   hasRemainingUnpaidOrders,
   mergeCartItem,
+  normalizeCartLines,
+  orderRemainingDue,
+  removeLine,
+  stepProductLine,
+  updateLineQuantity,
 } from './posCart';
 import { useCartPersistence } from './useCartPersistence';
 import { usePosTourSync } from './usePosTourSync';
@@ -69,7 +74,8 @@ const POSPage = () => {
   // doesn't wipe an in-progress order. The per-user key shape
   // (`pos_cart::<tenantId>::<userId>`, v2.8.97), the 12h TTL, and the
   // legacy-key migration all live in useCartPersistence (unit-tested).
-  const { cartItems, setCartItems } = useCartPersistence<CartItem>();
+  // normalizeCartLines backfills lineId on carts persisted pre-line-identity.
+  const { cartItems, setCartItems } = useCartPersistence<CartItem>(normalizeCartLines);
   const [discount, setDiscount] = useState(0);
   const [customerName, setCustomerName] = useState('');
   const [orderNotes, setOrderNotes] = useState('');
@@ -221,15 +227,17 @@ const POSPage = () => {
   // could charge a stale-low total — the backend accepts any amount ≤
   // remaining and records a silent PARTIAL payment. Resolve against the
   // freshest server row at render, falling back to the snapshot only while
-  // the live row isn't loaded. finalAmount may serialize as a string
-  // (Prisma Decimal) → Number().
+  // the live row isn't loaded. The live amount is the REMAINING due
+  // (finalAmount − COMPLETED payments), not the gross total: after a
+  // partial/progressive payment the backend rejects anything above the
+  // remainder, so charging finalAmount would dead-end the settle-up.
   const liveCurrentOrderAmount = currentOrder
-    ? Number(currentOrder.finalAmount)
+    ? orderRemainingDue(currentOrder)
     : currentOrderAmount;
   const livePayingOrderAmount = useMemo(() => {
     if (!payingOrderId) return payingOrderAmount;
     const live = tableOrders?.find((o) => o.id === payingOrderId);
-    return live ? Number(live.finalAmount) : payingOrderAmount;
+    return live ? orderRemainingDue(live) : payingOrderAmount;
   }, [payingOrderId, payingOrderAmount, tableOrders]);
 
   // Payment eligibility calculation for two-step checkout. The gate logic
@@ -343,18 +351,17 @@ const POSPage = () => {
     setProductForOptions(null);
   };
 
-  const handleUpdateQuantity = (productId: string, quantity: number) => {
+  // Line ops target lineId (product + modifiers + combo picks), NOT the bare
+  // product id — two lines of the same product with different modifiers are
+  // distinct bills, and a product-id match updated/removed every one of them.
+  const handleUpdateQuantity = (lineId: string, quantity: number) => {
     if (quantity < 1) return;
-    setCartItems((prev) =>
-      prev.map((item) =>
-        item.id === productId ? { ...item, quantity } : item
-      )
-    );
+    setCartItems((prev) => updateLineQuantity(prev, lineId, quantity));
     markCartDirty();
   };
 
-  const handleRemoveItem = (productId: string) => {
-    setCartItems((prev) => prev.filter((item) => item.id !== productId));
+  const handleRemoveItem = (lineId: string) => {
+    setCartItems((prev) => removeLine(prev, lineId));
     markCartDirty();
   };
 
@@ -369,25 +376,16 @@ const POSPage = () => {
   }, [cartItems]);
 
   // Inline +/- from a MenuPanel card. Only wired for non-modifier items (the
-  // panel hides the steppers for required-modifier products), which always
-  // collapse to a single cart line, so targeting by product id is safe.
+  // panel hides the steppers for required-modifier products/combos), which
+  // merge into a single plain line. stepProductLine resolves that ONE line
+  // (never a sibling modifier line a reopened order may have added).
   const handleMenuIncrement = (productId: string) => {
-    setCartItems((prev) =>
-      prev.map((item) =>
-        item.id === productId ? { ...item, quantity: item.quantity + 1 } : item,
-      ),
-    );
+    setCartItems((prev) => stepProductLine(prev, productId, 1));
     markCartDirty();
   };
 
   const handleMenuDecrement = (productId: string) => {
-    setCartItems((prev) =>
-      prev.flatMap((item) => {
-        if (item.id !== productId) return [item];
-        // Drop the line when it would hit zero, otherwise decrement.
-        return item.quantity <= 1 ? [] : [{ ...item, quantity: item.quantity - 1 }];
-      }),
-    );
+    setCartItems((prev) => stepProductLine(prev, productId, -1));
     markCartDirty();
   };
 

--- a/frontend/src/pages/pos/posCart.test.ts
+++ b/frontend/src/pages/pos/posCart.test.ts
@@ -11,10 +11,18 @@ import {
   hasRemainingUnpaidOrders,
   mapOrderItemsToCart,
   mergeCartItem,
+  orderPaidAmount,
+  orderRemainingDue,
+  computeCartLineId,
+  getCartLineId,
+  normalizeCartLines,
+  updateLineQuantity,
+  removeLine,
+  stepProductLine,
   type PosCartItem,
 } from './posCart';
 import type { CartItem } from './posTypes';
-import { OrderType, OrderStatus, type Order, type OrderItem, type Product, type OrderItemModifier, type Modifier } from '../../types';
+import { OrderType, OrderStatus, PaymentStatus, type Order, type OrderItem, type Product, type OrderItemModifier, type Modifier, type Payment } from '../../types';
 import type { SelectedModifier } from '../../components/pos/ProductOptionsModal';
 import { buildOrderData } from './buildOrderData';
 
@@ -378,7 +386,9 @@ describe('mapOrderItemsToCart', () => {
     const cart = mapOrderItemsToCart({
       orderItems: [orderItem({ quantity: 2, notes: '', product: { id: 'p-7', name: 'Fries', price: 5 } as Product })],
     } as Pick<Order, 'orderItems' | 'items'>);
-    expect(cart).toEqual([{ id: 'p-7', name: 'Fries', price: 5, quantity: 2, notes: undefined }]);
+    expect(cart).toEqual([
+      { id: 'p-7', name: 'Fries', price: 5, quantity: 2, notes: undefined, modifiers: undefined, lineId: 'p-7::::' },
+    ]);
   });
 
   it('keeps a real note', () => {
@@ -550,5 +560,181 @@ describe('mergeCartItem', () => {
     const start: CartItem[] = [{ ...product('p1'), quantity: 1, modifiers: [] }];
     const out = mergeCartItem(start, product('p2'), 1, []);
     expect(out.map((i) => i.id)).toEqual(['p1', 'p2']);
+  });
+});
+
+const payment = (
+  amount: number | string,
+  status: PaymentStatus = PaymentStatus.COMPLETED,
+): Payment => ({ id: `pay-${amount}-${status}`, amount, status } as unknown as Payment);
+
+const payableOrder = (
+  finalAmount: number | string,
+  payments?: Payment[],
+): Pick<Order, 'finalAmount' | 'payments'> =>
+  ({ finalAmount, payments } as Pick<Order, 'finalAmount' | 'payments'>);
+
+describe('orderPaidAmount / orderRemainingDue (settle-up after partial payments)', () => {
+  it('sums only COMPLETED payments — PENDING/FAILED/REFUNDED never count', () => {
+    expect(
+      orderPaidAmount(
+        payableOrder(100, [
+          payment(30),
+          payment(20, PaymentStatus.PENDING),
+          payment(15, PaymentStatus.FAILED),
+          payment(30, PaymentStatus.REFUNDED),
+        ]),
+      ),
+    ).toBe(30);
+  });
+
+  it('coerces string Decimal amounts from the API', () => {
+    expect(orderPaidAmount(payableOrder(100, [payment('12.50'), payment('7.25')]))).toBe(19.75);
+  });
+
+  it('treats a missing payments array as nothing paid (full amount due)', () => {
+    expect(orderPaidAmount(payableOrder(80))).toBe(0);
+    expect(orderRemainingDue(payableOrder(80))).toBe(80);
+    expect(orderRemainingDue({ finalAmount: '80.00' } as unknown as Order)).toBe(80);
+  });
+
+  it('remaining = finalAmount − completed paid (the amount the backend will accept)', () => {
+    // The old flow charged the gross 100 here → backend "exceeds remaining (40)"
+    // rejection with NO path to settle. 60 paid ⇒ collect exactly 40.
+    expect(orderRemainingDue(payableOrder(100, [payment(60)]))).toBe(40);
+  });
+
+  it('rounds to kuruş so float noise never leaks into the charged amount', () => {
+    // 10.3 − 10.2 = 0.09999999999999964 raw
+    expect(orderRemainingDue(payableOrder(10.3, [payment(10.2)]))).toBe(0.1);
+    expect(orderRemainingDue(payableOrder(0.3, [payment(0.1), payment(0.1)]))).toBe(0.1);
+  });
+
+  it('clamps at 0 when the order is already fully (or over-) covered', () => {
+    expect(orderRemainingDue(payableOrder(50, [payment(50)]))).toBe(0);
+    expect(orderRemainingDue(payableOrder(50, [payment(60)]))).toBe(0);
+  });
+});
+
+describe('cart line identity (lineId)', () => {
+  it('computeCartLineId keys product + modifier set + combo picks, selection-order-insensitive', () => {
+    expect(computeCartLineId('p1', [sel('m1'), sel('m2')])).toBe(
+      computeCartLineId('p1', [sel('m2'), sel('m1')]),
+    );
+    expect(computeCartLineId('p1', [sel('m1')])).not.toBe(computeCartLineId('p1', [sel('m2')]));
+    expect(
+      computeCartLineId('p1', [], [{ groupId: 'g1', componentProductId: 'c1' }]),
+    ).not.toBe(computeCartLineId('p1', []));
+  });
+
+  it('mergeCartItem stamps a deterministic lineId on appended lines', () => {
+    const out = mergeCartItem([], product('p1'), 1, [sel('m1')]);
+    expect(out[0].lineId).toBe(computeCartLineId('p1', [sel('m1')]));
+  });
+
+  it('same product with different modifier sets gets DISTINCT lineIds (unique React keys)', () => {
+    let cart = mergeCartItem([], product('p1'), 1, [sel('m1')]);
+    cart = mergeCartItem(cart, product('p1'), 2, [sel('m2')]);
+    expect(cart).toHaveLength(2);
+    expect(getCartLineId(cart[0])).not.toBe(getCartLineId(cart[1]));
+  });
+
+  it('updateLineQuantity touches ONLY the targeted line of a same-product pair', () => {
+    let cart = mergeCartItem([], product('p1'), 1, [sel('m1')]);
+    cart = mergeCartItem(cart, product('p1'), 2, [sel('m2')]);
+    const out = updateLineQuantity(cart, getCartLineId(cart[0]), 5);
+    expect(out[0].quantity).toBe(5);
+    expect(out[1].quantity).toBe(2); // sibling line untouched
+  });
+
+  it('removeLine removes ONLY the targeted line, never every line of the product', () => {
+    let cart = mergeCartItem([], product('p1'), 1, [sel('m1')]);
+    cart = mergeCartItem(cart, product('p1'), 2, [sel('m2')]);
+    const out = removeLine(cart, getCartLineId(cart[0]));
+    expect(out).toHaveLength(1);
+    expect(out[0].modifiers).toEqual([sel('m2')]);
+  });
+
+  it('normalizeCartLines backfills lineId on persisted pre-lineId carts (localStorage back-compat)', () => {
+    const legacy = [
+      { ...product('p1'), quantity: 1, modifiers: [sel('m1')] },
+      { ...product('p1'), quantity: 2, modifiers: [sel('m2')] },
+    ] as CartItem[];
+    const out = normalizeCartLines(legacy);
+    expect(out[0].lineId).toBe(computeCartLineId('p1', [sel('m1')]));
+    expect(out[1].lineId).toBe(computeCartLineId('p1', [sel('m2')]));
+  });
+
+  it('normalizeCartLines keeps an existing lineId and suffixes duplicate identities', () => {
+    const kept = { ...product('p1'), quantity: 1, lineId: 'custom-id' } as CartItem;
+    const dupA = { ...product('p2'), quantity: 1 } as CartItem;
+    const dupB = { ...product('p2'), quantity: 3 } as CartItem;
+    const out = normalizeCartLines([kept, dupA, dupB]);
+    expect(out[0].lineId).toBe('custom-id');
+    expect(out[1].lineId).toBe('p2::::');
+    expect(out[2].lineId).toBe('p2::::::2'); // unique despite identical identity
+  });
+
+  it('buildOrderData payload carries NO lineId (client-only, DTO unchanged)', () => {
+    let cart = mergeCartItem([], product('p1'), 1, [sel('m1')]);
+    cart = mergeCartItem(cart, product('p1'), 2, []);
+    const built = buildOrderData({
+      isTablelessMode: false,
+      selectedTable: { id: 't-1' } as never,
+      customerName: '',
+      orderNotes: '',
+      discount: 0,
+      cartItems: cart,
+      generateId: () => 'fixed-id',
+    });
+    for (const item of built.items) {
+      expect('lineId' in item).toBe(false);
+    }
+    expect(JSON.stringify(built)).not.toContain('lineId');
+  });
+
+  it('mapOrderItemsToCart stamps unique lineIds even for duplicate-identity order rows', () => {
+    const cart = mapOrderItemsToCart({
+      orderItems: [
+        orderItem({ id: 'oi-1', product: { id: 'p-1', name: 'Burger', price: 10 } as Product }),
+        orderItem({ id: 'oi-2', product: { id: 'p-1', name: 'Burger', price: 10 } as Product }),
+      ],
+    } as Pick<Order, 'orderItems' | 'items'>);
+    expect(cart).toHaveLength(2);
+    expect(cart[0].lineId).toBeDefined();
+    expect(cart[0].lineId).not.toBe(cart[1].lineId);
+  });
+});
+
+describe('stepProductLine (MenuPanel inline steppers, product-id addressed)', () => {
+  it('increments the plain line, never a modifier sibling of the same product', () => {
+    let cart = mergeCartItem([], product('p1'), 1, [sel('m1')]);
+    cart = mergeCartItem(cart, product('p1'), 2, []);
+    const out = stepProductLine(cart, 'p1', 1);
+    expect(out[0].quantity).toBe(1); // modifier line untouched
+    expect(out[1].quantity).toBe(3);
+  });
+
+  it('decrements and drops the plain line at quantity 1', () => {
+    const cart = mergeCartItem([], product('p1'), 1, []);
+    expect(stepProductLine(cart, 'p1', -1)).toHaveLength(0);
+    const two = mergeCartItem([], product('p1'), 2, []);
+    expect(stepProductLine(two, 'p1', -1)[0].quantity).toBe(1);
+  });
+
+  it('falls back to a sole line even when it carries modifiers', () => {
+    const cart = mergeCartItem([], product('p1'), 1, [sel('m1')]);
+    expect(stepProductLine(cart, 'p1', 1)[0].quantity).toBe(2);
+  });
+
+  it('touches nothing when several modifier lines make the target ambiguous', () => {
+    let cart = mergeCartItem([], product('p1'), 1, [sel('m1')]);
+    cart = mergeCartItem(cart, product('p1'), 2, [sel('m2')]);
+    expect(stepProductLine(cart, 'p1', 1)).toEqual(cart);
+  });
+
+  it('is a no-op for a product not in the cart', () => {
+    const cart = mergeCartItem([], product('p1'), 1, []);
+    expect(stepProductLine(cart, 'p9', 1)).toEqual(cart);
   });
 });

--- a/frontend/src/pages/pos/posCart.ts
+++ b/frontend/src/pages/pos/posCart.ts
@@ -1,4 +1,4 @@
-import { OrderType, OrderStatus, type Order, type OrderItem, type Product } from '../../types';
+import { OrderType, OrderStatus, PaymentStatus, type Order, type OrderItem, type Product } from '../../types';
 import type { SelectedModifier } from '../../components/pos/ProductOptionsModal';
 import type { CartItem } from './posTypes';
 
@@ -99,6 +99,37 @@ export function isTenderSufficient(total: number, tendered: number): boolean {
 }
 
 /**
+ * Sum of COMPLETED payments already recorded on an order. `payments` rides on
+ * every /orders list row (ORDER_DETAIL_INCLUDE serializes it); amounts may
+ * arrive as strings (Prisma Decimal) → Number(). Non-COMPLETED rows (PENDING/
+ * FAILED/REFUNDED) don't count — mirrors the backend's remaining-validation
+ * aggregate (payments.service, status: COMPLETED), so the two sides can never
+ * disagree on what "already paid" means. Kuruş-rounded like computeChangeDue.
+ */
+export function orderPaidAmount(order: Pick<Order, 'payments'>): number {
+  const paid = (order.payments ?? []).reduce(
+    (sum, p) =>
+      p.status === PaymentStatus.COMPLETED ? sum + Number(p.amount) : sum,
+    0,
+  );
+  return Math.round(paid * 100) / 100;
+}
+
+/**
+ * True balance still owed on an order — what "collect payment" must charge.
+ * After a partial/progressive payment the backend rejects anything above this
+ * ("Payment amount exceeds remaining"), so charging the gross finalAmount
+ * dead-ends the cashier with no way to settle the bill. Clamped at 0 (an
+ * over-paid order owes nothing) and kuruş-rounded against float noise.
+ */
+export function orderRemainingDue(
+  order: Pick<Order, 'finalAmount' | 'payments'>,
+): number {
+  const remaining = Number(order.finalAmount) - orderPaidAmount(order);
+  return Math.max(0, Math.round(remaining * 100) / 100);
+}
+
+/**
  * Stable identity key for a cart line: product id is implicit (caller already
  * matched on it); this keys the *modifier set* so the same product with
  * different modifiers stays a separate line. Modifier ids are sorted so order
@@ -119,6 +150,98 @@ function comboKeyOf(
     .map((s) => `${s.groupId}:${s.componentProductId}`)
     .sort()
     .join('|');
+}
+
+/**
+ * Client-only cart-line identity: product + modifier set + combo picks —
+ * EXACTLY the keys mergeCartItem merges on, so "same lineId" ⇔ "would merge".
+ * Line-level operations (update qty / remove / React keys) must target this,
+ * never the bare product id: two lines of the same product with different
+ * modifiers are distinct bills, and a product-id update/remove corrupted both.
+ */
+export function computeCartLineId(
+  productId: string,
+  modifiers?: { modifierId: string }[],
+  comboSelections?: { groupId: string; componentProductId: string }[],
+): string {
+  return `${productId}::${modifierKeyOf(modifiers ?? [])}::${comboKeyOf(comboSelections)}`;
+}
+
+/**
+ * Resolve a line's id, deriving it for legacy lines that lack one (a persisted
+ * pre-lineId cart that slipped past normalizeCartLines still targets correctly).
+ */
+export function getCartLineId(
+  item: Pick<CartItem, 'id' | 'lineId' | 'modifiers' | 'comboSelections'>,
+): string {
+  return (
+    item.lineId ?? computeCartLineId(item.id, item.modifiers, item.comboSelections)
+  );
+}
+
+/**
+ * Backfill `lineId` on carts persisted before line identity existed
+ * (localStorage back-compat) and on order-loaded lines. Deterministic —
+ * derived from the same merge keys — with an index suffix when two lines
+ * share an identity (possible when a reopened order carried duplicate item
+ * rows), so React keys and line targeting stay unique.
+ */
+export function normalizeCartLines(items: CartItem[]): CartItem[] {
+  const taken = new Set<string>();
+  return items.map((item) => {
+    const base = getCartLineId(item);
+    let lineId = base;
+    for (let n = 2; taken.has(lineId); n++) lineId = `${base}::${n}`;
+    taken.add(lineId);
+    return lineId === item.lineId ? item : { ...item, lineId };
+  });
+}
+
+/** Set a line's quantity by lineId, leaving sibling lines of the same product intact. */
+export function updateLineQuantity(
+  prev: CartItem[],
+  lineId: string,
+  quantity: number,
+): CartItem[] {
+  return prev.map((item) =>
+    getCartLineId(item) === lineId ? { ...item, quantity } : item,
+  );
+}
+
+/** Remove exactly one line by lineId (never every line of the product). */
+export function removeLine(prev: CartItem[], lineId: string): CartItem[] {
+  return prev.filter((item) => getCartLineId(item) !== lineId);
+}
+
+/**
+ * Resolve which line a MenuPanel inline stepper targets. Steppers pass a bare
+ * PRODUCT id and only render for simple products (no required modifiers,
+ * never combos), which merge into one plain line — but a reopened order can
+ * put an optional-modifier line of the same product in the cart. Prefer the
+ * plain line (the one a card-tap add merges into); fall back to a sole line;
+ * when several modifier lines make the target ambiguous, touch nothing rather
+ * than corrupt sibling lines.
+ */
+export function stepProductLine(
+  prev: CartItem[],
+  productId: string,
+  delta: 1 | -1,
+): CartItem[] {
+  const matches = prev.filter((item) => item.id === productId);
+  const plainKey = computeCartLineId(productId, [], undefined);
+  const target =
+    matches.find(
+      (item) =>
+        computeCartLineId(item.id, item.modifiers, item.comboSelections) ===
+        plainKey,
+    ) ?? (matches.length === 1 ? matches[0] : undefined);
+  if (!target) return prev;
+  return prev.flatMap((item) => {
+    if (item !== target) return [item];
+    const quantity = item.quantity + delta;
+    // Drop the line when it would hit zero, otherwise adjust.
+    return quantity < 1 ? [] : [{ ...item, quantity }];
+  });
 }
 
 /**
@@ -151,7 +274,17 @@ export function mergeCartItem(
         : item,
     );
   }
-  return [...prev, { ...product, quantity, modifiers, comboSelections }];
+  // Collision-free: a line sharing this identity would have merged above.
+  return [
+    ...prev,
+    {
+      ...product,
+      quantity,
+      modifiers,
+      comboSelections,
+      lineId: computeCartLineId(product.id, modifiers, comboSelections),
+    },
+  ];
 }
 
 /**
@@ -319,5 +452,6 @@ export function mapOrderItemsToCart(
       });
     }
   }
-  return result;
+  // Stamp line identities (suffix-deduped) so loaded lines are targetable.
+  return normalizeCartLines(result);
 }

--- a/frontend/src/pages/pos/posTypes.ts
+++ b/frontend/src/pages/pos/posTypes.ts
@@ -15,4 +15,9 @@ export interface CartItem extends Product {
   // For a COMBO line: the chosen component per slot. `price` on this item is
   // already the effective combo price (base + chosen slot deltas).
   comboSelections?: ComboSelectionInput[];
+  // CLIENT-ONLY line identity (product + modifier set + combo picks — see
+  // posCart.computeCartLineId). Targets qty/remove ops and React keys; never
+  // sent to the API (buildOrderData maps explicit fields only). Optional so
+  // persisted pre-lineId carts type-check; normalizeCartLines backfills it.
+  lineId?: string;
 }

--- a/frontend/src/pages/pos/useCartPersistence.test.ts
+++ b/frontend/src/pages/pos/useCartPersistence.test.ts
@@ -14,6 +14,7 @@ import type { User } from '../../types';
 interface Item {
   id: string;
   quantity: number;
+  lineId?: string;
 }
 
 const KEY = 'pos_cart::tenant-1::user-1';
@@ -172,5 +173,16 @@ describe('useCartPersistence hook', () => {
     const persisted = JSON.parse(localStorage.getItem(KEY)!);
     expect(persisted.items).toEqual([{ id: 'new', quantity: 7 }]);
     expect(typeof persisted.savedAt).toBe('number');
+  });
+
+  it('applies the normalize hook to loaded items (lineId back-compat backfill)', () => {
+    const items: Item[] = [{ id: 'p1', quantity: 2 }];
+    localStorage.setItem(KEY, JSON.stringify({ items, savedAt: Date.now() }));
+    useAuthStore.setState({ user: fakeUser('tenant-1', 'user-1') });
+
+    const normalize = (loaded: Item[]) =>
+      loaded.map((i) => ({ ...i, lineId: `${i.id}::` }));
+    const { result } = renderHook(() => useCartPersistence<Item>(normalize));
+    expect(result.current.cartItems).toEqual([{ id: 'p1', quantity: 2, lineId: 'p1::' }]);
   });
 });

--- a/frontend/src/pages/pos/useCartPersistence.ts
+++ b/frontend/src/pages/pos/useCartPersistence.ts
@@ -107,8 +107,12 @@ export function writePersistedCart<T>(
  * localStorage and a write-through persistence effect. Returns the same
  * tuple POSPage used inline plus the active storage key (so other reset
  * paths can clear it if ever needed — POSPage currently does not).
+ *
+ * `normalize` (optional) runs once on the loaded items — POSPage passes
+ * posCart.normalizeCartLines so carts persisted before line identity existed
+ * get their `lineId`s backfilled before any line operation targets them.
  */
-export function useCartPersistence<T>(): {
+export function useCartPersistence<T>(normalize?: (items: T[]) => T[]): {
   cartItems: T[];
   setCartItems: React.Dispatch<React.SetStateAction<T[]>>;
   cartStorageKey: string | null;
@@ -116,9 +120,10 @@ export function useCartPersistence<T>(): {
   const user = useAuthStore((s) => s.user);
   const cartStorageKey = buildCartStorageKey(user);
 
-  const [cartItems, setCartItems] = useState<T[]>(() =>
-    readPersistedCart<T>(cartStorageKey),
-  );
+  const [cartItems, setCartItems] = useState<T[]>(() => {
+    const items = readPersistedCart<T>(cartStorageKey);
+    return normalize ? normalize(items) : items;
+  });
 
   useEffect(() => {
     writePersistedCart(cartStorageKey, cartItems);

--- a/frontend/src/pages/pos/useTableSelection.test.tsx
+++ b/frontend/src/pages/pos/useTableSelection.test.tsx
@@ -163,7 +163,8 @@ describe('useTableSelection — occupied-load effect', () => {
     expect(result.current.state.discount).toBe(7);
     expect(result.current.state.orderNotes).toBe('table notes');
     expect(result.current.state.cartItems).toEqual([
-      { id: 'p-1', price: 10, quantity: 2, notes: undefined },
+      // lineId stamped by mapOrderItemsToCart (client-only line identity).
+      { id: 'p-1', price: 10, quantity: 2, notes: undefined, modifiers: undefined, lineId: 'p-1::::' },
     ]);
     expect(toast.info).toHaveBeenCalledWith('loadedExistingOrder');
   });


### PR DESCRIPTION
Review loop tick 5 — the two remaining HIGH findings from the POS modal review:

1. **Settle-up dead-end after partial payments.** AwaitingPaymentSection displayed and charged the full `finalAmount` even when progressive payments had already collected part of it — the server rightly rejected the overcharge, leaving no path to collect the true balance. New `orderPaidAmount`/`orderRemainingDue` helpers (COMPLETED-only sum, mirroring the backend validation aggregate, kuruş-rounded) now drive the section label (remaining due + struck-through gross) and the amount passed to the payment modal; the live amount resolution in POSPage uses the same helper, so the modal shows the true balance. No backend change — `/orders` already serializes `payments`.
2. **Cart lines keyed by bare product id.** Same-product lines with different modifiers/combo picks were updated/removed TOGETHER (and rendered with duplicate React keys). Every line now carries a stable `lineId` derived from exactly the merge-identity keys (`modifierKeyOf`/`comboKeyOf`), operations target it, MenuPanel steppers resolve the single plain line (no-op instead of corrupting siblings when ambiguous), persisted pre-lineId carts are normalized on load, and the order DTO provably excludes `lineId`.

Verification: 168 POS tests green (posCart at 80 specs; new AwaitingPaymentSection suite incl. REFUNDED-excluded and Decimal-string rounding), tsc clean, eslint clean, i18n parity 5 locales.
