### PR TITLE
fix(superadmin): reachable legal console, DEMO plan lockdown, plan-change amount sync

### DIFF
--- a/backend/src/modules/superadmin/services/superadmin-subscriptions.service.spec.ts
+++ b/backend/src/modules/superadmin/services/superadmin-subscriptions.service.spec.ts
@@ -757,3 +757,269 @@ describe("SuperAdminSubscriptionsService.extendSubscription reinstatement", () =
     );
   });
 });
+
+/**
+ * DEMO-plan protection (review F2). DemoGuardService keys the demo tenant's
+ * real-money block on currentPlan.name === "DEMO" and fails OPEN, so the plan
+ * name itself is a security invariant: renaming/deleting the DEMO plan (or
+ * renaming another plan to "DEMO", or assigning the DEMO plan to a real
+ * tenant) must be refused at the service layer.
+ */
+describe("SuperAdminSubscriptionsService DEMO-plan protection (plans)", () => {
+  let prisma: MockPrismaClient;
+  let audit: any;
+  let svc: SuperAdminSubscriptionsService;
+
+  const demoPlan: any = {
+    id: "plan-demo",
+    name: "DEMO",
+    displayName: "Demo",
+    isActive: false,
+  };
+
+  beforeEach(() => {
+    prisma = mockPrismaClient();
+    audit = { log: jest.fn().mockResolvedValue(undefined) };
+    svc = new SuperAdminSubscriptionsService(
+      prisma as any,
+      audit,
+      {} as any,
+      {
+        handleSubscriptionPeriodEnd: jest.fn(),
+        handleSubscriptionExpiryReminders: jest.fn(),
+      } as any,
+      {} as any,
+    );
+  });
+
+  it("updatePlan refuses renaming the DEMO plan (guard would be disarmed)", async () => {
+    prisma.subscriptionPlan.findUnique.mockResolvedValue(demoPlan);
+    await expect(
+      svc.updatePlan("plan-demo", { name: "DEMO2" } as any, "a1", "a@x"),
+    ).rejects.toBeInstanceOf(ConflictException);
+    expect(prisma.subscriptionPlan.update).not.toHaveBeenCalled();
+  });
+
+  it("updatePlan still allows editing the DEMO plan's OTHER fields (name omitted)", async () => {
+    prisma.subscriptionPlan.findUnique.mockResolvedValue(demoPlan);
+    prisma.subscriptionPlan.update.mockResolvedValue({
+      ...demoPlan,
+      maxUsers: 500,
+    });
+    await svc.updatePlan("plan-demo", { maxUsers: 500 } as any, "a1", "a@x");
+    expect(prisma.subscriptionPlan.update).toHaveBeenCalledTimes(1);
+  });
+
+  it("updatePlan allows a no-op resend of the same DEMO name", async () => {
+    prisma.subscriptionPlan.findUnique.mockResolvedValue(demoPlan);
+    prisma.subscriptionPlan.update.mockResolvedValue(demoPlan);
+    await svc.updatePlan("plan-demo", { name: "DEMO" } as any, "a1", "a@x");
+    expect(prisma.subscriptionPlan.update).toHaveBeenCalledTimes(1);
+  });
+
+  it("updatePlan refuses renaming ANOTHER plan to DEMO (its tenants would be money-blocked)", async () => {
+    prisma.subscriptionPlan.findUnique.mockResolvedValue({
+      id: "plan-pro",
+      name: "PRO",
+      isActive: true,
+    } as any);
+    await expect(
+      svc.updatePlan("plan-pro", { name: "DEMO" } as any, "a1", "a@x"),
+    ).rejects.toBeInstanceOf(ConflictException);
+    expect(prisma.subscriptionPlan.update).not.toHaveBeenCalled();
+  });
+
+  it("updatePlan still allows a normal rename of a non-DEMO plan", async () => {
+    prisma.subscriptionPlan.findUnique.mockResolvedValue({
+      id: "plan-pro",
+      name: "PRO",
+      isActive: true,
+    } as any);
+    prisma.subscriptionPlan.update.mockResolvedValue({
+      id: "plan-pro",
+      name: "PRO_2026",
+    } as any);
+    await svc.updatePlan("plan-pro", { name: "PRO_2026" } as any, "a1", "a@x");
+    expect(prisma.subscriptionPlan.update).toHaveBeenCalledTimes(1);
+  });
+
+  it("deletePlan refuses deleting the DEMO plan even with zero subscriptions", async () => {
+    prisma.subscriptionPlan.findUnique.mockResolvedValue({
+      ...demoPlan,
+      _count: { subscriptions: 0 },
+    });
+    await expect(
+      svc.deletePlan("plan-demo", "a1", "a@x"),
+    ).rejects.toBeInstanceOf(ConflictException);
+    expect(prisma.subscriptionPlan.delete).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * updateSubscription plan-assignment guards + amount recompute (review F2/F3).
+ */
+describe("SuperAdminSubscriptionsService.updateSubscription plan assignment", () => {
+  let prisma: MockPrismaClient;
+  let audit: any;
+  let subscriptionService: { emitSubscriptionReprojection: jest.Mock };
+  let svc: SuperAdminSubscriptionsService;
+
+  const SUB_ID = "sub-1";
+  const TENANT_ID = "tenant-1";
+  const existingSub: any = {
+    id: SUB_ID,
+    tenantId: TENANT_ID,
+    planId: "plan-old",
+    status: "ACTIVE",
+    billingCycle: "MONTHLY",
+    amount: new Prisma.Decimal("500"),
+    tenant: { id: TENANT_ID, name: "Test Restoran" },
+    plan: { name: "PRO" },
+  };
+
+  const targetPlan: any = {
+    id: "plan-new",
+    name: "BUSINESS",
+    displayName: "Business",
+    isActive: true,
+    monthlyPrice: "1799",
+    yearlyPrice: "17990",
+    maxUsers: -1,
+    maxTables: -1,
+    maxProducts: -1,
+    maxCategories: -1,
+  };
+
+  beforeEach(() => {
+    prisma = mockPrismaClient();
+    audit = { log: jest.fn().mockResolvedValue(undefined) };
+    subscriptionService = {
+      emitSubscriptionReprojection: jest.fn().mockResolvedValue(undefined),
+    };
+    prisma.subscription.findUnique.mockResolvedValue({ ...existingSub });
+    prisma.user.count.mockResolvedValue(0);
+    prisma.table.count.mockResolvedValue(0);
+    prisma.product.count.mockResolvedValue(0);
+    prisma.category.count.mockResolvedValue(0);
+    (prisma.$transaction as unknown as jest.Mock).mockImplementation(
+      async (cb: any) => cb(prisma),
+    );
+    prisma.subscription.update.mockImplementation(async (args: any) => ({
+      ...existingSub,
+      ...args.data,
+      tenant: { id: TENANT_ID, name: "Test Restoran" },
+      plan: { id: "plan-new", name: "BUSINESS", displayName: "Business" },
+    }));
+    svc = new SuperAdminSubscriptionsService(
+      prisma as any,
+      audit,
+      subscriptionService as any,
+      {
+        handleSubscriptionPeriodEnd: jest.fn(),
+        handleSubscriptionExpiryReminders: jest.fn(),
+      } as any,
+      {} as any,
+    );
+  });
+
+  it("refuses assigning the DEMO plan to a tenant whose current plan is not DEMO", async () => {
+    prisma.subscriptionPlan.findUnique.mockResolvedValue({
+      id: "plan-demo",
+      name: "DEMO",
+      isActive: false,
+      monthlyPrice: "0",
+      yearlyPrice: "0",
+      maxUsers: -1,
+      maxTables: -1,
+      maxProducts: -1,
+      maxCategories: -1,
+    } as any);
+    await expect(
+      svc.updateSubscription(SUB_ID, { planId: "plan-demo" }, "a1", "a@x"),
+    ).rejects.toBeInstanceOf(ConflictException);
+    expect(prisma.subscription.update).not.toHaveBeenCalled();
+  });
+
+  it("allows re-assigning DEMO when the subscription is already on the DEMO plan", async () => {
+    prisma.subscription.findUnique.mockResolvedValue({
+      ...existingSub,
+      plan: { name: "DEMO" },
+    });
+    prisma.subscriptionPlan.findUnique.mockResolvedValue({
+      id: "plan-demo",
+      name: "DEMO",
+      isActive: false,
+      monthlyPrice: "0",
+      yearlyPrice: "0",
+      maxUsers: -1,
+      maxTables: -1,
+      maxProducts: -1,
+      maxCategories: -1,
+    } as any);
+    await svc.updateSubscription(SUB_ID, { planId: "plan-demo" }, "a1", "a@x");
+    expect(prisma.subscription.update).toHaveBeenCalledTimes(1);
+  });
+
+  it("refuses assigning an inactive (retired) plan", async () => {
+    prisma.subscriptionPlan.findUnique.mockResolvedValue({
+      ...targetPlan,
+      isActive: false,
+    });
+    await expect(
+      svc.updateSubscription(SUB_ID, { planId: "plan-new" }, "a1", "a@x"),
+    ).rejects.toBeInstanceOf(BadRequestException);
+    expect(prisma.subscription.update).not.toHaveBeenCalled();
+  });
+
+  it("MONTHLY cycle: plan change recomputes subscription.amount from the new plan's monthly price", async () => {
+    prisma.subscriptionPlan.findUnique.mockResolvedValue(targetPlan);
+    await svc.updateSubscription(SUB_ID, { planId: "plan-new" }, "a1", "a@x");
+    const data = prisma.subscription.update.mock.calls[0][0].data;
+    expect(data.planId).toBe("plan-new");
+    expect(data.amount).toBeInstanceOf(Prisma.Decimal);
+    expect(data.amount.toString()).toBe("1799");
+    // planId change still moves tenant.currentPlanId + reprojects atomically.
+    expect(prisma.tenant.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: TENANT_ID },
+        data: { currentPlanId: "plan-new" },
+      }),
+    );
+    expect(
+      subscriptionService.emitSubscriptionReprojection,
+    ).toHaveBeenCalledTimes(1);
+  });
+
+  it("YEARLY cycle: plan change recomputes subscription.amount from the new plan's yearly price", async () => {
+    prisma.subscription.findUnique.mockResolvedValue({
+      ...existingSub,
+      billingCycle: "YEARLY",
+    });
+    prisma.subscriptionPlan.findUnique.mockResolvedValue(targetPlan);
+    await svc.updateSubscription(SUB_ID, { planId: "plan-new" }, "a1", "a@x");
+    const data = prisma.subscription.update.mock.calls[0][0].data;
+    expect(data.amount.toString()).toBe("17990");
+  });
+
+  it("honors a live plan discount when recomputing the amount (same rail as charges)", async () => {
+    const now = new Date();
+    prisma.subscriptionPlan.findUnique.mockResolvedValue({
+      ...targetPlan,
+      discountPercentage: 20,
+      isDiscountActive: true,
+      discountStartDate: new Date(now.getTime() - 86400000),
+      discountEndDate: new Date(now.getTime() + 86400000),
+    });
+    await svc.updateSubscription(SUB_ID, { planId: "plan-new" }, "a1", "a@x");
+    const data = prisma.subscription.update.mock.calls[0][0].data;
+    expect(data.amount.toString()).toBe("1439.2");
+  });
+
+  it("status-only update leaves amount and planId untouched", async () => {
+    await svc.updateSubscription(SUB_ID, { status: "CANCELLED" }, "a1", "a@x");
+    const data = prisma.subscription.update.mock.calls[0][0].data;
+    expect(data.amount).toBeUndefined();
+    expect(data.planId).toBeUndefined();
+    expect(prisma.tenant.update).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/modules/superadmin/services/superadmin-subscriptions.service.ts
+++ b/backend/src/modules/superadmin/services/superadmin-subscriptions.service.ts
@@ -20,6 +20,8 @@ import { SuperAdminAuditService } from "./superadmin-audit.service";
 import { AuditAction, EntityType } from "../dto/audit-filter.dto";
 import { SubscriptionService } from "../../subscriptions/services/subscription.service";
 import { SubscriptionSchedulerService } from "../../subscriptions/services/subscription-scheduler.service";
+import { resolvePlanAmount } from "../../subscriptions/plan-pricing.helper";
+import { DEMO_PLAN_NAME } from "../../demo/demo.constants";
 import { PaytrAdapter } from "../../payments/adapters/paytr.adapter";
 import {
   PaymentStatus,
@@ -175,6 +177,38 @@ export class SuperAdminSubscriptionsService {
       throw new NotFoundException("Plan not found");
     }
 
+    // The DEMO plan's internal name is load-bearing for the demo money-path
+    // guard: DemoGuardService keys isDemoTenant on
+    // currentPlan.name === DEMO_PLAN_NAME and FAILS OPEN, so renaming this
+    // plan silently disarms the block and the shared explore-demo tenant
+    // regains REAL PayTR money paths. Every other field stays editable.
+    if (
+      existingPlan.name === DEMO_PLAN_NAME &&
+      updateDto.name !== undefined &&
+      updateDto.name !== DEMO_PLAN_NAME
+    ) {
+      throw new ConflictException({
+        errorCode: "DEMO_PLAN_NAME_LOCKED",
+        message:
+          `The "${DEMO_PLAN_NAME}" plan's internal name is load-bearing for ` +
+          "the demo money-path guard and cannot be renamed.",
+      });
+    }
+    // Inverse direction: renaming ANOTHER plan to the demo name would make
+    // every tenant on it read as the demo tenant — 403-ing their real money
+    // paths (DemoGuardService matches by name, not id).
+    if (
+      existingPlan.name !== DEMO_PLAN_NAME &&
+      updateDto.name === DEMO_PLAN_NAME
+    ) {
+      throw new ConflictException({
+        errorCode: "DEMO_PLAN_NAME_RESERVED",
+        message:
+          `"${DEMO_PLAN_NAME}" is reserved for the internal demo plan and ` +
+          "cannot be used as another plan's name.",
+      });
+    }
+
     const plan = await this.prisma.subscriptionPlan.update({
       where: { id },
       data: {
@@ -251,6 +285,20 @@ export class SuperAdminSubscriptionsService {
 
     if (!plan) {
       throw new NotFoundException("Plan not found");
+    }
+
+    // The DEMO plan row must keep existing: DemoService re-seeds the demo
+    // tenant onto the plan with this exact name, and DemoGuardService keys
+    // the demo money-path block on it. Deleting it (possible while the demo
+    // tenant is not yet seeded, when _count.subscriptions === 0) would break
+    // the next demo seed and the guard's single source of truth.
+    if (plan.name === DEMO_PLAN_NAME) {
+      throw new ConflictException({
+        errorCode: "DEMO_PLAN_DELETE_BLOCKED",
+        message:
+          `The "${DEMO_PLAN_NAME}" plan is load-bearing for the demo ` +
+          "money-path guard and cannot be deleted.",
+      });
     }
 
     if (plan._count.subscriptions > 0) {
@@ -354,7 +402,11 @@ export class SuperAdminSubscriptionsService {
   ) {
     const existing = await this.prisma.subscription.findUnique({
       where: { id },
-      include: { tenant: { select: { id: true, name: true } } },
+      include: {
+        tenant: { select: { id: true, name: true } },
+        // Current plan's name feeds the DEMO-assignment guard below.
+        plan: { select: { name: true } },
+      },
     });
 
     if (!existing) {
@@ -366,6 +418,7 @@ export class SuperAdminSubscriptionsService {
       status?: string;
       trialEnd?: Date;
       trialStart?: Date;
+      amount?: Prisma.Decimal;
     } = {};
 
     if (updateDto.planId) {
@@ -374,6 +427,31 @@ export class SuperAdminSubscriptionsService {
       });
       if (!plan) {
         throw new NotFoundException("Plan not found");
+      }
+      // DEMO plan is internal to the single shared explore-demo tenant.
+      // Assigning it to any other tenant would 403 that tenant's every real
+      // money path (DemoGuardService keys on the plan name) — and widen the
+      // "demo tenant" population the guard assumes is exactly one. Only a
+      // subscription already ON the demo plan may be (re)assigned it.
+      if (
+        plan.name === DEMO_PLAN_NAME &&
+        existing.plan?.name !== DEMO_PLAN_NAME
+      ) {
+        throw new ConflictException({
+          errorCode: "DEMO_PLAN_ASSIGNMENT_BLOCKED",
+          message:
+            `The "${DEMO_PLAN_NAME}" plan is internal to the shared ` +
+            "explore-demo tenant and cannot be assigned to other tenants.",
+        });
+      }
+      // Mirror the tenant-side rule (SubscriptionService.changePlan refuses
+      // inactive plans): a retired plan must not be re-enterable through the
+      // SA path. The DEMO plan is deliberately isActive:false and already
+      // covered by the guard above, so it is exempt here.
+      if (plan.name !== DEMO_PLAN_NAME && !plan.isActive) {
+        throw new BadRequestException(
+          "Cannot assign an inactive plan to a subscription",
+        );
       }
       // Downgrade guard: refuse a plan change that would push the tenant
       // above the new plan's limits. The regular tenant flow already has
@@ -411,6 +489,14 @@ export class SuperAdminSubscriptionsService {
         );
       }
       updateData.planId = updateDto.planId;
+      // Recompute the stored billing amount from the NEW plan for the
+      // subscription's current billing cycle — through the SAME
+      // resolvePlanAmount every charge rail uses, so live plan discounts are
+      // honored. Without this the subscription kept the OLD plan's price:
+      // the SA Subscriptions list showed a stale amount and the tenant-side
+      // proration math (SubscriptionService.changePlan) later computed
+      // upgrade/downgrade diffs from it.
+      updateData.amount = resolvePlanAmount(plan, existing.billingCycle);
     }
 
     if (updateDto.status) {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -46,6 +46,9 @@ const SuperAdminSettingsPage = lazyWithReload(
 const MarketplaceAdminPage = lazyWithReload(
   () => import("./pages/superadmin/MarketplaceAdminPage"),
 );
+const LegalDocumentsPage = lazyWithReload(
+  () => import("./pages/superadmin/LegalDocumentsPage"),
+);
 import {
   SuperAdminLayout,
   SuperAdminProtectedRoute,
@@ -853,6 +856,7 @@ function App() {
                 path="/superadmin/audit-logs"
                 element={<AuditLogsPage />}
               />
+              <Route path="/superadmin/legal" element={<LegalDocumentsPage />} />
               <Route
                 path="/superadmin/settings"
                 element={<SuperAdminSettingsPage />}

--- a/frontend/src/features/legal/legalApi.test.tsx
+++ b/frontend/src/features/legal/legalApi.test.tsx
@@ -12,6 +12,18 @@ vi.mock('../../lib/api', () => ({
   },
 }));
 
+// F1: the /superadmin/legal/* admin hooks go through the SUPERADMIN axios
+// instance (the tenant client would 401 → tenant logout+redirect). Mock it
+// separately so the tests pin each hook to the correct client.
+const saGet = vi.fn();
+const saPost = vi.fn();
+vi.mock('../superadmin/api/superAdminApi', () => ({
+  superAdminApi: {
+    get: (...a: unknown[]) => saGet(...a),
+    post: (...a: unknown[]) => saPost(...a),
+  },
+}));
+
 import {
   legalKeys,
   useGetCurrentLegalDocument,
@@ -27,6 +39,8 @@ function wrapper({ children }: { children: React.ReactNode }) {
 beforeEach(() => {
   get.mockReset();
   post.mockReset();
+  saGet.mockReset();
+  saPost.mockReset();
   client = new QueryClient({
     defaultOptions: {
       queries: { retry: false, gcTime: 0 },
@@ -84,22 +98,25 @@ describe('useGetCurrentLegalDocument', () => {
 });
 
 describe('useListLegalDocuments', () => {
-  it('passes filters as query params', async () => {
-    get.mockResolvedValue({ data: [] });
+  it('passes filters as query params through the SUPERADMIN client', async () => {
+    saGet.mockResolvedValue({ data: [] });
     renderHook(() => useListLegalDocuments({ kind: 'PRIVACY_POLICY' }), {
       wrapper,
     });
     await waitFor(() =>
-      expect(get).toHaveBeenCalledWith('/superadmin/legal/documents', {
+      expect(saGet).toHaveBeenCalledWith('/superadmin/legal/documents', {
         params: { kind: 'PRIVACY_POLICY' },
       }),
     );
+    // Regression: must NOT hit the tenant client — a superadmin session has
+    // no tenant token, so that path 401s and force-logs-out the tenant app.
+    expect(get).not.toHaveBeenCalled();
   });
 });
 
 describe('usePublishLegalDocument', () => {
-  it('POSTs the input and invalidates the legal cache', async () => {
-    post.mockResolvedValue({ data: { id: 'new' } });
+  it('POSTs the input through the SUPERADMIN client and invalidates the legal cache', async () => {
+    saPost.mockResolvedValue({ data: { id: 'new' } });
     const invalidate = vi.spyOn(client, 'invalidateQueries');
     const { result } = renderHook(() => usePublishLegalDocument(), { wrapper });
     await result.current.mutateAsync({
@@ -109,10 +126,28 @@ describe('usePublishLegalDocument', () => {
       title: 'T',
       bodyMarkdown: 'body',
     });
-    expect(post).toHaveBeenCalledWith(
+    expect(saPost).toHaveBeenCalledWith(
       '/superadmin/legal/documents/publish',
       expect.objectContaining({ kind: 'TERMS_OF_SERVICE' }),
     );
+    expect(post).not.toHaveBeenCalled();
     expect(invalidate).toHaveBeenCalledWith({ queryKey: legalKeys.all });
+  });
+
+  it('toasts through getApiErrorMessage when the publish fails (onError wired)', async () => {
+    const { toast } = await import('sonner');
+    const errorSpy = vi.spyOn(toast, 'error').mockImplementation(() => '' as any);
+    saPost.mockRejectedValue(new Error('boom'));
+    const { result } = renderHook(() => usePublishLegalDocument(), { wrapper });
+    await expect(
+      result.current.mutateAsync({
+        kind: 'KVKK',
+        version: '2',
+        locale: 'tr',
+        title: 'T',
+        bodyMarkdown: 'body',
+      }),
+    ).rejects.toThrow('boom');
+    await waitFor(() => expect(errorSpy).toHaveBeenCalledTimes(1));
   });
 });

--- a/frontend/src/features/legal/legalApi.ts
+++ b/frontend/src/features/legal/legalApi.ts
@@ -1,5 +1,13 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
 import api from '../../lib/api';
+// Admin endpoints live under /superadmin/legal/* behind SuperAdminGuard, so
+// they MUST go through the superadmin axios instance: the tenant client
+// (lib/api.ts) attaches the tenant token (a superadmin session has none),
+// gets a 401, and its interceptor then logs the operator out of the TENANT
+// app and redirects to the tenant /login.
+import { superAdminApi } from '../superadmin/api/superAdminApi';
+import { getApiErrorMessage } from '../../lib/api-error';
 
 /**
  * Legal documents — KVKK, mesafeli satış, iade politikası, terms,
@@ -83,7 +91,7 @@ export const useListLegalDocuments = (
   return useQuery({
     queryKey: legalKeys.list(filters.kind, filters.locale),
     queryFn: async (): Promise<LegalDocument[]> => {
-      const response = await api.get('/superadmin/legal/documents', {
+      const response = await superAdminApi.get('/superadmin/legal/documents', {
         params: filters,
       });
       return response.data;
@@ -97,7 +105,10 @@ export const usePublishLegalDocument = () => {
     mutationFn: async (
       input: PublishLegalDocumentInput,
     ): Promise<LegalDocument> => {
-      const response = await api.post('/superadmin/legal/documents/publish', input);
+      const response = await superAdminApi.post(
+        '/superadmin/legal/documents/publish',
+        input,
+      );
       return response.data;
     },
     // After a new version lands every consumer should refetch — the
@@ -105,5 +116,8 @@ export const usePublishLegalDocument = () => {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: legalKeys.all });
     },
+    // Surface a failed publish (mirrors the superadminBankTransferApi
+    // sonner + getApiErrorMessage convention) so it never fails silently.
+    onError: (e) => toast.error(getApiErrorMessage(e, 'Yayınlama başarısız oldu.')),
   });
 };

--- a/frontend/src/features/superadmin/components/SuperAdminSidebar.test.tsx
+++ b/frontend/src/features/superadmin/components/SuperAdminSidebar.test.tsx
@@ -42,6 +42,7 @@ describe('SuperAdminSidebar', () => {
       '/superadmin/marketplace',
       '/superadmin/subscriptions',
       '/superadmin/audit-logs',
+      '/superadmin/legal',
       '/superadmin/settings',
     ];
     const hrefs = screen

--- a/frontend/src/features/superadmin/components/SuperAdminSidebar.tsx
+++ b/frontend/src/features/superadmin/components/SuperAdminSidebar.tsx
@@ -11,6 +11,7 @@ import {
   Settings,
   Layers,
   Banknote,
+  Scale,
   LogOut,
   ChevronDown,
 } from 'lucide-react';
@@ -26,6 +27,7 @@ const navigation = [
   { nameKey: 'nav.subscriptions', href: '/superadmin/subscriptions', icon: CreditCard },
   { nameKey: 'nav.bankTransfer', href: '/superadmin/bank-transfer', icon: Banknote, defaultLabel: 'Havale' },
   { nameKey: 'nav.auditLogs', href: '/superadmin/audit-logs', icon: FileText },
+  { nameKey: 'nav.legal', href: '/superadmin/legal', icon: Scale, defaultLabel: 'Yasal Belgeler' },
   { nameKey: 'nav.settings', href: '/superadmin/settings', icon: Settings },
 ];
 

--- a/frontend/src/i18n/locales/ar/superadmin.json
+++ b/frontend/src/i18n/locales/ar/superadmin.json
@@ -23,6 +23,7 @@
     "marketplace": "Marketplace",
     "subscriptions": "Subscriptions",
     "auditLogs": "Audit Logs",
+    "legal": "Legal Documents",
     "settings": "Settings",
     "signOut": "Sign out"
   },
@@ -179,6 +180,11 @@
     "usersTablesProducts": "{{users}} users · {{tables}} tables · {{products}} products",
     "current": "Current",
     "changePlanError": "Failed to change plan",
+    "newAmountInfo": "After the change the billing amount will be {{amount}} ({{cycle}}).",
+    "cycle": {
+      "MONTHLY": "Monthly",
+      "YEARLY": "Yearly"
+    },
     "changing": "Changing...",
     "cancel": "Cancel",
     "featureLabels": {
@@ -288,6 +294,8 @@
     "subtitle": "Manage subscription plans",
     "addPlan": "Add Plan",
     "confirmDelete": "Delete this plan?",
+    "demoLockBadge": "Locked",
+    "demoLockTooltip": "The DEMO plan's name keys the guard that blocks the demo tenant's real money paths; this plan cannot be edited or deleted.",
     "defaultDiscountLabel": "INDIRIM",
     "perMonth": "/mo",
     "perYear": "/year",
@@ -428,6 +436,7 @@
     "subtitle": "KVKK / Mesafeli Satış / İade ve diğer yasal metinleri yönetin. Yeni versiyon yayınladığınızda eski versiyon devre dışı kalır ama silinmez — mevcut Consent kayıtları geçerliliğini korur.",
     "publishNewVersion": "Yeni versiyon yayınla",
     "loading": "Yükleniyor...",
+    "loadFailed": "Failed to load legal documents.",
     "empty": "Henüz yasal belge yok. Yeni versiyon yayınlayın ya da seed'i çalıştırın.",
     "versionCount": "({{count}} versiyon)",
     "kindLabels": {

--- a/frontend/src/i18n/locales/en/superadmin.json
+++ b/frontend/src/i18n/locales/en/superadmin.json
@@ -23,6 +23,7 @@
     "marketplace": "Marketplace",
     "subscriptions": "Subscriptions",
     "auditLogs": "Audit Logs",
+    "legal": "Legal Documents",
     "settings": "Settings",
     "signOut": "Sign out"
   },
@@ -179,6 +180,11 @@
     "usersTablesProducts": "{{users}} users · {{tables}} tables · {{products}} products",
     "current": "Current",
     "changePlanError": "Failed to change plan",
+    "newAmountInfo": "After the change the billing amount will be {{amount}} ({{cycle}}).",
+    "cycle": {
+      "MONTHLY": "Monthly",
+      "YEARLY": "Yearly"
+    },
     "changing": "Changing...",
     "cancel": "Cancel",
     "featureLabels": {
@@ -288,6 +294,8 @@
     "subtitle": "Manage subscription plans",
     "addPlan": "Add Plan",
     "confirmDelete": "Delete this plan?",
+    "demoLockBadge": "Locked",
+    "demoLockTooltip": "The DEMO plan's name keys the guard that blocks the demo tenant's real money paths; this plan cannot be edited or deleted.",
     "defaultDiscountLabel": "INDIRIM",
     "perMonth": "/mo",
     "perYear": "/year",
@@ -428,6 +436,7 @@
     "subtitle": "KVKK / Mesafeli Satış / İade ve diğer yasal metinleri yönetin. Yeni versiyon yayınladığınızda eski versiyon devre dışı kalır ama silinmez — mevcut Consent kayıtları geçerliliğini korur.",
     "publishNewVersion": "Yeni versiyon yayınla",
     "loading": "Yükleniyor...",
+    "loadFailed": "Failed to load legal documents.",
     "empty": "Henüz yasal belge yok. Yeni versiyon yayınlayın ya da seed'i çalıştırın.",
     "versionCount": "({{count}} versiyon)",
     "kindLabels": {

--- a/frontend/src/i18n/locales/ru/superadmin.json
+++ b/frontend/src/i18n/locales/ru/superadmin.json
@@ -23,6 +23,7 @@
     "marketplace": "Marketplace",
     "subscriptions": "Subscriptions",
     "auditLogs": "Audit Logs",
+    "legal": "Legal Documents",
     "settings": "Settings",
     "signOut": "Sign out"
   },
@@ -179,6 +180,11 @@
     "usersTablesProducts": "{{users}} users · {{tables}} tables · {{products}} products",
     "current": "Current",
     "changePlanError": "Failed to change plan",
+    "newAmountInfo": "After the change the billing amount will be {{amount}} ({{cycle}}).",
+    "cycle": {
+      "MONTHLY": "Monthly",
+      "YEARLY": "Yearly"
+    },
     "changing": "Changing...",
     "cancel": "Cancel",
     "featureLabels": {
@@ -288,6 +294,8 @@
     "subtitle": "Manage subscription plans",
     "addPlan": "Add Plan",
     "confirmDelete": "Delete this plan?",
+    "demoLockBadge": "Locked",
+    "demoLockTooltip": "The DEMO plan's name keys the guard that blocks the demo tenant's real money paths; this plan cannot be edited or deleted.",
     "defaultDiscountLabel": "INDIRIM",
     "perMonth": "/mo",
     "perYear": "/year",
@@ -428,6 +436,7 @@
     "subtitle": "KVKK / Mesafeli Satış / İade ve diğer yasal metinleri yönetin. Yeni versiyon yayınladığınızda eski versiyon devre dışı kalır ama silinmez — mevcut Consent kayıtları geçerliliğini korur.",
     "publishNewVersion": "Yeni versiyon yayınla",
     "loading": "Yükleniyor...",
+    "loadFailed": "Failed to load legal documents.",
     "empty": "Henüz yasal belge yok. Yeni versiyon yayınlayın ya da seed'i çalıştırın.",
     "versionCount": "({{count}} versiyon)",
     "kindLabels": {

--- a/frontend/src/i18n/locales/tr/superadmin.json
+++ b/frontend/src/i18n/locales/tr/superadmin.json
@@ -23,6 +23,7 @@
     "marketplace": "Pazar Yeri",
     "subscriptions": "Abonelikler",
     "auditLogs": "Denetim Kayıtları",
+    "legal": "Yasal Belgeler",
     "settings": "Ayarlar",
     "signOut": "Çıkış yap"
   },
@@ -179,6 +180,11 @@
     "usersTablesProducts": "{{users}} kullanıcı · {{tables}} masa · {{products}} ürün",
     "current": "Mevcut",
     "changePlanError": "Plan değiştirilemedi",
+    "newAmountInfo": "Plan değişikliği sonrası faturalama tutarı {{amount}} olacak ({{cycle}}).",
+    "cycle": {
+      "MONTHLY": "Aylık",
+      "YEARLY": "Yıllık"
+    },
     "changing": "Değiştiriliyor...",
     "cancel": "İptal",
     "featureLabels": {
@@ -288,6 +294,8 @@
     "subtitle": "Abonelik planlarını yönetin",
     "addPlan": "Plan Ekle",
     "confirmDelete": "Bu plan silinsin mi?",
+    "demoLockBadge": "Kilitli",
+    "demoLockTooltip": "DEMO planının adı, demo kiracının gerçek ödeme yollarını kilitleyen korumanın anahtarıdır; bu plan düzenlenemez ve silinemez.",
     "defaultDiscountLabel": "İNDİRİM",
     "perMonth": "/ay",
     "perYear": "/yıl",
@@ -428,6 +436,7 @@
     "subtitle": "KVKK / Mesafeli Satış / İade ve diğer yasal metinleri yönetin. Yeni versiyon yayınladığınızda eski versiyon devre dışı kalır ama silinmez — mevcut Consent kayıtları geçerliliğini korur.",
     "publishNewVersion": "Yeni versiyon yayınla",
     "loading": "Yükleniyor...",
+    "loadFailed": "Yasal belgeler yüklenemedi.",
     "empty": "Henüz yasal belge yok. Yeni versiyon yayınlayın ya da seed'i çalıştırın.",
     "versionCount": "({{count}} versiyon)",
     "kindLabels": {

--- a/frontend/src/i18n/locales/uz/superadmin.json
+++ b/frontend/src/i18n/locales/uz/superadmin.json
@@ -23,6 +23,7 @@
     "marketplace": "Marketplace",
     "subscriptions": "Subscriptions",
     "auditLogs": "Audit Logs",
+    "legal": "Legal Documents",
     "settings": "Settings",
     "signOut": "Sign out"
   },
@@ -179,6 +180,11 @@
     "usersTablesProducts": "{{users}} users · {{tables}} tables · {{products}} products",
     "current": "Current",
     "changePlanError": "Failed to change plan",
+    "newAmountInfo": "After the change the billing amount will be {{amount}} ({{cycle}}).",
+    "cycle": {
+      "MONTHLY": "Monthly",
+      "YEARLY": "Yearly"
+    },
     "changing": "Changing...",
     "cancel": "Cancel",
     "featureLabels": {
@@ -288,6 +294,8 @@
     "subtitle": "Manage subscription plans",
     "addPlan": "Add Plan",
     "confirmDelete": "Delete this plan?",
+    "demoLockBadge": "Locked",
+    "demoLockTooltip": "The DEMO plan's name keys the guard that blocks the demo tenant's real money paths; this plan cannot be edited or deleted.",
     "defaultDiscountLabel": "INDIRIM",
     "perMonth": "/mo",
     "perYear": "/year",
@@ -428,6 +436,7 @@
     "subtitle": "KVKK / Mesafeli Satış / İade ve diğer yasal metinleri yönetin. Yeni versiyon yayınladığınızda eski versiyon devre dışı kalır ama silinmez — mevcut Consent kayıtları geçerliliğini korur.",
     "publishNewVersion": "Yeni versiyon yayınla",
     "loading": "Yükleniyor...",
+    "loadFailed": "Failed to load legal documents.",
     "empty": "Henüz yasal belge yok. Yeni versiyon yayınlayın ya da seed'i çalıştırın.",
     "versionCount": "({{count}} versiyon)",
     "kindLabels": {

--- a/frontend/src/pages/superadmin/LegalDocumentsPage.test.tsx
+++ b/frontend/src/pages/superadmin/LegalDocumentsPage.test.tsx
@@ -5,11 +5,23 @@ import LegalDocumentsPage from './LegalDocumentsPage';
 
 const publishAsync = vi.fn().mockResolvedValue({});
 let docsData: any;
+let listState: Partial<{ isError: boolean; error: unknown }> = {};
 
 vi.mock('../../features/legal/legalApi', () => ({
-  useListLegalDocuments: () => ({ data: docsData, isLoading: false }),
+  useListLegalDocuments: () => ({
+    data: docsData,
+    isLoading: false,
+    isError: false,
+    error: null,
+    ...listState,
+  }),
   usePublishLegalDocument: () => ({ mutateAsync: publishAsync, isPending: false }),
 }));
+
+// The page now renders list failures via getApiErrorMessage (lib/api-error),
+// which pulls in i18n/config; stub it so the partial react-i18next mock above
+// doesn't trip over initReactI18next at import time (mirrors PlansPage.test).
+vi.mock('../../i18n/config', () => ({ default: { t: (k: string) => k } }));
 
 // ReactMarkdown is ESM-heavy; stub it to a passthrough so the modal renders.
 vi.mock('react-markdown', () => ({
@@ -76,6 +88,7 @@ describe('LegalDocumentsPage — listing', () => {
   beforeEach(() => {
     publishAsync.mockClear();
     docsData = [doc()];
+    listState = {};
   });
   afterEach(() => vi.restoreAllMocks());
 
@@ -90,12 +103,31 @@ describe('LegalDocumentsPage — listing', () => {
     renderPage();
     expect(screen.getByText('legal.empty')).toBeInTheDocument();
   });
+
+  it('surfaces a list-load failure instead of a silent empty state', () => {
+    docsData = undefined;
+    listState = { isError: true, error: new Error('boom') };
+    renderPage();
+    // Non-axios error → getApiErrorMessage falls back to the i18n fallback.
+    expect(screen.getByText('Yasal belgeler yüklenemedi.')).toBeInTheDocument();
+    expect(screen.queryByText('legal.empty')).not.toBeInTheDocument();
+  });
+
+  it('F11 regression: rows render inside a single tbody (no nested tbody), preview included', () => {
+    docsData = [doc(), doc({ id: 'd2', version: '2.0', isCurrent: false })];
+    renderPage();
+    // Expand the first row's markdown preview so BOTH tr kinds are in the DOM.
+    fireEvent.click(screen.getAllByText('legal.preview')[0]);
+    expect(screen.getByText('# Hello')).toBeInTheDocument();
+    expect(document.querySelectorAll('tbody tbody')).toHaveLength(0);
+  });
 });
 
 describe('LegalDocumentsPage — PublishModal version-regex gate', () => {
   beforeEach(() => {
     publishAsync.mockClear();
     docsData = [];
+    listState = {};
   });
   afterEach(() => vi.restoreAllMocks());
 

--- a/frontend/src/pages/superadmin/LegalDocumentsPage.tsx
+++ b/frontend/src/pages/superadmin/LegalDocumentsPage.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { Fragment, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { FileText, Plus } from 'lucide-react';
 import ReactMarkdown from 'react-markdown';
@@ -9,6 +9,7 @@ import {
   usePublishLegalDocument,
 } from '../../features/legal/legalApi';
 import { canSubmitPublish, groupDocsByKind } from './legalDocuments.helpers';
+import { getApiErrorMessage } from '../../lib/api-error';
 
 const KIND_LABELS: Record<LegalDocumentKind, string> = {
   KVKK: 'KVKK Aydınlatma Metni',
@@ -41,7 +42,7 @@ const PUBLISH_KINDS: LegalDocumentKind[] = [
  */
 export default function LegalDocumentsPage() {
   const { t } = useTranslation('superadmin');
-  const { data: docs, isLoading } = useListLegalDocuments();
+  const { data: docs, isLoading, isError, error } = useListLegalDocuments();
   const publishMutation = usePublishLegalDocument();
   const [expandedDocId, setExpandedDocId] = useState<string | null>(null);
   const [showPublishModal, setShowPublishModal] = useState(false);
@@ -68,7 +69,15 @@ export default function LegalDocumentsPage() {
 
       {isLoading && <div className="text-slate-500">{t('legal.loading')}</div>}
 
-      {!isLoading && Object.keys(docsByKind).length === 0 && (
+      {/* useQuery (v5) has no onError — surface the list failure here so a
+          broken session/endpoint never renders as a silent empty state. */}
+      {isError && (
+        <div className="bg-red-50 border border-red-100 rounded-lg p-4 text-sm text-red-600">
+          {getApiErrorMessage(error, t('legal.loadFailed', 'Yasal belgeler yüklenemedi.'))}
+        </div>
+      )}
+
+      {!isLoading && !isError && Object.keys(docsByKind).length === 0 && (
         <div className="bg-white border border-slate-200 rounded-lg p-8 text-center text-slate-500">
           {t('legal.empty')}
         </div>
@@ -95,8 +104,11 @@ export default function LegalDocumentsPage() {
               </tr>
             </thead>
             <tbody>
+              {/* F11: the per-doc pair (row + optional preview row) used to be
+                  wrapped in a NESTED <tbody> — invalid DOM. A keyed Fragment
+                  groups the two <tr>s inside the single tbody instead. */}
               {items.map((d) => (
-                <tbody key={d.id}>
+                <Fragment key={d.id}>
                   <tr className="border-b border-slate-100">
                     <td className="px-4 py-2 font-mono text-xs">{d.version}</td>
                     <td className="px-4 py-2">{d.locale}</td>
@@ -135,7 +147,7 @@ export default function LegalDocumentsPage() {
                       </td>
                     </tr>
                   )}
-                </tbody>
+                </Fragment>
               ))}
             </tbody>
           </table>
@@ -175,8 +187,13 @@ function PublishModal({ onClose, onPublished, publishMutation }: PublishModalPro
 
   const handleSubmit = async () => {
     if (!canSubmit) return;
-    await publishMutation.mutateAsync(form);
-    onPublished();
+    try {
+      await publishMutation.mutateAsync(form);
+      onPublished();
+    } catch {
+      // The mutation's onError toast already surfaced the failure; keep the
+      // modal open so the operator's draft is preserved for a retry.
+    }
   };
 
   return (

--- a/frontend/src/pages/superadmin/PlansPage.test.tsx
+++ b/frontend/src/pages/superadmin/PlansPage.test.tsx
@@ -254,3 +254,49 @@ describe('PlansPage — limit fields (unlimited / blank handling)', () => {
     expect(body.maxMonthlyOrders).toBe(-1);
   });
 });
+
+describe('PlansPage — DEMO plan lock (F2)', () => {
+  beforeEach(() => {
+    updateMutate.mockReset();
+    deleteMutate.mockReset();
+    plansData = [
+      plan({ id: 'plan-demo', name: 'DEMO', displayName: 'Demo', isActive: false }),
+      plan({ id: 'p1', name: 'PRO', displayName: 'Pro Plan' }),
+    ];
+  });
+  afterEach(() => vi.restoreAllMocks());
+
+  function cardOf(displayName: string) {
+    return screen.getByText(displayName).closest('div')!.parentElement!
+      .parentElement as HTMLElement;
+  }
+
+  it('renders a lock badge on the DEMO plan card only', () => {
+    renderPage();
+    const demoCard = cardOf('Demo');
+    // t(key, fallback) mock returns the fallback string.
+    expect(within(demoCard).getByText('Kilitli')).toBeInTheDocument();
+    expect(within(cardOf('Pro Plan')).queryByText('Kilitli')).not.toBeInTheDocument();
+  });
+
+  it('disables Edit and Delete for the DEMO plan (tooltip present), leaves other plans editable', () => {
+    vi.spyOn(window, 'confirm').mockReturnValue(true);
+    renderPage();
+    const demoButtons = within(cardOf('Demo')).getAllByRole('button');
+    // [edit, delete] icon buttons in the card header.
+    const demoEdit = demoButtons[0];
+    const demoDelete = demoButtons[demoButtons.length - 1];
+    expect(demoEdit).toBeDisabled();
+    expect(demoDelete).toBeDisabled();
+    expect(demoEdit).toHaveAttribute('title', expect.stringContaining('DEMO'));
+    fireEvent.click(demoEdit);
+    fireEvent.click(demoDelete);
+    expect(updateMutate).not.toHaveBeenCalled();
+    expect(deleteMutate).not.toHaveBeenCalled();
+    expect(screen.queryByText('plans.modal.editTitle')).not.toBeInTheDocument();
+
+    const proButtons = within(cardOf('Pro Plan')).getAllByRole('button');
+    expect(proButtons[0]).not.toBeDisabled();
+    expect(proButtons[proButtons.length - 1]).not.toBeDisabled();
+  });
+});

--- a/frontend/src/pages/superadmin/PlansPage.tsx
+++ b/frontend/src/pages/superadmin/PlansPage.tsx
@@ -1,12 +1,12 @@
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
-import { Plus, Pencil, Trash2, Tag, AlertTriangle } from 'lucide-react';
+import { Plus, Pencil, Trash2, Tag, AlertTriangle, Lock } from 'lucide-react';
 import Modal from '../../components/ui/Modal';
 import { usePlans, useCreatePlan, useUpdatePlan, useDeletePlan } from '../../features/superadmin/api/superAdminApi';
 import { SubscriptionPlan } from '../../features/superadmin/types';
 import { getApiErrorMessage } from '../../lib/api-error';
-import { discountedMonthlyPrice } from './plans.helpers';
+import { discountedMonthlyPrice, isDemoPlan } from './plans.helpers';
 
 export default function PlansPage() {
   const { t } = useTranslation('superadmin');
@@ -20,6 +20,13 @@ export default function PlansPage() {
   const createMutation = useCreatePlan();
   const updateMutation = useUpdatePlan();
   const deleteMutation = useDeletePlan();
+
+  // The DEMO plan is locked: its name keys the demo money-path guard on the
+  // backend (which also refuses rename/delete). See plans.helpers.isDemoPlan.
+  const demoLockTooltip = t(
+    'plans.demoLockTooltip',
+    'DEMO planının adı, demo kiracının gerçek ödeme yollarını kilitleyen korumanın anahtarıdır; bu plan düzenlenemez ve silinemez.',
+  );
 
   const handleDelete = (id: string) => {
     if (window.confirm(t('plans.confirmDelete'))) {
@@ -91,18 +98,33 @@ export default function PlansPage() {
             <div className="flex items-start justify-between mb-4">
               <div>
                 <h3 className="text-base font-semibold text-zinc-900">{plan.displayName}</h3>
-                <p className="text-xs text-zinc-500 mt-0.5">{plan.name}</p>
+                <p className="text-xs text-zinc-500 mt-0.5 flex items-center gap-1.5">
+                  {plan.name}
+                  {isDemoPlan(plan) && (
+                    <span
+                      title={demoLockTooltip}
+                      className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-semibold uppercase bg-amber-50 text-amber-700 border border-amber-200"
+                    >
+                      <Lock className="w-3 h-3" />
+                      {t('plans.demoLockBadge', 'Kilitli')}
+                    </span>
+                  )}
+                </p>
               </div>
               <div className="flex gap-1">
                 <button
                   onClick={() => handleEdit(plan)}
-                  className="p-1.5 rounded-lg hover:bg-zinc-100 transition-colors"
+                  disabled={isDemoPlan(plan)}
+                  title={isDemoPlan(plan) ? demoLockTooltip : undefined}
+                  className="p-1.5 rounded-lg hover:bg-zinc-100 transition-colors disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:bg-transparent"
                 >
                   <Pencil className="w-4 h-4 text-zinc-400" />
                 </button>
                 <button
                   onClick={() => handleDelete(plan.id)}
-                  className="p-1.5 rounded-lg hover:bg-zinc-100 transition-colors"
+                  disabled={isDemoPlan(plan)}
+                  title={isDemoPlan(plan) ? demoLockTooltip : undefined}
+                  className="p-1.5 rounded-lg hover:bg-zinc-100 transition-colors disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:bg-transparent"
                 >
                   <Trash2 className="w-4 h-4 text-zinc-400" />
                 </button>

--- a/frontend/src/pages/superadmin/TenantDetailPage.test.tsx
+++ b/frontend/src/pages/superadmin/TenantDetailPage.test.tsx
@@ -292,3 +292,65 @@ describe('TenantDetailPage — change-plan modal', () => {
     expect(changePlanMutate).not.toHaveBeenCalled();
   });
 });
+
+describe('TenantDetailPage — change-plan modal: DEMO/inactive filtering + amount preview (F2/F3)', () => {
+  beforeEach(() => {
+    changePlanMutate.mockReset();
+    tenant = baseTenant();
+    overridesData = undefined;
+    plans = [
+      { id: 'p1', name: 'PRO', isActive: true, displayName: 'Pro Plan', monthlyPrice: 500, yearlyPrice: 5000, maxUsers: 5, maxTables: 10, maxProducts: 100 },
+      { id: 'p2', name: 'BUSINESS', isActive: true, displayName: 'Enterprise', monthlyPrice: 1500, yearlyPrice: 15000, maxUsers: 50, maxTables: 100, maxProducts: 1000 },
+      { id: 'p-demo', name: 'DEMO', isActive: false, displayName: 'Demo Plan', monthlyPrice: 0, yearlyPrice: 0, maxUsers: 999, maxTables: 999, maxProducts: 999 },
+      { id: 'p-old', name: 'LEGACY', isActive: false, displayName: 'Legacy Plan', monthlyPrice: 100, yearlyPrice: 1000, maxUsers: 1, maxTables: 1, maxProducts: 1 },
+    ];
+  });
+  afterEach(() => vi.restoreAllMocks());
+
+  function openModal() {
+    renderPage();
+    fireEvent.click(screen.getByRole('button', { name: 'tenantDetail.changePlan' }));
+  }
+
+  it('offers neither the DEMO plan nor inactive plans', () => {
+    openModal();
+    // "Pro Plan" also appears in the subscription summary card, so assert
+    // presence without the single-match constraint.
+    expect(screen.getAllByText('Pro Plan').length).toBeGreaterThan(0);
+    expect(screen.getByText('Enterprise')).toBeInTheDocument();
+    expect(screen.queryByText('Demo Plan')).not.toBeInTheDocument();
+    expect(screen.queryByText('Legacy Plan')).not.toBeInTheDocument();
+    expect(screen.getAllByRole('radio')).toHaveLength(2);
+  });
+
+  it('shows the resulting billing amount for the selected plan on the MONTHLY cycle', () => {
+    openModal();
+    // Preselected current plan (p1) → no preview yet.
+    expect(screen.queryByText(/tenantDetail\.newAmountInfo/)).not.toBeInTheDocument();
+    fireEvent.click(screen.getAllByRole('radio')[1]); // Enterprise
+    // t(key, {amount, cycle}) mock → "key::amount,cycle"; cycle label falls
+    // back to the raw cycle since t(key, fallbackString) returns the fallback.
+    expect(
+      screen.getByText('tenantDetail.newAmountInfo::₺1,500,MONTHLY'),
+    ).toBeInTheDocument();
+  });
+
+  it('uses the yearly price when the subscription bills YEARLY', () => {
+    tenant = baseTenant({
+      subscriptions: [
+        {
+          id: 'sub-1',
+          status: 'ACTIVE',
+          plan: { displayName: 'Pro Plan' },
+          billingCycle: 'YEARLY',
+          currentPeriodEnd: '2026-12-31T00:00:00.000Z',
+        },
+      ],
+    });
+    openModal();
+    fireEvent.click(screen.getAllByRole('radio')[1]);
+    expect(
+      screen.getByText('tenantDetail.newAmountInfo::₺15,000,YEARLY'),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/superadmin/TenantDetailPage.tsx
+++ b/frontend/src/pages/superadmin/TenantDetailPage.tsx
@@ -26,6 +26,7 @@ import {
   initLimitValues,
 } from './tenantOverrides.helpers';
 import { getApiErrorMessage } from '../../lib/api-error';
+import { isDemoPlan, resolvePlanAmountForCycle } from './plans.helpers';
 
 const statusStyles = {
   ACTIVE: 'bg-emerald-50 text-emerald-700 border-emerald-100',
@@ -127,6 +128,24 @@ export default function TenantDetailPage() {
   const activeSubscription = tenant.subscriptions?.find(
     (sub: { status: string }) => sub.status === 'ACTIVE' || sub.status === 'TRIALING',
   );
+
+  // Plan-change modal offers only assignable plans: the internal DEMO plan
+  // (its name keys the demo money-path guard; the backend refuses assigning
+  // it) and retired isActive:false plans are excluded.
+  const selectablePlans = (plans ?? []).filter(
+    (plan) => !isDemoPlan(plan) && plan.isActive !== false,
+  );
+
+  // F3 preview: the subscription keeps its billing cycle across a SA plan
+  // change, so the resulting amount is the NEW plan's price for the CURRENT
+  // cycle (discount-window aware — mirrors backend resolvePlanAmount, which
+  // recomputes the authoritative value on apply).
+  const billingCycle: string = activeSubscription?.billingCycle || 'MONTHLY';
+  const selectedPlan = selectablePlans.find((plan) => plan.id === selectedPlanId);
+  const newAmountPreview =
+    selectedPlan && selectedPlan.id !== tenant.currentPlan?.id
+      ? resolvePlanAmountForCycle(selectedPlan, billingCycle)
+      : null;
 
   const handleChangePlan = () => {
     if (!activeSubscription || !selectedPlanId) return;
@@ -560,7 +579,7 @@ export default function TenantDetailPage() {
               </p>
 
               <div className="space-y-2 mb-6">
-                {plans?.map((plan) => (
+                {selectablePlans.map((plan) => (
                   <label
                     key={plan.id}
                     className={`flex items-center justify-between p-4 border rounded-xl cursor-pointer transition-colors ${
@@ -596,6 +615,19 @@ export default function TenantDetailPage() {
                   </label>
                 ))}
               </div>
+
+              {/* F3: show the resulting billing amount so the operator sees
+                  the price the subscription row will carry after the change. */}
+              {newAmountPreview !== null && (
+                <div className="mb-4 p-3 bg-zinc-50 border border-zinc-200 rounded-lg">
+                  <p className="text-sm text-zinc-700">
+                    {t('tenantDetail.newAmountInfo', {
+                      amount: `₺${newAmountPreview.toLocaleString()}`,
+                      cycle: t(`tenantDetail.cycle.${billingCycle}`, billingCycle),
+                    })}
+                  </p>
+                </div>
+              )}
 
               {changePlanMutation.isError && (
                 <div className="mb-4 p-3 bg-red-50 border border-red-100 rounded-lg">

--- a/frontend/src/pages/superadmin/plans.helpers.test.ts
+++ b/frontend/src/pages/superadmin/plans.helpers.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { discountedMonthlyPrice } from './plans.helpers';
+import {
+  discountedMonthlyPrice,
+  isDemoPlan,
+  resolvePlanAmountForCycle,
+} from './plans.helpers';
 
 describe('discountedMonthlyPrice', () => {
   it('applies a percentage discount to a numeric price', () => {
@@ -21,5 +25,63 @@ describe('discountedMonthlyPrice', () => {
 
   it('handles fractional results (no rounding in the helper)', () => {
     expect(discountedMonthlyPrice(99.99, 10)).toBeCloseTo(89.991, 5);
+  });
+});
+
+describe('isDemoPlan', () => {
+  it('matches only the exact internal DEMO name', () => {
+    expect(isDemoPlan({ name: 'DEMO' })).toBe(true);
+    expect(isDemoPlan({ name: 'demo' })).toBe(false);
+    expect(isDemoPlan({ name: 'DEMO2' })).toBe(false);
+    expect(isDemoPlan({ name: undefined })).toBe(false);
+  });
+});
+
+describe('resolvePlanAmountForCycle', () => {
+  const base = { monthlyPrice: 1000, yearlyPrice: 10000 };
+
+  it('returns the monthly price for MONTHLY and yearly for YEARLY', () => {
+    expect(resolvePlanAmountForCycle(base, 'MONTHLY')).toBe(1000);
+    expect(resolvePlanAmountForCycle(base, 'YEARLY')).toBe(10000);
+  });
+
+  it('applies a live discount inside its window (mirrors backend resolvePlanAmount)', () => {
+    const now = new Date('2026-06-15T12:00:00Z');
+    const plan = {
+      ...base,
+      isDiscountActive: true,
+      discountPercentage: 20,
+      discountStartDate: '2026-06-01T00:00:00Z',
+      discountEndDate: '2026-06-30T23:59:59Z',
+    };
+    expect(resolvePlanAmountForCycle(plan, 'MONTHLY', now)).toBe(800);
+    expect(resolvePlanAmountForCycle(plan, 'YEARLY', now)).toBe(8000);
+  });
+
+  it('ignores a discount outside its window or with the flag off', () => {
+    const now = new Date('2026-07-15T12:00:00Z');
+    const expired = {
+      ...base,
+      isDiscountActive: true,
+      discountPercentage: 20,
+      discountStartDate: '2026-06-01T00:00:00Z',
+      discountEndDate: '2026-06-30T23:59:59Z',
+    };
+    expect(resolvePlanAmountForCycle(expired, 'MONTHLY', now)).toBe(1000);
+    const inactive = { ...expired, isDiscountActive: false, discountEndDate: '2026-12-31T00:00:00Z' };
+    expect(resolvePlanAmountForCycle(inactive, 'MONTHLY', now)).toBe(1000);
+  });
+
+  it('rounds discounted amounts to 2 decimals', () => {
+    const now = new Date('2026-06-15T12:00:00Z');
+    const plan = {
+      monthlyPrice: 1799,
+      yearlyPrice: 17990,
+      isDiscountActive: true,
+      discountPercentage: 33,
+      discountStartDate: '2026-06-01T00:00:00Z',
+      discountEndDate: '2026-06-30T23:59:59Z',
+    };
+    expect(resolvePlanAmountForCycle(plan, 'MONTHLY', now)).toBe(1205.33);
   });
 });

--- a/frontend/src/pages/superadmin/plans.helpers.ts
+++ b/frontend/src/pages/superadmin/plans.helpers.ts
@@ -11,3 +11,61 @@ export function discountedMonthlyPrice(
 ): number {
   return Number(monthlyPrice) * (1 - discountPercentage / 100);
 }
+
+// ──────────────────────────────────────────────────────────────────────────
+// DEMO-plan lock (review F2)
+// ──────────────────────────────────────────────────────────────────────────
+
+/**
+ * FE mirror of backend `DEMO_PLAN_NAME` (backend/src/modules/demo/
+ * demo.constants.ts). DemoGuardService keys the demo tenant's real-money
+ * block on `currentPlan.name === "DEMO"` and fails OPEN, so the name is a
+ * security invariant: the backend refuses renaming/deleting this plan and
+ * assigning it to non-demo tenants; the UI locks the same actions up front.
+ */
+export const DEMO_PLAN_NAME = 'DEMO';
+
+export function isDemoPlan(plan: { name?: string | null }): boolean {
+  return plan?.name === DEMO_PLAN_NAME;
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Plan amount preview (review F3)
+// ──────────────────────────────────────────────────────────────────────────
+
+export interface DiscountablePlanLike {
+  monthlyPrice: number | string;
+  yearlyPrice?: number | string;
+  discountPercentage?: number | null;
+  discountStartDate?: string | null;
+  discountEndDate?: string | null;
+  isDiscountActive?: boolean | null;
+}
+
+/**
+ * FE mirror of the backend's `resolvePlanAmount` (backend/src/modules/
+ * subscriptions/plan-pricing.helper.ts): the discounted (or full) gross
+ * amount for a billing cycle, honoring the plan's time-boxed promotional
+ * discount window. Used to PREVIEW the post-change billing amount in the
+ * superadmin plan-change modal — the backend recomputes the authoritative
+ * value on the same rule when the change is applied.
+ */
+export function resolvePlanAmountForCycle(
+  plan: DiscountablePlanLike,
+  billingCycle: string,
+  now: Date = new Date(),
+): number {
+  const base = Number(
+    billingCycle === 'YEARLY' ? (plan.yearlyPrice ?? plan.monthlyPrice) : plan.monthlyPrice,
+  );
+  const discountActive = !!(
+    plan.isDiscountActive &&
+    plan.discountPercentage &&
+    plan.discountStartDate &&
+    plan.discountEndDate &&
+    new Date(plan.discountStartDate) <= now &&
+    new Date(plan.discountEndDate) >= now
+  );
+  if (!discountActive) return base;
+  return Math.round(base * (1 - plan.discountPercentage! / 100) * 100) / 100;
+}


### PR DESCRIPTION
Review loop tick 9 — the three most severe findings from the superadmin frontend review:

1. **HIGH: Legal Documents console was unreachable** — the page existed but had no route and no sidebar entry, so the platform's KVKK / distance-sales / refund documents could not be published through any UI. Worse, its admin hooks used the TENANT axios client: had the route existed, a superadmin would 401 → tenant-interceptor logout → ejected to the tenant login. Now routed (`/superadmin/legal` + sidebar entry), hooks pinned to `superAdminApi`, publish failures surfaced, nested-`tbody` DOM fixed (regression-tested).
2. **HIGH: DEMO plan lockdown.** The demo money-path guard keys on the plan's internal name and fails open — a single rename would hand the anonymous shared demo tenant real PayTR money paths. Backend now 409s renaming/deleting the DEMO plan, renaming another plan TO "DEMO", and assigning DEMO to any non-demo subscription; inactive plans can no longer be assigned via superadmin (mirrors the tenant-side rule). UI shows a lock badge and filters DEMO/inactive plans from the plan-change modal. 13 new backend specs.
3. **MED-HIGH: superadmin plan changes now recompute `subscription.amount`** inside the same transaction (via the backend's single discount-aware pricing helper) — previously the old plan's price stuck, showing wrong amounts and corrupting later tenant-side proration bases. The plan-change modal previews the resulting billing amount.

Verification: backend 618 tests (43 suites), frontend 211 tests, both tsc clean, eslint clean, i18n parity ×5.
