### PR TITLE
fix(landing): switch the web chat off until Jeeta allows framing

### DIFF
--- a/landing/src/lib/webchat.ts
+++ b/landing/src/lib/webchat.ts
@@ -7,13 +7,27 @@
  * apart — a drift whose only symptom is a launcher that silently never appears,
  * because the script tag is in the DOM but the browser refuses to run it.
  *
- * Blank the key (NEXT_PUBLIC_WEBCHAT_WIDGET_KEY="") on staging and preview: the
- * widget stops rendering AND the CSP stops being widened, so test traffic can
- * neither open real conversations nor pull a third-party script.
+ * Blanking the key switches the widget off AND un-widens the CSP, so a staging
+ * or preview deploy can neither open real conversations nor pull a third-party
+ * script.
+ */
+
+/**
+ * OFF by default, deliberately.
+ *
+ * The loader frames `<host>/widget?key=…`, and that route answers with
+ * `X-Frame-Options: SAMEORIGIN` — so the panel cannot render on any origin but
+ * Jeeta's own. Everything on our side works (the script loads, the launcher
+ * paints, the iframe is created with the right URL); the browser refuses the
+ * frame at the last step, leaving a chat button that opens an empty box.
+ *
+ * A launcher that opens nothing is worse than no launcher, so the key stays
+ * empty until Jeeta serves that route with a `frame-ancestors` policy that
+ * admits customer domains. Set NEXT_PUBLIC_WEBCHAT_WIDGET_KEY to the workspace
+ * key (wc_…) to switch it back on — no code change needed.
  */
 export const WEBCHAT_WIDGET_KEY =
-  process.env.NEXT_PUBLIC_WEBCHAT_WIDGET_KEY ??
-  'wc_b6fe4a2d8c1d42cc9643b5136892ae18';
+  process.env.NEXT_PUBLIC_WEBCHAT_WIDGET_KEY ?? '';
 
 export const WEBCHAT_HOST = (
   process.env.NEXT_PUBLIC_WEBCHAT_HOST ?? 'https://jeetagrowth.com'


### PR DESCRIPTION
Verified on production after v3.6.3: the launcher paints, the iframe is created with the right URL — and then the browser refuses to render it.

```
GET https://jeetagrowth.com/widget?key=wc_b6fe…ae18
X-Frame-Options: SAMEORIGIN
```

The panel cannot appear on any origin but Jeeta's own. Their embed loader — whose own header comment documents dropping it onto a customer's site — disagrees with the route it frames.

Right now a visitor to landing.hummytummy.com gets an orange chat button that opens an empty box. That is worse than no button.

## What changes

Only the default key is emptied. Nothing else is reverted, because nothing else is wrong: the CSP still carries the origin *only while the widget is on*, and the component and the header still read the same constant. With the key blank the launcher stops rendering and the CSP goes back to its tighter form.

Turning it back on is an **env change, not a code change** — set `NEXT_PUBLIC_WEBCHAT_WIDGET_KEY` once Jeeta serves `/widget` with a `frame-ancestors` policy that admits customer domains. (`X-Frame-Options` has no syntax for "these other hosts"; CSP `frame-ancestors` is the header that does.)

The Jeeta-side channel stays live and keeps the customer-service agent attached, so nothing needs re-creating when it is re-enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)