### PR TITLE
fix(pos): persistent delivery inbox opener, transfer view reset, mobile cart parity, shared scroll lock

### DIFF
--- a/frontend/src/components/pos/CartDrawer.tsx
+++ b/frontend/src/components/pos/CartDrawer.tsx
@@ -1,6 +1,7 @@
 import { X } from 'lucide-react';
 import { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
+import { acquireBodyScrollLock, releaseBodyScrollLock } from '../ui/bodyScrollLock';
 
 interface CartDrawerProps {
   isOpen: boolean;
@@ -11,15 +12,14 @@ interface CartDrawerProps {
 const CartDrawer = ({ isOpen, onClose, children }: CartDrawerProps) => {
   const { t } = useTranslation('pos');
 
+  // Participate in the SHARED refcounted body scroll lock (ui/bodyScrollLock).
+  // Writing document.body.style.overflow directly here used to bypass Modal's
+  // refcount, so closing a Modal opened over the drawer restored body scroll
+  // under the still-open drawer.
   useEffect(() => {
-    if (isOpen) {
-      document.body.style.overflow = 'hidden';
-    } else {
-      document.body.style.overflow = 'unset';
-    }
-    return () => {
-      document.body.style.overflow = 'unset';
-    };
+    if (!isOpen) return;
+    acquireBodyScrollLock();
+    return () => releaseBodyScrollLock();
   }, [isOpen]);
 
   useEffect(() => {

--- a/frontend/src/components/pos/DeliveryInboxButton.test.tsx
+++ b/frontend/src/components/pos/DeliveryInboxButton.test.tsx
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { DELIVERY_INBOX_ACTIVE_STATUSES } from './deliveryInbox';
+
+/**
+ * Specs for the persistent delivery-inbox opener. Pins the three things the
+ * button exists for: it renders even when NOTHING is pending (the
+ * NotificationBar hides at 0 counts — this button must not), its badge
+ * counts only DELIVERY orders in the active window, and it reuses the
+ * PendingOrdersPanel's exact query filters (shared react-query cache entry).
+ */
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (k: string) => k }),
+}));
+
+let ordersResult: any;
+const useOrdersMock = vi.fn((..._args: unknown[]) => ordersResult);
+vi.mock('../../features/orders/ordersApi', () => ({
+  useOrders: (...args: unknown[]) => useOrdersMock(...args),
+}));
+
+import DeliveryInboxButton from './DeliveryInboxButton';
+
+const deliveryOrder = (id: string, status: string) => ({
+  id,
+  status,
+  source: 'TRENDYOL',
+  externalOrderId: `ext-${id}`,
+});
+const internalOrder = (id: string, status: string) => ({ id, status });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  ordersResult = { data: [] };
+});
+
+describe('DeliveryInboxButton', () => {
+  it('renders without a badge when there are no active delivery orders', () => {
+    ordersResult = { data: [internalOrder('i1', 'PENDING_APPROVAL')] };
+    render(<DeliveryInboxButton onOpen={() => {}} />);
+    const button = screen.getByRole('button', { name: 'title' });
+    expect(button).toBeInTheDocument();
+    expect(button.textContent).toBe('');
+  });
+
+  it('badges the count of delivery orders only (accepted PREPARING included)', () => {
+    ordersResult = {
+      data: [
+        deliveryOrder('d1', 'PREPARING'),
+        deliveryOrder('d2', 'PREPARING'),
+        deliveryOrder('d3', 'READY'),
+        internalOrder('i1', 'PENDING_APPROVAL'),
+      ],
+    };
+    render(<DeliveryInboxButton onOpen={() => {}} />);
+    expect(screen.getByText('3')).toBeInTheDocument();
+  });
+
+  it('queries the shared inbox active window (same key as PendingOrdersPanel)', () => {
+    render(<DeliveryInboxButton onOpen={() => {}} />);
+    expect(useOrdersMock).toHaveBeenCalledWith({
+      status: DELIVERY_INBOX_ACTIVE_STATUSES,
+    });
+  });
+
+  it('fires onOpen on click', () => {
+    const onOpen = vi.fn();
+    render(<DeliveryInboxButton onOpen={onOpen} />);
+    fireEvent.click(screen.getByRole('button', { name: 'title' }));
+    expect(onOpen).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/components/pos/DeliveryInboxButton.tsx
+++ b/frontend/src/components/pos/DeliveryInboxButton.tsx
@@ -1,0 +1,48 @@
+import { Package } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { useOrders } from '../../features/orders/ordersApi';
+import { DELIVERY_INBOX_ACTIVE_STATUSES, isDeliveryOrder } from './deliveryInbox';
+
+interface DeliveryInboxButtonProps {
+  onOpen: () => void;
+}
+
+/**
+ * Persistent opener for the POS delivery/package-order inbox
+ * (PendingOrdersPanel). The NotificationBar only surfaces while something
+ * needs approval — an accepted PREPARING/READY delivery order has no other
+ * entry point (the old /admin/delivery-orders page redirects to /pos) — so
+ * this compact button stays visible in the POS header at all times.
+ *
+ * It issues the panel's EXACT query (same filters → same react-query key),
+ * so the two share a single cache entry instead of duplicating the fetch.
+ * Like the NotificationBar counts, freshness rides the socket-driven
+ * 'orders' invalidations (usePosSocket) — no polling here; the panel adds
+ * its own 15s refetch only while open.
+ */
+const DeliveryInboxButton = ({ onOpen }: DeliveryInboxButtonProps) => {
+  const { t } = useTranslation('deliveryOrders');
+  const { data: orders = [] } = useOrders({
+    status: DELIVERY_INBOX_ACTIVE_STATUSES,
+  });
+  const activeCount = orders.filter(isDeliveryOrder).length;
+
+  return (
+    <button
+      type="button"
+      onClick={onOpen}
+      title={t('title')}
+      aria-label={t('title')}
+      className="relative inline-flex items-center justify-center w-10 h-9 rounded-lg border border-slate-200 bg-white text-slate-500 hover:text-slate-700 hover:bg-slate-50 transition-colors shrink-0"
+    >
+      <Package className="w-4 h-4" />
+      {activeCount > 0 && (
+        <span className="absolute -top-1.5 -right-1.5 bg-amber-500 text-white text-[10px] font-bold rounded-full h-4 min-w-[1rem] px-1 flex items-center justify-center">
+          {activeCount}
+        </span>
+      )}
+    </button>
+  );
+};
+
+export default DeliveryInboxButton;

--- a/frontend/src/components/pos/PendingOrdersPanel.tsx
+++ b/frontend/src/components/pos/PendingOrdersPanel.tsx
@@ -6,30 +6,21 @@ import {
   useCancelOrder,
 } from '../../features/orders/ordersApi';
 import { useFormatCurrency } from '../../hooks/useFormatCurrency';
-import { Order, OrderStatus } from '../../types';
+import { OrderStatus } from '../../types';
 import { cn } from '../../lib/utils';
 import Spinner from '../ui/Spinner';
 import { useTranslation } from 'react-i18next';
 import DeliveryOrderBadge from '../delivery-platforms/DeliveryOrderBadge';
 import DeliveryOrderModerationPanel from '../delivery-platforms/DeliveryOrderModerationPanel';
 import { PLATFORM_DISPLAY } from '../delivery-platforms/platformDisplay';
+// Active-window statuses + delivery predicate are shared with the persistent
+// header DeliveryInboxButton (same query key → single cache entry).
+import { DELIVERY_INBOX_ACTIVE_STATUSES, isDeliveryOrder } from './deliveryInbox';
 
 interface PendingOrdersPanelProps {
   isOpen: boolean;
   onClose: () => void;
 }
-
-// Delivery orders travel a wider lifecycle (accepted → preparing → ready)
-// than the internal QR/in-house approve queue (which only lives in
-// PENDING_APPROVAL). Fetch the full active window so the POS panel is the
-// single "Paket Siparişleri" inbox — the standalone /admin/delivery-orders
-// page was folded in here.
-const ACTIVE_STATUSES = [
-  OrderStatus.PENDING_APPROVAL,
-  OrderStatus.PENDING,
-  OrderStatus.PREPARING,
-  OrderStatus.READY,
-].join(',');
 
 const PLATFORM_FILTERS = ['ALL', ...Object.keys(PLATFORM_DISPLAY)];
 
@@ -40,8 +31,6 @@ const STATUS_PILL: Record<string, string> = {
   [OrderStatus.READY]: 'bg-emerald-100 text-emerald-700',
 };
 
-const isDelivery = (o: Order) => !!o.source && !!o.externalOrderId;
-
 const PendingOrdersPanel = ({ isOpen, onClose }: PendingOrdersPanelProps) => {
   const { t } = useTranslation('pos');
   const { t: td } = useTranslation('deliveryOrders');
@@ -51,7 +40,7 @@ const PendingOrdersPanel = ({ isOpen, onClose }: PendingOrdersPanelProps) => {
   // Single query for both surfaces; refetch keeps the inbox live like the
   // old standalone page did.
   const { data: orders = [], isLoading } = useOrders(
-    { status: ACTIVE_STATUSES },
+    { status: DELIVERY_INBOX_ACTIVE_STATUSES },
     { refetchInterval: 15_000, keepPreviousData: true, enabled: isOpen },
   );
   const approveOrder = useApproveOrder();
@@ -61,7 +50,7 @@ const PendingOrdersPanel = ({ isOpen, onClose }: PendingOrdersPanelProps) => {
   const deliveryOrders = useMemo(
     () =>
       orders
-        .filter(isDelivery)
+        .filter(isDeliveryOrder)
         .filter(
           (o) => platform === 'ALL' || o.source?.toUpperCase() === platform,
         )
@@ -77,16 +66,16 @@ const PendingOrdersPanel = ({ isOpen, onClose }: PendingOrdersPanelProps) => {
   const internalPending = useMemo(
     () =>
       orders.filter(
-        (o) => !isDelivery(o) && o.status === OrderStatus.PENDING_APPROVAL,
+        (o) => !isDeliveryOrder(o) && o.status === OrderStatus.PENDING_APPROVAL,
       ),
     [orders],
   );
 
-  const hasDelivery = orders.some(isDelivery);
+  const hasDelivery = orders.some(isDeliveryOrder);
   const pendingApprovalCount = useMemo(
     () =>
       orders.filter(
-        (o) => isDelivery(o) && o.status === OrderStatus.PENDING_APPROVAL,
+        (o) => isDeliveryOrder(o) && o.status === OrderStatus.PENDING_APPROVAL,
       ).length,
     [orders],
   );

--- a/frontend/src/components/pos/deliveryInbox.ts
+++ b/frontend/src/components/pos/deliveryInbox.ts
@@ -1,0 +1,17 @@
+import { Order, OrderStatus } from '../../types';
+
+// Delivery orders travel a wider lifecycle (accepted → preparing → ready)
+// than the internal QR/in-house approve queue (which only lives in
+// PENDING_APPROVAL). The POS PendingOrdersPanel is the single "Paket
+// Siparişleri" inbox (the standalone /admin/delivery-orders page redirects
+// to /pos), so both the panel and the header DeliveryInboxButton badge fetch
+// this full active window. Sharing the exact filter string keeps their
+// react-query keys identical → one cache entry, no duplicated fetching.
+export const DELIVERY_INBOX_ACTIVE_STATUSES = [
+  OrderStatus.PENDING_APPROVAL,
+  OrderStatus.PENDING,
+  OrderStatus.PREPARING,
+  OrderStatus.READY,
+].join(',');
+
+export const isDeliveryOrder = (o: Order) => !!o.source && !!o.externalOrderId;

--- a/frontend/src/components/ui/Modal.tsx
+++ b/frontend/src/components/ui/Modal.tsx
@@ -2,24 +2,11 @@ import React, { useEffect, useId } from 'react';
 import { X } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { cn } from '../../lib/utils';
-
-// Refcount how many Modal instances currently want body scroll locked.
-// Without this, a nested modal closing earlier than the outer one would
-// restore body scroll while the outer modal is still on screen — the
-// backdrop suddenly scrolls under the visible modal.
-let scrollLockRefcount = 0;
-function acquireScrollLock() {
-  scrollLockRefcount += 1;
-  if (scrollLockRefcount === 1) {
-    document.body.style.overflow = 'hidden';
-  }
-}
-function releaseScrollLock() {
-  scrollLockRefcount = Math.max(0, scrollLockRefcount - 1);
-  if (scrollLockRefcount === 0) {
-    document.body.style.overflow = 'unset';
-  }
-}
+// Shared refcounted lock: a nested overlay (another Modal, the POS cart
+// drawer) closing earlier than this one must not restore body scroll while
+// this one is still on screen. The refcount lives in bodyScrollLock so every
+// overlay participates in the SAME count.
+import { acquireBodyScrollLock, releaseBodyScrollLock } from './bodyScrollLock';
 
 interface ModalProps {
   isOpen: boolean;
@@ -50,12 +37,12 @@ const Modal: React.FC<ModalProps> = ({
 
     if (isOpen) {
       document.addEventListener('keydown', handleEscape);
-      acquireScrollLock();
+      acquireBodyScrollLock();
     }
 
     return () => {
       document.removeEventListener('keydown', handleEscape);
-      if (isOpen) releaseScrollLock();
+      if (isOpen) releaseBodyScrollLock();
     };
   }, [isOpen, onClose]);
 

--- a/frontend/src/components/ui/bodyScrollLock.test.ts
+++ b/frontend/src/components/ui/bodyScrollLock.test.ts
@@ -1,0 +1,39 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * The refcount is module-level state, so each test re-imports a fresh copy
+ * via vi.resetModules to keep the count from leaking between tests.
+ */
+const load = () => import('./bodyScrollLock');
+
+beforeEach(() => {
+  vi.resetModules();
+  document.body.style.overflow = 'unset';
+});
+
+describe('bodyScrollLock', () => {
+  it('locks on first acquire and only unlocks on the LAST release', async () => {
+    const { acquireBodyScrollLock, releaseBodyScrollLock } = await load();
+
+    acquireBodyScrollLock(); // e.g. the cart drawer opens
+    expect(document.body.style.overflow).toBe('hidden');
+
+    acquireBodyScrollLock(); // a modal opens over it
+    releaseBodyScrollLock(); // modal closes — drawer still open
+    expect(document.body.style.overflow).toBe('hidden');
+
+    releaseBodyScrollLock(); // drawer closes — last holder gone
+    expect(document.body.style.overflow).toBe('unset');
+  });
+
+  it('an extra release neither goes negative nor breaks the next acquire', async () => {
+    const { acquireBodyScrollLock, releaseBodyScrollLock } = await load();
+
+    releaseBodyScrollLock(); // spurious release at count 0
+    acquireBodyScrollLock();
+    expect(document.body.style.overflow).toBe('hidden');
+
+    releaseBodyScrollLock();
+    expect(document.body.style.overflow).toBe('unset');
+  });
+});

--- a/frontend/src/components/ui/bodyScrollLock.ts
+++ b/frontend/src/components/ui/bodyScrollLock.ts
@@ -1,0 +1,21 @@
+// Refcounted body scroll lock shared by every full-screen overlay (Modal,
+// the POS CartDrawer, …). Without a single shared refcount, an overlay that
+// closes earlier than another one stacked over/under it would restore body
+// scroll while the other surface is still on screen — the page suddenly
+// scrolls under the visible overlay. Each overlay acquires on open and
+// releases on close/unmount; the body style only changes on the 0↔1 edges.
+let scrollLockRefcount = 0;
+
+export function acquireBodyScrollLock() {
+  scrollLockRefcount += 1;
+  if (scrollLockRefcount === 1) {
+    document.body.style.overflow = 'hidden';
+  }
+}
+
+export function releaseBodyScrollLock() {
+  scrollLockRefcount = Math.max(0, scrollLockRefcount - 1);
+  if (scrollLockRefcount === 0) {
+    document.body.style.overflow = 'unset';
+  }
+}

--- a/frontend/src/pages/pos/POSPage.test.tsx
+++ b/frontend/src/pages/pos/POSPage.test.tsx
@@ -15,7 +15,17 @@ import { toast } from 'sonner';
 
 // --- child components: lightweight stubs --------------------------------
 vi.mock('../../components/pos/MenuPanel', () => ({ default: () => <div data-testid="menu-panel" /> }));
-vi.mock('../../components/pos/OrderCart', () => ({ default: () => <div data-testid="order-cart" /> }));
+// OrderCart: expose onProgressivePay so the progressive-modal lifecycle spec
+// can open the modal the way a cashier does.
+vi.mock('../../components/pos/OrderCart', () => ({
+  default: ({ onProgressivePay }: any) => (
+    <div data-testid="order-cart">
+      {onProgressivePay && (
+        <button data-testid="open-progressive" onClick={onProgressivePay} />
+      )}
+    </div>
+  ),
+}));
 // PaymentModal: expose onConfirm so the terminal-flow spec can fire a CARD
 // payment (the stub renders regardless of isOpen — POSPage mounts it always).
 vi.mock('../../components/pos/PaymentModal', () => ({
@@ -30,14 +40,39 @@ vi.mock('../../components/pos/ProductOptionsModal', () => ({ default: () => null
 vi.mock('../../components/pos/StickyCartBar', () => ({ default: () => <div data-testid="sticky-cart" /> }));
 vi.mock('../../components/pos/CartDrawer', () => ({ default: () => null }));
 vi.mock('../../components/pos/NotificationBar', () => ({ default: () => <div data-testid="notif-bar" /> }));
+// DeliveryInboxButton: the persistent inbox opener (its own badge/count logic
+// is pinned in DeliveryInboxButton.test.tsx — here we only pin the wiring).
+vi.mock('../../components/pos/DeliveryInboxButton', () => ({
+  default: ({ onOpen }: any) => (
+    <button data-testid="delivery-inbox-btn" onClick={onOpen} />
+  ),
+}));
 vi.mock('../../components/pos/AwaitingPaymentSection', () => ({ default: () => null }));
-vi.mock('../../components/pos/PendingOrdersPanel', () => ({ default: () => null }));
+// PendingOrdersPanel: surface isOpen so the inbox-opener spec can assert the
+// button actually opens the panel.
+vi.mock('../../components/pos/PendingOrdersPanel', () => ({
+  default: ({ isOpen }: any) =>
+    isOpen ? <div data-testid="pending-orders-panel" /> : null,
+}));
 vi.mock('../../components/pos/WaiterRequestsPanel', () => ({ default: () => null }));
 vi.mock('../../components/pos/BillRequestsPanel', () => ({ default: () => null }));
-vi.mock('../../components/pos/TransferTableModal', () => ({ default: () => null }));
+// TransferTableModal: expose onConfirm so the transfer spec can complete a
+// transfer (the modal itself only renders while a table is selected).
+vi.mock('../../components/pos/TransferTableModal', () => ({
+  default: ({ onConfirm }: any) => (
+    <button data-testid="transfer-confirm" onClick={() => onConfirm('tbl-2')} />
+  ),
+}));
 vi.mock('../../components/pos/TableMergeModal', () => ({ default: () => null }));
 vi.mock('../../components/pos/BillSplitModal', () => ({ default: () => null }));
-vi.mock('../../components/pos/ProgressiveSplitModal', () => ({ default: () => null }));
+// ProgressiveSplitModal: render a marker while open so the lifecycle spec can
+// assert POSPage keeps it MOUNTED when the active-order list empties.
+vi.mock('../../components/pos/ProgressiveSplitModal', () => ({
+  default: ({ isOpen, orders }: any) =>
+    isOpen ? (
+      <div data-testid="progressive-modal" data-order-count={orders.length} />
+    ) : null,
+}));
 vi.mock('../../components/pos/ReservationActionDialog', () => ({ default: () => null }));
 vi.mock('../../components/pos/ManualLockDialog', () => ({ default: () => null }));
 // TerminalChargeModal: surface the charge state POSPage passes down (status +
@@ -84,13 +119,21 @@ vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn(), info: vi.f
 
 // --- feature hooks: inert defaults --------------------------------------
 let tablesResult: any;
+// Transfer resolves synchronously so the transfer spec can drive the
+// onSuccess reset path (view back to table-selection).
+const transferTableOrdersMock = vi.fn(
+  (_vars: any, opts?: { onSuccess?: () => void }) => opts?.onSuccess?.(),
+);
 vi.mock('../../features/orders/ordersApi', () => {
   const mutation = () => ({ mutate: vi.fn(), mutateAsync: vi.fn(), isPending: false });
   return {
     useCreateOrder: mutation,
     useUpdateOrder: mutation,
     useOrders: () => ({ data: [], isLoading: false }),
-    useTransferTableOrders: mutation,
+    useTransferTableOrders: () => ({
+      mutate: transferTableOrdersMock,
+      isPending: false,
+    }),
     useSplitBill: mutation,
     useGroupBillSummary: () => ({ data: null }),
     useCreatePayment: mutation,
@@ -185,6 +228,76 @@ describe('POSPage — table selection screen', () => {
     tablesResult = { data: undefined, isLoading: true };
     render(<POSPage />);
     expect(screen.getByTestId('spinner')).toBeInTheDocument();
+  });
+});
+
+/** Drive the page into the order view with a selected table (the state the
+ *  transfer/progressive flows start from), via the setters POSPage hands to
+ *  the mocked useTableSelection. */
+const enterOrderViewWithTable = () => {
+  act(() => {
+    tableSelectionArgs.setSelectedTable({
+      id: 'tbl-1',
+      number: '1',
+      status: 'OCCUPIED',
+      capacity: 4,
+    });
+    tableSelectionArgs.setCurrentView('order');
+  });
+};
+
+describe('POSPage — persistent delivery inbox opener', () => {
+  it('renders on the table-selection screen (even with zero notifications)', () => {
+    render(<POSPage />);
+    expect(screen.getByTestId('delivery-inbox-btn')).toBeInTheDocument();
+  });
+
+  it('renders on the order screen too', () => {
+    render(<POSPage />);
+    enterOrderViewWithTable();
+    expect(screen.getByTestId('delivery-inbox-btn')).toBeInTheDocument();
+  });
+
+  it('opens the pending/delivery orders panel on click', () => {
+    render(<POSPage />);
+    expect(screen.queryByTestId('pending-orders-panel')).not.toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('delivery-inbox-btn'));
+    expect(screen.getByTestId('pending-orders-panel')).toBeInTheDocument();
+  });
+});
+
+describe('POSPage — table transfer', () => {
+  it('returns to the table-selection view after a successful transfer', () => {
+    render(<POSPage />);
+    enterOrderViewWithTable();
+    expect(screen.queryByText('tableSelection.title')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('transfer-confirm'));
+
+    expect(transferTableOrdersMock).toHaveBeenCalledWith(
+      expect.objectContaining({ sourceTableId: 'tbl-1', targetTableId: 'tbl-2' }),
+      expect.anything(),
+    );
+    // Pre-fix: stayed on 'order' with no table — a "Takeaway order" header
+    // whose Create is blocked by the no-table guard.
+    expect(screen.getByText('tableSelection.title')).toBeInTheDocument();
+  });
+});
+
+describe('POSPage — progressive split modal lifecycle', () => {
+  it('keeps the OPEN modal mounted while the active-order list is empty (fullyPaid reachable)', () => {
+    render(<POSPage />);
+    enterOrderViewWithTable();
+
+    // useOrders is mocked to an empty list — exactly the state after the
+    // last order flips PAID and drops out of the status-filtered refetch.
+    fireEvent.click(screen.getByTestId('open-progressive'));
+
+    // Pre-fix: POSPage returned null here, unmounting the open modal the
+    // moment the list emptied, so its fullyPaid confirmation never showed.
+    const modal = screen.getByTestId('progressive-modal');
+    expect(modal).toBeInTheDocument();
+    expect(modal.dataset.orderCount).toBe('0');
   });
 });
 

--- a/frontend/src/pages/pos/POSPage.tsx
+++ b/frontend/src/pages/pos/POSPage.tsx
@@ -9,6 +9,7 @@ import PaymentModal from '../../components/pos/PaymentModal';
 import ProductOptionsModal, { SelectedModifier } from '../../components/pos/ProductOptionsModal';
 import StickyCartBar from '../../components/pos/StickyCartBar';
 import CartDrawer from '../../components/pos/CartDrawer';
+import DeliveryInboxButton from '../../components/pos/DeliveryInboxButton';
 import NotificationBar from '../../components/pos/NotificationBar';
 import AwaitingPaymentSection from '../../components/pos/AwaitingPaymentSection';
 import PendingOrdersPanel from '../../components/pos/PendingOrdersPanel';
@@ -25,7 +26,7 @@ import ManualLockDialog from '../../components/pos/ManualLockDialog';
 import { useTables, useUpdateTableStatus, useMergeTables, useUnmergeTable, useUnmergeAll } from '../../features/tables/tablesApi';
 import { useGetPosSettings } from '../../features/pos/posApi';
 import { usePosSocket } from '../../features/pos/usePosSocket';
-import { Product, Table, TableStatus, OrderType, OrderStatus, SplitType, SplitPaymentEntry, Payment, ComboSelectionInput } from '../../types';
+import { Product, Table, TableStatus, OrderStatus, SplitType, SplitPaymentEntry, Payment, ComboSelectionInput } from '../../types';
 import { useResponsive, BREAKPOINTS } from '../../hooks/useResponsive';
 import { useFormatCurrency } from '../../hooks/useFormatCurrency';
 import Spinner from '../../components/ui/Spinner';
@@ -809,6 +810,13 @@ const POSPage = () => {
           setCurrentOrderId(null);
           setCurrentOrderAmount(null);
           setCartDirtySinceOrder(false); // deep-review FH2
+          // The transfer cleared the table context, so land back on
+          // table-selection (mirrors handleBackToTables). Staying on
+          // 'order' with no table flips the header to "Takeaway order"
+          // while the no-table guard blocks Create — a dead end.
+          // (Unreachable in tableless mode: transfers need a selected
+          // table, which tableless never has.)
+          setCurrentView('table-selection');
         },
       }
     );
@@ -912,26 +920,32 @@ const POSPage = () => {
                 {t('tableSelection.description')}
               </p>
             </div>
-            {/* Grid / live-map view toggle */}
-            <div className="inline-flex rounded-lg border border-slate-200 bg-white p-0.5 shrink-0">
-              <button
-                type="button"
-                onClick={() => setTableViewMode('grid')}
-                aria-pressed={tableViewMode === 'grid'}
-                aria-label={t('tableSelection.viewGrid', 'Izgara')}
-                className={`flex items-center justify-center w-10 h-9 rounded-md transition-colors ${tableViewMode === 'grid' ? 'bg-primary-50 text-primary-700' : 'text-slate-500 hover:text-slate-700'}`}
-              >
-                <LayoutGrid className="w-4 h-4" />
-              </button>
-              <button
-                type="button"
-                onClick={() => setTableViewMode('map')}
-                aria-pressed={tableViewMode === 'map'}
-                aria-label={t('tableSelection.viewMap', 'Plan')}
-                className={`flex items-center justify-center w-10 h-9 rounded-md transition-colors ${tableViewMode === 'map' ? 'bg-primary-50 text-primary-700' : 'text-slate-500 hover:text-slate-700'}`}
-              >
-                <MapIcon className="w-4 h-4" />
-              </button>
+            <div className="flex items-center gap-2 shrink-0">
+              {/* Persistent delivery-inbox opener — the NotificationBar hides
+                  itself at 0 pending counts, but accepted delivery orders
+                  (PREPARING/READY) still need a way into the panel. */}
+              <DeliveryInboxButton onOpen={() => setIsPendingOrdersPanelOpen(true)} />
+              {/* Grid / live-map view toggle */}
+              <div className="inline-flex rounded-lg border border-slate-200 bg-white p-0.5">
+                <button
+                  type="button"
+                  onClick={() => setTableViewMode('grid')}
+                  aria-pressed={tableViewMode === 'grid'}
+                  aria-label={t('tableSelection.viewGrid', 'Izgara')}
+                  className={`flex items-center justify-center w-10 h-9 rounded-md transition-colors ${tableViewMode === 'grid' ? 'bg-primary-50 text-primary-700' : 'text-slate-500 hover:text-slate-700'}`}
+                >
+                  <LayoutGrid className="w-4 h-4" />
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setTableViewMode('map')}
+                  aria-pressed={tableViewMode === 'map'}
+                  aria-label={t('tableSelection.viewMap', 'Plan')}
+                  className={`flex items-center justify-center w-10 h-9 rounded-md transition-colors ${tableViewMode === 'map' ? 'bg-primary-50 text-primary-700' : 'text-slate-500 hover:text-slate-700'}`}
+                >
+                  <MapIcon className="w-4 h-4" />
+                </button>
+              </div>
             </div>
           </div>
 
@@ -1118,6 +1132,10 @@ const POSPage = () => {
                 )}
               </p>
             </div>
+            {/* Persistent delivery-inbox opener — mirrored from the
+                table-selection header so it stays reachable mid-order and in
+                tableless mode (where table-selection never renders). */}
+            <DeliveryInboxButton onOpen={() => setIsPendingOrdersPanelOpen(true)} />
             {/* Cart pill for mobile (only when the side cart is hidden). Now
                 surfaces the running TOTAL alongside the count so the cashier
                 can glance the bill without opening the drawer. */}
@@ -1253,6 +1271,22 @@ const POSPage = () => {
             setIsCartDrawerOpen(false);
             handleTransferTable();
           }}
+          // Same table-ops the desktop cart gets — phone waiters need
+          // merge/split/progressive too. The modals are page-level siblings
+          // of the drawer, so close the drawer first (the established
+          // checkout/transfer pattern) rather than stacking them over it.
+          onMergeTables={() => {
+            setIsCartDrawerOpen(false);
+            setIsMergeModalOpen(true);
+          }}
+          onSplitBill={() => {
+            setIsCartDrawerOpen(false);
+            setIsBillSplitModalOpen(true);
+          }}
+          onProgressivePay={() => {
+            setIsCartDrawerOpen(false);
+            setIsProgressiveModalOpen(true);
+          }}
           isCheckingOut={isCreatingOrder || isUpdatingOrder}
           isTwoStepCheckout={isTwoStepCheckout}
           hasActiveOrder={!!currentOrderId}
@@ -1379,7 +1413,12 @@ const POSPage = () => {
             tableNumber: selectedTable?.number,
           }));
         const orders = groupId && groupSummary ? groupOrders : standaloneOrders;
-        if (!orders.length) return null;
+        // Never unmount while the modal is OPEN: paying the last items flips
+        // the order PAID, the status-filtered refetch empties `orders`, and
+        // unmounting here would destroy the modal at that exact moment — its
+        // own fullyPaid confirmation (which it renders from the still-loaded
+        // payable summary) could never be seen.
+        if (!orders.length && !isProgressiveModalOpen) return null;
         return (
           <ProgressiveSplitModal
             isOpen={isProgressiveModalOpen}


### PR DESCRIPTION
Review loop tick 7 — final POS cleanup sweep (closes the POS modal/panel review):

1. **Delivery inbox always reachable**: persistent Package-icon opener with an active-count badge in both POS headers (shares the panel's exact query — one cache entry, socket-invalidated). Previously the NotificationBar was the only opener and vanished at zero pending counts, making PREPARING/READY delivery orders and prep-time updates unreachable.
2. Transfer success returns to table selection (no more "Takeaway order" stranding).
3. Mobile cart drawer gains split/progressive-pay/merge parity with desktop (drawer closes before each modal opens).
4. ProgressiveSplitModal stays mounted while open so its "fully paid" confirmation is actually reachable.
5. Body scroll-lock extracted to a shared refcounted util used by Modal and CartDrawer (closing a modal over the drawer no longer restores scroll underneath it).

Verification: 319/319 tests in the POS+UI sweep (11 new specs; the two behavior specs verified to fail with fixes reverted), tsc clean, eslint clean, i18n parity green (no new keys — existing deliveryOrders:title reused).
