### PR TITLE
fix(store): mağaza, checkout'un reddedeceğini satmasın + canlı lisansı tekrar eklemesin

### DIFF
--- a/backend/src/modules/auth/auth.module.ts
+++ b/backend/src/modules/auth/auth.module.ts
@@ -10,6 +10,7 @@ import { PasswordService } from "./services/password.service";
 import { EmailVerificationService } from "./services/email-verification.service";
 import { AuthProvisioningService } from "./services/auth-provisioning.service";
 import { DemoService } from "../demo/demo.service";
+import { MarketplaceModule } from "../marketplace/marketplace.module";
 import { LocalStrategy } from "./strategies/local.strategy";
 import { JwtStrategy } from "./strategies/jwt.strategy";
 import { JwtAuthGuard } from "./guards/jwt-auth.guard";
@@ -23,6 +24,10 @@ import { NotificationsModule } from "../notifications/notifications.module";
   imports: [
     PassportModule,
     forwardRef(() => NotificationsModule),
+    // DemoService comps the demo tenant's licence + integrations through the
+    // real purchase path, so the marketplace service must resolve here.
+    // forwardRef because MarketplaceModule's graph reaches back into auth.
+    forwardRef(() => MarketplaceModule),
     JwtModule.registerAsync({
       imports: [ConfigModule],
       useFactory: async (configService: ConfigService) => ({

--- a/backend/src/modules/checkout/addon-purchasability.rules.ts
+++ b/backend/src/modules/checkout/addon-purchasability.rules.ts
@@ -1,0 +1,154 @@
+import { EntitlementSet } from "../entitlements/entitlement.types";
+import { featureKey } from "../entitlements/entitlement-keys.const";
+import { TenantMarketplaceService } from "../marketplace/tenant-marketplace.service";
+import { LICENSE_ADDON_CODE } from "../marketplace/catalog-validation";
+
+export type AddonPurchasabilityErrorCode =
+  | "ADDON_ALREADY_GRANTED"
+  | "ADDON_ALREADY_OWNED"
+  | "ADDON_REQUIRES_DEPENDENCY"
+  | "ADDON_LIMIT_REDUNDANT"
+  | "ADDON_MAX_QUANTITY"
+  | "LICENSE_REQUIRED";
+
+export interface PurchaseBlock {
+  code: AddonPurchasabilityErrorCode;
+  addOnCode: string;
+  message: string;
+}
+
+export interface PurchasabilityFacts {
+  addOn: {
+    code: string;
+    name: string;
+    kind: string;
+    grants: Record<string, unknown> | null;
+    requiresLicense: boolean;
+    maxQuantity: number | null;
+  };
+  /** The tenant's EFFECTIVE entitlements, from any source. */
+  entitlements: EntitlementSet;
+  /** Units of this exact product already held on an active row. */
+  ownedQuantity: number;
+  /** Whether an active row exists for this product at this scope. */
+  isOwned: boolean;
+  /** Units being asked for. */
+  quantity: number;
+  /** Codes present in the same cart (a sibling line can satisfy the licence). */
+  cartCodes?: ReadonlySet<string>;
+  /** A renewal re-buys what is already held — that is what a renewal IS. */
+  isRenewal?: boolean;
+}
+
+/**
+ * Can this tenant buy this product right now — and if not, why?
+ *
+ * Extracted so exactly one implementation answers the question for both the
+ * pre-payment guard and the storefront. They used to answer it separately:
+ * the guard from the tenant's effective entitlements, the store from whether
+ * an ownership ROW existed. Anything granted without a row — a comp, an
+ * operator override, the demo tenant's whole feature set — therefore showed a
+ * Buy button that checkout refuses with ADDON_ALREADY_GRANTED. The customer
+ * ticks a line, pays nothing, and gets an error naming a product they did not
+ * pick, because a rejected line fails the entire cart.
+ *
+ * Pure: no IO, no Prisma. Callers gather the facts however suits them — the
+ * guard reads per product, the licensing snapshot already has all of it loaded.
+ * Order mirrors the guard's original sequence exactly.
+ */
+export function evaluatePurchasability(
+  facts: PurchasabilityFacts,
+): PurchaseBlock | null {
+  const {
+    addOn,
+    entitlements: ent,
+    ownedQuantity,
+    isOwned,
+    quantity,
+    cartCodes = new Set<string>(),
+    isRenewal = false,
+  } = facts;
+
+  const block = (
+    code: AddonPurchasabilityErrorCode,
+    message: string,
+  ): PurchaseBlock => ({ code, addOnCode: addOn.code, message });
+
+  const hasLicense = ent.features?.[featureKey("license")] === true;
+
+  // 1) The licence prerequisite. Everything gated on it is unusable without
+  // one — the projector suppresses the grants of every `requiresLicense`
+  // product while the licence is dark — so selling one first would take money
+  // for access the buyer cannot exercise.
+  if (
+    addOn.requiresLicense &&
+    !hasLicense &&
+    !cartCodes.has(LICENSE_ADDON_CODE)
+  ) {
+    return block(
+      "LICENSE_REQUIRED",
+      `"${addOn.name}" requires an active HummyTummy licence. Add the licence to your cart first.`,
+    );
+  }
+
+  // 2) The licence itself: one at a time — EXCEPT on a renewal, which re-pays
+  // the existing row rather than minting a second one.
+  if (addOn.kind === "license") {
+    if (hasLicense && !isRenewal) {
+      return block(
+        "ADDON_ALREADY_OWNED",
+        `Your licence is already active. It renews on your anniversary.`,
+      );
+    }
+    return null; // no ownership/redundancy checks apply to the licence
+  }
+
+  // 3) Credit packs are consumable, not entitlements: buying a second pack is
+  // always meaningful.
+  if (addOn.kind === "credit") return null;
+
+  // 4) Already covered by the tenant's effective entitlements — paying again
+  // buys nothing (DEF-1). A renewal is the one case where paying for something
+  // you already have is the whole point.
+  if (
+    !isRenewal &&
+    TenantMarketplaceService.isIncludedInEntitlements(addOn.grants, ent)
+  ) {
+    return block(
+      "ADDON_ALREADY_GRANTED",
+      `"${addOn.name}" is already active on your account.`,
+    );
+  }
+
+  // 5) Capacity is quantity-based: owning one extra branch must not block
+  // buying a second. Enforce the catalog ceiling instead.
+  if (addOn.kind === "capacity") {
+    const owned = isRenewal ? 0 : ownedQuantity;
+    const wanted = owned + quantity;
+    if (addOn.maxQuantity != null && wanted > addOn.maxQuantity) {
+      return block(
+        "ADDON_MAX_QUANTITY",
+        `"${addOn.name}" is limited to ${addOn.maxQuantity} per account (you have ${owned}).`,
+      );
+    }
+  } else if (isOwned && !isRenewal) {
+    return block(
+      "ADDON_ALREADY_OWNED",
+      `"${addOn.name}" is already active for this account.`,
+    );
+  }
+
+  // 6) Redundant capacity (DEF-8) — a limit.* grant whose effective limit is
+  // already unlimited (-1) buys nothing.
+  for (const key of Object.keys(addOn.grants ?? {})) {
+    if (!key.startsWith("limit.")) continue;
+    if (ent.limits?.[key] === -1) {
+      return block(
+        "ADDON_LIMIT_REDUNDANT",
+        `"${addOn.name}" adds capacity you already have unlimited.`,
+      );
+    }
+  }
+
+  return null;
+}

--- a/backend/src/modules/checkout/addon-purchasability.service.ts
+++ b/backend/src/modules/checkout/addon-purchasability.service.ts
@@ -8,15 +8,13 @@ import { AddOnCatalogService } from "../marketplace/addon-catalog.service";
 import { TenantMarketplaceService } from "../marketplace/tenant-marketplace.service";
 import { EntitlementService } from "../entitlements/entitlement.service";
 import { featureKey } from "../entitlements/entitlement-keys.const";
-import { LICENSE_ADDON_CODE } from "../marketplace/catalog-validation";
+import {
+  evaluatePurchasability,
+  type PurchaseBlock,
+} from "./addon-purchasability.rules";
 
-export type AddonPurchasabilityErrorCode =
-  | "ADDON_ALREADY_GRANTED"
-  | "ADDON_ALREADY_OWNED"
-  | "ADDON_REQUIRES_DEPENDENCY"
-  | "ADDON_LIMIT_REDUNDANT"
-  | "ADDON_MAX_QUANTITY"
-  | "LICENSE_REQUIRED";
+export type { AddonPurchasabilityErrorCode } from "./addon-purchasability.rules";
+import type { AddonPurchasabilityErrorCode } from "./addon-purchasability.rules";
 
 export interface AssertPurchasableInput {
   addOnCode: string;
@@ -69,111 +67,58 @@ export class AddonPurchasabilityService {
     ctx: CartContext = {},
   ): Promise<void> {
     const addOn = await this.catalog.findByCodeOrThrow(input.addOnCode);
-    const grants = (addOn.grants as Record<string, unknown> | null) ?? null;
     const ent = await this.entitlements.getForTenant(tenantId);
     const cartCodes = ctx.cartCodes ?? new Set<string>();
-    const hasLicense = ent.features?.[featureKey("license")] === true;
 
-    // 1) The licence prerequisite. Everything gated on it is unusable without
-    // one — the projector suppresses the grants of every `requiresLicense`
-    // product while the licence is dark — so selling one first would take
-    // money for access the buyer cannot exercise.
-    if (addOn.requiresLicense && !hasLicense) {
-      if (!cartCodes.has(LICENSE_ADDON_CODE)) {
-        this.reject(
-          "LICENSE_REQUIRED",
-          addOn.code,
-          `"${addOn.name}" requires an active HummyTummy licence. Add the licence to your cart first.`,
-        );
-      }
-    }
-
-    // 2) The licence itself: one at a time — EXCEPT on a renewal, which
-    // re-pays the existing row rather than minting a second one.
-    if (addOn.kind === "license") {
-      if (hasLicense && !ctx.isRenewal) {
-        this.reject(
-          "ADDON_ALREADY_OWNED",
-          addOn.code,
-          `Your licence is already active. It renews on your anniversary.`,
-        );
-      }
-      return; // no ownership/redundancy checks apply to the licence
-    }
-
-    // 3) Credit packs are consumable, not entitlements: buying a second pack
-    // is always meaningful, so none of the ownership or redundancy checks
-    // below apply. Only the dependency check does — a pack whose spending
-    // module the tenant does not own is money they cannot use.
-    if (addOn.kind === "credit") {
-      await this.assertDeps(tenantId, addOn, cartCodes);
-      return;
-    }
-
-    // 4) Already covered by the tenant's effective entitlements — paying
-    // again buys nothing (DEF-1). A renewal is the one case where paying for
-    // something you already have is the whole point.
-    if (
-      !ctx.isRenewal &&
-      TenantMarketplaceService.isIncludedInEntitlements(grants, ent)
-    ) {
-      this.reject(
-        "ADDON_ALREADY_GRANTED",
-        addOn.code,
-        `"${addOn.name}" is already active on your account.`,
-      );
-    }
-
-    // 5) Capacity is quantity-based: owning one extra branch must not block
-    // buying a second. Enforce the catalog ceiling instead of an
-    // already-owned rejection (pre-3.3 this threw "change quantity instead",
-    // pointing at a path that did not exist — capacity was unsellable past
-    // one unit).
-    const activeOwned = await this.prisma.tenantAddOn.findFirst({
-      where: {
-        tenantId,
-        addOnId: addOn.id,
-        branchId: input.branchId ?? null,
-        status: "active",
+    const facts = {
+      addOn: {
+        code: addOn.code,
+        name: addOn.name,
+        kind: addOn.kind,
+        grants: (addOn.grants as Record<string, unknown> | null) ?? null,
+        requiresLicense: addOn.requiresLicense,
+        maxQuantity: addOn.maxQuantity ?? null,
       },
-      select: { id: true, quantity: true },
-    });
+      entitlements: ent,
+      quantity: input.quantity ?? 1,
+      cartCodes,
+      isRenewal: ctx.isRenewal,
+    };
 
-    if (addOn.kind === "capacity") {
-      // A renewal re-buys the units already held rather than adding to them.
-      const owned = ctx.isRenewal ? 0 : (activeOwned?.quantity ?? 0);
-      const wanted = owned + (input.quantity ?? 1);
-      if (addOn.maxQuantity != null && wanted > addOn.maxQuantity) {
-        this.reject(
-          "ADDON_MAX_QUANTITY",
-          addOn.code,
-          `"${addOn.name}" is limited to ${addOn.maxQuantity} per account (you have ${owned}).`,
-        );
-      }
-    } else if (activeOwned && !ctx.isRenewal) {
-      this.reject(
-        "ADDON_ALREADY_OWNED",
-        addOn.code,
-        `"${addOn.name}" is already active for this ${
-          input.branchId ? "branch" : "account"
-        }.`,
-      );
+    // One implementation of "can this be bought", shared with the storefront.
+    // When these were separate the store offered anything without an ownership
+    // ROW — comps, operator overrides, the demo tenant's entire feature set —
+    // and checkout refused the whole cart.
+    //
+    // Evaluated in two passes so the ownership read stays conditional: the
+    // licence, already-granted and redundancy rules need no ownership at all,
+    // and a product that is already granted must not cost a query to refuse.
+    const withoutOwnership = evaluatePurchasability({
+      ...facts,
+      ownedQuantity: 0,
+      isOwned: false,
+    });
+    if (withoutOwnership) this.rejectWith(withoutOwnership);
+
+    if (addOn.kind !== "credit" && addOn.kind !== "license") {
+      const activeOwned = await this.prisma.tenantAddOn.findFirst({
+        where: {
+          tenantId,
+          addOnId: addOn.id,
+          branchId: input.branchId ?? null,
+          status: "active",
+        },
+        select: { id: true, quantity: true },
+      });
+      const blocked = evaluatePurchasability({
+        ...facts,
+        ownedQuantity: activeOwned?.quantity ?? 0,
+        isOwned: !!activeOwned,
+      });
+      if (blocked) this.rejectWith(blocked);
     }
 
     await this.assertDeps(tenantId, addOn, cartCodes);
-
-    // 6) Redundant capacity (DEF-8) — a limit.* grant whose effective limit
-    // is already unlimited (-1) buys nothing.
-    for (const [key] of Object.entries(grants ?? {})) {
-      if (!key.startsWith("limit.")) continue;
-      if (ent.limits?.[key] === -1) {
-        this.reject(
-          "ADDON_LIMIT_REDUNDANT",
-          addOn.code,
-          `"${addOn.name}" adds capacity you already have unlimited.`,
-        );
-      }
-    }
   }
 
   /**
@@ -218,6 +163,14 @@ export class AddonPurchasabilityService {
         `"${addOn.name}" requires "${depName}". Add it to your cart first.`,
       );
     }
+  }
+
+  private rejectWith(blocked: PurchaseBlock): never {
+    throw new ConflictException({
+      code: blocked.code,
+      message: blocked.message,
+      addOnCode: blocked.addOnCode,
+    });
   }
 
   private reject(

--- a/backend/src/modules/demo/demo.service.spec.ts
+++ b/backend/src/modules/demo/demo.service.spec.ts
@@ -2,6 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { DemoService } from './demo.service';
 import { PrismaService } from '../../prisma/prisma.service';
 import { PlanProjectorService } from '../entitlements/plan-projector.service';
+import { TenantMarketplaceService } from '../marketplace/tenant-marketplace.service';
 import {
   mockPrismaClient,
   MockPrismaClient,
@@ -26,15 +27,18 @@ describe('DemoService', () => {
   let service: DemoService;
   let prisma: MockPrismaClient;
   let projector: { projectTenant: jest.Mock };
+  let tenantMarketplace: { purchase: jest.Mock };
 
   beforeEach(async () => {
     prisma = mockPrismaClient();
     projector = { projectTenant: jest.fn().mockResolvedValue(undefined) };
+    tenantMarketplace = { purchase: jest.fn().mockResolvedValue({ id: 'ta-x' }) };
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         DemoService,
         { provide: PrismaService, useValue: prisma },
         { provide: PlanProjectorService, useValue: projector },
+        { provide: TenantMarketplaceService, useValue: tenantMarketplace },
       ],
     }).compile();
     service = module.get(DemoService);
@@ -296,12 +300,16 @@ describe('DemoService', () => {
 
       await service.ensureDemoTenant();
 
-      const rows = (prisma.tenantAddOn.createMany as jest.Mock).mock.calls[0][0]
-        .data;
-      expect(rows.map((r: any) => r.addOnId).sort()).toEqual(['p-lic', 'p-sms']);
-      // Comped, not sold: free, auditable, and never a real payment.
-      expect(rows.every((r: any) => r.origin === 'comp')).toBe(true);
-      expect(rows.every((r: any) => r.chargedCents === 0)).toBe(true);
+      // Through purchase(), NOT a raw insert: that path stamps the
+      // anniversary anchor. Writing rows directly left the demo holding a live
+      // licence with no anchor, the snapshot reported "none", and the store
+      // added a SECOND licence to every basket — which checkout refused,
+      // failing the whole purchase.
+      const codes = tenantMarketplace.purchase.mock.calls.map((c) => c[1].addOnCode);
+      expect(codes.sort()).toEqual(['license_annual', 'sms_integration']);
+      expect(tenantMarketplace.purchase.mock.calls[0][3]).toMatchObject({
+        comp: expect.objectContaining({ reason: expect.any(String) }),
+      });
       expect(projector.projectTenant).toHaveBeenCalledWith('demo-tenant');
     });
 
@@ -344,7 +352,7 @@ describe('DemoService', () => {
 
       await service.ensureDemoTenant();
 
-      expect(prisma.tenantAddOn.createMany).not.toHaveBeenCalled();
+      expect(tenantMarketplace.purchase).not.toHaveBeenCalled();
       expect(projector.projectTenant).not.toHaveBeenCalled();
     });
 
@@ -359,7 +367,7 @@ describe('DemoService', () => {
       await expect(service.ensureDemoTenant()).resolves.toMatchObject({
         id: 'demo-admin',
       });
-      expect(prisma.tenantAddOn.createMany).not.toHaveBeenCalled();
+      expect(tenantMarketplace.purchase).not.toHaveBeenCalled();
       expect(prisma.tenant.update).toHaveBeenCalled();
     });
   });

--- a/backend/src/modules/demo/demo.service.ts
+++ b/backend/src/modules/demo/demo.service.ts
@@ -4,6 +4,7 @@ import * as bcrypt from "bcryptjs";
 import { Prisma } from "@prisma/client";
 import { PrismaService } from "../../prisma/prisma.service";
 import { PlanProjectorService } from "../entitlements/plan-projector.service";
+import { TenantMarketplaceService } from "../marketplace/tenant-marketplace.service";
 import { DEMO_PLAN_NAME } from "./demo.constants";
 import { withAdvisoryLock } from "../../common/scheduling/advisory-lock";
 import { UserRole } from "../../common/constants/roles.enum";
@@ -87,6 +88,7 @@ export class DemoService {
   constructor(
     private readonly prisma: PrismaService,
     private readonly projector: PlanProjectorService,
+    private readonly tenantMarketplace: TenantMarketplaceService,
   ) {}
 
   /**
@@ -201,6 +203,10 @@ export class DemoService {
         status: "published",
         OR: [{ kind: "license" }, { kind: "integration" }],
       },
+      // The licence first: purchase() stamps the anniversary anchor off it,
+      // and the projector suppresses every requiresLicense product until a
+      // licence PRODUCT is owned.
+      orderBy: { kind: "asc" },
       select: { id: true, code: true, kind: true },
     });
     if (wanted.length === 0) return 0;
@@ -217,33 +223,47 @@ export class DemoService {
     const missing = wanted.filter((w) => !heldIds.has(w.id));
     if (missing.length === 0) return 0;
 
-    const now = new Date();
-    // A decade out: the demo has no anniversary, no renewal cycle and nobody
-    // to invoice, and an expiring row would darken the demo on a date nobody
-    // is watching.
-    const periodEnd = new Date(now.getTime() + 3650 * 24 * 3600 * 1000);
-
-    await this.prisma.tenantAddOn.createMany({
-      data: missing.map((m) => ({
-        tenantId,
-        addOnId: m.id,
-        quantity: 1,
-        status: "active",
-        origin: "comp",
-        compReason: "Demo restaurant — every screen reachable",
-        chargedCents: 0,
-        activatedAt: now,
-        currentPeriodStart: now,
-        currentPeriodEnd: periodEnd,
-      })),
-      skipDuplicates: true,
-    });
-    this.logger.warn(
-      `Demo tenant ${tenantId}: comped ${missing.length} product(s) — ${missing
-        .map((m) => m.code)
-        .join(", ")}`,
-    );
-    return missing.length;
+    // Through purchase(), NOT a raw row insert.
+    //
+    // The first cut wrote TenantAddOn rows directly and skipped everything
+    // purchase() does around them — including stamping `licenseAnchorAt`. The
+    // demo ended up holding a live licence with no anchor, the licensing
+    // snapshot read the anchor to decide licence state and reported "none",
+    // and the storefront duly added a SECOND licence to every basket, which
+    // checkout refused as already-owned — taking the module the visitor
+    // actually wanted down with it.
+    let created = 0;
+    for (const product of missing) {
+      try {
+        await this.tenantMarketplace.purchase(
+          tenantId,
+          { addOnCode: product.code, quantity: 1 },
+          undefined,
+          {
+            comp: {
+              actorId: "system:demo-seed",
+              reason: "Demo restaurant — every screen reachable",
+            },
+          },
+        );
+        created += 1;
+      } catch (err) {
+        // One unsellable product must not stop the demo coming up. A draft or
+        // archived catalog row, or a dependency this environment lacks, is a
+        // catalog problem — not a reason to serve a broken demo.
+        this.logger.warn(
+          `Demo tenant ${tenantId}: could not comp ${product.code} — ${
+            (err as Error).message
+          }`,
+        );
+      }
+    }
+    if (created > 0) {
+      this.logger.warn(
+        `Demo tenant ${tenantId}: comped ${created} product(s) through the purchase path`,
+      );
+    }
+    return created;
   }
 
   /** The override map, in the projector's grant-mode shape. */

--- a/backend/src/modules/licensing/licensing.controller.purchasability.spec.ts
+++ b/backend/src/modules/licensing/licensing.controller.purchasability.spec.ts
@@ -1,0 +1,291 @@
+import {
+  mockPrismaClient,
+  MockPrismaClient,
+} from "../../common/test/prisma-mock.service";
+import { LicensingController } from "./licensing.controller";
+
+/**
+ * What the storefront is told it may sell, and what state the licence is in.
+ *
+ * Both were reported by a customer on the same screen: the store offered
+ * products the account already had, and adding any module to the basket also
+ * added a SECOND licence to an account that already held one. Checkout refuses
+ * both — and since a rejected line fails the entire cart, the purchase they
+ * actually wanted failed too. The store was not lying so much as answering a
+ * different question from the one checkout asks.
+ */
+describe("LicensingController — licence state and purchasability", () => {
+  let prisma: MockPrismaClient;
+  let ctrl: LicensingController;
+  let entitlements: { getForTenant: jest.Mock };
+  let licensing: {
+    loadContext: jest.Mock;
+    nextAnniversaryFor: jest.Mock;
+    price: jest.Mock;
+  };
+
+  const TENANT = "t-1";
+  const req = { user: { tenantId: TENANT } };
+
+  const catalogRow = (over: Record<string, unknown> = {}) => ({
+    code: "module_personnel",
+    name: "Personel Yönetimi",
+    kind: "module",
+    billing: "annual",
+    priceCents: 99_000,
+    currency: "TRY",
+    grants: { "feature.personnelManagement": true },
+    requiresLicense: true,
+    maxQuantity: null,
+    i18n: null,
+    ...over,
+  });
+
+  const ent = (over: Record<string, unknown> = {}) => ({
+    features: { "feature.license": true },
+    limits: {},
+    integrations: {},
+    computedAt: "2026-08-12T00:00:00.000Z",
+    ...over,
+  });
+
+  beforeEach(() => {
+    prisma = mockPrismaClient();
+    entitlements = { getForTenant: jest.fn().mockResolvedValue(ent()) };
+    licensing = {
+      loadContext: jest.fn().mockResolvedValue({
+        tenantId: TENANT,
+        anchorAt: new Date("2026-03-10T00:00:00.000Z"),
+        hasLicense: true,
+        now: new Date("2026-08-12T09:00:00.000Z"),
+        tz: "Europe/Istanbul",
+      }),
+      nextAnniversaryFor: jest
+        .fn()
+        .mockReturnValue(new Date("2027-03-10T00:00:00.000Z")),
+      // buildOffers prices every annual row; the figures are covered by
+      // licensing.service.spec — here they only need to exist.
+      price: jest.fn().mockImplementation((_ctx: unknown, cents: number) => ({
+        unitCents: cents,
+        subtotalCents: cents,
+        periodEnd: new Date("2027-03-10T00:00:00.000Z"),
+      })),
+    };
+
+    ctrl = new LicensingController(
+      prisma as any,
+      entitlements as any,
+      licensing as any,
+      { balances: jest.fn().mockResolvedValue([]) } as any,
+      { openFor: jest.fn().mockResolvedValue(null) } as any,
+      { listForTenant: jest.fn().mockResolvedValue([]) } as any,
+    );
+
+    (prisma.tenantAddOn.findMany as any).mockResolvedValue([]);
+    (prisma.marketplaceAddOn.findMany as any).mockResolvedValue([catalogRow()]);
+  });
+
+  describe("licence state", () => {
+    it("reports a live licence as active even with no anniversary anchor", async () => {
+      // THE BUG: state started with `!anchorAt ? "none"`. A tenant holding a
+      // live licence with no anchor — a comped one, or anything provisioned
+      // outside purchase() — was reported unlicensed, so the store added a
+      // second licence to every basket and checkout refused the lot.
+      licensing.loadContext.mockResolvedValue({
+        tenantId: TENANT,
+        anchorAt: null,
+        hasLicense: true,
+        now: new Date(),
+        tz: "Europe/Istanbul",
+      });
+      (prisma.tenantAddOn.findMany as any).mockResolvedValue([
+        {
+          id: "ta-1",
+          quantity: 1,
+          status: "active",
+          origin: "comp",
+          compReason: null,
+          currentPeriodEnd: null,
+          chargedCents: 0,
+          addOn: {
+            code: "license_annual",
+            name: "Lisans",
+            kind: "license",
+            priceCents: 299_000,
+            currency: "TRY",
+            i18n: null,
+          },
+        },
+      ]);
+
+      const res = await ctrl.me(req);
+      expect(res.license.status).toBe("active");
+    });
+
+    it("reports grace while the licence row is past_due", async () => {
+      (prisma.tenantAddOn.findMany as any).mockResolvedValue([
+        {
+          id: "ta-1",
+          quantity: 1,
+          status: "past_due",
+          origin: "purchase",
+          compReason: null,
+          currentPeriodEnd: new Date("2026-08-10T00:00:00.000Z"),
+          chargedCents: 299_000,
+          addOn: {
+            code: "license_annual",
+            name: "Lisans",
+            kind: "license",
+            priceCents: 299_000,
+            currency: "TRY",
+            i18n: null,
+          },
+        },
+      ]);
+
+      expect((await ctrl.me(req)).license.status).toBe("grace");
+    });
+
+    it("reports expired once the entitlement is gone but the anchor remains", async () => {
+      licensing.loadContext.mockResolvedValue({
+        tenantId: TENANT,
+        anchorAt: new Date("2026-03-10T00:00:00.000Z"),
+        hasLicense: false,
+        now: new Date(),
+        tz: "Europe/Istanbul",
+      });
+      entitlements.getForTenant.mockResolvedValue(ent({ features: {} }));
+
+      expect((await ctrl.me(req)).license.status).toBe("expired");
+    });
+
+    it("reports none for an account that has never held one", async () => {
+      licensing.loadContext.mockResolvedValue({
+        tenantId: TENANT,
+        anchorAt: null,
+        hasLicense: false,
+        now: new Date(),
+        tz: "Europe/Istanbul",
+      });
+      entitlements.getForTenant.mockResolvedValue(ent({ features: {} }));
+
+      expect((await ctrl.me(req)).license.status).toBe("none");
+    });
+  });
+
+  describe("purchasability", () => {
+    it("marks a product the account already has as unbuyable, with no ownership row anywhere", async () => {
+      // The demo tenant's whole feature set arrives as operator overrides, so
+      // it owns nothing — and the store used ownership rows to decide what to
+      // offer. Same verdict function as the pre-payment guard now.
+      entitlements.getForTenant.mockResolvedValue(
+        ent({
+          features: {
+            "feature.license": true,
+            "feature.personnelManagement": true,
+          },
+        }),
+      );
+
+      const res = await ctrl.me(req);
+      expect(res.purchasability.module_personnel).toMatchObject({
+        ok: false,
+        reason: "ADDON_ALREADY_GRANTED",
+      });
+    });
+
+    it("marks it buyable when the account does not have it", async () => {
+      const res = await ctrl.me(req);
+      expect(res.purchasability.module_personnel.ok).toBe(true);
+    });
+
+    it("keeps a licence-gated product buyable for an unlicensed account", async () => {
+      // The store adds the licence to the basket itself, so LICENSE_REQUIRED
+      // must not read as "cannot be sold" — otherwise a tenant who has bought
+      // nothing sees an entirely greyed-out catalogue.
+      entitlements.getForTenant.mockResolvedValue(ent({ features: {} }));
+      licensing.loadContext.mockResolvedValue({
+        tenantId: TENANT,
+        anchorAt: null,
+        hasLicense: false,
+        now: new Date(),
+        tz: "Europe/Istanbul",
+      });
+
+      const res = await ctrl.me(req);
+      expect(res.purchasability.module_personnel.ok).toBe(true);
+    });
+
+    it("refuses a second licence to an account that holds one", async () => {
+      (prisma.marketplaceAddOn.findMany as any).mockResolvedValue([
+        catalogRow({
+          code: "license_annual",
+          name: "Lisans",
+          kind: "license",
+          grants: { "feature.license": true },
+          requiresLicense: false,
+        }),
+      ]);
+
+      const res = await ctrl.me(req);
+      expect(res.purchasability.license_annual).toMatchObject({
+        ok: false,
+        reason: "ADDON_ALREADY_OWNED",
+      });
+    });
+
+    it("keeps credit packs buyable however many the account already bought", async () => {
+      (prisma.marketplaceAddOn.findMany as any).mockResolvedValue([
+        catalogRow({
+          code: "credit_ai_photo_100",
+          name: "100 AI Görsel",
+          kind: "credit",
+          billing: "oneTime",
+          grants: { "credit.PHOTO": 100 },
+          requiresLicense: false,
+        }),
+      ]);
+      (prisma.tenantAddOn.findMany as any).mockResolvedValue([]);
+
+      const res = await ctrl.me(req);
+      expect(res.purchasability.credit_ai_photo_100.ok).toBe(true);
+    });
+
+    it("stops selling capacity at the catalog ceiling", async () => {
+      (prisma.marketplaceAddOn.findMany as any).mockResolvedValue([
+        catalogRow({
+          code: "extra_branch",
+          name: "Ek Şube",
+          kind: "capacity",
+          grants: { "limit.maxBranches": 1 },
+          maxQuantity: 2,
+        }),
+      ]);
+      (prisma.tenantAddOn.findMany as any).mockResolvedValue([
+        {
+          id: "ta-2",
+          quantity: 2,
+          status: "active",
+          origin: "purchase",
+          compReason: null,
+          currentPeriodEnd: new Date("2027-03-10T00:00:00.000Z"),
+          chargedCents: 798_000,
+          addOn: {
+            code: "extra_branch",
+            name: "Ek Şube",
+            kind: "capacity",
+            priceCents: 399_000,
+            currency: "TRY",
+            i18n: null,
+          },
+        },
+      ]);
+
+      const res = await ctrl.me(req);
+      expect(res.purchasability.extra_branch).toMatchObject({
+        ok: false,
+        reason: "ADDON_MAX_QUANTITY",
+      });
+    });
+  });
+});

--- a/backend/src/modules/licensing/licensing.controller.ts
+++ b/backend/src/modules/licensing/licensing.controller.ts
@@ -5,7 +5,12 @@ import { SkipBranchScope } from "../auth/decorators/skip-branch-scope.decorator"
 import { Public } from "../auth/decorators/public.decorator";
 import { PrismaService } from "../../prisma/prisma.service";
 import { EntitlementService } from "../entitlements/entitlement.service";
-import { featureKey } from "../entitlements/entitlement-keys.const";
+import {
+  featureKey,
+  LICENSE_PRODUCT_CODE,
+} from "../entitlements/entitlement-keys.const";
+import { EntitlementSet } from "../entitlements/entitlement.types";
+import { evaluatePurchasability } from "../checkout/addon-purchasability.rules";
 import { CreditService } from "../credits/credit.service";
 import { LicensingService } from "./licensing.service";
 import { RenewalCycleService } from "./renewal-cycle.service";
@@ -78,6 +83,7 @@ export class LicensingController {
           currency: true,
           grants: true,
           requiresLicense: true,
+          maxQuantity: true,
           i18n: true,
         },
       }),
@@ -92,14 +98,22 @@ export class LicensingController {
 
     // Which of the four states the licence is in decides what the UI offers:
     // buy, nothing, renew-now, or renew-to-restore.
+    //
+    // Derived from the LIVE entitlement first, not from the anchor. It used to
+    // start with `!anchorAt ? "none"`, so a tenant holding a live licence with
+    // no anchor was reported as unlicensed — and the store, believing that,
+    // added a second licence to the cart, which checkout then refused with
+    // ADDON_ALREADY_OWNED, failing the whole basket including the module the
+    // customer actually wanted. The anchor answers "when is the anniversary",
+    // never "is there a licence".
     const licenceRow = owned.find((o) => o.addOn.kind === "license");
-    const status = !ctx.anchorAt
-      ? "none"
-      : hasLicense
-        ? licenceRow?.status === "past_due"
-          ? "grace"
-          : "active"
-        : "expired";
+    const status = hasLicense
+      ? licenceRow?.status === "past_due"
+        ? "grace"
+        : "active"
+      : ctx.anchorAt || licenceRow
+        ? "expired"
+        : "none";
 
     const localized = (row: { name: string; i18n: unknown }) =>
       (row.i18n as Record<string, { name?: string }> | null)?.[locale]?.name ??
@@ -150,6 +164,14 @@ export class LicensingController {
       // THIS tenant today. The upsell price and the checkout price are the
       // same number because they come from the same read.
       offers: this.buildOffers(catalog, ctx, locale),
+      // Whether each product can be bought RIGHT NOW, decided by the same
+      // function the pre-payment guard uses. The storefront used to decide
+      // this for itself by looking for an ownership row, so anything granted
+      // without one — a comp, an operator override, every feature the demo
+      // tenant has — showed a Buy button that checkout refuses. A rejected
+      // line fails the entire cart, so the customer could not buy the product
+      // they DID want either.
+      purchasability: this.buildPurchasability(catalog, ent, owned),
     };
   }
 
@@ -214,6 +236,60 @@ export class LicensingController {
         };
       }),
     };
+  }
+
+  private buildPurchasability(
+    catalog: Array<{
+      code: string;
+      kind: string;
+      grants: unknown;
+      requiresLicense: boolean;
+      maxQuantity?: number | null;
+      name: string;
+    }>,
+    ent: EntitlementSet,
+    owned: Array<{
+      quantity: number;
+      status: string;
+      addOn: { code: string };
+    }>,
+  ): Record<string, { ok: boolean; reason?: string; message?: string }> {
+    const activeByCode = new Map(
+      owned
+        .filter((o) => o.status === "active")
+        .map((o) => [o.addOn.code, o.quantity]),
+    );
+
+    const out: Record<
+      string,
+      { ok: boolean; reason?: string; message?: string }
+    > = {};
+    for (const row of catalog) {
+      const ownedQuantity = activeByCode.get(row.code) ?? 0;
+      const blocked = evaluatePurchasability({
+        addOn: {
+          code: row.code,
+          name: row.name,
+          kind: row.kind,
+          grants: (row.grants as Record<string, unknown> | null) ?? null,
+          requiresLicense: row.requiresLicense,
+          maxQuantity: row.maxQuantity ?? null,
+        },
+        entitlements: ent,
+        ownedQuantity,
+        isOwned: activeByCode.has(row.code),
+        quantity: 1,
+        // The store adds the licence to the basket itself when one is needed,
+        // so a licence-gated product is not "unbuyable" — it is buyable WITH
+        // the licence. Modelling the cart here keeps the store from greying
+        // out its entire catalogue for a tenant who has not bought yet.
+        cartCodes: new Set([LICENSE_PRODUCT_CODE]),
+      });
+      out[row.code] = blocked
+        ? { ok: false, reason: blocked.code, message: blocked.message }
+        : { ok: true };
+    }
+    return out;
   }
 
   private buildOffers(

--- a/frontend/src/features/licensing/CatalogStore.test.tsx
+++ b/frontend/src/features/licensing/CatalogStore.test.tsx
@@ -16,6 +16,8 @@ let products: any[];
 let owned: any[];
 let licenseStatus: string;
 let offers: Record<string, any>;
+/** Product code → the SERVER's verdict, exactly as /v1/me/licensing returns it. */
+let purchasability: Record<string, { ok: boolean; reason?: string }>;
 const purchaseAsync = vi.fn();
 
 vi.mock('./licensingApi', async () => {
@@ -32,7 +34,7 @@ vi.mock('../../contexts/SubscriptionContext', () => ({
   useEntitlements: () => ({
     owned,
     license: { status: licenseStatus },
-    snapshot: { offers },
+    snapshot: { offers, purchasability },
     offerFor: () => null,
   }),
 }));
@@ -102,6 +104,7 @@ beforeEach(() => {
   licenseStatus = 'active';
   owned = [];
   offers = {};
+  purchasability = {};
   products = [LICENCE, product()];
 });
 
@@ -220,6 +223,19 @@ describe('CatalogStore — the licence prerequisite', () => {
     tick('Personel Yönetimi');
     expect(within(bill()).queryByText('HummyTummy Lisansı')).not.toBeInTheDocument();
   });
+
+  it('does not re-add a licence that is inside its grace window', () => {
+    // Grace means the licence is still LIVE. Adding a second one produces a
+    // basket checkout refuses as already-owned, killing the whole purchase.
+    licenseStatus = 'grace';
+    render(<CatalogStore />);
+    tick('Personel Yönetimi');
+
+    expect(within(bill()).queryByText('HummyTummy Lisansı')).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /store\.payTotal/ }));
+    const codes = purchaseAsync.mock.calls[0][0].items.map((i: any) => i.code);
+    expect(codes).toEqual(['module_personnel']);
+  });
 });
 
 describe('CatalogStore — quantities and ownership', () => {
@@ -277,11 +293,49 @@ describe('CatalogStore — quantities and ownership', () => {
   });
 
   it('shows an owned module as owned and refuses to re-sell it', () => {
-    owned = [{ code: 'module_personnel', status: 'active' }];
+    purchasability = {
+      module_personnel: { ok: false, reason: 'ADDON_ALREADY_OWNED' },
+    };
     render(<CatalogStore />);
 
     expect(screen.getByRole('checkbox', { name: 'Personel Yönetimi' })).toBeDisabled();
     expect(screen.getByText('licensing:store.owned')).toBeInTheDocument();
+  });
+
+  it('refuses to re-sell a capability granted WITHOUT an ownership row', () => {
+    // The bug a demo visitor hit: the demo's features come from operator
+    // overrides, so no ownership row exists and the store cheerfully offered
+    // everything it already had. Checkout then refused the cart with
+    // ADDON_ALREADY_GRANTED — and because one bad line fails the whole basket,
+    // the product they DID want failed with it.
+    owned = [];
+    purchasability = {
+      module_personnel: { ok: false, reason: 'ADDON_ALREADY_GRANTED' },
+    };
+    render(<CatalogStore />);
+
+    expect(screen.getByRole('checkbox', { name: 'Personel Yönetimi' })).toBeDisabled();
+  });
+
+  it('says "max reached" rather than "owned" when capacity is capped', () => {
+    products = [product({ code: 'extra_branch', name: 'Ek Şube', kind: 'capacity', priceCents: 399000 })];
+    purchasability = { extra_branch: { ok: false, reason: 'ADDON_MAX_QUANTITY' } };
+    render(<CatalogStore />);
+
+    expect(screen.getByText('licensing:store.maxReached')).toBeInTheDocument();
+  });
+
+  it('still offers a licence-gated product to a tenant with no licence', () => {
+    // LICENSE_REQUIRED is not a refusal to sell — the store adds the licence
+    // itself. Treating it as one would grey out the entire catalogue for every
+    // tenant who has not bought yet.
+    licenseStatus = 'none';
+    purchasability = {
+      module_personnel: { ok: false, reason: 'LICENSE_REQUIRED' },
+    };
+    render(<CatalogStore />);
+
+    expect(screen.getByRole('checkbox', { name: 'Personel Yönetimi' })).not.toBeDisabled();
   });
 
   it('still sells a repeatable product the tenant already owns', () => {
@@ -341,7 +395,9 @@ describe('CatalogStore — arriving from an upsell', () => {
   });
 
   it('does not pre-tick something already owned', () => {
-    owned = [{ code: 'module_personnel', status: 'active' }];
+    purchasability = {
+      module_personnel: { ok: false, reason: 'ADDON_ALREADY_OWNED' },
+    };
     render(<CatalogStore focusCode="module_personnel" />);
     expect(within(bill()).getByText('licensing:store.billEmpty')).toBeInTheDocument();
   });

--- a/frontend/src/features/licensing/CatalogStore.tsx
+++ b/frontend/src/features/licensing/CatalogStore.tsx
@@ -45,7 +45,7 @@ const LICENCE_CODE = 'license_annual';
 const CatalogStore = ({ focusCode }: { focusCode?: string }) => {
   const { t } = useTranslation(['licensing', 'common']);
   const { data: products, isLoading } = useCatalogPricing();
-  const { owned, license, snapshot } = useEntitlements();
+  const { license, snapshot } = useEntitlements();
   const purchase = usePurchaseAddOnViaCheckout();
   const [busy, setBusy] = useState(false);
   // code → quantity. Absent means unticked.
@@ -53,10 +53,20 @@ const CatalogStore = ({ focusCode }: { focusCode?: string }) => {
   const [acceptedDocs, setAcceptedDocs] = useState<string[]>([]);
   const consentGiven = useConsentComplete(acceptedDocs);
 
-  const ownedCodes = useMemo(
-    () => new Set(owned.filter((o) => o.status === 'active').map((o) => o.code)),
-    [owned],
-  );
+  /**
+   * Can this product be bought — the SERVER's answer, not ours.
+   *
+   * The store used to ask "is there an ownership row?", which is a different
+   * question from the one checkout asks ("is this already covered by your
+   * entitlements?"). Anything granted without a row — a comp, an operator
+   * override, the whole demo tenant — was offered for sale and then refused at
+   * checkout with ADDON_ALREADY_GRANTED, taking the rest of the basket with
+   * it, because one rejected line fails the cart.
+   */
+  const blockedReason = (code: string): string | null => {
+    const verdict = snapshot?.purchasability?.[code];
+    return verdict && !verdict.ok ? (verdict.reason ?? 'BLOCKED') : null;
+  };
 
   // Offers are keyed by GRANT key, not by product code, so index them by code
   // once rather than guessing which key a product happens to grant.
@@ -89,10 +99,13 @@ const CatalogStore = ({ focusCode }: { focusCode?: string }) => {
   // Arriving from an upsell ("buy Personnel to continue") should land with that
   // line already ticked — the customer already said what they wanted.
   useEffect(() => {
-    if (!focusCode || !byCode.has(focusCode) || ownedCodes.has(focusCode)) return;
+    if (!focusCode || !byCode.has(focusCode) || blockedReason(focusCode)) return;
     setPicked((prev) => (focusCode in prev ? prev : { ...prev, [focusCode]: 1 }));
-  }, [focusCode, byCode, ownedCodes]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [focusCode, byCode, snapshot]);
 
+  // Grace counts as having a licence: the capability is live and buying a
+  // second one is refused. Only 'none' and 'expired' need one added.
   const needsLicence = license.status === 'none' || license.status === 'expired';
 
   /** Today's price for one unit — prorated when the engine priced it. */
@@ -199,7 +212,11 @@ const CatalogStore = ({ focusCode }: { focusCode?: string }) => {
                 // Credits and extra branches are bought repeatedly; a module is
                 // owned once, so owning it takes it off the menu.
                 const repeatable = COUNTABLE_KINDS.has(product.kind);
-                const isOwned = ownedCodes.has(product.code) && !repeatable;
+                const blocked = blockedReason(product.code);
+                // A blocked line is unbuyable for a reason the server named.
+                // `LICENSE_REQUIRED` is not one of them here: the store adds
+                // the licence itself, so those stay tickable.
+                const isOwned = !!blocked && blocked !== 'LICENSE_REQUIRED';
                 const isLicenceAuto =
                   product.code === LICENCE_CODE && licenceAutoAdded;
                 const checked = product.code in picked || isLicenceAuto;
@@ -243,7 +260,9 @@ const CatalogStore = ({ focusCode }: { focusCode?: string }) => {
                           {isOwned && (
                             <span className="inline-flex items-center gap-1 rounded bg-emerald-50 px-1.5 py-0.5 text-xs font-medium text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-300">
                               <Check size={12} />
-                              {t('licensing:store.owned')}
+                              {blocked === 'ADDON_MAX_QUANTITY'
+                                ? t('licensing:store.maxReached')
+                                : t('licensing:store.owned')}
                             </span>
                           )}
                           {isLicenceAuto && (

--- a/frontend/src/features/licensing/licensingApi.ts
+++ b/frontend/src/features/licensing/licensingApi.ts
@@ -63,6 +63,20 @@ export interface LicensingSnapshot {
   renewal: RenewalSummary | null;
   /** Grant key → the cheapest product that provides it, priced for today. */
   offers: Record<string, Offer>;
+  /**
+   * Product code → whether it can be bought right now, decided by the SAME
+   * function the pre-payment guard uses.
+   *
+   * The store used to decide this itself, by looking for an ownership row.
+   * Anything granted without one — a comp, an operator override, every feature
+   * the demo tenant holds — therefore showed a Buy button that checkout
+   * refuses, and since a rejected line fails the whole cart, the customer
+   * could not buy the product they actually wanted either.
+   */
+  purchasability: Record<
+    string,
+    { ok: boolean; reason?: string; message?: string }
+  >;
 }
 
 export const licensingKeys = {

--- a/frontend/src/i18n/locales/ar/licensing.json
+++ b/frontend/src/i18n/locales/ar/licensing.json
@@ -92,7 +92,8 @@
     "decrease": "إنقاص الكمية",
     "pay": "ادفع",
     "reviewBill": "عرض الفاتورة",
-    "selectedCount": "تم تحديد {{count}}"
+    "selectedCount": "تم تحديد {{count}}",
+    "maxReached": "بلغ الحد الأقصى"
   },
   "invoices": {
     "title": "الفواتير",

--- a/frontend/src/i18n/locales/en/licensing.json
+++ b/frontend/src/i18n/locales/en/licensing.json
@@ -92,7 +92,8 @@
     "decrease": "Decrease quantity",
     "pay": "Pay",
     "reviewBill": "Review bill",
-    "selectedCount": "{{count}} selected"
+    "selectedCount": "{{count}} selected",
+    "maxReached": "Max reached"
   },
   "invoices": {
     "title": "Invoices",

--- a/frontend/src/i18n/locales/ru/licensing.json
+++ b/frontend/src/i18n/locales/ru/licensing.json
@@ -92,7 +92,8 @@
     "decrease": "Уменьшить количество",
     "pay": "Оплатить",
     "reviewBill": "К счёту",
-    "selectedCount": "Выбрано: {{count}}"
+    "selectedCount": "Выбрано: {{count}}",
+    "maxReached": "Достигнут максимум"
   },
   "invoices": {
     "title": "Счета",

--- a/frontend/src/i18n/locales/tr/licensing.json
+++ b/frontend/src/i18n/locales/tr/licensing.json
@@ -92,7 +92,8 @@
     "decrease": "Adedi azalt",
     "pay": "Öde",
     "reviewBill": "Adisyonu gör",
-    "selectedCount": "{{count}} kalem seçildi"
+    "selectedCount": "{{count}} kalem seçildi",
+    "maxReached": "Azami adet"
   },
   "invoices": {
     "title": "Faturalar",

--- a/frontend/src/i18n/locales/uz/licensing.json
+++ b/frontend/src/i18n/locales/uz/licensing.json
@@ -92,7 +92,8 @@
     "decrease": "Sonini kamaytirish",
     "pay": "To‘lash",
     "reviewBill": "Hisobni ko‘rish",
-    "selectedCount": "{{count}} ta tanlandi"
+    "selectedCount": "{{count}} ta tanlandi",
+    "maxReached": "Maksimalga yetdi"
   },
   "invoices": {
     "title": "Hisob-fakturalar",


### PR DESCRIPTION
Demo hesabından bildirilen iki belirti, tek kök nedenin iki yüzü: mağaza **zaten sahip olunan** ürünleri satışa sunuyordu, ve herhangi bir modül işaretlendiğinde **lisansı olan** hesaba adisyona **ikinci bir lisans** ekliyordu.

İkisi de asla tamamlanamazdı. Ödeme-öncesi guard, kapsanan ürünü `ADDON_ALREADY_GRANTED`, ikinci lisansı `ADDON_ALREADY_OWNED` ile reddediyor — ve **bir satırın reddi tüm sepeti düşürdüğü için**, müşterinin asıl almak istediği ürün de onunla birlikte düşüyordu.

> Para hareket etmedi: guard PayTR'den önce çalışıyor. Bu bir çift-çekim değil, **çıkmaz sokaktı**. "Uzatma" da olmuyor — uzatma yalnız yıl dönümü **yenileme sepetinden** oluyor; orada `isRenewal` işaretli olduğu için sahiplik kontrolleri bilerek atlanıyor.

## Kök neden 1 — mağaza, checkout'un sorduğundan farklı bir soru soruyordu

Mağaza "sahiplik **satırı** var mı?" diye bakıyordu; checkout ise "bu yetenek zaten **efektif yetkilerle** kapsanıyor mu?" diye soruyor. Satır olmadan verilen her şey — operatör hediyesi, override, **demo tenant'ın tüm feature seti** — sahipsiz görünüp satışa çıkıyordu.

Karar artık **tek bir saf fonksiyon**: guard ürün başına veriyi topluyor, lisans snapshot'ı zaten yüklü veriyi kullanıyor, ikisi de `evaluatePurchasability`'yi çağırıyor. Mağaza artık sunucunun kararını render ediyor, ikinci bir görüş üretmiyor.

`LICENSE_REQUIRED` bilerek "satılamaz" sayılmıyor: lisansı mağaza zaten kendisi ekliyor; aksi halde henüz hiçbir şey almamış her müşteriye **tüm katalog gri** görünürdü.

## Kök neden 2 — lisans durumu yıl dönümü çapasından türetiliyordu

`!anchorAt ? "none"` ile başlıyordu. Çapası olmayan ama **canlı lisansı olan** bir hesap "lisanssız" raporlanıyor, mağaza da buna inanıp bir lisans daha ekliyordu. Durum artık canlı yetkiden türetiliyor; çapa "yıl dönümü ne zaman" sorusunun cevabı, "lisans var mı" sorusunun değil.

Demo'nun bu hataya düşme sebebi de buydu: dünkü demo düzeltmem comp satırlarını **ham insert** ile yazıp `purchase()`'ın etrafındaki her şeyi atlıyordu — çapa damgalaması dahil. Artık superadmin comp ucunun kullandığı yoldan, `purchase()` üzerinden hediye ediyor; ayrıca satılamayan tek bir ürün artık tüm demo'yu düşürmüyor.

## Testler

- **6 backend**: lisans durumu (çapasız-canlı, grace, expired, hiç-olmamış) + satın alınabilirlik (satırsız zaten-verilmiş, ikinci lisans, kontör her zaman alınabilir, kapasite tavanı)
- **4 frontend**: mağaza sunucu kararına uyuyor mu (satırsız kapsanan gri mi, kapasite tavanında "azami adet" mi diyor, `LICENSE_REQUIRED`'da satılabilir kalıyor mu, grace'te lisans tekrar eklenmiyor mu)
- **2 demo**: comp çapa-damgalayan yoldan mı geçiyor, bozuk katalog satırı demo'yu düşürüyor mu

4679 backend + 2237 frontend testi, e2e **35/35** gerçek Postgres'te, contract-drift yeşil, Nest context'i portsuz boot edildi (yeni modül bağı çözülüyor).