### PR TITLE
fix(landing): katalog isteğinde /api ön eki ikileniyordu

### DIFF
--- a/landing/src/lib/api.ts
+++ b/landing/src/lib/api.ts
@@ -54,13 +54,29 @@ export interface CatalogProduct {
   sortOrder: number;
 }
 
+/**
+ * Join the configured base with an API path exactly once.
+ *
+ * Prod builds pass NEXT_PUBLIC_API_URL=https://hummytummy.com/api — already
+ * carrying the prefix — while a dev build points at http://localhost:3000,
+ * which does not. The previous code appended `/api` unconditionally, so every
+ * production fetch went to /api/api/... and 404'd. That failure was invisible:
+ * the fetch swallowed it, returned [], and the pricing section fell back to
+ * hardcoded tier prices, so the page looked right while showing numbers no
+ * API had confirmed for months.
+ */
+function apiUrl(path: string): string {
+  const root = API_BASE.replace(/\/+$/, '');
+  return `${root}${root.endsWith('/api') ? '' : '/api'}${path}`;
+}
+
 export async function getCatalog(locale = 'tr'): Promise<CatalogProduct[]> {
   // Static generation with no API base configured renders the free core and a
   // contact CTA. A missing price is recoverable; a stale one is not.
   if (!API_BASE) return [];
   try {
     const res = await fetch(
-      `${API_BASE}/api/v1/catalog/pricing?locale=${encodeURIComponent(locale)}`,
+      apiUrl(`/v1/catalog/pricing?locale=${encodeURIComponent(locale)}`),
       { next: { revalidate: 300 } },
     );
     if (!res.ok) return [];


### PR DESCRIPTION
Prod build'i `NEXT_PUBLIC_API_URL=https://hummytummy.com/api` veriyor — ön ek zaten var — kod bir tane daha ekliyordu. Yani her istek `/api/api/...`'ye gidip **404** alıyordu.

Hata tasarımı gereği görünmezdi: fetch hatayı yutup boş liste döndürüyor, bu sürüme kadar da fiyat bölümü liste boş gelince **sabit paket fiyatlarına** düşüyordu. Sayfa doğru görünüyor ama aylardır hiçbir API'nin doğrulamadığı rakamları gösteriyordu. Ancak fallback kaldırılıp bölüm canlı ve çalışan bir uca karşı "fiyat listesi yüklenemedi" deyince ortaya çıktı.

Artık tek sefer birleştiriyor; ön eki taşımayan dev tabanıyla (`http://localhost:3000`) da taşıyan prod tabanıyla da çalışıyor.

Canlıya karşı doğrulandı: `/api/v1/catalog/pricing` → 200, `/api/api/v1/catalog/pricing` → 404.