### PR TITLE
fix(demo): demo hesabının yetkilerini her girişte onar + açılamayan kapı sınıfını kapat

### DIFF
--- a/backend/src/modules/demo/demo.service.spec.ts
+++ b/backend/src/modules/demo/demo.service.spec.ts
@@ -25,15 +25,26 @@ import {
 describe('DemoService', () => {
   let service: DemoService;
   let prisma: MockPrismaClient;
+  let projector: { projectTenant: jest.Mock };
 
   beforeEach(async () => {
     prisma = mockPrismaClient();
+    projector = { projectTenant: jest.fn().mockResolvedValue(undefined) };
     const module: TestingModule = await Test.createTestingModule({
-      providers: [DemoService, { provide: PrismaService, useValue: prisma }],
+      providers: [
+        DemoService,
+        { provide: PrismaService, useValue: prisma },
+        { provide: PlanProjectorService, useValue: projector },
+      ],
     }).compile();
     service = module.get(DemoService);
     jest.spyOn(service['logger'], 'log').mockImplementation(() => undefined);
     jest.spyOn(service['logger'], 'debug').mockImplementation(() => undefined);
+    jest.spyOn(service['logger'], 'warn').mockImplementation(() => undefined);
+    // Reconcile reads these on every entry; default to "already correct" so
+    // only the tests that care about repair have to arrange it.
+    (prisma.marketplaceAddOn.findMany as jest.Mock).mockResolvedValue([]);
+    (prisma.tenantAddOn.findMany as jest.Mock).mockResolvedValue([]);
     // resetDemoData now runs under a Postgres advisory lock (multi-replica
     // guard). Grant it by default so the body runs; a dedicated test overrides
     // this to assert the lock actually gates the destructive wipe.
@@ -206,5 +217,150 @@ describe('DemoService', () => {
     // fires once as the v2 lock holder — assert on the body's calls.)
     expect(prisma.tenant.findFirst).not.toHaveBeenCalled();
     expect(prisma.order.deleteMany).not.toHaveBeenCalled();
+  });
+
+  describe('entitlement repair on every entry', () => {
+    // THE BUG THIS PINS: ensureDemoTenant used to return the moment the demo
+    // admin existed, so grants were written once, at first seed. The v3.3.0
+    // free_core migration then cleared Tenant.featureOverrides for EVERY
+    // tenant — demo included — and nothing wrote them back. The demo silently
+    // fell to the free core: no reports, reservations, personnel, stock, AI or
+    // API, and the settings nav quietly went short. Nobody noticed until a
+    // human did.
+    const existingAdmin = {
+      id: 'demo-admin',
+      email: DemoService.ADMIN_EMAIL,
+      firstName: 'Demo',
+      lastName: 'Yönetici',
+      role: 'ADMIN',
+      tenantId: 'demo-tenant',
+      phone: '+905550000000',
+      locale: 'tr',
+    };
+
+    beforeEach(() => {
+      (prisma.user.findFirst as jest.Mock).mockResolvedValue(existingAdmin);
+    });
+
+    it('restores feature overrides a data migration wiped', async () => {
+      (prisma.tenant.findUnique as jest.Mock).mockResolvedValue({
+        featureOverrides: null,
+      });
+
+      await service.ensureDemoTenant();
+
+      const written = (prisma.tenant.update as jest.Mock).mock.calls[0][0].data
+        .featureOverrides;
+      expect(written.advancedReports).toEqual({ mode: 'grant' });
+      expect(written.reservationSystem).toEqual({ mode: 'grant' });
+      expect(written.aiContentGeneration).toEqual({ mode: 'grant' });
+      // …and the tenant is re-projected, or the repair would sit in the DB
+      // without reaching the entitlement engine.
+      expect(projector.projectTenant).toHaveBeenCalledWith('demo-tenant');
+    });
+
+    it('leaves a healthy demo alone', async () => {
+      (prisma.tenant.findUnique as jest.Mock).mockResolvedValue({
+        featureOverrides: Object.fromEntries(
+          Object.keys((DemoService as any).ALL_FEATURES).map((k) => [
+            k,
+            { mode: 'grant' },
+          ]),
+        ),
+      });
+
+      await service.ensureDemoTenant();
+
+      expect(prisma.tenant.update).not.toHaveBeenCalled();
+      expect(projector.projectTenant).not.toHaveBeenCalled();
+    });
+
+    it('grants integrations as owned products, which overrides cannot express', async () => {
+      // The projector writes `feature.${key}` for every override entry, so an
+      // integration grant has no route through that map at all. SMS settings,
+      // e-Belge/ÖKC and caller-ID were therefore unreachable in the demo even
+      // before the migration.
+      (prisma.tenant.findUnique as jest.Mock).mockResolvedValue({
+        featureOverrides: Object.fromEntries(
+          Object.keys((DemoService as any).ALL_FEATURES).map((k) => [
+            k,
+            { mode: 'grant' },
+          ]),
+        ),
+      });
+      (prisma.marketplaceAddOn.findMany as jest.Mock).mockResolvedValue([
+        { id: 'p-lic', code: 'license_annual', kind: 'license' },
+        { id: 'p-sms', code: 'sms_integration', kind: 'integration' },
+      ]);
+      (prisma.tenantAddOn.findMany as jest.Mock).mockResolvedValue([]);
+
+      await service.ensureDemoTenant();
+
+      const rows = (prisma.tenantAddOn.createMany as jest.Mock).mock.calls[0][0]
+        .data;
+      expect(rows.map((r: any) => r.addOnId).sort()).toEqual(['p-lic', 'p-sms']);
+      // Comped, not sold: free, auditable, and never a real payment.
+      expect(rows.every((r: any) => r.origin === 'comp')).toBe(true);
+      expect(rows.every((r: any) => r.chargedCents === 0)).toBe(true);
+      expect(projector.projectTenant).toHaveBeenCalledWith('demo-tenant');
+    });
+
+    it('comps the LICENCE too, or every integration it grants stays dark', async () => {
+      // The projector suppresses a requiresLicense product while no LICENCE
+      // PRODUCT is owned — a feature.license override does not satisfy it,
+      // because the check reads ownership rows.
+      (prisma.tenant.findUnique as jest.Mock).mockResolvedValue({
+        featureOverrides: { license: { mode: 'grant' } },
+      });
+      (prisma.marketplaceAddOn.findMany as jest.Mock).mockResolvedValue([
+        { id: 'p-lic', code: 'license_annual', kind: 'license' },
+      ]);
+      (prisma.tenantAddOn.findMany as jest.Mock).mockResolvedValue([]);
+
+      await service.ensureDemoTenant();
+
+      const where = (prisma.marketplaceAddOn.findMany as jest.Mock).mock
+        .calls[0][0].where;
+      expect(where.OR).toEqual(
+        expect.arrayContaining([{ kind: 'license' }, { kind: 'integration' }]),
+      );
+    });
+
+    it('does not re-comp what the demo already owns', async () => {
+      (prisma.tenant.findUnique as jest.Mock).mockResolvedValue({
+        featureOverrides: Object.fromEntries(
+          Object.keys((DemoService as any).ALL_FEATURES).map((k) => [
+            k,
+            { mode: 'grant' },
+          ]),
+        ),
+      });
+      (prisma.marketplaceAddOn.findMany as jest.Mock).mockResolvedValue([
+        { id: 'p-lic', code: 'license_annual', kind: 'license' },
+      ]);
+      (prisma.tenantAddOn.findMany as jest.Mock).mockResolvedValue([
+        { addOnId: 'p-lic' },
+      ]);
+
+      await service.ensureDemoTenant();
+
+      expect(prisma.tenantAddOn.createMany).not.toHaveBeenCalled();
+      expect(projector.projectTenant).not.toHaveBeenCalled();
+    });
+
+    it('still comes up on an environment with no catalog at all', async () => {
+      // A `prisma db push` dev database has no catalog rows. Features come
+      // from overrides precisely so the demo works there.
+      (prisma.tenant.findUnique as jest.Mock).mockResolvedValue({
+        featureOverrides: null,
+      });
+      (prisma.marketplaceAddOn.findMany as jest.Mock).mockResolvedValue([]);
+
+      await expect(service.ensureDemoTenant()).resolves.toMatchObject({
+        id: 'demo-admin',
+      });
+      expect(prisma.tenantAddOn.createMany).not.toHaveBeenCalled();
+      expect(prisma.tenant.update).toHaveBeenCalled();
+    });
   });
 });

--- a/backend/src/modules/demo/demo.service.ts
+++ b/backend/src/modules/demo/demo.service.ts
@@ -3,6 +3,7 @@ import { Cron, CronExpression } from "@nestjs/schedule";
 import * as bcrypt from "bcryptjs";
 import { Prisma } from "@prisma/client";
 import { PrismaService } from "../../prisma/prisma.service";
+import { PlanProjectorService } from "../entitlements/plan-projector.service";
 import { DEMO_PLAN_NAME } from "./demo.constants";
 import { withAdvisoryLock } from "../../common/scheduling/advisory-lock";
 import { UserRole } from "../../common/constants/roles.enum";
@@ -83,7 +84,10 @@ export class DemoService {
     license: true,
   };
 
-  constructor(private readonly prisma: PrismaService) {}
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly projector: PlanProjectorService,
+  ) {}
 
   /**
    * Returns the demo admin user (with the fields generateTokens needs),
@@ -104,9 +108,151 @@ export class DemoService {
         locale: true,
       },
     });
-    if (existing) return existing;
+    if (existing) {
+      // RECONCILE, don't just return.
+      //
+      // This used to return the moment the demo user existed, so everything
+      // the tenant is granted was written exactly once, at first seed. The
+      // v3.3.0 `free_core` migration then archived and cleared
+      // `Tenant.featureOverrides` for EVERY tenant — the demo included — and
+      // nothing ever wrote them back. The demo silently dropped to the free
+      // core: no reports, no reservations, no personnel, no stock, no AI, no
+      // API. It stayed that way until a human noticed the settings nav had
+      // gone short.
+      //
+      // A demo whose entitlements are written once is a demo that any future
+      // data migration can quietly strip. Repairing on every entry costs a
+      // couple of queries on a cold path and makes that class of failure
+      // self-healing.
+      await this.reconcileEntitlements(existing.tenantId);
+      return existing;
+    }
 
     return this.seed();
+  }
+
+  /**
+   * Bring the demo tenant's grants back to what the demo promises: every
+   * screen reachable.
+   *
+   * Two mechanisms, because one cannot express the other:
+   *
+   *   - FEATURES come from grant-mode `featureOverrides`. They work even in an
+   *     environment whose catalog was never seeded (a `db push` dev database),
+   *     which is why the demo does not rely on owning products for these.
+   *   - INTEGRATIONS cannot be expressed as overrides at all — the projector
+   *     writes `feature.${key}` for every override entry, so an
+   *     `integration.sms` grant has no route through that map. They come from
+   *     comped ownership rows instead, which is also the honest path: the demo
+   *     exercises catalog → ownership → projector → guard exactly as a paying
+   *     tenant does, instead of a special lane where an entire gate class can
+   *     go untested. SMS settings, e-Belge/ÖKC and caller-ID were unreachable
+   *     in the demo for this reason even before the migration.
+   */
+  private async reconcileEntitlements(tenantId: string): Promise<void> {
+    const desired = DemoService.featureOverridePayload();
+    const tenant = await this.prisma.tenant.findUnique({
+      where: { id: tenantId },
+      select: { featureOverrides: true },
+    });
+
+    const current = (tenant?.featureOverrides ?? null) as Record<
+      string,
+      unknown
+    > | null;
+    const featuresStale =
+      !current || Object.keys(desired).some((k) => !(k in current));
+
+    if (featuresStale) {
+      await this.prisma.tenant.update({
+        where: { id: tenantId },
+        data: { featureOverrides: desired as any },
+      });
+      this.logger.warn(
+        `Demo tenant ${tenantId}: feature overrides were missing or stale — restored`,
+      );
+    }
+
+    const comped = await this.compIntegrationProducts(tenantId);
+
+    if (featuresStale || comped > 0) {
+      await this.projector.projectTenant(tenantId);
+    }
+  }
+
+  /**
+   * Own the licence + every published integration product, for free.
+   *
+   * The licence first, and not only for symmetry: the projector suppresses
+   * every `requiresLicense` product's grants while no LICENCE PRODUCT is
+   * owned — a `feature.license` override does not satisfy it, because the
+   * check reads ownership rows. Comping the integrations without the licence
+   * would write rows that grant nothing.
+   *
+   * Products absent from the catalog are skipped rather than created: an
+   * environment seeded with `prisma db push` has no catalog at all, and the
+   * demo must still come up there.
+   *
+   * Returns how many rows it had to create.
+   */
+  private async compIntegrationProducts(tenantId: string): Promise<number> {
+    const wanted = await this.prisma.marketplaceAddOn.findMany({
+      where: {
+        status: "published",
+        OR: [{ kind: "license" }, { kind: "integration" }],
+      },
+      select: { id: true, code: true, kind: true },
+    });
+    if (wanted.length === 0) return 0;
+
+    const held = await this.prisma.tenantAddOn.findMany({
+      where: {
+        tenantId,
+        status: "active",
+        addOnId: { in: wanted.map((w) => w.id) },
+      },
+      select: { addOnId: true },
+    });
+    const heldIds = new Set(held.map((h) => h.addOnId));
+    const missing = wanted.filter((w) => !heldIds.has(w.id));
+    if (missing.length === 0) return 0;
+
+    const now = new Date();
+    // A decade out: the demo has no anniversary, no renewal cycle and nobody
+    // to invoice, and an expiring row would darken the demo on a date nobody
+    // is watching.
+    const periodEnd = new Date(now.getTime() + 3650 * 24 * 3600 * 1000);
+
+    await this.prisma.tenantAddOn.createMany({
+      data: missing.map((m) => ({
+        tenantId,
+        addOnId: m.id,
+        quantity: 1,
+        status: "active",
+        origin: "comp",
+        compReason: "Demo restaurant — every screen reachable",
+        chargedCents: 0,
+        activatedAt: now,
+        currentPeriodStart: now,
+        currentPeriodEnd: periodEnd,
+      })),
+      skipDuplicates: true,
+    });
+    this.logger.warn(
+      `Demo tenant ${tenantId}: comped ${missing.length} product(s) — ${missing
+        .map((m) => m.code)
+        .join(", ")}`,
+    );
+    return missing.length;
+  }
+
+  /** The override map, in the projector's grant-mode shape. */
+  private static featureOverridePayload(): Record<string, { mode: string }> {
+    return Object.fromEntries(
+      Object.entries(DemoService.ALL_FEATURES)
+        .filter(([, on]) => on)
+        .map(([key]) => [key, { mode: "grant" }]),
+    );
   }
 
   private async seed() {
@@ -162,11 +308,7 @@ export class DemoService {
         status: "ACTIVE",
         currentPlanId: plan.id,
         // Grant-mode overrides: plain `true` grants, never `__replace:false`.
-        featureOverrides: Object.fromEntries(
-          Object.entries(DemoService.ALL_FEATURES)
-            .filter(([, on]) => on)
-            .map(([key]) => [key, { mode: "grant" }]),
-        ) as any,
+        featureOverrides: DemoService.featureOverridePayload() as any,
       },
     });
 
@@ -243,6 +385,10 @@ export class DemoService {
     if (categoryCount === 0) {
       await this.seedContent(tenant.id, branch.id, admin.id);
     }
+    // Integrations + the licence they hang off, and the projection that makes
+    // any of it visible.
+    await this.reconcileEntitlements(tenant.id);
+
     this.logger.log(`Ensured demo tenant ${tenant.id} (${tenant.subdomain})`);
     return admin;
   }

--- a/backend/src/modules/entitlements/entitlement-keys.const.ts
+++ b/backend/src/modules/entitlements/entitlement-keys.const.ts
@@ -68,13 +68,22 @@ export const LIMIT_KEYS = [
   "maxMonthlyOrders",
 ] as const;
 
-/** Integration domains. Values are vendor-id arrays, UNIONed across grants. */
+/**
+ * Integration domains. Values are vendor-id arrays, UNIONed across grants.
+ *
+ * Every domain here MUST be grantable by a published product — a domain no
+ * product sells is a permanently-locked capability, and the code that gates on
+ * it looks correct while denying every tenant forever. `accounting` was
+ * exactly that: nothing granted it, the backend route it guarded was
+ * re-pointed at `fiscal` after 403'ing for everyone, and a finance counter
+ * went on reading it long after. `catalog-coverage.spec.ts` now fails if a
+ * domain drifts out of the catalog.
+ */
 export const INTEGRATION_KEYS = [
   "delivery",
   "fiscal",
   "caller",
   "sms",
-  "accounting",
 ] as const;
 
 /**

--- a/frontend/src/pages/admin/finance/FinanceOverview.tsx
+++ b/frontend/src/pages/admin/finance/FinanceOverview.tsx
@@ -142,18 +142,17 @@ function FiscalUpsellCard() {
   );
 }
 
-/** Sayaç iki koşullu kaynaktan gelebilir (accounting sync-failed + fiscal
- *  pending-receipts). Rules-of-hooks: hangi hook'ların çağrılacağı entegrasyon
- *  setine göre DEĞİŞTİĞİ için (fiscal'siz tenant'ta useListPendingReceipts hiç
- *  çağrılmamalı — 403'e bağlı gereksiz istek), varyant bileşenlere ayrılır;
- *  her varyant kendi sabit hook setini koşulsuz çağırır. */
+/** Sayaç iki kaynaktan toplanır: muhasebe senkron hatası + bekleyen fiş.
+ *
+ *  İkisi de `fiscal` entegrasyonuna bağlı — `/accounting-settings/sync-status`
+ *  ucu da `@RequiresIntegration("fiscal")` ile kapılı. Burada ayrı bir
+ *  `accounting` entegrasyonu okunuyordu; onu hiçbir ürün vermiyor, dolayısıyla
+ *  senkron sayacı HİÇBİR tenant'ta çalışmıyordu (ve `accounting` var ama
+ *  `fiscal` yok varyantı hiç render edilemezdi). Tek kapı, tek varyant. */
 function DocumentsCounterRow({ onNavigate }: { onNavigate: NavigateFn }) {
   const { hasIntegration } = useSubscription();
-  const acc = hasIntegration('accounting');
-  const fis = hasIntegration('fiscal');
-  if (!acc && !fis) return null;
-  if (fis) return <DocumentsCounterWithFiscal acc={acc} onNavigate={onNavigate} />;
-  return <DocumentsCounterAccountingOnly onNavigate={onNavigate} />;
+  if (!hasIntegration('fiscal')) return null;
+  return <DocumentsCounterWithFiscal onNavigate={onNavigate} />;
 }
 
 function DocumentsCounterBody({ failedDocs, onNavigate }: { failedDocs: number; onNavigate: NavigateFn }) {
@@ -177,17 +176,10 @@ function DocumentsCounterBody({ failedDocs, onNavigate }: { failedDocs: number; 
 }
 
 /** fiscal entegrasyonu VAR — iki hook da koşulsuz çağrılır. */
-function DocumentsCounterWithFiscal({ acc, onNavigate }: { acc: boolean; onNavigate: NavigateFn }) {
-  const sync = useAccountingSyncStatus(acc);
-  const pending = useListPendingReceipts();
-  const failedDocs = (acc ? (sync.data?.failed ?? 0) : 0) + (pending.data?.length ?? 0);
-  return <DocumentsCounterBody failedDocs={failedDocs} onNavigate={onNavigate} />;
-}
-
-/** fiscal YOK, sadece accounting — useListPendingReceipts hiç çağrılmaz. */
-function DocumentsCounterAccountingOnly({ onNavigate }: { onNavigate: NavigateFn }) {
+function DocumentsCounterWithFiscal({ onNavigate }: { onNavigate: NavigateFn }) {
   const sync = useAccountingSyncStatus(true);
-  const failedDocs = sync.data?.failed ?? 0;
+  const pending = useListPendingReceipts();
+  const failedDocs = (sync.data?.failed ?? 0) + (pending.data?.length ?? 0);
   return <DocumentsCounterBody failedDocs={failedDocs} onNavigate={onNavigate} />;
 }
 

--- a/scripts/check-contract-drift.mjs
+++ b/scripts/check-contract-drift.mjs
@@ -255,6 +255,151 @@ try {
   console.error(`✗ branch-scope mirror: ${err.message}`);
 }
 
+
+// ---------------------------------------------------------------------------
+// Entitlement reachability: every gate must be openable.
+//
+// A gate keyed on something no product sells and no baseline grants is a
+// permanent denial that reads like working code. It has happened twice:
+// `integration.accounting` gated the e-document credential surface and 403'd
+// for EVERY tenant until someone re-pointed the route, and a finance counter
+// went on reading the same dead domain for months afterwards.
+//
+// So: collect the vocabulary, collect what the catalog + free baseline can
+// actually grant, collect every gate the code declares, and fail when a gate
+// cannot be opened or names something outside the vocabulary.
+// ---------------------------------------------------------------------------
+try {
+  const keysSrc = read("backend/src/modules/entitlements/entitlement-keys.const.ts");
+  const listOf = (name) => {
+    const m = keysSrc.match(
+      new RegExp(`export const ${name} = \\[([\\s\\S]*?)\\] as const`),
+    );
+    return m ? [...m[1].matchAll(/"([^"]+)"/g)].map((x) => x[1]) : [];
+  };
+  const features = listOf("FEATURE_KEYS");
+  const integrations = listOf("INTEGRATION_KEYS");
+
+  // A gate that has been COMMENTED OUT is not a gate. Without this the
+  // scanner flags the very comment left behind explaining why a dead gate was
+  // removed, and the only way to keep CI green is to delete the explanation.
+  const stripComments = (src) =>
+    src.replace(/\/\*[\s\S]*?\*\//g, "").replace(/^\s*\/\/.*$/gm, "");
+
+  const catalogSrc = read("backend/src/modules/marketplace/alacarte-catalog.const.ts");
+  const baselineSrc = read("backend/src/modules/entitlements/free-baseline.const.ts");
+  const grantable = new Set(
+    [...catalogSrc.matchAll(/"(feature|integration)\.([A-Za-z0-9]+)"/g)].map(
+      (m) => `${m[1]}.${m[2]}`,
+    ),
+  );
+  for (const m of baselineSrc.matchAll(/featureKey\("([A-Za-z0-9]+)"\)/g)) {
+    grantable.add(`feature.${m[1]}`);
+  }
+
+  const unreachable = [
+    ...features.map((f) => `feature.${f}`),
+    ...integrations.map((i) => `integration.${i}`),
+  ].filter((k) => !grantable.has(k));
+
+  // Every gate declared anywhere in the product.
+  const gates = new Map(); // key -> sample location
+  const scan = (dir, exts, patterns) => {
+    const stack = [dir];
+    while (stack.length) {
+      const cur = stack.pop();
+      for (const entry of readdirSync(cur, { withFileTypes: true })) {
+        const full = join(cur, entry.name);
+        if (entry.isDirectory()) {
+          if (entry.name !== "node_modules") stack.push(full);
+        } else if (
+          exts.some((e) => entry.name.endsWith(e)) &&
+          !/\.(spec|test)\./.test(entry.name)
+        ) {
+          const src = stripComments(readFileSync(full, "utf8"));
+          for (const [re, prefix] of patterns) {
+            for (const m of src.matchAll(re)) {
+              const key = `${prefix}.${m[1]}`;
+              if (!gates.has(key)) gates.set(key, `${full}`);
+            }
+          }
+        }
+      }
+    }
+  };
+
+  const PLAN_FEATURE = new Map(
+    [...read("backend/src/common/constants/subscription.enum.ts").matchAll(
+      /(\w+)\s*=\s*"([A-Za-z0-9]+)"/g,
+    )].map((m) => [m[1], m[2]]),
+  );
+
+  scan(join(repoRoot, "backend/src"), [".ts"], [
+    [/@RequiresIntegration\(\s*["']([a-z]+)["']/g, "integration"],
+  ]);
+  // PlanFeature.X enum members resolve through the enum map.
+  {
+    const stack = [join(repoRoot, "backend/src")];
+    while (stack.length) {
+      const cur = stack.pop();
+      for (const entry of readdirSync(cur, { withFileTypes: true })) {
+        const full = join(cur, entry.name);
+        if (entry.isDirectory()) {
+          if (entry.name !== "node_modules") stack.push(full);
+        } else if (full.endsWith(".ts") && !/\.(spec|test)\./.test(entry.name)) {
+          const src = stripComments(readFileSync(full, "utf8"));
+          for (const m of src.matchAll(/@RequiresFeature\(\s*PlanFeature\.([A-Z_0-9]+)\s*\)/g)) {
+            const resolved = PLAN_FEATURE.get(m[1]);
+            if (resolved && !gates.has(`feature.${resolved}`)) {
+              gates.set(`feature.${resolved}`, full);
+            }
+          }
+        }
+      }
+    }
+  }
+  scan(join(repoRoot, "frontend/src"), [".ts", ".tsx"], [
+    [/hasIntegration\(\s*["']([a-z]+)["']/g, "integration"],
+    [/hasFeature\(\s*["']([A-Za-z]+)["']/g, "feature"],
+    [/\bdomain:\s*["']([a-z]+)["']/g, "integration"],
+  ]);
+
+  const known = new Set([
+    ...features.map((f) => `feature.${f}`),
+    ...integrations.map((i) => `integration.${i}`),
+  ]);
+  const badGates = [...gates.entries()].filter(([k]) => !known.has(k));
+
+  if (unreachable.length === 0 && badGates.length === 0) {
+    console.log(
+      `✓ entitlement reachability (${features.length} features + ${integrations.length} integrations, every gate openable)`,
+    );
+  } else {
+    failures += 1;
+    if (unreachable.length > 0) {
+      console.error(
+        "✗ entitlement vocabulary contains keys NO published product and no free baseline grants:",
+      );
+      for (const k of unreachable) console.error(`    ${k}`);
+      console.error(
+        "    Sell it (add a catalog product), give it away (free baseline), or drop the key.",
+      );
+    }
+    if (badGates.length > 0) {
+      console.error("✗ gates reference keys outside the entitlement vocabulary:");
+      for (const [k, where] of badGates) {
+        console.error(`    ${k}  (${where.replace(repoRoot + "/", "")})`);
+      }
+      console.error(
+        "    A gate on an unknown key can never open. Fix the key or add it to entitlement-keys.const.ts AND the catalog.",
+      );
+    }
+  }
+} catch (err) {
+  failures += 1;
+  console.error(`✗ entitlement reachability: ${err.message}`);
+}
+
 if (failures > 0) {
   console.error(
     `\n${failures} mirrored contract(s) drifted. Align the values above (the backend is the source of truth) or update CHECKS if a mirror was intentionally retired.`,


### PR DESCRIPTION
Demo restoranı bir süredir **yalnız ücretsiz çekirdek** üzerinde çalışıyormuş. Raporlar, rezervasyon, personel, stok, AI stüdyosu, API — hepsi kapalı; Ayarlar menüsü de sessizce kısalmış. Feature-flag sorunu gibi görünüyordu çünkü öyleydi.

## Kök neden

`ensureDemoTenant`, demo admini var olur olmaz **erken dönüyordu**; yani tenant'a verilen her şey tek bir kez, ilk seed'de yazılıyordu. Sonra v3.3.0'ın `free_core` migration'ı **her tenant'ın** `featureOverrides`'ını arşivleyip temizledi — demo'yu ayıran bir istisna yoktu — ve hiçbir kod yolu geri yazmadı.

Yetkileri bir kez yazılan bir demo, sonraki her data migration'ının sessizce boşaltabileceği bir demodur. Artık **her girişte mutabakat** yapıyor: soğuk yolda iki sorgu, karşılığında bu hata sınıfı kendi kendini onarır hale geliyor.

## İkinci, daha eski delik: entegrasyonlar

Projektör override haritasındaki her giriş için `feature.${key}` yazıyor — yani bir **entegrasyon** grant'ının o haritadan geçen hiçbir yolu yok. SMS ayarları, e-Belge/ÖKC ve Çağrı-ID demo'da **migration'dan önce de** erişilemezdi; kimse fark etmedi çünkü demo, gerçek hiçbir tenant'ın kullanmadığı özel bir override şeridinden besleniyordu.

Artık lisansı ve yayınlanmış tüm entegrasyonları **hediye edilmiş sahiplik satırı** olarak sahipleniyor; böylece katalog → sahiplik → projektör → guard zincirini ödeme yapan bir tenant gibi yürüyor. Lisans burada isteğe bağlı değil: projektör, **lisans ÜRÜNÜ** sahipliği yokken `requiresLicense` olan her ürünü bastırıyor ve `feature.license` override'ı bu kontrolü karşılamıyor.

## Aynı belirtinin hak ettiği geniş tarama

Üründeki her kapıyı, onu gerçekten verebilecek her şeye karşı taradım:

- **`integration.accounting` sözlükteydi ve hiçbir şey vermiyordu.** Koruduğu backend ucu, herkese 403 verdikten sonra zaten `fiscal`'a yönlendirilmişti; ama bir finans sayacı onu okumaya devam ediyordu — yani "belge gönderilemedi" sayacının muhasebe-senkron yarısı **hiçbir tenant'ta** çalışamazdı. Hem ölü okuma hem ölü alan kaldırıldı; sayaç artık ucunun gerçekten zorladığı kapıyı kullanıyor.
- Diğer tüm feature ve entegrasyon anahtarları erişilebilir: ya ücretsiz tabanda ya da yayınlanmış bir üründe.

## Tekrarlamaması için

Zaten bloklayıcı olan **contract-drift** işi artık **açılamayan kapıda başarısız oluyor**: hiçbir ürünün satmadığı ve tabanın vermediği bir sözlük anahtarı, ya da sözlük dışı bir anahtara dayanan bir kapı. Isırdığını `integration.bookkeeping` ekleyip CI'ın reddettiğini görerek doğruladım. Yorum satırına alınmış kapılar atlanıyor — ölü bir kapının neden kaldırıldığını anlatan not, build'i düşürmesin diye.

## Doğrulama

Nest context'i **portsuz boot** edildi, DI çözülüyor (tsc de jest de kırık grafiği geçiriyor — bu sürümde bir kez yaşandı). 4669 backend + 2233 frontend testi; 6 yeni test demo onarımını pinliyor (migration override'ları sildiğinde geri yazılıyor mu, sağlıklı demo'ya dokunulmuyor mu, entegrasyonlar sahiplikle mi veriliyor, lisans da hediye ediliyor mu, sahip olunan yeniden hediye edilmiyor mu, katalogsuz ortamda ayağa kalkıyor mu).