### PR TITLE
feat(landing): put the web-chat launcher on the site

### DIFF
--- a/README.md
+++ b/README.md
@@ -593,6 +593,18 @@ VITE_API_URL=https://api.yourdomain.com
 VITE_WS_URL=https://api.yourdomain.com
 ```
 
+**Landing (.env):**
+```env
+NEXT_PUBLIC_BASE_URL=https://hummytummy.com
+NEXT_PUBLIC_API_URL=https://api.hummytummy.com
+
+# Web-chat launcher. Both have working defaults, so production needs no
+# wiring. Set the key to an EMPTY string on staging/preview so test traffic
+# does not open real conversations in the shared inbox.
+NEXT_PUBLIC_WEBCHAT_WIDGET_KEY=wc_...
+NEXT_PUBLIC_WEBCHAT_HOST=https://jeetagrowth.com
+```
+
 ## 🤝 Contributing
 
 Contributions are welcome! Please follow these steps:

--- a/landing/src/app/[locale]/layout.tsx
+++ b/landing/src/app/[locale]/layout.tsx
@@ -5,6 +5,7 @@ import { getMessages, setRequestLocale } from 'next-intl/server';
 import { Inter } from 'next/font/google';
 import { locales, localeConfig, type Locale } from '@/i18n/config';
 import { FloatingMascot } from '@/components/FloatingMascot';
+import { WebChatWidget } from '@/components/WebChatWidget';
 import '../globals.css';
 
 const inter = Inter({ subsets: ['latin', 'cyrillic'] });
@@ -146,6 +147,7 @@ export default async function LocaleLayout({ children, params }: Props) {
           {children}
           <FloatingMascot />
         </NextIntlClientProvider>
+        <WebChatWidget />
       </body>
     </html>
   );

--- a/landing/src/components/WebChatWidget.tsx
+++ b/landing/src/components/WebChatWidget.tsx
@@ -1,0 +1,35 @@
+/**
+ * Jeeta web-chat launcher.
+ *
+ * The loader at `<host>/widget.js` reads its own `data-*` attributes off
+ * `document.currentScript` and returns early when that is null. `next/script`
+ * with the default `afterInteractive` strategy appends the tag programmatically,
+ * which leaves `currentScript` null — so this stays a plain parser-inserted
+ * `<script>`, the same way the JSON-LD block in the layout does.
+ *
+ * Rendering is skipped when the key is blank, which is how a staging or preview
+ * deploy opts out: set NEXT_PUBLIC_WEBCHAT_WIDGET_KEY="" there so test traffic
+ * does not open real conversations in the shared inbox.
+ */
+const WIDGET_KEY =
+  process.env.NEXT_PUBLIC_WEBCHAT_WIDGET_KEY ??
+  'wc_b6fe4a2d8c1d42cc9643b5136892ae18';
+
+const WIDGET_HOST = (
+  process.env.NEXT_PUBLIC_WEBCHAT_HOST ?? 'https://jeetagrowth.com'
+).replace(/\/+$/, '');
+
+export function WebChatWidget() {
+  if (!WIDGET_KEY) return null;
+
+  return (
+    <script
+      src={`${WIDGET_HOST}/widget.js`}
+      data-widget-key={WIDGET_KEY}
+      // --brand from globals.css (orange-500), so the launcher matches the site
+      // instead of the loader's own #1e40af default.
+      data-accent="#f97316"
+      async
+    />
+  );
+}


### PR DESCRIPTION
The workspace inbox only ever received Instagram, WhatsApp and Messenger traffic. There was no way for someone reading hummytummy.com to start a conversation — the one channel a visitor reaches for while they still have the pricing page open.

The Jeeta channel is **created and live** (`wc_b6fe…ae18`) with the customer-service agent attached, so answers come back with the current pricing guardrails rather than the retired plan story.

## Two details worth keeping

**This is a plain `<script>`, not `next/script`.** The loader at `/widget.js` reads its `data-*` attributes off `document.currentScript` and returns early when that is null — which is exactly what `afterInteractive` produces, since it appends the tag programmatically. A parser-inserted tag is the only shape that works, and it matches how the layout already emits its JSON-LD block.

**Rendering is skipped when the key is blank.** Staging and preview deploys set `NEXT_PUBLIC_WEBCHAT_WIDGET_KEY=""` so test traffic does not open real conversations in the shared inbox. Both env vars have working defaults, so production needs no wiring.

Accent is `--brand` (#f97316) rather than the loader's own `#1e40af` default.

## Verification

- `tsc --noEmit` clean, `eslint` clean on both changed files
- dev server renders the script into the **server HTML** with the right key and accent
- blanking the key renders nothing (`widget.js` occurrences: 0)

`next build` fails on the Windows box this was written on, at the final `.next/standalone` copy step — a Next internal chunk is named `[externals]_node:inspector_….js` and Windows rejects the colon. Unrelated to this change; compilation itself succeeds. Note that CI has no landing job, so this was verified locally rather than by the pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)