### PR TITLE
fix(catalog): eski aylık ürünleri satıştan kaldır + oneTime fiyat deliğini kapat

### DIFF
--- a/backend/prisma/migrations/20260811150000_retire_legacy_monthly_catalog/down.sql
+++ b/backend/prisma/migrations/20260811150000_retire_legacy_monthly_catalog/down.sql
@@ -1,0 +1,25 @@
+-- Rollback: put the eight legacy monthly rows back on sale.
+--
+-- Same codes, same billing guard, opposite status. It touches nothing else —
+-- no ownership rows, no new catalog rows, no tenant data — and is a no-op when
+-- run twice, because the second pass finds nothing still archived.
+--
+-- One asymmetry, stated rather than papered over: nothing marks WHICH rows the
+-- up archived, so if an operator archives one of these eight between the up and
+-- the down, this publishes it again along with the rest. All eight were
+-- verified `published` in production before the up ran, so the rollback is
+-- exact for the state it was written against.
+UPDATE "marketplace_addons"
+   SET "status" = 'published', "updatedAt" = NOW()
+ WHERE "status" = 'archived'
+   AND "billing" = 'MONTHLY'
+   AND "code" IN (
+     'custom_branding',
+     'delivery_integration',
+     'integration_efatura',
+     'integration_sms',
+     'inventory_tracking',
+     'multi_branch',
+     'personnel_management',
+     'reservation_system'
+   );

--- a/backend/prisma/migrations/20260811150000_retire_legacy_monthly_catalog/migration.sql
+++ b/backend/prisma/migrations/20260811150000_retire_legacy_monthly_catalog/migration.sql
@@ -1,0 +1,46 @@
+-- @doctor:idempotent verified=single status UPDATE on marketplace_addons scoped to eight legacy codes with billing='MONTHLY' and status='published'; re-running matches nothing. Catalog/config data only.
+--
+-- Retire the pre-à-la-carte monthly catalog.
+--
+-- The à-la-carte migrations published the new annual products but left the old
+-- monthly rows exactly as they were: still `published`, still billing='MONTHLY'.
+-- The live price list came out of the deploy listing both, which is wrong three
+-- separate ways.
+--
+--   1. It advertises monthly billing, in a release whose entire premise is that
+--      monthly billing no longer exists.
+--   2. Six of the eight duplicate a new annual product — personnel_management
+--      ₺49,99/ay next to module_personnel ₺990/yıl, and so on.
+--   3. Two of them sell what is now free: custom_branding and multi_branch
+--      cover feature.customBranding and feature.multiLocation, both of which
+--      every tenant now gets from free:baseline at no cost.
+--
+-- Worse than the display: the quote engine priced anything non-`annual` as a
+-- flat oneTime line, so ₺49,99/month became ₺49,99 ONCE, granting the feature
+-- with no period to expire — a permanent licence to a ₺990/yr module for the
+-- price of one month. That hole is closed in code as well (QuoteService now
+-- refuses any cadence that is neither annual nor oneTime); this migration
+-- removes the rows that made it reachable.
+--
+-- Ownership is deliberately untouched. Archiving a catalog row stops it being
+-- sold; it does not revoke anything. The projector grants from TenantAddOn
+-- joined to the catalog row and never consults the row's own status, so a
+-- tenant who already owns one of these keeps every grant it carries.
+--
+-- Scoped to the exact codes AND to billing='MONTHLY' AND status='published': an
+-- operator who has already archived one keeps that decision, and a code reused
+-- later for a real annual product is not caught by a stale rule.
+UPDATE "marketplace_addons"
+   SET "status" = 'archived', "updatedAt" = NOW()
+ WHERE "status" = 'published'
+   AND "billing" = 'MONTHLY'
+   AND "code" IN (
+     'custom_branding',
+     'delivery_integration',
+     'integration_efatura',
+     'integration_sms',
+     'inventory_tracking',
+     'multi_branch',
+     'personnel_management',
+     'reservation_system'
+   );

