### PR TITLE
fix(landing): let the web-chat loader past our own CSP

### DIFF
--- a/landing/next.config.ts
+++ b/landing/next.config.ts
@@ -1,4 +1,5 @@
 import type { NextConfig } from 'next';
+import { WEBCHAT_CSP_ORIGIN } from './src/lib/webchat';
 import createNextIntlPlugin from 'next-intl/plugin';
 import { withSentryConfig } from '@sentry/nextjs';
 
@@ -41,9 +42,14 @@ const nextConfig: NextConfig = {
     // 2. swap Sentry's CDN replay worker for self-hosted to drop the
     //    sentry.io entry from connect-src.
     const isProd = process.env.NODE_ENV === 'production';
+    // The web-chat loader is fetched from, and frames, the Jeeta host. Both
+    // directives are widened from the SAME constant the widget tag renders
+    // from, and the constant is empty when the widget is switched off, so a
+    // staging deploy keeps the tighter header.
+    const webchat = WEBCHAT_CSP_ORIGIN ? ` ${WEBCHAT_CSP_ORIGIN}` : '';
     const scriptSrc = isProd
-      ? "script-src 'self' 'unsafe-inline'"
-      : "script-src 'self' 'unsafe-inline' 'unsafe-eval'";
+      ? `script-src 'self' 'unsafe-inline'${webchat}`
+      : `script-src 'self' 'unsafe-inline' 'unsafe-eval'${webchat}`;
     const csp = [
       "default-src 'self'",
       scriptSrc,
@@ -51,6 +57,9 @@ const nextConfig: NextConfig = {
       "img-src 'self' data: blob: https://hummytummy.com https://staging.hummytummy.com https://*.hugin.com.tr https://www.beko.com.tr https://www.epson.com.tr https://www.sunmi.com https://shop.interpay.com.tr https://www.penetek.com https://sps.honeywell.com https://www.zebra.com https://images.samsung.com https://productimages.hepsiburada.net https://cdn.dsmcdn.com https://img.akakce.com",
       "font-src 'self' data:",
       "connect-src 'self' https://*.sentry.io https://hummytummy.com https://staging.hummytummy.com",
+      // Without this the loader's iframe falls back to default-src 'self'
+      // and the chat panel never opens.
+      `frame-src 'self'${webchat}`,
       "frame-ancestors 'self'",
       "base-uri 'self'",
       "form-action 'self'",

--- a/landing/src/components/WebChatWidget.tsx
+++ b/landing/src/components/WebChatWidget.tsx
@@ -11,21 +11,15 @@
  * deploy opts out: set NEXT_PUBLIC_WEBCHAT_WIDGET_KEY="" there so test traffic
  * does not open real conversations in the shared inbox.
  */
-const WIDGET_KEY =
-  process.env.NEXT_PUBLIC_WEBCHAT_WIDGET_KEY ??
-  'wc_b6fe4a2d8c1d42cc9643b5136892ae18';
-
-const WIDGET_HOST = (
-  process.env.NEXT_PUBLIC_WEBCHAT_HOST ?? 'https://jeetagrowth.com'
-).replace(/\/+$/, '');
+import { WEBCHAT_HOST, WEBCHAT_WIDGET_KEY } from '@/lib/webchat';
 
 export function WebChatWidget() {
-  if (!WIDGET_KEY) return null;
+  if (!WEBCHAT_WIDGET_KEY) return null;
 
   return (
     <script
-      src={`${WIDGET_HOST}/widget.js`}
-      data-widget-key={WIDGET_KEY}
+      src={`${WEBCHAT_HOST}/widget.js`}
+      data-widget-key={WEBCHAT_WIDGET_KEY}
       // --brand from globals.css (orange-500), so the launcher matches the site
       // instead of the loader's own #1e40af default.
       data-accent="#f97316"

--- a/landing/src/lib/webchat.ts
+++ b/landing/src/lib/webchat.ts
@@ -1,0 +1,23 @@
+/**
+ * Web-chat launcher configuration.
+ *
+ * Shared on purpose: `WebChatWidget` renders the loader tag and
+ * `next.config.ts` has to widen the CSP for the very same origin. Keeping the
+ * key and host in one place is what stops the header and the tag from drifting
+ * apart — a drift whose only symptom is a launcher that silently never appears,
+ * because the script tag is in the DOM but the browser refuses to run it.
+ *
+ * Blank the key (NEXT_PUBLIC_WEBCHAT_WIDGET_KEY="") on staging and preview: the
+ * widget stops rendering AND the CSP stops being widened, so test traffic can
+ * neither open real conversations nor pull a third-party script.
+ */
+export const WEBCHAT_WIDGET_KEY =
+  process.env.NEXT_PUBLIC_WEBCHAT_WIDGET_KEY ??
+  'wc_b6fe4a2d8c1d42cc9643b5136892ae18';
+
+export const WEBCHAT_HOST = (
+  process.env.NEXT_PUBLIC_WEBCHAT_HOST ?? 'https://jeetagrowth.com'
+).replace(/\/+$/, '');
+
+/** Empty when the widget is switched off, so the CSP stays as tight as it was. */
+export const WEBCHAT_CSP_ORIGIN = WEBCHAT_WIDGET_KEY ? WEBCHAT_HOST : '';


### PR DESCRIPTION
v3.6.2 shipped the launcher tag but **it never ran.** The site sends `script-src 'self' 'unsafe-inline'`, so the browser refused to fetch `jeetagrowth.com/widget.js` — the tag sat in the DOM and no button was ever created. `frame-src` was undeclared too, so the chat panel would have been blocked by the `default-src 'self'` fallback even if the script had run.

Caught by checking the live page after the release rather than trusting the deploy:

```js
{ scriptVar: true,                                   // tag is there
  widgetKey: 'wc_b6fe…ae18',                         // key is right
  accent: '#f97316',                                 // accent is right
  launcherSayisi: 0 }                                // …and nothing happened
```

That is a nasty failure mode: the markup looks correct in view-source, the deploy is green, and the only symptom is a launcher that silently never appears.

## The fix

Both directives are widened, and from **the same constant the widget tag renders from** — `src/lib/webchat.ts`, imported by both `WebChatWidget` and `next.config.ts`. Keeping the key and host in one place is what stops the header and the tag from drifting apart, which is exactly the drift that produces this silent failure.

The constant is empty when the key is blank, so switching the widget off on staging also **un-widens the CSP** rather than leaving a third-party origin allowed for nothing.

## Verified both ways on a dev server

| | `script-src` | `frame-src` | tag |
|---|---|---|---|
| key set | `… https://jeetagrowth.com` | `'self' https://jeetagrowth.com` | rendered |
| key blank | `'self' 'unsafe-inline'` | `'self'` | absent |

`tsc --noEmit` and `eslint` clean. Note CI has no landing job, so this was verified locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)