--- a/backend/src/modules/checkout/quote.service.spec.ts
+++ b/backend/src/modules/checkout/quote.service.spec.ts
@@ -144,7 +144,7 @@ describe('QuoteService', () => {
   it('still mixes addon + hardware + service into one quote (no plan)', async () => {
     addons.findByCodeOrThrow.mockResolvedValue({
       code: 'kds_extra_screen', name: 'Extra KDS screen', status: 'published',
-      billing: 'recurring', priceCents: 5000, currency: 'TRY', id: 'a-1', kind: 'capacity',
+      billing: 'oneTime', priceCents: 5000, currency: 'TRY', id: 'a-1', kind: 'capacity',
     } as any);
     // v2.8.87: catalog.findBySkuOrThrow is now hit for BOTH hardware and
     // service items (services live as HardwareProduct rows with
@@ -182,6 +182,45 @@ describe('QuoteService', () => {
     expect(q.totalCents).toBe(340_000); // 335000 gross + 5000 shipping
     expect(q.shippingCents).toBe(5_000);
     expect(q.isPureRecurring).toBe(false);
+  });
+
+  it('refuses to price a legacy monthly row instead of selling it flat', async () => {
+    // Shipped-and-caught: the à-la-carte catalog went live alongside the old
+    // monthly rows, which were still published. The pricer treated everything
+    // non-`annual` as oneTime, so personnel_management at ₺49,99/MONTH was
+    // quoted as ₺49,99 ONCE — a permanent grant of the same feature the annual
+    // product sells for ₺990/yr, with no period to ever expire.
+    addons.findByCodeOrThrow.mockResolvedValue({
+      id: 'legacy-1', code: 'personnel_management', name: 'Personel Yonetimi',
+      status: 'published', kind: 'SOFTWARE', billing: 'MONTHLY',
+      priceCents: 4_999, currency: 'TRY', requiresLicense: true,
+    } as any);
+
+    const q = await priceCart({
+      items: [{ type: 'addon', code: 'personnel_management' }],
+    });
+
+    expect(q.lines).toHaveLength(0);
+    expect(q.totalCents).toBe(0);
+    expect(q.warnings).toContainEqual({
+      code: 'addon_not_purchasable',
+      ref: 'personnel_management',
+    });
+  });
+
+  it('refuses any cadence the pricer does not understand', async () => {
+    // Not just 'MONTHLY' — the guard is an allowlist, so a future or
+    // hand-edited cadence cannot fall through to a flat charge either.
+    addons.findByCodeOrThrow.mockResolvedValue({
+      id: 'weird-1', code: 'weekly_thing', name: 'Weekly thing',
+      status: 'published', kind: 'module', billing: 'weekly',
+      priceCents: 1_000, currency: 'TRY', requiresLicense: true,
+    } as any);
+
+    const q = await priceCart({ items: [{ type: 'addon', code: 'weekly_thing' }] });
+
+    expect(q.lines).toHaveLength(0);
+    expect(q.warnings.map((w: any) => w.code)).toContain('addon_not_purchasable');
   });
 
   it('refuses to price a rental for SKUs without a rental price', async () => {
@@ -298,7 +337,7 @@ describe('QuoteService', () => {
 
   it('does not double-count KDV: a KDV-inclusive add-on totals the displayed price', async () => {
     addons.findByCodeOrThrow.mockResolvedValue({
-      billing: 'recurring',
+      billing: 'oneTime',
       priceCents: 49_900,
       currency: 'TRY',
       id: 'a-kdv',

--- a/backend/src/modules/checkout/quote.service.ts
+++ b/backend/src/modules/checkout/quote.service.ts
@@ -112,6 +112,18 @@ export class QuoteService {
               requiresLicense: addOn.requiresLicense,
             },
           });
+        } else if (addOn.billing !== "oneTime") {
+          // Fail-closed on anything that is neither annual nor oneTime.
+          //
+          // This branch used to be a bare `else`, which meant a row carrying a
+          // legacy cadence — the pre-à-la-carte catalog wrote billing='MONTHLY'
+          // — was priced as a flat one-time charge with no period at all. A
+          // ₺49,99/month product became ₺49,99 once, granting its feature
+          // permanently, while the annual product covering the same feature
+          // cost ₺990/year. Only `oneTime` may be sold as a flat price; a
+          // cadence the pricer does not understand is not purchasable.
+          warnings.push({ code: "addon_not_purchasable", ref: addOn.code });
+          continue;
         } else {
           // oneTime — credit packs and services. Flat price, no period.
           lines.push({


### PR DESCRIPTION
v3.3.0 yeni yıllık katalogu yayına aldı ama **eskisini indirmedi**. Canlı fiyat listesi 30 ürün döndürüyordu: 21 à-la-carte satır + 8 eski `MONTHLY` satır, hepsi `published`.

## Sorun

| Eski satır (aylık) | Çakıştığı yeni satır |
|---|---|
| `personnel_management` ₺49,99/ay | `module_personnel` ₺990/yıl |
| `reservation_system` ₺39,99/ay | `module_reservations` ₺990/yıl |
| `inventory_tracking` ₺39,99/ay | `module_inventory` ₺1.490/yıl |
| `delivery_integration` ₺79,99/ay | 3 ayrı platform kalemi |
| `integration_efatura` ₺49,99/ay | `fiscal_efatura` ₺1.990/yıl |
| `integration_sms` ₺29,99/ay | `sms_integration` ₺990/yıl |
| `custom_branding` ₺29,99/ay | **artık ücretsiz** (free baseline) |
| `multi_branch` ₺99,99/ay | **artık ücretsiz** (`multiLocation`) |

Asıl mesele görüntü değil, **fiyat deliği**: `QuoteService` `annual`'ı orantılıyor, geri kalan her şeyi çıplak bir `else` ile **düz oneTime** satır olarak fiyatlıyordu. Yani ₺49,99/**ay** olan satır ₺49,99'a **BİR KEZ** satılabiliyor, feature'ı **süresiz** veriyordu — aynı feature'ı ₺990/yıl satan yıllık ürünün ~20 katı altında, hiç dolmayacak şekilde. Mağazadan, görünen fiyatla, herkes tarafından erişilebilirdi.

## Düzeltme

İkisi birlikte iniyor; biri tek başına diğerini açık bırakır:

- **Fiyatlayıcı artık allowlist.** `annual` orantılanır, `oneTime` düz geçer, başka her cadence (`MONTHLY`, `recurring`, sonradan elle yazılmış herhangi bir şey) mevcut `addon_not_purchasable` uyarısıyla reddedilir.
- **Migration 8 satırı arşivler.** Arşivlemek satışı durdurur, hiçbir şeyi geri almaz: projektör `TenantAddOn` üzerinden grant üretir ve katalog satırının kendi status'una bakmaz — mevcut sahip her grant'ını korur. Tam kod listesine + `billing='MONTHLY'` + `status='published'` ile sınırlı; `down.sql` geri yayınlar.

## Doğrulama

- `up→up→down→down→up` Postgres 16'da round-trip edildi, idempotent
- 4711 backend testi geçiyor; deliği pinleyen 2 yeni test (`MONTHLY` reddi + bilinmeyen cadence reddi)
- tsc + lint temiz (0 error)